### PR TITLE
[test] Fix MockProcessFactory inject when existing

### DIFF
--- a/tests/mock_process_factory.cpp
+++ b/tests/mock_process_factory.cpp
@@ -59,6 +59,7 @@ void mpt::MockProcessFactory::register_callback(const mpt::MockProcessFactory::C
 
 std::unique_ptr<mp::test::MockProcessFactory::Scope> mp::test::MockProcessFactory::Inject()
 {
+    ProcessFactory::reset();
     ProcessFactory::mock<MockProcessFactory>();
     return std::make_unique<mp::test::MockProcessFactory::Scope>();
 }


### PR DESCRIPTION
### TLDR 

Reset the ProcessFactory singleton when injecting a mock, since it could
have already been initialized. Fixes #1003.

### Diagnosis

OK, I finally got this. Unlike `MockSettings`, which is registered at the beginning of a testing run and stays alive until the end, `MockProcessFactory` works with "[scopes](https://github.com/canonical/multipass/blob/15f82c97749c4f4a000b231cda489f494e20a3db/tests/mock_process_factory.h#L47)" to register and reset the factory mock repeatedly over program execution. But tested code can still call `ProcessFactory::instance()` outside of the lifetime window of these scopes. The first such call after each scope's d'tor encounters a null singleton and initializes it with the real thing. 

Subsequent calls to instance() encounter the real factory, including when next trying to inject a mock. That injection has no effect (other than producing a new scope). Then, when `mpt::MockProcessFactory::mock_instance` is called, the cast to mock fails and we get an error. 

The scope is eventually destroyed, resetting the singleton again. At that point, we are back at the beginning, and things go well until the singleton is initialized without a mock again.

### Quick-fix compromise

The quick fix here just resets the singleton before setting the mock, to make sure it sticks for that scope.

I am not sure this is the ideal status yet, because calls to ProcessFactory may launch real processes inadvertently. That may include `iptables`, `dnsmasq`, `qemu`, `sshfs`, etc. This fix limits that to outside mock scopes, but it is still perfectly possible. If that sounds concerning, we can open an issue and I can work on that later on.

Ideally, I think the best would be something closer to MockSettings, where we know that the mock is there during test execution. But I would have to see if that is even possible or if, in some tests, we really need the factory to launch processes (e.g. apparmor?).

FWIW, a fresh mock could be created for each test if necessary (via `TestEventListener`). But all of this would take work, not least because this stuff is already intertwined with `StubProcessFactory`, `ApparmoredProcessTest`...