### PR TITLE
Install the multipass-sshfs Snap for mount support 

### DIFF
--- a/include/multipass/sshfs_mount/sftp_server.h
+++ b/include/multipass/sshfs_mount/sftp_server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 #define MULTIPASS_SFTP_SERVER_H
 
 #include <multipass/ssh/ssh_session.h>
+#include <multipass/sshfs_mount/sshfs_mount.h>
 
 #include <libssh/sftp.h>
 
@@ -38,7 +39,7 @@ class SftpServer
 public:
     SftpServer(SSHSession&& ssh_session, const std::string& source, const std::string& target,
                const std::unordered_map<int, int>& gid_map, const std::unordered_map<int, int>& uid_map,
-               int default_uid, int default_gid);
+               int default_uid, int default_gid, const SshfsMount::SshfsPkgType sshfs_pkg_type);
     SftpServer(SftpServer&& other);
     ~SftpServer();
 
@@ -84,6 +85,7 @@ private:
     const std::unordered_map<int, int> uid_map;
     const int default_uid;
     const int default_gid;
+    const SshfsMount::SshfsPkgType sshfs_pkg_type;
     bool stop_invoked{false};
 };
 } // namespace multipass

--- a/include/multipass/sshfs_mount/sftp_server.h
+++ b/include/multipass/sshfs_mount/sftp_server.h
@@ -19,7 +19,6 @@
 #define MULTIPASS_SFTP_SERVER_H
 
 #include <multipass/ssh/ssh_session.h>
-#include <multipass/sshfs_mount/sshfs_mount.h>
 
 #include <libssh/sftp.h>
 
@@ -39,7 +38,7 @@ class SftpServer
 public:
     SftpServer(SSHSession&& ssh_session, const std::string& source, const std::string& target,
                const std::unordered_map<int, int>& gid_map, const std::unordered_map<int, int>& uid_map,
-               int default_uid, int default_gid, const SshfsMount::SshfsPkgType sshfs_pkg_type);
+               int default_uid, int default_gid, const std::string& sshfs_exec_line);
     SftpServer(SftpServer&& other);
     ~SftpServer();
 
@@ -85,7 +84,7 @@ private:
     const std::unordered_map<int, int> uid_map;
     const int default_uid;
     const int default_gid;
-    const SshfsMount::SshfsPkgType sshfs_pkg_type;
+    const std::string sshfs_exec_line;
     bool stop_invoked{false};
 };
 } // namespace multipass

--- a/include/multipass/sshfs_mount/sshfs_mount.h
+++ b/include/multipass/sshfs_mount/sshfs_mount.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +29,12 @@ class SftpServer;
 class SshfsMount
 {
 public:
+    enum class SshfsPkgType
+    {
+        debian,
+        snap
+    };
+
     SshfsMount(SSHSession&& session, const std::string& source, const std::string& target,
                const std::unordered_map<int, int>& gid_map, const std::unordered_map<int, int>& uid_map);
     SshfsMount(SshfsMount&& other);

--- a/include/multipass/sshfs_mount/sshfs_mount.h
+++ b/include/multipass/sshfs_mount/sshfs_mount.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,12 +29,6 @@ class SftpServer;
 class SshfsMount
 {
 public:
-    enum class SshfsPkgType
-    {
-        debian,
-        snap
-    };
-
     SshfsMount(SSHSession&& session, const std::string& source, const std::string& target,
                const std::unordered_map<int, int>& gid_map, const std::unordered_map<int, int>& uid_map);
     SshfsMount(SshfsMount&& other);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@
 
 #include <chrono>
 #include <functional>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -72,6 +73,7 @@ std::string escape_char(const std::string& s, char c);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
 std::string generate_mac_address();
 std::string timestamp();
+std::string match_line_for(std::istringstream& output, const std::string& matcher);
 bool is_running(const VirtualMachine::State& state);
 void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                        std::function<void()> const& ensure_vm_is_running = []() {});

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -19,6 +19,7 @@
 #define MULTIPASS_UTILS_H
 
 #include <multipass/path.h>
+#include <multipass/ssh/ssh_session.h>
 #include <multipass/virtual_machine.h>
 
 #include <chrono>
@@ -79,6 +80,7 @@ void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::millisecond
                        std::function<void()> const& ensure_vm_is_running = []() {});
 void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                          const SSHKeyProvider& key_provider);
