### PR TITLE
Throwaway hunt optional deref

### DIFF
--- a/include/multipass/optional.h
+++ b/include/multipass/optional.h
@@ -41,6 +41,14 @@ public:
     }
     using std::optional<T>::operator=;
     using std::optional<T>::optional;
+
+private:
+    constexpr const T* operator->() const;
+    constexpr T* operator->();
+    constexpr const T& operator*() const&;
+    constexpr T& operator*() &;
+    constexpr const T&& operator*() const&&;
+    constexpr T&& operator*() &&;
 };
 
 template <typename _Tp>

--- a/include/multipass/process.h
+++ b/include/multipass/process.h
@@ -51,7 +51,7 @@ struct ProcessState
     {
         if (error)
         {
-            return error->message;
+            return error.value().message;
         }
         if (exit_code && exit_code.value() != 0)
         {

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -199,7 +199,7 @@ std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_info_for(const Query& qu
 
     auto image = info_for(query);
     if (image != nullopt)
-        images.push_back(*image);
+        images.push_back(image.value());
 
     return images;
 }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -325,13 +325,13 @@ auto validate_create_arguments(const mp::LaunchRequest* request)
     const auto opt_disk_space = try_mem_size(disk_space_str.empty() ? mp::default_disk_size : disk_space_str);
 
     mp::MemorySize mem_size{}, disk_space{};
-    if (opt_mem_size && *opt_mem_size >= min_mem)
-        mem_size = *opt_mem_size;
+    if (opt_mem_size && opt_mem_size.value() >= min_mem)
+        mem_size = opt_mem_size.value();
     else
         option_errors.add_error_codes(mp::LaunchError::INVALID_MEM_SIZE);
 
-    if (opt_disk_space && *opt_disk_space >= min_disk)
-        disk_space = *opt_disk_space;
+    if (opt_disk_space && opt_disk_space.value() >= min_disk)
+        disk_space = opt_disk_space.value();
     else
         option_errors.add_error_codes(mp::LaunchError::INVALID_DISK_SIZE);
 

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -370,7 +370,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
             if (running_future)
             {
                 monitor(LaunchProgress::WAITING, -1);
-                future = *running_future;
+                future = running_future.value();
             }
             else
             {
@@ -452,7 +452,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
             if (running_future)
             {
                 monitor(LaunchProgress::WAITING, -1);
-                future = *running_future;
+                future = running_future.value();
             }
             else
             {
@@ -604,7 +604,7 @@ mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
 
     if (existing_source_image)
     {
-        source_image = *existing_source_image;
+        source_image = existing_source_image.value();
     }
     else
     {
@@ -764,7 +764,7 @@ mp::VMImageInfo mp::DefaultVMImageVault::info_for(const mp::Query& query)
         auto info = it->second->info_for(query);
 
         if (info != nullopt)
-            return *info;
+            return info.value();
     }
     else
     {
@@ -774,7 +774,7 @@ mp::VMImageInfo mp::DefaultVMImageVault::info_for(const mp::Query& query)
 
             if (info)
             {
-                return *info;
+                return info.value();
             }
         }
     }

--- a/src/daemon/delayed_shutdown_timer.cpp
+++ b/src/daemon/delayed_shutdown_timer.cpp
@@ -32,14 +32,14 @@ void write_shutdown_message(mp::optional<mp::SSHSession>& ssh_session, const std
     {
         if (time_left > std::chrono::milliseconds::zero())
         {
-            ssh_session->exec(
+            ssh_session.value().exec(
                 fmt::format("wall \"The system is going down for poweroff in {} minute{}, use 'multipass stop "
                             "--cancel {}' to cancel the shutdown.\"",
                             time_left.count(), time_left > std::chrono::minutes(1) ? "s" : "", name));
         }
         else
         {
-            ssh_session->exec(fmt::format("wall The system is going down for poweroff now"));
+            ssh_session.value().exec(fmt::format("wall The system is going down for poweroff now"));
         }
     }
 }
@@ -60,7 +60,7 @@ mp::DelayedShutdownTimer::~DelayedShutdownTimer()
             if (ssh_session)
             {
                 // exit_code() is here to make sure the command finishes before continuing in the dtor
-                ssh_session->exec("wall The system shutdown has been cancelled").exit_code();
+                ssh_session.value().exec("wall The system shutdown has been cancelled").exit_code();
             }
             mpl::log(mpl::Level::info, virtual_machine->vm_name, fmt::format("Cancelling delayed shutdown"));
             virtual_machine->state = VirtualMachine::State::running;

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -262,8 +262,10 @@ void mp::QemuVirtualMachine::start()
         auto process_state = vm_process->process_state();
         if (process_state.error)
         {
-            mpl::log(mpl::Level::error, vm_name, fmt::format("Qemu failed to start: {}", process_state.error->message));
-            throw std::runtime_error(fmt::format("failed to start qemu instance: {}", process_state.error->message));
+            mpl::log(mpl::Level::error, vm_name,
+                     fmt::format("Qemu failed to start: {}", process_state.error.value().message));
+            throw std::runtime_error(
+                fmt::format("failed to start qemu instance: {}", process_state.error.value().message));
         }
         else if (process_state.exit_code)
         {
@@ -547,7 +549,7 @@ void mp::QemuVirtualMachine::initialize_vm_process()
         }
         if (process_state.error)
         {
-            if (process_state.error->state == QProcess::Crashed &&
+            if (process_state.error.value().state == QProcess::Crashed &&
                 (state == State::suspending || state == State::suspended))
             {
                 // when suspending, we ask Qemu to savevm. Once it confirms that's done, we kill it. Catch the "crash"
@@ -555,7 +557,7 @@ void mp::QemuVirtualMachine::initialize_vm_process()
             }
             else
             {
-                mpl::log(mpl::Level::error, vm_name, fmt::format("error: {}", process_state.error->message));
+                mpl::log(mpl::Level::error, vm_name, fmt::format("error: {}", process_state.error.value().message));
             }
         }
 

--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -90,19 +90,19 @@ QStringList mp::QemuVMProcessSpec::arguments() const
 
     if (resume_data)
     {
-        if (resume_data->arguments.length() > 0)
+        if (resume_data.value().arguments.length() > 0)
         {
             // arguments used were saved externally, import them
-            args = resume_data->arguments;
+            args = resume_data.value().arguments;
         }
         else
         {
             // fall-back to reconstructing arguments
-            args = initial_qemu_arguments(desc, tap_device_name, resume_data->use_cdrom_flag);
+            args = initial_qemu_arguments(desc, tap_device_name, resume_data.value().use_cdrom_flag);
         }
 
         // need to append extra arguments for resume
-        QString machine_type = resume_data->machine_type;
+        QString machine_type = resume_data.value().machine_type;
         if (machine_type.isEmpty())
         {
             mpl::log(mpl::Level::info, desc.vm_name,
@@ -110,7 +110,7 @@ QStringList mp::QemuVMProcessSpec::arguments() const
             machine_type = default_machine_type();
         }
 
-        args << "-loadvm" << resume_data->suspend_tag;
+        args << "-loadvm" << resume_data.value().suspend_tag;
         args << "-machine" << machine_type;
     }
     else

--- a/src/platform/backends/shared/basic_process.cpp
+++ b/src/platform/backends/shared/basic_process.cpp
@@ -50,7 +50,7 @@ mp::BasicProcess::BasicProcess(std::shared_ptr<mp::ProcessSpec> spec) : process_
 
                 if (exit_status == QProcess::NormalExit)
                 {
-                    process_state.exit_code = exit_code;
+                    process_state.exit_code = mp::make_optional(exit_code);
                 }
                 else // crash
                 {
@@ -138,7 +138,7 @@ mp::ProcessState mp::BasicProcess::process_state() const
     }
     else if (process.state() != QProcess::Running && process.exitStatus() == QProcess::NormalExit)
     {
-        state.exit_code = process.exitCode();
+        state.exit_code = mp::make_optional(process.exitCode());
     }
 
     return state;
@@ -187,7 +187,7 @@ mp::ProcessState mp::BasicProcess::execute(const int timeout)
         return exit_state;
     }
 
-    exit_state.exit_code = process.exitCode();
+    exit_state.exit_code = mp::make_optional(process.exitCode());
     return exit_state;
 }
 

--- a/src/platform/update/default_update_prompt.cpp
+++ b/src/platform/update/default_update_prompt.cpp
@@ -49,10 +49,10 @@ void mp::DefaultUpdatePrompt::populate(mp::UpdateInfo* update_info)
     auto new_release = monitor->get_new_release();
     if (new_release)
     {
-        update_info->set_version(new_release->version.toStdString());
-        update_info->set_url(new_release->url.toEncoded());
-        update_info->set_title(new_release->title.toStdString());
-        update_info->set_description(new_release->description.toStdString());
+        update_info->set_version(new_release.value().version.toStdString());
+        update_info->set_url(new_release.value().url.toEncoded());
+        update_info->set_title(new_release.value().title.toStdString());
+        update_info->set_description(new_release.value().description.toStdString());
         last_shown = std::chrono::system_clock::now();
     }
 }

--- a/src/platform/update/new_release_monitor.cpp
+++ b/src/platform/update/new_release_monitor.cpp
@@ -130,7 +130,7 @@ void mp::NewReleaseMonitor::latest_release_found(const NewReleaseInfo& latest_re
         {
             new_release = latest_release;
             mpl::log(mpl::Level::info, "update",
-                     fmt::format("A New Multipass release is available: {}", qPrintable(new_release->version)));
+                     fmt::format("A New Multipass release is available: {}", qPrintable(latest_release.version)));
         }
     }
     catch (const version::Parse_error& e)

--- a/src/ssh/ssh_process.cpp
+++ b/src/ssh/ssh_process.cpp
@@ -58,7 +58,7 @@ private:
     static void channel_exit_status_cb(ssh_session, ssh_channel, int exit_status, void* userdata)
     {
         auto exit_code = reinterpret_cast<mp::optional<int>*>(userdata);
-        *exit_code = exit_status;
+        *exit_code = mp::make_optional(exit_status);
     }
     ssh_channel channel;
     ssh_channel_callbacks_struct cb{};

--- a/src/ssh/ssh_process.cpp
+++ b/src/ssh/ssh_process.cpp
@@ -101,7 +101,7 @@ int mp::SSHProcess::exit_code(std::chrono::milliseconds timeout)
     if (!exit_status) // we expect SSH_AGAIN or SSH_OK (unchanged) when there is a timeout
         throw ExitlessSSHProcessException{cmd, rc == SSH_ERROR ? std::strerror(errno) : "timeout"};
 
-    return *exit_status;
+    return exit_status.value();
 }
 
 std::string mp::SSHProcess::read_std_output()

--- a/tests/linux/test_apparmored_process.cpp
+++ b/tests/linux/test_apparmored_process.cpp
@@ -99,8 +99,8 @@ TEST_F(ApparmoredProcessTest, execute_missing_command)
     EXPECT_FALSE(process_state.completed_successfully());
     EXPECT_FALSE(process_state.exit_code);
 
-    EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::ProcessError::FailedToStart, process_state.error->state);
+    ASSERT_TRUE(process_state.error);
+    EXPECT_EQ(QProcess::ProcessError::FailedToStart, process_state.error.value().state);
 }
 
 TEST_F(ApparmoredProcessTest, execute_crashing_command)
