### PR TITLE
Fix include coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ if(cmake_build_type_lower MATCHES "coverage")
         --remove coverage.info
         '/usr/*'
         ${CMAKE_SOURCE_DIR}'/3rd-party/*'
+        ${CMAKE_SOURCE_DIR}'/tests/*'
         ${CMAKE_BINARY_DIR}
         --output-file coverage.cleaned
       COMMAND ${CMAKE_COMMAND} -E remove coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 # these we want to apply even to 3rd-party
 if(cmake_build_type_lower MATCHES "coverage")
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(--coverage)
     if(COMMAND add_link_options)
       add_link_options(--coverage)
     else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,14 +12,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-if(cmake_build_type_lower MATCHES "coverage")
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(--coverage)
-  else()
-    message(FATAL_ERROR "Coverage build only supported with GCC")
-  endif()
-endif()
-
 configure_file(
   version.h.in
   ${MULTIPASS_GENERATED_SOURCE_DIR}/multipass/version.h


### PR DESCRIPTION
Enable coverage in test compilation, to measure header code execution properly (from include). Then, exclude the tests themselves from coverage reporting.