+void install_sshfs_for(const std::string& name, SSHSession& session);
 void link_autostart_file(const QDir& link_dir, const QString& autostart_subdir, const QString& autostart_filename);
 void check_and_create_config_file(const QString& config_file_path);
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -80,7 +80,8 @@ void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::millisecond
                        std::function<void()> const& ensure_vm_is_running = []() {});
 void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                          const SSHKeyProvider& key_provider);
-void install_sshfs_for(const std::string& name, SSHSession& session);
+void install_sshfs_for(const std::string& name, SSHSession& session,
+                       const std::chrono::milliseconds timeout = std::chrono::minutes(5));
 void link_autostart_file(const QDir& link_dir, const QString& autostart_subdir, const QString& autostart_filename);
 void check_and_create_config_file(const QString& config_file_path);
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -74,7 +74,7 @@ std::string escape_char(const std::string& s, char c);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
 std::string generate_mac_address();
 std::string timestamp();
-std::string match_line_for(std::istringstream& output, const std::string& matcher);
+std::string match_line_for(const std::string& output, const std::string& matcher);
 bool is_running(const VirtualMachine::State& state);
 void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
                        std::function<void()> const& ensure_vm_is_running = []() {});

--- a/src/client/cli/formatter/CMakeLists.txt
+++ b/src/client/cli/formatter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018 Canonical Ltd.
+# Copyright © 2018-2020 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -22,5 +22,6 @@ add_library(formatter
 target_link_libraries(formatter
   fmt
   rpc
+  ssh_common
   yaml
   Qt5::Core)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -77,8 +77,9 @@ constexpr auto reboot_cmd = "sudo reboot";
 constexpr auto up_timeout = 2min; // This may be tweaked as appropriate and used in places that wait for ssh to be up
 constexpr auto cloud_init_timeout = 5min;
 constexpr auto stop_ssh_cmd = "sudo systemctl stop ssh";