@@ -111,8 +111,8 @@ TEST_F(ApparmoredProcessTest, execute_crashing_command)
     EXPECT_FALSE(process_state.completed_successfully());
     EXPECT_FALSE(process_state.exit_code);
 
-    EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::ProcessError::Crashed, process_state.error->state);
+    ASSERT_TRUE(process_state.error);
+    EXPECT_EQ(QProcess::ProcessError::Crashed, process_state.error.value().state);
 }
 
 TEST_F(ApparmoredProcessTest, execute_good_command_with_positive_exit_code)
@@ -182,8 +182,8 @@ TEST_F(ApparmoredProcessTest, process_state_when_runs_but_fails_to_stop)
     process_state = process->process_state();
     EXPECT_FALSE(process_state.exit_code);
 
-    EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::Timedout, process_state.error->state);
+    ASSERT_TRUE(process_state.error);
+    EXPECT_EQ(QProcess::Timedout, process_state.error.value().state);
 }
 
 TEST_F(ApparmoredProcessTest, process_state_when_crashes_on_start)
@@ -196,8 +196,8 @@ TEST_F(ApparmoredProcessTest, process_state_when_crashes_on_start)
     auto process_state = process->process_state();
 
     EXPECT_FALSE(process_state.exit_code);
-    EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::Crashed, process_state.error->state);
+    ASSERT_TRUE(process_state.error);
+    EXPECT_EQ(QProcess::Crashed, process_state.error.value().state);
 }
 
 TEST_F(ApparmoredProcessTest, process_state_when_crashes_while_running)
