### PR TITLE
utils: Add function to check for a config file

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -78,6 +78,7 @@ void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::millisecond
 void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                          const SSHKeyProvider& key_provider);
 void link_autostart_file(const QDir& link_dir, const QString& autostart_subdir, const QString& autostart_filename);
+void check_and_create_config_file(const QString& config_file_path);
 
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>
 void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds timeout, TryAction&& try_action,

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -133,7 +133,10 @@ mp::ReturnCode cmd::GuiCmd::run(mp::ArgParser* parser)
 
 void cmd::GuiCmd::create_actions()
 {
-    config_watcher.addPath(Settings::get_client_settings_file_path());
+    auto client_config_path = Settings::get_client_settings_file_path();
+
+    mp::utils::check_and_create_config_file(client_config_path);
+    config_watcher.addPath(client_config_path);
     QObject::connect(&config_watcher, &QFileSystemWatcher::fileChanged, this, [this](const QString& path) {
         autostart_option.setChecked(Settings::instance().get_as<bool>(autostart_key));
         // Needed since the original watched file may be removed and opened as a new file

--- a/src/daemon/daemon_monitor_settings.cpp
+++ b/src/daemon/daemon_monitor_settings.cpp
@@ -21,8 +21,6 @@
 #include <multipass/utils.h>
 
 #include <QCoreApplication>
-#include <QFile>
-#include <QFileInfo>
 #include <QFileSystemWatcher>
 #include <QObject>
 
@@ -31,18 +29,12 @@ namespace mp = multipass;
 namespace
 {
 constexpr const int settings_changed_code = 42;
-void init_settings(const QString& filename)
-{
-    mp::utils::make_dir({}, QFileInfo{filename}.dir().path()); // make sure parent dir is there
-    QFile file{filename};
-    file.open(QIODevice::WriteOnly | QIODevice::Append);
-}
 } // namespace
 
 void multipass::monitor_and_quit_on_settings_change() // temporary
 {
     static const auto filename = mp::Settings::get_daemon_settings_file_path();
-    init_settings(filename); // create if not there
+    mp::utils::check_and_create_config_file(filename); // create if not there
 
     static QFileSystemWatcher monitor{{filename}};
     QObject::connect(&monitor, &QFileSystemWatcher::fileChanged, [] { QCoreApplication::exit(settings_changed_code); });

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -331,3 +331,14 @@ bool mp::utils::is_running(const VirtualMachine::State& state)
 {
     return state == VirtualMachine::State::running || state == VirtualMachine::State::delayed_shutdown;
 }
+
+void mp::utils::check_and_create_config_file(const QString& config_file_path)
+{
+    QFile config_file{config_file_path};
+
+    if (!config_file.exists())
+    {
+        make_dir({}, QFileInfo{config_file_path}.dir().path()); // make sure parent dir is there
+        config_file.open(QIODevice::WriteOnly);
+    }
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -19,7 +19,9 @@
 
 #include "file_operations.h"
 #include "temp_dir.h"
+#include "temp_file.h"
 
+#include <QDateTime>
 #include <QRegExp>
 
 #include <gmock/gmock.h>
@@ -371,7 +373,7 @@ TEST(Utils, vm_stopped_returns_false)
     EXPECT_FALSE(mp::utils::is_running(state));
 }
 
-TEST(Utils, no_config_file_and_dir_are_created)
+TEST(Utils, absent_config_file_and_dir_are_created)
 {
     mpt::TempDir temp_dir;
     const QString config_file_path{QString("%1/config_dir/config").arg(temp_dir.path())};
@@ -379,4 +381,18 @@ TEST(Utils, no_config_file_and_dir_are_created)
     mp::utils::check_and_create_config_file(config_file_path);
 
     EXPECT_TRUE(QFile::exists(config_file_path));
+}
+
+TEST(Utils, existing_config_file_is_untouched)
+{
+    mpt::TempFile config_file;
+    QFileInfo config_file_info{config_file.name()};
+
+    auto original_last_modified = config_file_info.lastModified();
+
+    mp::utils::check_and_create_config_file(config_file.name());
+
+    auto new_last_modified = config_file_info.lastModified();
+
+    EXPECT_THAT(new_last_modified, Eq(original_last_modified));
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -370,3 +370,13 @@ TEST(Utils, vm_stopped_returns_false)
 
     EXPECT_FALSE(mp::utils::is_running(state));
 }
+
+TEST(Utils, no_config_file_and_dir_are_created)
+{
+    mpt::TempDir temp_dir;
+    const QString config_file_path{QString("%1/config_dir/config").arg(temp_dir.path())};
+
+    mp::utils::check_and_create_config_file(config_file_path);
+
+    EXPECT_TRUE(QFile::exists(config_file_path));
+}


### PR DESCRIPTION
Creates an empty config file if it doesn't exists.

Fixes #1242