### PR TITLE
[qemu] fall back to system default machine type

### DIFF
--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -292,8 +292,6 @@ TEST_F(QemuBackend, verify_some_common_qemu_arguments)
 
 TEST_F(QemuBackend, verify_qemu_arguments_when_resuming_suspend_image)
 {
-    constexpr auto default_machine_type = "pc-i440fx-xenial";
-
     auto factory = mpt::MockProcessFactory::Inject();
     factory->register_callback(handle_external_process_calls);
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
@@ -313,8 +311,6 @@ TEST_F(QemuBackend, verify_qemu_arguments_when_resuming_suspend_image)
     ASSERT_TRUE(qemu != processes.cend());
     EXPECT_TRUE(qemu->arguments.contains("-loadvm"));
     EXPECT_TRUE(qemu->arguments.contains(suspend_tag));
-    EXPECT_TRUE(qemu->arguments.contains("-machine"));
-    EXPECT_TRUE(qemu->arguments.contains(default_machine_type));
 }
 
 TEST_F(QemuBackend, verify_qemu_arguments_when_resuming_suspend_image_uses_metadata)

--- a/tests/qemu/test_qemu_vm_process_spec.cpp
+++ b/tests/qemu/test_qemu_vm_process_spec.cpp
@@ -155,7 +155,7 @@ TEST_F(TestQemuVMProcessSpec, resume_with_missing_machine_type_guesses_correctly
 
     mp::QemuVMProcessSpec spec(desc, tap_device_name, resume_data_missing_machine_info);
 
-    EXPECT_EQ(spec.arguments(), QStringList({"-args", "-loadvm", "suspend_tag", "-machine", "pc-i440fx-xenial"}));
+    EXPECT_EQ(spec.arguments(), QStringList({"-args", "-loadvm", "suspend_tag"}));
 }
 
 TEST_F(TestQemuVMProcessSpec, apparmor_profile_has_correct_name)


### PR DESCRIPTION
Rather than hardcoding xenial, as it's unlikely that someone's still
transitioning from core16 to core18.