@@ -212,8 +212,8 @@ TEST_F(ApparmoredProcessTest, process_state_when_crashes_while_running)
 
     auto process_state = process->process_state();
     EXPECT_FALSE(process_state.exit_code);
-    EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::Crashed, process_state.error->state);
+    ASSERT_TRUE(process_state.error);
+    EXPECT_EQ(QProcess::Crashed, process_state.error.value().state);
 }
 
 TEST_F(ApparmoredProcessTest, process_state_when_failed_to_start)
@@ -226,8 +226,8 @@ TEST_F(ApparmoredProcessTest, process_state_when_failed_to_start)
     auto process_state = process->process_state();
 
     EXPECT_FALSE(process_state.exit_code);
-    EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::FailedToStart, process_state.error->state);
+    ASSERT_TRUE(process_state.error);
+    EXPECT_EQ(QProcess::FailedToStart, process_state.error.value().state);
 }
 
 TEST_F(ApparmoredProcessTest, process_state_when_runs_and_stops_immediately)

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -109,7 +109,7 @@ void test_image_resizing(const char* img, const mp::MemorySize& img_virtual_size
 
     if (throw_msg_matcher)
         MP_EXPECT_THROW_THAT(mp::backend::resize_instance_image(requested_size, img), std::runtime_error,
-                             Property(&std::runtime_error::what, *throw_msg_matcher));
+                             Property(&std::runtime_error::what, throw_msg_matcher.value()));
     else
         mp::backend::resize_instance_image(requested_size, img);
 

