### PR TITLE
metrics_provider: Use 'info' logging level for metrics issues

### DIFF
--- a/src/metrics/metrics_provider.cpp
+++ b/src/metrics/metrics_provider.cpp
@@ -60,7 +60,7 @@ void post_request(const QUrl& metrics_url, const QByteArray& body)
     if (reply->error() == QNetworkReply::ProtocolInvalidOperationError)
     {
         auto error_msg = QJsonDocument::fromJson(buff).object();
-        mpl::log(mpl::Level::error, category,
+        mpl::log(mpl::Level::info, category,
                  fmt::format("Metrics error: {} - {}", error_msg["code"].toString().toStdString(),
                              error_msg["message"].toString().toStdString()));
     }
@@ -150,7 +150,7 @@ mp::MetricsProvider::MetricsProvider(const QUrl& url, const QString& unique_id, 
               }
               catch (const std::exception& e)
               {
-                  mpl::log(mpl::Level::error, category, fmt::format("{} - Attempting to resend", e.what()));
+                  mpl::log(mpl::Level::info, category, fmt::format("{} - Attempting to resend", e.what()));
 
                   metrics_failed = true;
 


### PR DESCRIPTION
This will keep messages from bubbling up to the client unless '-vv' or greater is used.

Fixes #486