-const std::string sshfs_error_template = "Error enabling mount support in '{}'"
-                                         "\n\nPlease install 'sshfs' manually inside the instance.";
+const std::string sshfs_error_template =
+    "Error enabling mount support in '{}'"
+    "\n\nPlease install the 'multipass-sshfs' snap package manually inside the instance.";
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
 {
@@ -2067,9 +2068,10 @@ void mp::Daemon::install_sshfs(VirtualMachine* vm, const std::string& name)
     {
         mpl::log(mpl::Level::warning, category, fmt::format("Snap support is not installed for \'{}\'", name));
         throw std::runtime_error(
-            fmt::format("Snap support needs to be installed for \'{}\' in order to support mounts. "
-                        "Please see https://docs.snapcraft.io/installing-snapd for information on "
-                        "how to install Snap support for your instance's distribution.",
+            fmt::format("Snap support needs to be installed in \'{}\' in order to support mounts.\n\n"
+                        "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
+                        "\nhow to install Snap support for your instance's distribution."
+                        "\n\nAlternatively, install `sshfs` manually inside the instance.",
                         name));
     }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2063,8 +2063,8 @@ void mp::Daemon::install_sshfs(VirtualMachine* vm, const std::string& name)
     mpl::log(mpl::Level::info, category, fmt::format("Installing the multipass-sshfs snap in \'{}\'", name));
 
     // Check if snap support is installed in the instance
-    auto proc = session.exec("which snap");
-    if (proc.exit_code() != 0)
+    auto which_proc = session.exec("which snap");
+    if (which_proc.exit_code() != 0)
     {
         mpl::log(mpl::Level::warning, category, fmt::format("Snap support is not installed in \'{}\'", name));
         throw std::runtime_error(
@@ -2072,6 +2072,18 @@ void mp::Daemon::install_sshfs(VirtualMachine* vm, const std::string& name)
                         "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
                         "\nhow to install snap support for your instance's distribution."
                         "\n\nAlternatively, install `sshfs` manually inside the instance.",
+                        name));
+    }
+
+    // Check if /snap exists for "classic" snap support
+    auto test_file_proc = session.exec("[ -e /snap ]");
+    if (test_file_proc.exit_code() != 0)
+    {
+        mpl::log(mpl::Level::warning, category, fmt::format("Classic snap support symlink is needed in \'{}\'", name));
+        throw std::runtime_error(
+            fmt::format("Classic snap support is needed in \'{}\' in order to support mounts."
+                        "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
+                        "\nhow to enable classic snap support for your instance's distribution.",
                         name));
     }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2060,17 +2060,17 @@ void mp::Daemon::install_sshfs(VirtualMachine* vm, const std::string& name)
 
     SSHSession session{vm->ssh_hostname(), vm->ssh_port(), vm->ssh_username(), key_provider};
 
-    mpl::log(mpl::Level::info, category, fmt::format("Installing the multipass-sshfs Snap for \'{}\'", name));
+    mpl::log(mpl::Level::info, category, fmt::format("Installing the multipass-sshfs snap for \'{}\'", name));
 
     // Check if Snap support is installed in the instance
     auto proc = session.exec("which snap");
     if (proc.exit_code() != 0)
     {
-        mpl::log(mpl::Level::warning, category, fmt::format("Snap support is not installed for \'{}\'", name));
+        mpl::log(mpl::Level::warning, category, fmt::format("Snap support is not installed in \'{}\'", name));
         throw std::runtime_error(
             fmt::format("Snap support needs to be installed in \'{}\' in order to support mounts.\n\n"
                         "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
-                        "\nhow to install Snap support for your instance's distribution."
+                        "\nhow to install snap support for your instance's distribution."
                         "\n\nAlternatively, install `sshfs` manually inside the instance.",
                         name));
     }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -77,9 +77,8 @@ constexpr auto reboot_cmd = "sudo reboot";
 constexpr auto up_timeout = 2min; // This may be tweaked as appropriate and used in places that wait for ssh to be up
 constexpr auto cloud_init_timeout = 5min;
 constexpr auto stop_ssh_cmd = "sudo systemctl stop ssh";
-const std::string sshfs_error_template =
-    "Error enabling mount support in '{}'"
-    "\n\nPlease install the 'multipass-sshfs' snap manually inside the instance.";
+const std::string sshfs_error_template = "Error enabling mount support in '{}'"
+                                         "\n\nPlease install the 'multipass-sshfs' snap manually inside the instance.";
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
 {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -79,7 +79,7 @@ constexpr auto cloud_init_timeout = 5min;
 constexpr auto stop_ssh_cmd = "sudo systemctl stop ssh";
 const std::string sshfs_error_template =
     "Error enabling mount support in '{}'"
-    "\n\nPlease install the 'multipass-sshfs' snap package manually inside the instance.";
+    "\n\nPlease install the 'multipass-sshfs' snap manually inside the instance.";
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
 {
@@ -2060,15 +2060,15 @@ void mp::Daemon::install_sshfs(VirtualMachine* vm, const std::string& name)
 
     SSHSession session{vm->ssh_hostname(), vm->ssh_port(), vm->ssh_username(), key_provider};
 
-    mpl::log(mpl::Level::info, category, fmt::format("Installing the multipass-sshfs snap for \'{}\'", name));
+    mpl::log(mpl::Level::info, category, fmt::format("Installing the multipass-sshfs snap in \'{}\'", name));
 
-    // Check if Snap support is installed in the instance
+    // Check if snap support is installed in the instance
     auto proc = session.exec("which snap");
     if (proc.exit_code() != 0)
     {
         mpl::log(mpl::Level::warning, category, fmt::format("Snap support is not installed in \'{}\'", name));
         throw std::runtime_error(
-            fmt::format("Snap support needs to be installed in \'{}\' in order to support mounts.\n\n"
+            fmt::format("Snap support needs to be installed in \'{}\' in order to support mounts."
                         "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
                         "\nhow to install snap support for your instance's distribution."
                         "\n\nAlternatively, install `sshfs` manually inside the instance.",

--- a/src/metrics/CMakeLists.txt
+++ b/src/metrics/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright © 2018 Canonical Ltd.
-# 
+# Copyright © 2018-2020 Canonical Ltd.
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
 # published by the Free Software Foundation.
@@ -17,5 +17,6 @@ add_library(metrics STATIC
 
 target_link_libraries(metrics
   fmt
+  ssh_common
   Qt5::Core
   Qt5::Network)

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -93,13 +93,17 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
     auto fuse_version_line = mp::utils::match_line_for(version_info, fuse_version_string);
     if (!fuse_version_line.empty())
     {
+        std::string fuse_version;
+
         // split on the fuse_version_string along with 0 or 1 colon(s)
         auto tokens = mp::utils::split(fuse_version_line, fmt::format("{}:? ", fuse_version_string));
-        auto fuse_version = tokens[1];
+        if (tokens.size() == 2)
+            fuse_version = tokens[1];
 
         if (fuse_version.empty())
         {
             mpl::log(mpl::Level::warning, category, fmt::format("Unable to parse the {}", fuse_version_string));
+            mpl::log(mpl::Level::debug, category, fmt::format("Value is {}", fuse_version_line));
         }
         // The option was made the default in libfuse 3.0
         else if (version::Semver200_version(fuse_version) < version::Semver200_version("3.0.0"))

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -58,7 +58,7 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
     try
     {
         // Prefer to use Snap package version first
-        std::istringstream sshfs_env{run_cmd(session, "sudo multipass-sshfs.env")};
+        std::istringstream sshfs_env{run_cmd(session, "snap run multipass-sshfs.env")};
 
         auto ld_library_path = mp::utils::match_line_for(sshfs_env, ld_library_path_key);
         auto snap_path = mp::utils::match_line_for(sshfs_env, snap_path_key);

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -68,7 +68,8 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
     }
     catch (const std::exception& e)
     {
-        mpl::log(mpl::Level::debug, category, fmt::format("'multipass-sshfs' snap package is not installed: {}", e.what()));
+        mpl::log(mpl::Level::debug, category,
+                 fmt::format("'multipass-sshfs' snap package is not installed: {}", e.what()));
 
         // Fallback to looking for distro version if snap is not found
         try

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -91,10 +91,10 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
     if (!fuse_version_line.empty())
     {
         // split on the fuse_version_string along with 0 or more colons
-        auto tokens = mp::utils::split(fuse_version_line, fmt::format("{}:* ", fuse_version_string));
+        auto tokens = mp::utils::split(fuse_version_line, fmt::format("{}:? ", fuse_version_string));
         auto fuse_version = tokens[1];
 
-        // The option was removed in libfuse 3.0
+        // The option was made the default in libfuse 3.0
         if (!fuse_version.empty() && (version::Semver200_version(fuse_version) < version::Semver200_version("3.0.0")))
             sshfs_exec += " -o nonempty";
     }

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -58,7 +58,7 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
     try
     {
         // Prefer to use Snap package version first
-        std::istringstream sshfs_env{run_cmd(session, "snap run multipass-sshfs.env")};
+        auto sshfs_env{run_cmd(session, "snap run multipass-sshfs.env")};
 
         auto ld_library_path = mp::utils::match_line_for(sshfs_env, ld_library_path_key);
         auto snap_path = mp::utils::match_line_for(sshfs_env, snap_path_key);
@@ -86,7 +86,7 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
 
     sshfs_exec = mp::utils::trim_end(sshfs_exec);
 
-    std::istringstream version_info{run_cmd(session, fmt::format("sudo {} -V", sshfs_exec))};
+    auto version_info{run_cmd(session, fmt::format("sudo {} -V", sshfs_exec))};
 
     sshfs_exec += " -o slave -o transform_symlinks -o allow_other";
 

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -81,7 +81,7 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
     }
     catch (const std::exception& e)
     {
-        mpl::log(mpl::Level::debug, category, fmt::format("'sshfs' snap package is not installed: {}", e.what()));
+        mpl::log(mpl::Level::debug, category, fmt::format("'multipass-sshfs' snap package is not installed: {}", e.what()));
 
         // Fallback to looking for distro version if snap is not found
         try

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -103,7 +103,7 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
         if (fuse_version.empty())
         {
             mpl::log(mpl::Level::warning, category, fmt::format("Unable to parse the {}", fuse_version_string));
-            mpl::log(mpl::Level::debug, category, fmt::format("Value is {}", fuse_version_line));
+            mpl::log(mpl::Level::debug, category, fmt::format("Unable to parse the {}: {}", fuse_version_string, fuse_version_line));
         }
         // The option was made the default in libfuse 3.0
         else if (version::Semver200_version(fuse_version) < version::Semver200_version("3.0.0"))

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -325,6 +325,22 @@ std::string mp::utils::timestamp()
 {
     auto time = QDateTime::currentDateTime();
     return time.toString(Qt::ISODateWithMs).toStdString();
+}
+
+std::string mp::utils::match_line_for(std::istringstream& output, const std::string& matcher)
+{
+    output.seekg(0, output.beg);
+
+    std::string line;
+    while (std::getline(output, line, '\n'))
+    {
+        if (line.find(matcher) != std::string::npos)
+        {
+            return line;
+        }
+    }
+
+    return std::string{};
 }
 
 bool mp::utils::is_running(const VirtualMachine::State& state)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -17,6 +17,8 @@
 
 #include <multipass/constants.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
+#include <multipass/exceptions/exitless_sshprocess_exception.h>
+#include <multipass/exceptions/sshfs_missing_error.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/settings.h>
@@ -45,6 +47,8 @@ namespace mpl = multipass::logging;
 
 namespace
 {
+constexpr auto category = "utils";
+
 auto quote_for(const std::string& arg, mp::utils::QuoteType quote_type)
 {
     if (quote_type == mp::utils::QuoteType::no_quotes)
@@ -210,6 +214,53 @@ void mp::utils::wait_for_cloud_init(mp::VirtualMachine* virtual_machine, std::ch
     };
     auto on_timeout = [] { throw std::runtime_error("timed out waiting for initialization to complete"); };
     mp::utils::try_action_for(on_timeout, timeout, action);
+}
+
+void mp::utils::install_sshfs_for(const std::string& name, mp::SSHSession& session)
+{
+    mpl::log(mpl::Level::info, category, fmt::format("Installing the multipass-sshfs snap in \'{}\'", name));
+
+    // Check if snap support is installed in the instance
+    auto which_proc = session.exec("which snap");
+    if (which_proc.exit_code() != 0)
+    {
+        mpl::log(mpl::Level::warning, category, fmt::format("Snap support is not installed in \'{}\'", name));
+        throw std::runtime_error(
+            fmt::format("Snap support needs to be installed in \'{}\' in order to support mounts."
+                        "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
+                        "\nhow to install snap support for your instance's distribution."
+                        "\n\nAlternatively, install `sshfs` manually inside the instance.",
+                        name));
+    }
+
+    // Check if /snap exists for "classic" snap support
+    auto test_file_proc = session.exec("[ -e /snap ]");
+    if (test_file_proc.exit_code() != 0)
+    {
+        mpl::log(mpl::Level::warning, category, fmt::format("Classic snap support symlink is needed in \'{}\'", name));
+        throw std::runtime_error(
+            fmt::format("Classic snap support is needed in \'{}\' in order to support mounts."
+                        "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
+                        "\nhow to enable classic snap support for your instance's distribution.",
+                        name));
+    }
+
+    try
+    {
+        auto proc = session.exec("sudo snap install multipass-sshfs");
+        if (proc.exit_code(std::chrono::minutes(5)) != 0)
+        {
+            auto error_msg = proc.read_std_error();
+            mpl::log(mpl::Level::warning, category,
+                     fmt::format("Failed to install \'multipass-sshfs\', error message: \'{}\'",
+                                 mp::utils::trim_end(error_msg)));
+            throw mp::SSHFSMissingError();
+        }
+    }
+    catch (const mp::ExitlessSSHProcessException&)
+    {
+        mpl::log(mpl::Level::info, category, fmt::format("Timeout while installing 'sshfs' in '{}'", name));
+    }
 }
 
 void mp::utils::link_autostart_file(const QDir& link_dir, const QString& autostart_subdir,

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -226,10 +226,12 @@ void mp::utils::install_sshfs_for(const std::string& name, mp::SSHSession& sessi
     {
         mpl::log(mpl::Level::warning, category, fmt::format("Snap support is not installed in \'{}\'", name));
         throw std::runtime_error(
-            fmt::format("Snap support needs to be installed in \'{}\' in order to support mounts."
-                        "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
-                        "\nhow to install snap support for your instance's distribution."
-                        "\n\nAlternatively, install `sshfs` manually inside the instance.",
+            fmt::format("Snap support needs to be installed in \'{}\' in order to support mounts.\n"
+                        "Please see https://docs.snapcraft.io/installing-snapd for information on\n"
+                        "how to install snap support for your instance's distribution.\n\n"
+                        "If your distribution's instructions specify enabling classic snap support,\n"
+                        "please do that as well.\n\n"
+                        "Alternatively, install `sshfs` manually inside the instance.",
                         name));
     }
 
@@ -239,9 +241,9 @@ void mp::utils::install_sshfs_for(const std::string& name, mp::SSHSession& sessi
     {
         mpl::log(mpl::Level::warning, category, fmt::format("Classic snap support symlink is needed in \'{}\'", name));
         throw std::runtime_error(
-            fmt::format("Classic snap support is needed in \'{}\' in order to support mounts."
-                        "\n\nPlease see https://docs.snapcraft.io/installing-snapd for information on"
-                        "\nhow to enable classic snap support for your instance's distribution.",
+            fmt::format("Classic snap support is not enabled for \'{}\'!\n\n"
+                        "Please see https://docs.snapcraft.io/installing-snapd for information on\n"
+                        "how to enable classic snap support for your instance's distribution.",
                         name));
     }
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -380,12 +380,12 @@ std::string mp::utils::timestamp()
     return time.toString(Qt::ISODateWithMs).toStdString();
 }
 
-std::string mp::utils::match_line_for(std::istringstream& output, const std::string& matcher)
+std::string mp::utils::match_line_for(const std::string& output, const std::string& matcher)
 {
-    output.seekg(0, output.beg);
-
+    std::istringstream ss{output};
     std::string line;
-    while (std::getline(output, line, '\n'))
+
+    while (std::getline(ss, line, '\n'))
     {
         if (line.find(matcher) != std::string::npos)
         {

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -216,7 +216,8 @@ void mp::utils::wait_for_cloud_init(mp::VirtualMachine* virtual_machine, std::ch
     mp::utils::try_action_for(on_timeout, timeout, action);
 }
 
-void mp::utils::install_sshfs_for(const std::string& name, mp::SSHSession& session)
+void mp::utils::install_sshfs_for(const std::string& name, mp::SSHSession& session,
+                                  const std::chrono::milliseconds timeout)
 {
     mpl::log(mpl::Level::info, category, fmt::format("Installing the multipass-sshfs snap in \'{}\'", name));
 
@@ -250,7 +251,7 @@ void mp::utils::install_sshfs_for(const std::string& name, mp::SSHSession& sessi
     try
     {
         auto proc = session.exec("sudo snap install multipass-sshfs");
-        if (proc.exit_code(std::chrono::minutes(5)) != 0)
+        if (proc.exit_code(timeout) != 0)
         {
             auto error_msg = proc.read_std_error();
             mpl::log(mpl::Level::warning, category,

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -52,7 +52,8 @@ struct SftpServer : public mp::test::SftpServerTest
     mp::SftpServer make_sftpserver(const std::string& path)
     {
         mp::SSHSession session{"a", 42};
-        return {std::move(session), path, path, default_map, default_map, default_id, default_id};
+        return {std::move(session), path,       path,       default_map,
+                default_map,        default_id, default_id, mp::SshfsMount::SshfsPkgType::debian};
     }
 
     auto make_msg(uint8_t type = SFTP_BAD_MESSAGE)

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -52,8 +52,7 @@ struct SftpServer : public mp::test::SftpServerTest
     mp::SftpServer make_sftpserver(const std::string& path)
     {
         mp::SSHSession session{"a", 42};
-        return {std::move(session), path,       path,       default_map,
-                default_map,        default_id, default_id, mp::SshfsMount::SshfsPkgType::debian};
+        return {std::move(session), path, path, default_map, default_map, default_id, default_id, "sshfs"};
     }
 
     auto make_msg(uint8_t type = SFTP_BAD_MESSAGE)

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -191,6 +191,7 @@ struct SshfsMount : public mp::test::SftpServerTest
         {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0"},
         {"id -u", "1000"},
         {"id -g", "1000"},
+        {"pwd", "/home/ubuntu"},
         {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o allow_other :\"source\" "
          "\"target\"",
          "don't care"}};
@@ -394,8 +395,9 @@ TEST_F(SshfsMount, blank_fuse_version_logs_error)
         .WillRepeatedly(Return());
     EXPECT_CALL(*logger, log(Eq(mpl::Level::warning), make_cstring_matcher(StrEq("sshfs mount")),
                              make_cstring_matcher(StrEq("Unable to parse the FUSE library version"))));
-    EXPECT_CALL(*logger, log(Eq(mpl::Level::debug), make_cstring_matcher(StrEq("sshfs mount")),
-                             make_cstring_matcher(StrEq("Value is FUSE library version:"))));
+    EXPECT_CALL(*logger,
+                log(Eq(mpl::Level::debug), make_cstring_matcher(StrEq("sshfs mount")),
+                    make_cstring_matcher(StrEq("Unable to parse the FUSE library version: FUSE library version:"))));
 
     test_command_execution(commands);
 }

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -163,7 +163,7 @@ struct SshfsMount : public mp::test::SftpServerTest
 TEST_F(SshfsMount, throws_when_sshfs_does_not_exist)
 {
     bool invoked{false};
-    auto request_exec = make_exec_that_fails_for({"snap list multipass-sshfs", "which sshfs"}, invoked);
+    auto request_exec = make_exec_that_fails_for({"sudo multipass-sshfs.env", "which sshfs"}, invoked);
     REPLACE(ssh_channel_request_exec, request_exec);
 
     EXPECT_THROW(make_sshfsmount(), mp::SSHFSMissingError);

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -350,7 +350,7 @@ TEST_F(SshfsMount, invalid_fuse_version_throws)
 
     auto request_exec = [&invoked, &remaining, &output](ssh_channel, const char* raw_cmd) {
         std::string cmd{raw_cmd};
-        if (cmd.find("sudo multipass-sshfs.env") != std::string::npos)
+        if (cmd.find("snap run multipass-sshfs.env") != std::string::npos)
         {
             output = "LD_LIBRARY_PATH=/foo/bar\nSNAP=/baz\n";
             remaining = output.size();

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -409,5 +409,47 @@ TEST_F(SshfsMount, works_with_absolute_paths)
 
     test_command_execution(commands, std::string("/home/ubuntu/target"));
 }
-=======
->>>>>>> tests: Add test_sshfsmount test for detecting invalid version
+
+TEST_F(SshfsMount, throws_install_sshfs_which_snap_fails)
+{
+    bool invoked{false};
+    auto request_exec = make_exec_that_fails_for({"which snap"}, invoked);
+    REPLACE(ssh_channel_request_exec, request_exec);
+
+    mp::SSHSession session{"a", 42};
+
+    EXPECT_THROW(mp::utils::install_sshfs_for("foo", session), std::runtime_error);
+    EXPECT_TRUE(invoked);
+}
+
+TEST_F(SshfsMount, throws_install_sshfs_no_snap_dir_fails)
+{
+    bool invoked{false};
+    auto request_exec = make_exec_that_fails_for({"[ -e /snap ]"}, invoked);
+    REPLACE(ssh_channel_request_exec, request_exec);
+
+    mp::SSHSession session{"a", 42};
+
+    EXPECT_THROW(mp::utils::install_sshfs_for("foo", session), std::runtime_error);
+    EXPECT_TRUE(invoked);
+}
+
+TEST_F(SshfsMount, throws_install_sshfs_snap_install_fails)
+{
+    bool invoked{false};
+    auto request_exec = make_exec_that_fails_for({"sudo snap install multipass-sshfs"}, invoked);
+    REPLACE(ssh_channel_request_exec, request_exec);
+
+    mp::SSHSession session{"a", 42};
+
+    EXPECT_THROW(mp::utils::install_sshfs_for("foo", session), mp::SSHFSMissingError);
+    EXPECT_TRUE(invoked);
+}
+
+TEST_F(SshfsMount, install_sshfs_no_failures_does_not_throw)
+{
+    mp::SSHSession session{"a", 42};
+
+    EXPECT_NO_THROW(mp::utils::install_sshfs_for("foo", session));
+}
+>>>>>>> sshfs_mount/tests: Refactor code to allow testing of install_sshfs

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -333,7 +333,7 @@ TEST_F(SshfsMount, unblocks_when_sftpserver_exits)
 TEST_F(SshfsMount, throws_when_unable_to_change_dir)
 {
     bool invoked{false};
-    auto request_exec = make_exec_that_fails_for("cd", invoked);
+    auto request_exec = make_exec_that_fails_for({"cd"}, invoked);
     REPLACE(ssh_channel_request_exec, request_exec);
 
     EXPECT_THROW(make_sshfsmount(), std::runtime_error);
@@ -372,7 +372,7 @@ TEST_F(SshfsMount, invalid_fuse_version_throws)
 TEST_F(SshfsMount, throws_when_unable_to_get_current_dir)
 {
     bool invoked{false};
-    auto request_exec = make_exec_that_fails_for("pwd", invoked);
+    auto request_exec = make_exec_that_fails_for({"pwd"}, invoked);
     REPLACE(ssh_channel_request_exec, request_exec);
 
     EXPECT_THROW(make_sshfsmount(), std::runtime_error);
@@ -452,4 +452,3 @@ TEST_F(SshfsMount, install_sshfs_no_failures_does_not_throw)
 
     EXPECT_NO_THROW(mp::utils::install_sshfs_for("foo", session));
 }
->>>>>>> sshfs_mount/tests: Refactor code to allow testing of install_sshfs

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -488,3 +488,47 @@ TEST_F(SshfsMount, install_sshfs_no_failures_does_not_throw)
 
     EXPECT_NO_THROW(mp::utils::install_sshfs_for("foo", session));
 }
+
+TEST_F(SshfsMount, install_sshfs_timeout_logs_info)
+{
+    ssh_channel_callbacks callbacks{nullptr};
+    bool sleep{false};
+
+    auto request_exec = [&sleep](ssh_channel, const char* raw_cmd) {
+        std::string cmd{raw_cmd};
+        if (cmd == "sudo snap install multipass-sshfs")
+            sleep = true;
+
+        return SSH_OK;
+    };
+    REPLACE(ssh_channel_request_exec, request_exec);
+
+    auto add_channel_cbs = [&callbacks](ssh_channel, ssh_channel_callbacks cb) mutable {
+        callbacks = cb;
+        return SSH_OK;
+    };
+    REPLACE(ssh_add_channel_callbacks, add_channel_cbs);
+
+    auto event_dopoll = [&callbacks, &sleep](ssh_event, int timeout) {
+        if (!callbacks)
+            return SSH_ERROR;
+
+        if (sleep)
+            std::this_thread::sleep_for(std::chrono::milliseconds(timeout + 1));
+        else
+            callbacks->channel_exit_status_function(nullptr, nullptr, 0, callbacks->userdata);
+
+        return SSH_OK;
+    };
+    REPLACE(ssh_event_dopoll, event_dopoll);
+
+    EXPECT_CALL(*logger, log(Matcher<multipass::logging::Level>(_), Matcher<multipass::logging::CString>(_),
+                             Matcher<multipass::logging::CString>(_)))
+        .WillRepeatedly(Return());
+    EXPECT_CALL(*logger, log(Eq(mpl::Level::info), make_cstring_matcher(StrEq("utils")),
+                             make_cstring_matcher(StrEq("Timeout while installing 'sshfs' in 'foo'"))));
+
+    mp::SSHSession session{"a", 42};
+
+    mp::utils::install_sshfs_for("foo", session, std::chrono::milliseconds(1));
+}

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -429,7 +429,6 @@ TEST_F(SshfsMount, throws_when_unable_to_get_current_dir)
 TEST_F(SshfsMount, executes_commands)
 {
     CommandVector commands = {
-        {"pwd", "/home/ubuntu"},
         {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
          "/home/ubuntu/"},
         {"sudo /bin/bash -c 'cd \"/home/ubuntu/\" && mkdir -p \"target\"'", ""},

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -396,3 +396,23 @@ TEST(Utils, existing_config_file_is_untouched)
 
     EXPECT_THAT(new_last_modified, Eq(original_last_modified));
 }
+
+TEST(Utils, line_matcher_returns_expected_line)
+{
+    std::istringstream data{"LD_LIBRARY_PATH=/foo/lib\nSNAP=/foo/bin\nDATA=/bar/baz\n"};
+    std::string matcher{"SNAP="};
+
+    auto snap_data = mp::utils::match_line_for(data, matcher);
+
+    EXPECT_THAT(snap_data, Eq("SNAP=/foo/bin"));
+}
+
+TEST(Utils, line_matcher_no_match_returns_empty_string)
+{
+    std::istringstream data{"LD_LIBRARY_PATH=/foo/lib\nSNAP=/foo/bin\nDATA=/bar/baz\n"};
+    std::string matcher{"FOO="};
+
+    auto snap_data = mp::utils::match_line_for(data, matcher);
+
+    EXPECT_TRUE(snap_data.empty());
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -399,7 +399,7 @@ TEST(Utils, existing_config_file_is_untouched)
 
 TEST(Utils, line_matcher_returns_expected_line)
 {
-    std::istringstream data{"LD_LIBRARY_PATH=/foo/lib\nSNAP=/foo/bin\nDATA=/bar/baz\n"};
+    std::string data{"LD_LIBRARY_PATH=/foo/lib\nSNAP=/foo/bin\nDATA=/bar/baz\n"};
     std::string matcher{"SNAP="};
 
     auto snap_data = mp::utils::match_line_for(data, matcher);
@@ -409,7 +409,7 @@ TEST(Utils, line_matcher_returns_expected_line)
 
 TEST(Utils, line_matcher_no_match_returns_empty_string)
 {
-    std::istringstream data{"LD_LIBRARY_PATH=/foo/lib\nSNAP=/foo/bin\nDATA=/bar/baz\n"};
+    std::string data{"LD_LIBRARY_PATH=/foo/lib\nSNAP=/foo/bin\nDATA=/bar/baz\n"};
     std::string matcher{"FOO="};
 
     auto snap_data = mp::utils::match_line_for(data, matcher);


### PR DESCRIPTION
Fixes #627

---

Notes about testing:
1. If an instance already has a mount defined, then `multipassd` should just use the `sshfs` that is already installed.
1. Any new instances or existing instances without a mount defined that then has a mount defined should install the `multipass-sshfs` snap and use that.
1. Mounts on `core16` and `core18` should work now.