--- a/tests/mock_process_factory.cpp
+++ b/tests/mock_process_factory.cpp
@@ -36,12 +36,12 @@ mpt::MockProcess::MockProcess(std::unique_ptr<mp::ProcessSpec>&& spec,
                               std::vector<mpt::MockProcessFactory::ProcessInfo>& process_list)
     : spec{std::move(spec)}
 {
-    success_exit_state.exit_code = 0;
+    success_exit_state.exit_code = make_optional(0);
 
     ON_CALL(*this, start()).WillByDefault(Invoke([this] { emit started(); }));
     ON_CALL(*this, kill()).WillByDefault(Invoke([this] {
         mp::ProcessState exit_state;
-        exit_state.exit_code = 0;
+        exit_state.exit_code = mp::make_optional(0);
         emit finished(exit_state);
     }));
     ON_CALL(*this, running()).WillByDefault(Return(true));

--- a/tests/qemu/test_iptables_config.cpp
+++ b/tests/qemu/test_iptables_config.cpp
@@ -44,13 +44,13 @@ struct IPTablesConfig : public Test
             if (process->arguments().contains(goodbr0))
             {
                 mp::ProcessState exit_state;
-                exit_state.exit_code = 0;
+                exit_state.exit_code = mp::make_optional(0);
                 EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             }
             else if (process->arguments().contains(evilbr0))
             {
                 mp::ProcessState exit_state;
-                exit_state.exit_code = 1;
+                exit_state.exit_code = mp::make_optional(1);
                 EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
                 ON_CALL(*process, read_all_standard_error()).WillByDefault(Return("Evil bridge detected!\n"));
             }

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -69,14 +69,14 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
         if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
         {
             mp::ProcessState exit_state;
-            exit_state.exit_code = 0;
+            exit_state.exit_code = mp::make_optional(0);
             ON_CALL(*process, execute(_)).WillByDefault(Return(exit_state));
             ON_CALL(*process, read_all_standard_output()).WillByDefault(Return(suspend_tag));
         }
         else if (process->program() == "iptables")
         {
             mp::ProcessState exit_state;
-            exit_state.exit_code = 0;
+            exit_state.exit_code = mp::make_optional(0);
             ON_CALL(*process, execute(_)).WillByDefault(Return(exit_state));
         }
     };
