### PR TITLE
output: Use qUtf8Printable() instead of qPrintable()

### DIFF
--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -112,9 +112,9 @@ mp::ParseCode mp::ArgParser::parse()
     {
         if (!parser_result)
         {
-            cerr << qPrintable(parser.errorText()) << "\n\n";
+            cerr << qUtf8Printable(parser.errorText()) << "\n\n";
         }
-        cout << qPrintable(generalHelpText());
+        cout << qUtf8Printable(generalHelpText());
         return (help_requested) ? ParseCode::HelpRequested : ParseCode::CommandFail;
     }
 
@@ -130,12 +130,12 @@ mp::ParseCode mp::ArgParser::parse()
 
     if (help_requested)
     {
-        cout << qPrintable(generalHelpText());
+        cout << qUtf8Printable(generalHelpText());
         return ParseCode::HelpRequested;
     }
 
     // Fall through
-    cout << "Error: Unknown Command '" << qPrintable(requested_command) << "' (try \"multipass help\")\n";
+    cout << "Error: Unknown Command '" << qUtf8Printable(requested_command) << "' (try \"multipass help\")\n";
     return ParseCode::CommandLineError;
 }
 
@@ -145,13 +145,13 @@ mp::ParseCode mp::ArgParser::commandParse(cmd::Command* command)
     const bool parsedOk = parser.parse(arguments);
     if (!parsedOk)
     {
-        cerr << qPrintable(parser.errorText()) << '\n';
+        cerr << qUtf8Printable(parser.errorText()) << '\n';
         return ParseCode::CommandLineError;
     }
 
     if (help_requested)
     {
-        cout << qPrintable(helpText(command));
+        cout << qUtf8Printable(helpText(command));
         return ParseCode::HelpRequested;
     }
     return ParseCode::Ok;
@@ -182,7 +182,7 @@ void mp::ArgParser::forceCommandHelp()
 
 void mp::ArgParser::forceGeneralHelp()
 {
-    cout << qPrintable(generalHelpText());
+    cout << qUtf8Printable(generalHelpText());
 }
 
 // Prints generic help

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -36,7 +36,7 @@ mp::ReturnCode cmd::Get::run(mp::ArgParser* parser)
     {
         try
         {
-            cout << qPrintable(Settings::instance().get(key)) << "\n";
+            cout << qUtf8Printable(Settings::instance().get(key)) << "\n";
         }
         catch (const SettingsException& e)
         {

--- a/src/client/cli/cmd/help.cpp
+++ b/src/client/cli/cmd/help.cpp
@@ -34,7 +34,7 @@ mp::ReturnCode cmd::Help::run(mp::ArgParser* parser)
 
     if (cmd == nullptr)
     {
-        cerr << "Error: Unknown Command: '" << qPrintable(command) << "'\n";
+        cerr << "Error: Unknown Command: '" << qUtf8Printable(command) << "'\n";
         return ReturnCode::CommandLineError;
     }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -96,14 +96,15 @@ void set_ip_forward()
     QFile ip_forward("/proc/sys/net/ipv4/ip_forward");
     if (!ip_forward.open(QFile::ReadWrite))
     {
-        mpl::log(mpl::Level::warning, "daemon", fmt::format("Unable to open {}", qPrintable(ip_forward.fileName())));
+        mpl::log(mpl::Level::warning, "daemon",
+                 fmt::format("Unable to open {}", qUtf8Printable(ip_forward.fileName())));
         return;
     }
 
     if (ip_forward.write("1") < 0)
     {
         mpl::log(mpl::Level::warning, "daemon",
-                 fmt::format("Failed to write to {}", qPrintable(ip_forward.fileName())));
+                 fmt::format("Failed to write to {}", qUtf8Printable(ip_forward.fileName())));
     }
 }
 

