### PR TITLE
daemon: Also check for the restarting state on start()

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1435,7 +1435,8 @@ try // clang-format on
     for (const auto& name : vms)
     {
         auto it = vm_instances.find(name);
-        if (it->second->current_state() != VirtualMachine::State::starting)
+        auto state = it->second->current_state();
+        if (state != VirtualMachine::State::starting && state != VirtualMachine::State::restarting)
             it->second->start();
     }
 


### PR DESCRIPTION
No need to issue a backend start() when the instance is in a restarting state.

Fixes #1315

---

I tested using the following method:

- Create an instance.
- `multipass exec <foo> -- sudo reboot`
- Confirm instance is in the `restarting` state.
- Issue `multipass start <foo>` while instance is in the `restarting` state.