@@ -195,7 +195,7 @@ TEST_F(QemuBackend, includes_error_when_shutdown_while_starting)
 
     std::thread finishing_thread{[vmproc]() {
         mp::ProcessState exit_state;
-        exit_state.exit_code = 1;
+        exit_state.exit_code = mp::make_optional(1);
         emit vmproc->finished(exit_state); /* note that this waits on a condition variable that is unblocked by
                                               ensure_vm_is_running */
     }};
@@ -378,7 +378,7 @@ TEST_F(QemuBackend, verify_qemu_arguments_from_metadata_are_used)
         if (process->program().contains("qemu-img") && process->arguments().contains("snapshot"))
         {
             mp::ProcessState exit_state;
-            exit_state.exit_code = 0;
+            exit_state.exit_code = mp::make_optional(0);
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillOnce(Return(suspend_tag));
         }
@@ -417,7 +417,7 @@ TEST_F(QemuBackend, returns_version_string)
         if (process->program().contains("qemu-system-") && process->arguments().contains("--version"))
         {
             mp::ProcessState exit_state;
-            exit_state.exit_code = 0;
+            exit_state.exit_code = mp::make_optional(0);
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillOnce(Return(qemu_version_output));
         }
@@ -439,7 +439,7 @@ TEST_F(QemuBackend, returns_version_string_when_failed_parsing)
         if (process->program().contains("qemu-system-") && process->arguments().contains("--version"))
         {
             mp::ProcessState exit_state;
-            exit_state.exit_code = 0;
+            exit_state.exit_code = mp::make_optional(0);
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillRepeatedly(Return(qemu_version_output));
         }
@@ -459,7 +459,7 @@ TEST_F(QemuBackend, returns_version_string_when_errored)
         if (process->program().contains("qemu-system-") && process->arguments().contains("--version"))
         {
             mp::ProcessState exit_state;
-            exit_state.exit_code = 1;
+            exit_state.exit_code = mp::make_optional(1);
             EXPECT_CALL(*process, execute(_)).WillOnce(Return(exit_state));
             EXPECT_CALL(*process, read_all_standard_output()).WillOnce(Return("Standard output\n"));
             EXPECT_CALL(*process, read_all_standard_error()).WillOnce(Return("Standard error\n"));

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -58,7 +58,7 @@ public:
     void terminate() override
     {
         mp::ProcessState exit_state;
-        exit_state.exit_code = 0;
+        exit_state.exit_code = mp::make_optional(0);
         emit finished(exit_state);
     }
     void kill() override
@@ -108,7 +108,7 @@ public:
     mp::ProcessState execute(const int /*timeout*/ = 3000) override
     {
         mp::ProcessState process_state;
-        process_state.exit_code = 0;
+        process_state.exit_code = mp::make_optional(0);
         return process_state;
     }
 

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -57,14 +57,13 @@ public:
     }
     void terminate() override
     {
-        mp::ProcessState exit_state;
-        exit_state.exit_code = mp::make_optional(0);
+        mp::ProcessState exit_state{0, mp::nullopt};
         emit finished(exit_state);
     }
     void kill() override
     {
-        mp::ProcessState exit_state;
-        exit_state.error->state = QProcess::Crashed;
+        mp::ProcessState exit_state{};
+        exit_state.error = mp::ProcessState::Error{QProcess::Crashed, QStringLiteral("")};
         emit finished(exit_state);
     }
 

