### PR TITLE
daemon_config: Detect proxy env var and use it if found

### DIFF
--- a/include/multipass/url_downloader.h
+++ b/include/multipass/url_downloader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,9 +23,11 @@
 
 #include <QByteArray>
 #include <QDateTime>
+#include <QNetworkProxy>
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 
 class QUrl;
 class QString;
@@ -52,6 +54,7 @@ private:
 
     const Path cache_dir_path;
     std::chrono::milliseconds timeout;
+    std::unique_ptr<QNetworkProxy> network_proxy;
 };
 }
 #endif // MULTIPASS_URL_DOWNLOADER_H

--- a/include/multipass/url_downloader.h
+++ b/include/multipass/url_downloader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2019 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,11 +23,9 @@
 
 #include <QByteArray>
 #include <QDateTime>
-#include <QNetworkProxy>
 
 #include <atomic>
 #include <chrono>
-#include <memory>
 
 class QUrl;
 class QString;
@@ -54,7 +52,6 @@ private:
 
     const Path cache_dir_path;
     std::chrono::milliseconds timeout;
-    std::unique_ptr<QNetworkProxy> network_proxy;
 };
 }
 #endif // MULTIPASS_URL_DOWNLOADER_H

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<QNetworkProxy> discover_http_proxy()
 
     if (!http_proxy.isEmpty())
     {
-        if (!http_proxy.startsWith("http://"))
+        if (!http_proxy.contains("://"))
         {
             http_proxy.prepend("http://");
         }

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +31,8 @@
 #include <multipass/utils.h>
 
 #include <QStandardPaths>
+#include <QString>
+#include <QUrl>
 
 #include <chrono>
 #include <memory>
@@ -50,6 +52,39 @@ std::string server_name_from(const std::string& server_address)
     if (server_name == "unix")
         return "localhost";
     return server_name;
+}
+
+std::unique_ptr<QNetworkProxy> discover_http_proxy()
+{
+    std::unique_ptr<QNetworkProxy> proxy_ptr{nullptr};
+
+    QString http_proxy{qgetenv("http_proxy")};
+    if (http_proxy.isEmpty())
+    {
+        // Some OS's are case senstive
+        http_proxy = qgetenv("HTTP_PROXY");
+    }
+
+    if (!http_proxy.isEmpty())
+    {
+        if (!http_proxy.startsWith("http://"))
+        {
+            http_proxy.prepend("http://");
+        }
+
+        QUrl proxy_url{http_proxy};
+        const auto host = proxy_url.host();
+        const auto port = proxy_url.port();
+
+        auto network_proxy = QNetworkProxy(QNetworkProxy::HttpProxy, host, static_cast<quint16>(port),
+                                           proxy_url.userName(), proxy_url.password());
+
+        QNetworkProxy::setApplicationProxy(network_proxy);
+
+        proxy_ptr = std::make_unique<QNetworkProxy>(network_proxy);
+    }
+
+    return proxy_ptr;
 }
 } // namespace
 
@@ -116,9 +151,12 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
     if (ssh_username.empty())
         ssh_username = "ubuntu";
 
-    return std::unique_ptr<const DaemonConfig>(
-        new DaemonConfig{std::move(url_downloader), std::move(factory), std::move(image_hosts), std::move(vault),
-                         std::move(name_generator), std::move(ssh_key_provider), std::move(cert_provider),
-                         std::move(client_cert_store), std::move(update_prompt), multiplexing_logger, cache_directory,
-                         data_directory, server_address, ssh_username, connection_type, image_refresh_timer});
+    if (network_proxy == nullptr)
+        network_proxy = discover_http_proxy();
+
+    return std::unique_ptr<const DaemonConfig>(new DaemonConfig{
+        std::move(url_downloader), std::move(factory), std::move(image_hosts), std::move(vault),
+        std::move(name_generator), std::move(ssh_key_provider), std::move(cert_provider), std::move(client_cert_store),
+        std::move(update_prompt), multiplexing_logger, std::move(network_proxy), cache_directory, data_directory,
+        server_address, ssh_username, connection_type, image_refresh_timer});
 }

--- a/src/daemon/daemon_config.h
+++ b/src/daemon/daemon_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,6 +34,8 @@
 #include <multipass/vm_image_host.h>
 #include <multipass/vm_image_vault.h>
 
+#include <QNetworkProxy>
+
 #include <memory>
 #include <vector>
 
@@ -52,6 +54,7 @@ struct DaemonConfig
     const std::unique_ptr<CertStore> client_cert_store;
     const std::unique_ptr<UpdatePrompt> update_prompt;
     const std::shared_ptr<logging::MultiplexingLogger> logger;
+    const std::unique_ptr<QNetworkProxy> network_proxy;
     const multipass::Path cache_directory;
     const multipass::Path data_directory;
     const std::string server_address;
