### PR TITLE
Adds link to documentation on Discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,6 @@ cp <multipass>/data/multipass.gui.autostart.desktop ~/.local/share/multipass/
 <multipass>/build/bin/multipass launch --name foo
 ```
 
+# More information
+
+See [the Multipass documentation](https://discourse.ubuntu.com/c/multipass/doc).


### PR DESCRIPTION
A temporary measure until the docs are generated as part of the Multipass site.

Fixes #1053.