### PR TITLE
[logging] add trace level (Fixes #1371)

### DIFF
--- a/include/multipass/logging/level.h
+++ b/include/multipass/logging/level.h
@@ -29,7 +29,8 @@ enum class Level : int
     error = 0,
     warning = 1,
     info = 2,
-    debug = 3
+    debug = 3,
+    trace = 4
 };
 
 constexpr CString as_string(const Level& l) noexcept
@@ -44,6 +45,8 @@ constexpr CString as_string(const Level& l) noexcept
         return "info";
     case Level::warning:
         return "warning";
+    case Level::trace:
+        return "trace";
     }
     return "unknown";
 }

--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -331,9 +331,9 @@ QStringList mp::ArgParser::positionalArguments() const
 
 void mp::ArgParser::setVerbosityLevel(int verbosity)
 {
-    if (verbosity > 3 || verbosity < 0)
+    if (verbosity > 4 || verbosity < 0)
     {
-        cerr << "Verbosity level is incorrect. Must be between 0 and 3.\n";
+        cerr << "Verbosity level is incorrect. Must be between 0 and 4.\n";
     }
     else if (verbosity_level != verbosity)
     {

--- a/src/daemon/cli.cpp
+++ b/src/daemon/cli.cpp
@@ -41,6 +41,8 @@ multipass::logging::Level to_logging_level(const QString& value)
         return mpl::Level::info;
     if (value == "debug")
         return mpl::Level::debug;
+    if (value == "trace")
+        return mpl::Level::trace;
 
     throw std::runtime_error("invalid logging verbosity: " + value.toStdString());
 }
@@ -55,7 +57,7 @@ mp::DaemonConfigBuilder mp::cli::parse(const QCoreApplication& app)
 
     QCommandLineOption logger_option{"logger", "specifies which logger to use", "platform|stderr"};
     QCommandLineOption verbosity_option{
-        {"V", "verbosity"}, "specifies the logging verbosity level", "error|warning|info|debug"};
+        {"V", "verbosity"}, "specifies the logging verbosity level", "error|warning|info|debug|trace"};
     QCommandLineOption address_option{"address",
                                       "specifies which address to use for the multipassd service;"
                                       " a socket can be specified using unix:<socket_file>",

--- a/src/platform/backends/shared/linux/apparmor.cpp
+++ b/src/platform/backends/shared/linux/apparmor.cpp
@@ -89,7 +89,7 @@ void mp::AppArmor::load_policy(const QByteArray& aa_policy) const
     process.closeWriteChannel();
     process.waitForFinished();
 
-    mpl::log(mpl::Level::debug, "daemon", fmt::format("Loading AppArmor policy: \n{}", aa_policy));
+    mpl::log(mpl::Level::trace, "daemon", fmt::format("Loading AppArmor policy: \n{}", aa_policy));
 
     if (process.exitCode() != 0)
     {
@@ -107,7 +107,7 @@ void mp::AppArmor::remove_policy(const QByteArray& aa_policy) const
     process.closeWriteChannel();
     process.waitForFinished();
 
-    mpl::log(mpl::Level::debug, "daemon", fmt::format("Removing AppArmor policy: \n{}", aa_policy));
+    mpl::log(mpl::Level::trace, "daemon", fmt::format("Removing AppArmor policy: \n{}", aa_policy));
 
     if (process.exitCode() != 0)
     {

--- a/src/platform/logger/journald_logger.cpp
+++ b/src/platform/logger/journald_logger.cpp
@@ -29,6 +29,8 @@ constexpr auto to_syslog_priority(const mpl::Level& level) noexcept
 {
     switch (level)
     {
+    case mpl::Level::trace:
+        return LOG_DEBUG;
     case mpl::Level::debug:
         return LOG_DEBUG;
     case mpl::Level::error:

--- a/src/platform/logger/journald_logger.cpp
+++ b/src/platform/logger/journald_logger.cpp
@@ -30,7 +30,6 @@ constexpr auto to_syslog_priority(const mpl::Level& level) noexcept
     switch (level)
     {
     case mpl::Level::trace:
-        return LOG_DEBUG;
     case mpl::Level::debug:
         return LOG_DEBUG;
     case mpl::Level::error:


### PR DESCRIPTION
Move AppArmor profile logging contents to the trace level to avoid spamming the logs.