@@ -72,6 +75,7 @@ struct DaemonConfigBuilder
     std::unique_ptr<CertStore> client_cert_store;
     std::unique_ptr<UpdatePrompt> update_prompt;
     std::unique_ptr<logging::Logger> logger;
+    std::unique_ptr<QNetworkProxy> network_proxy;
     multipass::Path cache_directory;
     multipass::Path data_directory;
     std::string server_address;

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -109,39 +109,6 @@ QByteArray download(QNetworkAccessManager* manager, const Time& timeout, QUrl co
     }
     return reply->readAll();
 }
-
-std::unique_ptr<QNetworkProxy> discover_http_proxy()
-{
-    std::unique_ptr<QNetworkProxy> proxy_ptr{nullptr};
-
-    QString http_proxy{qgetenv("http_proxy")};
-    if (http_proxy.isEmpty())
-    {
-        // Some OS's are case senstive
-        http_proxy = qgetenv("HTTP_PROXY");
-    }
-
-    if (!http_proxy.isEmpty())
-    {
-        if (!http_proxy.startsWith("http://"))
-        {
-            http_proxy.prepend("http://");
-        }
-
-        QUrl proxy_url{http_proxy};
-        const auto host = proxy_url.host();
-        const auto port = proxy_url.port();
-
-        auto network_proxy = QNetworkProxy(QNetworkProxy::HttpProxy, host, static_cast<quint16>(port),
-                                           proxy_url.userName(), proxy_url.password());
-
-        QNetworkProxy::setApplicationProxy(network_proxy);
-
-        proxy_ptr = std::make_unique<QNetworkProxy>(network_proxy);
-    }
-
-    return proxy_ptr;
-}
 } // namespace
 
 mp::URLDownloader::URLDownloader(std::chrono::milliseconds timeout) : URLDownloader{Path(), timeout}
@@ -149,7 +116,7 @@ mp::URLDownloader::URLDownloader(std::chrono::milliseconds timeout) : URLDownloa
 }
 
 mp::URLDownloader::URLDownloader(const mp::Path& cache_dir, std::chrono::milliseconds timeout)
-    : cache_dir_path{QDir(cache_dir).filePath("network-cache")}, timeout{timeout}, network_proxy{discover_http_proxy()}
+    : cache_dir_path{QDir(cache_dir).filePath("network-cache")}, timeout{timeout}
 {
 }
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -47,7 +47,10 @@
 #include <gtest/gtest.h>
 
 #include <QCoreApplication>
+#include <QNetworkProxyFactory>
 #include <QSysInfo>
+
+#include <scope_guard.hpp>
 
 #include <memory>
 #include <ostream>
@@ -370,6 +373,11 @@ TEST_F(Daemon, failed_restart_command_returns_fulfilled_promise)
 
 TEST_F(Daemon, proxy_contains_valid_info)
 {
+    auto guard = sg::make_scope_guard([] {
+        // Resets proxy back to what the system is configured for
+        QNetworkProxyFactory::setUseSystemConfiguration(true);
+    });
+
     QString username{"username"};
     QString password{"password"};
     QString hostname{"192.168.1.1"};

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -30,6 +30,7 @@
 #include <multipass/vm_image_host.h>
 #include <multipass/vm_image_vault.h>
 
+#include "mock_environment_helpers.h"
 #include "mock_virtual_machine_factory.h"
 #include "stub_cert_store.h"
 #include "stub_certprovider.h"
@@ -367,6 +368,23 @@ TEST_F(Daemon, failed_restart_command_returns_fulfilled_promise)
     EXPECT_TRUE(is_ready(status_promise.get_future()));
 }
 
+TEST_F(Daemon, proxy_contains_valid_info)
+{
+    QString username{"username"};
+    QString password{"password"};
+    QString hostname{"192.168.1.1"};
+    qint16 port{3128};
+    QString proxy = QString("%1:%2@%3:%4").arg(username).arg(password).arg(hostname).arg(port);
+
+    mpt::SetEnvScope env("http_proxy", proxy.toUtf8());
+
+    auto config = config_builder.build();
+
+    EXPECT_THAT(config->network_proxy->user(), username);
+    EXPECT_THAT(config->network_proxy->password(), password);
+    EXPECT_THAT(config->network_proxy->hostName(), hostname);
+    EXPECT_THAT(config->network_proxy->port(), port);
+}
 
 namespace
 {


### PR DESCRIPTION
Fixes #885

---

This was tricky to test.  I had to create an Ubuntu VM using Hyper-V and then in the VM, install `squid` and set it up.  Then I would set the `http_proxy` environment variable before running `multipassd`.

Also, after trying this and manually testing various failure scenarios, I have found the `URLDownloader` class, `CommonVMImageHost` and its derived classes, and the daemon need some pretty major refactoring to better handle long running network operations like when a host is unreachable and to also better getting these issues back to the user.

That said, this PR is *only* for getting the proxy values, but does nothing for failure scenarios.  That will come with a follow up PR.