### PR TITLE
[travis] fix release handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   # regexes for release branch and tag
   - MULTIPASS_RELEASE_BRANCH_PATTERN="^release/([0-9\.]+)$"
   - MULTIPASS_RELEASE_TAG_PATTERN="^v([0-9]+\.[0-9]+)\.[0-9]+$"
+  # upstream to use as reference for release version matching
+  - MULTIPASS_UPSTREAM="origin"
   # build label added to the version string
   - MULTIPASS_BUILD_LABEL=""
   # whether to publish the built packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,17 +51,18 @@ before_install:
 
     # when it's a release branch or tag
     if [[ "${TRAVIS_BRANCH}" =~ ${MULTIPASS_RELEASE_BRANCH_PATTERN} \
+          || "${TRAVIS_PULL_REQUEST_BRANCH}" =~ ${MULTIPASS_RELEASE_BRANCH_PATTERN} \
           || "${TRAVIS_BRANCH}" =~ ${MULTIPASS_RELEASE_TAG_PATTERN} ]]; then
 
-      # publish pushes on candidate/*
+      # only publish pushes, on candidate/*
       if [ "${TRAVIS_EVENT_TYPE}" == "push" ]; then
         MULTIPASS_PUBLISH="true"
         MULTIPASS_SNAP_CHANNEL="candidate/${BASH_REMATCH[1]}"
-      fi
 
