### PR TITLE
[cmake] use a CMake variable for MULTIPASS_UPSTREAM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,8 +133,9 @@ jobs:
       - sg lxd -c '/snap/bin/lxc profile device add default ccache disk source=${HOME}/.ccache/ path=/root/.ccache'
       - ccache --zero-stats
 
-      # inject build identifier
+      # inject build identifier and upstream
       - sed -i "/configflags:/a \    - -DMULTIPASS_BUILD_LABEL=${MULTIPASS_BUILD_LABEL}" snap/snapcraft.yaml
+      - sed -i "/configflags:/a \    - -DMULTIPASS_UPSTREAM=${MULTIPASS_UPSTREAM}" snap/snapcraft.yaml
 
       script:
       - sg lxd -c '/snap/bin/snapcraft --use-lxd'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,7 @@ find_package(Qt5 COMPONENTS Core Network Widgets REQUIRED)
 
 function(determine_version OUTPUT_VARIABLE)
   # use upstream repo as the authoritative reference when checking for release status
-  # set MULTIPASS_UPSTREAM="*" to use the local repository
-  set(MULTIPASS_UPSTREAM $ENV{MULTIPASS_UPSTREAM})
+  # set -DMULTIPASS_UPSTREAM="" to use the local repository
   if(MULTIPASS_UPSTREAM)
     set(MULTIPASS_UPSTREAM "${MULTIPASS_UPSTREAM}/")
   endif()
@@ -83,7 +82,7 @@ function(determine_version OUTPUT_VARIABLE)
   # only use -rc tags on release/* branches
   string(REGEX MATCH "release/[0-9]+.[0-9]+" GIT_RELEASE_MATCH "${GIT_RELEASE_BRANCH}")
   if(GIT_RELEASE_MATCH)
-      if(NOT DEFINED ENV{MULTIPASS_UPSTREAM})
+      if(NOT DEFINED MULTIPASS_UPSTREAM)
         message(FATAL_ERROR "You need to set MULTIPASS_UPSTREAM for a release build.\
                              \nUse an empty string to make local the authoritative repository.")
       endif()


### PR DESCRIPTION
Rather than reading straight from the environment.

---

Working in real life:
https://github.com/canonical/multipass/pull/1375#issuecomment-589569113

Testing:
1. `MULTIPASS_UPSTREAM` is required on a `release/*` branch
   ```console
   $ git checkout -b release/0.0
   $ cmake . -UMULTIPASS_UPSTREAM
   # ...
   CMake Error at CMakeLists.txt:87 (message):
     You need to set MULTIPASS_UPSTREAM for a release build.

     Use an empty string to make local the authoritative repository.
   ```
1. setting `MULTIPASS_UPSTREAM=origin` makes it ignore the `release/*` branch
   ```console
   $ git checkout -b release/0.0
   $ cmake . -DMULTIPASS_UPSTREAM=origin
   # ...
   -- Setting version to: 1.1.0-dev.84+g4a33a0a9
   $ git tag -as v0.0.0 -m Foo
   $ cmake . -DMULTIPASS_UPSTREAM=origin
   # ...
   -- Setting version to: 1.1.0-dev.84+g4a33a0a9
   $ git tag -d v0.0.0
   ```

1. setting `MULTIPASS_UPSTREAM=` makes it respect the `release/*` branch
   ```console
   $ git checkout -b release/0.0
   $ cmake . -DMULTIPASS_UPSTREAM=
   # ...
   -- Setting version to: 1.1.0-rc.84+g4a33a0a9
   $ git tag -as v0.0.0 -m Foo
   $ cmake . -DMULTIPASS_UPSTREAM=
   # ...
   -- Setting version to: 0.0.0
   $ git tag -d v0.0.0
   ```