--- a/tests/test_basic_process.cpp
+++ b/tests/test_basic_process.cpp
@@ -40,7 +40,7 @@ TEST_F(BasicProcessTest, execute_missing_command)
     EXPECT_FALSE(process_state.exit_code);
 
     EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::ProcessError::FailedToStart, process_state.error->state);
+    EXPECT_EQ(QProcess::ProcessError::FailedToStart, process_state.error.value().state);
 }
 
 TEST_F(BasicProcessTest, execute_crashing_command)
@@ -52,7 +52,7 @@ TEST_F(BasicProcessTest, execute_crashing_command)
     EXPECT_FALSE(process_state.exit_code);
 
     EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::ProcessError::Crashed, process_state.error->state);
+    EXPECT_EQ(QProcess::ProcessError::Crashed, process_state.error.value().state);
 }
 
 TEST_F(BasicProcessTest, execute_good_command_with_positive_exit_code)
@@ -123,7 +123,7 @@ TEST_F(BasicProcessTest, process_state_when_runs_but_fails_to_stop)
     EXPECT_FALSE(process_state.exit_code);
 
     EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::Timedout, process_state.error->state);
+    EXPECT_EQ(QProcess::Timedout, process_state.error.value().state);
 }
 
 TEST_F(BasicProcessTest, process_state_when_crashes_on_start)
@@ -137,7 +137,7 @@ TEST_F(BasicProcessTest, process_state_when_crashes_on_start)
 
     EXPECT_FALSE(process_state.exit_code);
     EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::Crashed, process_state.error->state);
+    EXPECT_EQ(QProcess::Crashed, process_state.error.value().state);
 }
 
 TEST_F(BasicProcessTest, process_state_when_crashes_while_running)
@@ -153,7 +153,7 @@ TEST_F(BasicProcessTest, process_state_when_crashes_while_running)
     auto process_state = process.process_state();
     EXPECT_FALSE(process_state.exit_code);
     EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::Crashed, process_state.error->state);
+    EXPECT_EQ(QProcess::Crashed, process_state.error.value().state);
 }
 
 TEST_F(BasicProcessTest, process_state_when_failed_to_start)
@@ -167,7 +167,7 @@ TEST_F(BasicProcessTest, process_state_when_failed_to_start)
 
     EXPECT_FALSE(process_state.exit_code);
     EXPECT_TRUE(process_state.error);