--- a/src/platform/backends/shared/basic_process.cpp
+++ b/src/platform/backends/shared/basic_process.cpp
@@ -77,7 +77,7 @@ mp::BasicProcess::BasicProcess(std::shared_ptr<mp::ProcessSpec> spec) : process_
         process.setReadChannel(QProcess::StandardError);
         QByteArray data = process.peek(process.bytesAvailable());
         process.setReadChannel(original);
-        mpl::log(process_spec->error_log_level(), qPrintable(process_spec->program()), qPrintable(data));
+        mpl::log(process_spec->error_log_level(), qUtf8Printable(process_spec->program()), qUtf8Printable(data));
     });
 }
 
@@ -182,7 +182,7 @@ mp::ProcessState mp::BasicProcess::execute(const int timeout)
     if (!process.waitForStarted(timeout) || !process.waitForFinished(timeout) ||
         process.exitStatus() != QProcess::NormalExit)
     {
-        mpl::log(mpl::Level::error, qPrintable(process_spec->program()), qPrintable(process.errorString()));
+        mpl::log(mpl::Level::error, qUtf8Printable(process_spec->program()), qUtf8Printable(process.errorString()));
         exit_state.error = mp::ProcessState::Error{process.error(), error_string()};
         return exit_state;
     }

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -83,7 +83,7 @@ auto virtual_switch_subnet(const QString& bridge_name)
     if (subnet.isNull())
     {
         mpl::log(mpl::Level::info, "daemon",
-                 fmt::format("Unable to determine subnet for the {} subnet", qPrintable(bridge_name)));
+                 fmt::format("Unable to determine subnet for the {} subnet", qUtf8Printable(bridge_name)));
     }
     return subnet.toStdString();
 }

--- a/src/platform/update/new_release_monitor.cpp
+++ b/src/platform/update/new_release_monitor.cpp
@@ -79,17 +79,19 @@ public:
             release.description = manifest[::json_description].toString();
 
             mpl::log(mpl::Level::debug, "update",
-                     fmt::format("Latest Multipass release available is version {}", qPrintable(release.version)));
+                     fmt::format("Latest Multipass release available is version {}", qUtf8Printable(release.version)));
 
             emit latest_release_found(release);
         }
         catch (const mp::DownloadException& e)
         {
-            mpl::log(mpl::Level::info, "update", fmt::format("Failed to fetch update info: {}", qPrintable(e.what())));
+            mpl::log(mpl::Level::info, "update",
+                     fmt::format("Failed to fetch update info: {}", qUtf8Printable(e.what())));
         }
         catch (const std::runtime_error& e)
         {
-            mpl::log(mpl::Level::info, "update", fmt::format("Failed to parse update info: {}", qPrintable(e.what())));
+            mpl::log(mpl::Level::info, "update",
+                     fmt::format("Failed to parse update info: {}", qUtf8Printable(e.what())));
         }
     }
 signals:
@@ -130,14 +132,14 @@ void mp::NewReleaseMonitor::latest_release_found(const NewReleaseInfo& latest_re
         {
             new_release = latest_release;
             mpl::log(mpl::Level::info, "update",
-                     fmt::format("A New Multipass release is available: {}", qPrintable(new_release->version)));
+                     fmt::format("A New Multipass release is available: {}", qUtf8Printable(new_release->version)));
         }
     }
     catch (const version::Parse_error& e)
     {
         mpl::log(mpl::Level::warning, "update",
-                 fmt::format("Version strings {} and {} not comparable: {}", qPrintable(current_version),
-                             qPrintable(latest_release.version), e.what()));
+                 fmt::format("Version strings {} and {} not comparable: {}", qUtf8Printable(current_version),
+                             qUtf8Printable(latest_release.version), e.what()));
     }
 }
 


### PR DESCRIPTION
This is supposed to be used for logging and will also help with proper UTF8 output
on Windows.

---

This PR in conjunction with canonical/multipass-private#216 should make unicode characters in our help output properly.

Also note that this is Qt's recommendation: https://doc.qt.io/qt-5/qtglobal.html#qPrintable
> ...qUtf8Printable() should be used for logging strings instead of qPrintable().