### PR TITLE
unix_console: Better handle SIGWINCH

### DIFF
--- a/src/platform/console/unix_console.h
+++ b/src/platform/console/unix_console.h
@@ -30,8 +30,6 @@
 
 namespace multipass
 {
-class WindowChangedSignalHandler;
-
 class UnixConsole final : public Console
 {
 public:
@@ -50,8 +48,7 @@ private:
 
     UnixTerminal* term;
     struct termios saved_terminal;
-
-    std::unique_ptr<WindowChangedSignalHandler> handler;
+    struct sigaction winch_action;
 };
 } // namespace multipass
 #endif // MULTIPASS_UNIX_CONSOLE_H


### PR DESCRIPTION
On OSX, SIGWINCH is ignored by default and thus, the way the console code was waiting on the signal,
it was never being delivered and the console size would never change.

Since OSX and Linux handle the console code the same, this change is for both platforms.

Fixes #1327

---

On Linux, `sigwait()` will not ignore any signals set in the `sigset` even if any of the signals are ignored by default.  However, OSX will ignore any signals in this case and `SIGWINCH` is ignored by default.

For testing, on Linux, the behavior should not change at all.  This does simplify the code though.  On OSX, you'll notice that the console stty would never change when `shell`ed into an instance, but with this change, that should work now.