-      # but report on the PR if it's a release branch
-      if [[ "${TRAVIS_BRANCH}" == release/* ]]; then
-        MULTIPASS_REPORT_OPTIONS+=("--branch" "${TRAVIS_BRANCH}")
+        # but report on the PR if it's a release branch
+        if [[ "${TRAVIS_BRANCH}" == release/* ]]; then
+          MULTIPASS_REPORT_OPTIONS+=("--branch" "${TRAVIS_BRANCH}")
+        fi
       fi
 
     # other branches publish on the commits by default
@@ -78,7 +79,7 @@ before_install:
         MULTIPASS_REPORT_OPTIONS+=("--parent")
       fi
 
-    # non-release publish on edge/pr*
+    # publish all other PRs on edge/pr*
     elif [ "${TRAVIS_EVENT_TYPE}" == "pull_request" ]; then
       MULTIPASS_PUBLISH="true"
       MULTIPASS_SNAP_CHANNEL="edge/${MULTIPASS_BUILD_LABEL}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ add_subdirectory(3rd-party)
 find_package(Qt5 COMPONENTS Core Network Widgets REQUIRED)
 
 function(determine_version OUTPUT_VARIABLE)
-  execute_process(COMMAND git describe --all --match release/*
+  execute_process(COMMAND git describe --all --match origin/release/*
                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                   ERROR_QUIET
                   OUTPUT_VARIABLE GIT_BRANCH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,13 @@ add_subdirectory(3rd-party)
 find_package(Qt5 COMPONENTS Core Network Widgets REQUIRED)
 
 function(determine_version OUTPUT_VARIABLE)
-  execute_process(COMMAND git describe --all --match origin/release/*
+  # default to the "origin" remote when checking for release status
+  set(MULTIPASS_UPSTREAM $ENV{MULTIPASS_UPSTREAM})
+  if(NOT MULTIPASS_UPSTREAM)
+    set(MULTIPASS_UPSTREAM origin)
+  endif()
+
+  execute_process(COMMAND git describe --all --match ${MULTIPASS_UPSTREAM}/release/*
                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                   ERROR_QUIET
                   OUTPUT_VARIABLE GIT_BRANCH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,32 +62,38 @@ add_subdirectory(3rd-party)
 find_package(Qt5 COMPONENTS Core Network Widgets REQUIRED)
 
 function(determine_version OUTPUT_VARIABLE)
-  # default to the "origin" remote when checking for release status
+  # use upstream repo as the authoritative reference when checking for release status
+  # set MULTIPASS_UPSTREAM="*" to use the local repository
   set(MULTIPASS_UPSTREAM $ENV{MULTIPASS_UPSTREAM})
-  if(NOT MULTIPASS_UPSTREAM)
-    set(MULTIPASS_UPSTREAM origin)
+  if(MULTIPASS_UPSTREAM)
+    set(MULTIPASS_UPSTREAM "${MULTIPASS_UPSTREAM}/")
   endif()
 
-  execute_process(COMMAND git describe --all --match ${MULTIPASS_UPSTREAM}/release/*
+  execute_process(COMMAND git describe --all --exact --match "${MULTIPASS_UPSTREAM}release/*"
                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                  ERROR_QUIET
-                  OUTPUT_VARIABLE GIT_BRANCH
-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  execute_process(COMMAND git describe --exact
-                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                  OUTPUT_VARIABLE GIT_RELEASE
+                  OUTPUT_VARIABLE GIT_RELEASE_BRANCH
                   OUTPUT_STRIP_TRAILING_WHITESPACE
                   ERROR_QUIET)
 
-  execute_process(COMMAND git describe
+  execute_process(COMMAND git describe --long
                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                   OUTPUT_VARIABLE GIT_VERSION
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   # only use -rc tags on release/* branches
-  string(REGEX MATCH "release/[0-9]+.[0-9]+$" GIT_BRANCH_MATCH "${GIT_BRANCH}")
-  if(GIT_BRANCH_MATCH)
+  string(REGEX MATCH "release/[0-9]+.[0-9]+" GIT_RELEASE_MATCH "${GIT_RELEASE_BRANCH}")
+  if(GIT_RELEASE_MATCH)
+      if(NOT DEFINED ENV{MULTIPASS_UPSTREAM})
+        message(FATAL_ERROR "You need to set MULTIPASS_UPSTREAM for a release build.\
+                             \nUse an empty string to make local the authoritative repository.")
+      endif()
+
+      execute_process(COMMAND git describe --exact
+                      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                      OUTPUT_VARIABLE GIT_RELEASE
+                      OUTPUT_STRIP_TRAILING_WHITESPACE
+                      ERROR_QUIET)
+
       execute_process(COMMAND git describe --tags --match *-rc --abbrev=0
                       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                       OUTPUT_VARIABLE GIT_TAG


### PR DESCRIPTION
We incorrectly published on PRs of `release/0.9` branches, and the version determination required for `release/*` to be a local ref instead of one in the `origin` remote.

---

Testing:
1. `MULTIPASS_UNLOCK` is required on a `release/*` branch
   ```console
   $ git checkout -b release/0.0
   $ cmake .
   # ...
   CMake Error at CMakeLists.txt:87 (message):
     You need to set MULTIPASS_UPSTREAM for a release build.

     Use an empty string to make local the authoritative repository.
   ```
1. setting `MULTIPASS_UPSTREAM=origin` makes it ignore the `release/*` branch
   ```console
   $ git checkout -b release/0.0
   $ MULTIPASS_UPSTREAM=origin cmake .
   # ...
   -- Setting version to: 1.1.0-dev.84+g4a33a0a9
   $ git tag -as v0.0.0 -m Foo
   $ MULTIPASS_UPSTREAM=origin cmake .
   # ...
   -- Setting version to: 1.1.0-dev.84+g4a33a0a9
   $ git tag -d v0.0.0
   ```

1. setting `MULTIPASS_UPSTREAM=` makes it respect the `release/*` branch
   ```console
   $ git checkout -b release/0.0
   $ MULTIPASS_UPSTREAM=origin cmake .
   # ...
   -- Setting version to: 1.1.0-rc.84+g4a33a0a9
   $ git tag -as v0.0.0 -m Foo
   $ MULTIPASS_UPSTREAM=origin cmake .
   # ...
   -- Setting version to: 0.0.0
   $ git tag -d v0.0.0
   ```

1. `release/*` pull requests don't get published
   ```console
   ( python3 -c 'import yaml
   t = yaml.safe_load(open(".travis.yml")) 
   print("\n".join(t["env"]["global"]))
   print(t["before_install"][0])'
   for var in PUBLISH BUILD_LABEL SNAP_CHANNEL REPORT_OPTIONS; do
     echo "echo MULTIPASS_${var}=\${MULTIPASS_${var}}"
   done
   ) \
   | env TRAVIS_SECURE_ENV_VARS=true TRAVIS_EVENT_TYPE=pull_request TRAVIS_PULL_REQUEST=123 TRAVIS_PULL_REQUEST_BRANCH=release/0.0 bash

   MULTIPASS_PUBLISH=               # rather than "true"
   MULTIPASS_BUILD_LABEL=pr123
   MULTIPASS_SNAP_CHANNEL=          # rather than "edge/pr123"
   MULTIPASS_REPORT_OPTIONS=
   ```

1. `release/*` pushes still get published on `--branch`
   ```console
   ( python3 -c 'import yaml
   t = yaml.safe_load(open(".travis.yml")) 
   print("\n".join(t["env"]["global"]))
   print(t["before_install"][0])'
   for var in PUBLISH BUILD_LABEL SNAP_CHANNEL REPORT_OPTIONS; do
     echo "echo MULTIPASS_${var}=\${MULTIPASS_${var}}"
   done
   ) \
   | env TRAVIS_SECURE_ENV_VARS=true TRAVIS_EVENT_TYPE=push TRAVIS_BRANCH=release/0.0 bash
   MULTIPASS_PUBLISH=true
   MULTIPASS_BUILD_LABEL=
   MULTIPASS_SNAP_CHANNEL=candidate/0.0
   MULTIPASS_REPORT_OPTIONS=--branch
   ```