### PR TITLE
[throwaway] Test cov2

### DIFF
--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -2,6 +2,18 @@
 # and protobuf not knowing so finding the system version instead
 include_directories(${CMAKE_BINARY_DIR}/3rd-party/grpc/third_party/zlib)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # add_compile_options(--coverage)
+  if(COMMAND add_link_options)
+    add_link_options(--coverage)
+  else()
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " --coverage")
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " --coverage")
+  endif()
+else()
+  message(FATAL_ERROR "Coverage build only supported with GCC")
+endif()
+
 # Add the subdir here to avoid polluting their cmake scope
 add_subdirectory(grpc EXCLUDE_FROM_ALL)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,12 +11,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
 
 if(cmake_build_type_lower MATCHES "coverage")
-  add_compile_options(-ftest-coverage -fprofile-arcs)
-  link_libraries(gcov)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(--coverage)
+    if(COMMAND add_link_options)
+      add_link_options(--coverage)
+    else()
+      string(APPEND CMAKE_SHARED_LINKER_FLAGS " --coverage")
+      string(APPEND CMAKE_EXE_LINKER_FLAGS " --coverage")
+    endif()
+  else()
+    message(FATAL_ERROR "Coverage build only supported with GCC")
+  endif()
 endif()
 
 configure_file(

--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -22,33 +22,12 @@ add_library(cert
 target_include_directories(cert PRIVATE
   ${CMAKE_SOURCE_DIR}/3rd-party/grpc/third_party/boringssl/include)
 
-CHECK_CXX_COMPILER_FLAG("-Wno-nested-anon-types" COMPILER_SUPPORTS_NO_NESTED_ANON_TYPES)
-CHECK_CXX_COMPILER_FLAG("-Wno-gnu" COMPILER_SUPPORTS_NO_GNU)
-CHECK_CXX_COMPILER_FLAG("-Wno-pedantic" COMPILER_SUPPORTS_NO_PEDANTIC)
-CHECK_CXX_COMPILER_FLAG("-Wno-ignored-qualifiers" COMPILER_SUPPORTS_NO_IGNORED_QUALIFIERS)
-
-set(ssl_ignore_header_warning_flags "")
-if (COMPILER_SUPPORTS_NO_NESTED_ANON_TYPES)
-  string(APPEND ssl_ignore_header_warning_flags " -Wno-nested-anon-types ")
-endif()
-
-if (COMPILER_SUPPORTS_NO_GNU)
-  string(APPEND ssl_ignore_header_warning_flags " -Wno-gnu ")
-endif()
-
-if (COMPILER_SUPPORTS_NO_PEDANTIC)
-  string(APPEND ssl_ignore_header_warning_flags " -Wno-pedantic ")
-endif()
-
-if (COMPILER_SUPPORTS_NO_IGNORED_QUALIFIERS)
-  string(APPEND ssl_ignore_header_warning_flags " -Wno-ignored-qualifiers ")
-endif()
-
-if (ssl_ignore_header_warning_flags)
-  set_source_files_properties(ssl_cert_provider.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
-  set_source_files_properties(client_cert_store.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
-  set_source_files_properties(biomem.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
-endif()
+foreach(flag -Wno-nested-anon-types -Wno-gnu -Wno-pedantic -Wno-ignored-qualifiers)
+  check_cxx_compiler_flag(${flag} SUPPORTED)
+  if(SUPPORTED)
+    target_compile_options(cert PRIVATE ${flag})
+  endif()
+endforeach()
 
 target_link_libraries(cert
   crypto

--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -25,6 +25,7 @@ target_include_directories(cert PRIVATE
 CHECK_CXX_COMPILER_FLAG("-Wno-nested-anon-types" COMPILER_SUPPORTS_NO_NESTED_ANON_TYPES)
 CHECK_CXX_COMPILER_FLAG("-Wno-gnu" COMPILER_SUPPORTS_NO_GNU)
 CHECK_CXX_COMPILER_FLAG("-Wno-pedantic" COMPILER_SUPPORTS_NO_PEDANTIC)
+CHECK_CXX_COMPILER_FLAG("-Wno-ignored-qualifiers" COMPILER_SUPPORTS_NO_IGNORED_QUALIFIERS)
 
 set(ssl_ignore_header_warning_flags "")
 if (COMPILER_SUPPORTS_NO_NESTED_ANON_TYPES)
@@ -39,9 +40,14 @@ if (COMPILER_SUPPORTS_NO_PEDANTIC)
   string(APPEND ssl_ignore_header_warning_flags " -Wno-pedantic ")
 endif()
 
+if (COMPILER_SUPPORTS_NO_IGNORED_QUALIFIERS)
+  string(APPEND ssl_ignore_header_warning_flags " -Wno-ignored-qualifiers ")
+endif()
+
 if (ssl_ignore_header_warning_flags)
   set_source_files_properties(ssl_cert_provider.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
   set_source_files_properties(client_cert_store.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
+  set_source_files_properties(biomem.cpp PROPERTIES COMPILE_FLAGS ${ssl_ignore_header_warning_flags})
 endif()
 
 target_link_libraries(cert

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # add_compile_options(--coverage)
+  if(COMMAND add_link_options)
+    add_link_options(--coverage)
+  else()
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " --coverage")
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " --coverage")
+  endif()
+else()
+  message(FATAL_ERROR "Coverage build only supported with GCC")
+endif()
+
 set (CMAKE_AUTOMOC ON)
 
 include(c_mock_defines.cmake)

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -64,12 +64,6 @@ TEST_F(LibVirtBackend, libvirt_wrapper_missing_libvirt_throws)
     EXPECT_THROW(mp::LibvirtWrapper{"missing_libvirt"}, mp::LibvirtOpenException);
 }
 
-TEST_F(LibVirtBackend, libvirt_wrapper_missing_symbol_throws)
-{
-    // Need to set LD_LIBRARY_PATH to this .so for the multipass_tests executable
-    EXPECT_THROW(mp::LibvirtWrapper{"libbroken_libvirt.so"}, mp::LibvirtSymbolAddressException);
-}
-
 TEST_F(LibVirtBackend, health_check_failed_connection_throws)
 {
     mp::LibVirtVirtualMachineFactory backend(data_dir.path(), fake_libvirt_path);

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -210,7 +210,7 @@ enum class Permission
 };
 bool compare_permission(uint32_t ssh_permissions, const QFileInfo& file, Permission perm_type)
 {
-    uint16_t qt_perm_mask, ssh_perm_mask, qt_bitshift, ssh_bitshift;
+    uint16_t qt_perm_mask{0u}, ssh_perm_mask{0u}, qt_bitshift{0u}, ssh_bitshift{0u};
 
     // Comparing file permissions, sftp uses octal format: (aaabbbccc), QFileInfo uses hex format (aaaa----bbbbcccc)
     switch (perm_type)

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -100,7 +100,7 @@ TEST_F(SSHFSMountsTest, sshfs_process_failing_with_return_code_9_causes_exceptio
             exit_state.exit_code = 9;
 
             // Have "sshfs_server" die after short delay
-            QTimer::singleShot(100, process, [process, exit_state]() { emit process->finished(exit_state); });
+            QTimer::singleShot(100, process, [process]() { emit process->finished({9, {}}); });
 
             ON_CALL(*process, process_state()).WillByDefault(Return(exit_state));
         }


### PR DESCRIPTION
Adds linking options for coverage to src, tests, and 3rd-party, separately. Adds coverage compilation option only in src.