### PR TITLE
Mute new werror

### DIFF
--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -22,33 +22,12 @@ add_library(cert
 target_include_directories(cert PRIVATE
   ${CMAKE_SOURCE_DIR}/3rd-party/grpc/third_party/boringssl/include)
 
-CHECK_CXX_COMPILER_FLAG("-Wno-nested-anon-types" COMPILER_SUPPORTS_NO_NESTED_ANON_TYPES)
-CHECK_CXX_COMPILER_FLAG("-Wno-gnu" COMPILER_SUPPORTS_NO_GNU)
-CHECK_CXX_COMPILER_FLAG("-Wno-pedantic" COMPILER_SUPPORTS_NO_PEDANTIC)
-CHECK_CXX_COMPILER_FLAG("-Wno-ignored-qualifiers" COMPILER_SUPPORTS_NO_IGNORED_QUALIFIERS)
-
-set(ssl_ignore_header_warning_flags "")
-if (COMPILER_SUPPORTS_NO_NESTED_ANON_TYPES)
-  string(APPEND ssl_ignore_header_warning_flags " -Wno-nested-anon-types ")
-endif()
-
-if (COMPILER_SUPPORTS_NO_GNU)
-  string(APPEND ssl_ignore_header_warning_flags " -Wno-gnu ")
-endif()
-
-if (COMPILER_SUPPORTS_NO_PEDANTIC)
-  string(APPEND ssl_ignore_header_warning_flags " -Wno-pedantic ")
-endif()
-
-if (COMPILER_SUPPORTS_NO_IGNORED_QUALIFIERS)
-  string(APPEND ssl_ignore_header_warning_flags " -Wno-ignored-qualifiers ")
-endif()
-
-if (ssl_ignore_header_warning_flags)
-  set_source_files_properties(ssl_cert_provider.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
-  set_source_files_properties(client_cert_store.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
-  set_source_files_properties(biomem.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
-endif()
+foreach(flag -Wno-nested-anon-types -Wno-gnu -Wno-pedantic -Wno-ignored-qualifiers)
+  check_cxx_compiler_flag(${flag} SUPPORTED)
+  if(SUPPORTED)
+    target_compile_options(cert PRIVATE ${flag})
+  endif()
+endforeach()
 
 target_link_libraries(cert
   crypto

--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -25,6 +25,7 @@ target_include_directories(cert PRIVATE
 CHECK_CXX_COMPILER_FLAG("-Wno-nested-anon-types" COMPILER_SUPPORTS_NO_NESTED_ANON_TYPES)
 CHECK_CXX_COMPILER_FLAG("-Wno-gnu" COMPILER_SUPPORTS_NO_GNU)
 CHECK_CXX_COMPILER_FLAG("-Wno-pedantic" COMPILER_SUPPORTS_NO_PEDANTIC)
+CHECK_CXX_COMPILER_FLAG("-Wno-ignored-qualifiers" COMPILER_SUPPORTS_NO_IGNORED_QUALIFIERS)
 
 set(ssl_ignore_header_warning_flags "")
 if (COMPILER_SUPPORTS_NO_NESTED_ANON_TYPES)
@@ -39,9 +40,14 @@ if (COMPILER_SUPPORTS_NO_PEDANTIC)
   string(APPEND ssl_ignore_header_warning_flags " -Wno-pedantic ")
 endif()
 
+if (COMPILER_SUPPORTS_NO_IGNORED_QUALIFIERS)
+  string(APPEND ssl_ignore_header_warning_flags " -Wno-ignored-qualifiers ")
+endif()
+
 if (ssl_ignore_header_warning_flags)
   set_source_files_properties(ssl_cert_provider.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
   set_source_files_properties(client_cert_store.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
+  set_source_files_properties(biomem.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
 endif()
 
 target_link_libraries(cert

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -210,7 +210,7 @@ enum class Permission
 };
 bool compare_permission(uint32_t ssh_permissions, const QFileInfo& file, Permission perm_type)
 {
-    uint16_t qt_perm_mask, ssh_perm_mask, qt_bitshift, ssh_bitshift;
+    uint16_t qt_perm_mask{0u}, ssh_perm_mask{0u}, qt_bitshift{0u}, ssh_bitshift{0u};
 
     // Comparing file permissions, sftp uses octal format: (aaabbbccc), QFileInfo uses hex format (aaaa----bbbbcccc)
     switch (perm_type)

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -100,7 +100,7 @@ TEST_F(SSHFSMountsTest, sshfs_process_failing_with_return_code_9_causes_exceptio
             exit_state.exit_code = 9;
 
             // Have "sshfs_server" die after short delay
-            QTimer::singleShot(100, process, [process, exit_state]() { emit process->finished(exit_state); });
+            QTimer::singleShot(100, process, [process]() { emit process->finished({9, {}}); });
 
             ON_CALL(*process, process_state()).WillByDefault(Return(exit_state));
         }


### PR DESCRIPTION
This addresses a bunch of problems when building in disco (gcc 8.3.0) with the updated grpc. With this on top, the newer grpc fixes the other issue I had when building in debug and with -Og. It appears the newer gcc issues a lot of maybe-uninitialized warnings that are false-positives (maybe others too?). But they depend on the level of optimization!

Expand the commit messages for more details. The last warning in particular got me really puzzled.

I wanted to build with clang too, but got other issues: #1197