-    EXPECT_EQ(QProcess::FailedToStart, process_state.error->state);
+    EXPECT_EQ(QProcess::FailedToStart, process_state.error.value().state);
 }
 
 TEST_F(BasicProcessTest, process_state_when_runs_and_stops_immediately)

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -56,7 +56,7 @@ TEST_F(CustomImageHost, returns_expected_data_for_core)
 {
     mp::CustomVMImageHost host{&url_downloader, default_ttl, test_path};
 
-    auto info = *host.info_for(make_query("core", ""));
+    auto info = host.info_for(make_query("core", "")).value();
 
     EXPECT_THAT(info.image_location, Eq(QUrl::fromLocalFile(test_path + "ubuntu-core-16-amd64.img.xz").toString()));
     EXPECT_THAT(info.id, Eq(QString("934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7")));
@@ -70,7 +70,7 @@ TEST_F(CustomImageHost, returns_expected_data_for_core16)
 {
     mp::CustomVMImageHost host{&url_downloader, default_ttl, test_path};
 
-    auto info = *host.info_for(make_query("core16", ""));
+    auto info = host.info_for(make_query("core16", "")).value();
 
     EXPECT_THAT(info.image_location, Eq(QUrl::fromLocalFile(test_path + "ubuntu-core-16-amd64.img.xz").toString()));
     EXPECT_THAT(info.id, Eq(QString("934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7")));
@@ -84,7 +84,7 @@ TEST_F(CustomImageHost, returns_expected_data_for_core18)
 {
     mp::CustomVMImageHost host{&url_downloader, default_ttl, test_path};
 
-    auto info = *host.info_for(make_query("core18", ""));
+    auto info = host.info_for(make_query("core18", "")).value();
 
     EXPECT_THAT(info.image_location, Eq(QUrl::fromLocalFile(test_path + "ubuntu-core-18-amd64.img.xz").toString()));
     EXPECT_THAT(info.id, Eq(QString("1ffea8a9caf5a4dcba4f73f9144cb4afe1e4fc1987f4ab43bed4c02fad9f087f")));
@@ -98,7 +98,7 @@ TEST_F(CustomImageHost, returns_expected_data_for_snapcraft_core)
 {
     mp::CustomVMImageHost host{&url_downloader, default_ttl, test_path};
 
-    auto info = *host.info_for(make_query("core", "snapcraft"));
+    auto info = host.info_for(make_query("core", "snapcraft")).value();
 
     EXPECT_THAT(info.image_location,
                 Eq(QUrl::fromLocalFile(test_path + "ubuntu-16.04-minimal-cloudimg-amd64-disk1.img").toString()));
@@ -113,7 +113,7 @@ TEST_F(CustomImageHost, returns_expected_data_for_snapcraft_core18)
 {
     mp::CustomVMImageHost host{&url_downloader, default_ttl, test_path};
 
-    auto info = *host.info_for(make_query("core18", "snapcraft"));
+    auto info = host.info_for(make_query("core18", "snapcraft")).value();
 
     EXPECT_THAT(info.image_location,
                 Eq(QUrl::fromLocalFile(test_path + "ubuntu-18.04-minimal-cloudimg-amd64.img").toString()));

--- a/tests/test_new_release_monitor.cpp
+++ b/tests/test_new_release_monitor.cpp
@@ -81,8 +81,8 @@ TEST(NewReleaseMonitor, checks_new_release)
     auto new_release = check_for_new_release("0.1.0", "0.2.0", "https://something_unique.com");
 
     ASSERT_TRUE(new_release);
-    EXPECT_EQ("0.2.0", new_release->version.toStdString());
-    EXPECT_EQ("https://something_unique.com", new_release->url.toString().toStdString());
+    EXPECT_EQ("0.2.0", new_release.value().version.toStdString());
+    EXPECT_EQ("https://something_unique.com", new_release.value().url.toString().toStdString());
 }
 
 TEST(NewReleaseMonitor, checks_new_release_when_nothing_new)
@@ -125,7 +125,7 @@ TEST(NewReleaseMonitor, dev_prerelease_ordering_correct1)
     auto new_release = check_for_new_release("0.6.0-dev.238+g5c642f4", "0.6.0");
 
     ASSERT_TRUE(new_release);
-    EXPECT_EQ("0.6.0", new_release->version.toStdString());
+    EXPECT_EQ("0.6.0", new_release.value().version.toStdString());
 }
 
 TEST(NewReleaseMonitor, rc_prerelease_ordering_correct)

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -97,7 +97,7 @@ TEST_F(SSHFSMountsTest, sshfs_process_failing_with_return_code_9_causes_exceptio
         if (process->program().contains("sshfs_server"))
         {
             mp::ProcessState exit_state;
-            exit_state.exit_code = 9;
+            exit_state.exit_code = mp::make_optional(9);
 
             // Have "sshfs_server" die after short delay
             QTimer::singleShot(100, process, [process]() { emit process->finished({9, {}}); });
@@ -125,7 +125,7 @@ TEST_F(SSHFSMountsTest, sshfs_process_failing_causes_runtime_exception)
         if (process->program().contains("sshfs_server"))
         {
             mp::ProcessState exit_state;
-            exit_state.exit_code = 1;
+            exit_state.exit_code = mp::make_optional(1);
 
             // Have "sshfs_server" die after short delay
             ON_CALL(*process, read_all_standard_error()).WillByDefault(Return("Whoopsie"));

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -63,7 +63,7 @@ TEST_F(UbuntuImageHost, returns_expected_info)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
 
-    auto info = *host.info_for(make_query("xenial", release_remote_spec.first));
+    auto info = host.info_for(make_query("xenial", release_remote_spec.first)).value();
 
     EXPECT_THAT(info.image_location, Eq(expected_location));
     EXPECT_THAT(info.id, Eq(expected_id));
@@ -73,7 +73,7 @@ TEST_F(UbuntuImageHost, uses_default_on_unspecified_release)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
 
-    auto info = *host.info_for(make_query("", release_remote_spec.first));
+    auto info = host.info_for(make_query("", release_remote_spec.first)).value();
 
     EXPECT_THAT(info.image_location, Eq(expected_location));
     EXPECT_THAT(info.id, Eq(expected_id));
@@ -101,7 +101,7 @@ TEST_F(UbuntuImageHost, can_query_by_hash)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
     const auto expected_id = "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac";
-    auto info = *host.info_for(make_query(expected_id, release_remote_spec.first));
+    auto info = host.info_for(make_query(expected_id, release_remote_spec.first)).value();
     EXPECT_THAT(info.id, Eq(expected_id));
 }
 
@@ -117,7 +117,7 @@ TEST_F(UbuntuImageHost, can_query_by_partial_hash)
 
     for (const auto& hash : short_hashes)
     {
-        auto info = *host.info_for(make_query(hash.toStdString(), release_remote_spec.first));
+        auto info = host.info_for(make_query(hash.toStdString(), release_remote_spec.first)).value();
         EXPECT_THAT(info.id, Eq(expected_id));
     }
 
@@ -131,12 +131,12 @@ TEST_F(UbuntuImageHost, supports_multiple_manifests)
     QString daily_expected_location{daily_url + "newest-artful.img"};
     QString daily_expected_id{"c09f123b9589c504fe39ec6e9ebe5188c67be7d1fc4fb80c969bf877f5a8333a"};
 
-    auto info = *host.info_for(make_query("artful", daily_remote_spec.first));
+    auto info = host.info_for(make_query("artful", daily_remote_spec.first)).value();
 
     EXPECT_THAT(info.image_location, Eq(daily_expected_location));
     EXPECT_THAT(info.id, Eq(daily_expected_id));
 
-    auto xenial_info = *host.info_for(make_query("xenial", release_remote_spec.first));
+    auto xenial_info = host.info_for(make_query("xenial", release_remote_spec.first)).value();
 
     EXPECT_THAT(xenial_info.image_location, Eq(expected_location));
     EXPECT_THAT(xenial_info.id, Eq(expected_id));
@@ -149,7 +149,7 @@ TEST_F(UbuntuImageHost, looks_for_aliases_before_hashes)
     QString daily_expected_location{daily_url + "newest-artful.img"};
     QString daily_expected_id{"c09f123b9589c504fe39ec6e9ebe5188c67be7d1fc4fb80c969bf877f5a8333a"};
 
-    auto info = *host.info_for(make_query("a", daily_remote_spec.first));
+    auto info = host.info_for(make_query("a", daily_remote_spec.first)).value();
 
     EXPECT_THAT(info.image_location, Eq(daily_expected_location));
     EXPECT_THAT(info.id, Eq(daily_expected_id));
@@ -232,7 +232,7 @@ TEST_F(UbuntuImageHost, invalid_remote_throws_error)
     mpt::StubURLDownloader stub_url_downloader;
     mp::UbuntuVMImageHost host{all_remote_specs, &stub_url_downloader, default_ttl};
 
-    EXPECT_THROW(*host.info_for(make_query("xenial", "foo")), std::runtime_error);
+    EXPECT_THROW(host.info_for(make_query("xenial", "foo")), std::runtime_error);
 }
 
 TEST_F(UbuntuImageHost, handles_and_recovers_from_initial_network_failure)
@@ -282,5 +282,5 @@ TEST_F(UbuntuImageHost, throws_unsupported_image_when_image_not_supported)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
 
-    EXPECT_THROW(*host.info_for(make_query("artful", release_remote_spec.first)), mp::UnsupportedImageException);
+    EXPECT_THROW(host.info_for(make_query("artful", release_remote_spec.first)), mp::UnsupportedImageException);
 }


### PR DESCRIPTION
Something like this should help us detect unprotected optional dereferencing cases. 

The build stops fast (even with `make --keep-going`), so the process would be to replace such cases with `value()` iteratively, noting down the ones we'd actually want to change.