### PR TITLE
[qemu] Keep qemu error when shutdown during start

### DIFF
--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -365,7 +365,9 @@ void mp::QemuVirtualMachine::on_shutdown()
     std::unique_lock<decltype(state_mutex)> lock{state_mutex};
     if (state == State::starting)
     {
-        saved_error_msg = fmt::format("{}: shutdown called while starting", vm_name);
+        if (!saved_error_msg.empty() && saved_error_msg.back() != '\n')
+            saved_error_msg.append("\n");
+        saved_error_msg.append(fmt::format("{}: shutdown called while starting", vm_name));
         state_wait.wait(lock, [this] { return state == State::off; });
     }
     else


### PR DESCRIPTION
Fixes #882. The error message from qemu says it all, and we had it already saved, but it was being overwritten in `on_shutdown`. This is useful also for other cases beside OOM (see tests below).

I tried adding tests for this, but I am being bitten by a variation of #1003. That is something that I would like to have a go at, otherwise it may always byte us back when we try to add tests. So keeping this no-merge for now, will check next week.

Here is how I tested manually:

### Test too much memory

1. `multipass launch --mem 1234G`

Output before fix:

```
launch failed: The following errors occurred:
first-crane: shutdown called while starting
```

And after fix:

```
launch failed: The following errors occurred:
qemu-system-x86_64: cannot set up guest memory 'pc.ram': Cannot allocate memory
equipped-robin: shutdown called while starting
```

### Test by removing firmware

This on a local build.

1. `sudo mv /usr/share/seabios{,.bak}` don't forget to undo this
2. run daemon
3. `multipass launch`

Output before fix:

```
launch failed: The following errors occurred:
speedy-grison: shutdown called while starting
```
And after fix:

```
launch failed: The following errors occurred:
qemu: could not load PC BIOS 'bios-256k.bin'
casual-haddock: shutdown called while starting
```
