### PR TITLE
[general] compatibility with macOS's c++17 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,7 +11,7 @@
 	url = https://github.com/CanonicalLtd/libssh.git
 [submodule "3rd-party/fmt"]
 	path = 3rd-party/fmt
-	url = https://github.com/fmtlib/fmt.git
+	url = https://github.com/canonical/fmt.git
 [submodule "3rd-party/xz-decoder/xz-embedded"]
 	path = 3rd-party/xz-decoder/xz-embedded
 	url = https://git.tukaani.org/xz-embedded.git

--- a/include/multipass/process.h
+++ b/include/multipass/process.h
@@ -45,7 +45,7 @@ struct ProcessState
 {
     bool completed_successfully() const // if process stopped successfully with exit code 0
     {
-        return !error && exit_code && exit_code.value() == 0;
+        return !error && exit_code && *exit_code == 0;
     }
     QString failure_message() const
     {
@@ -53,9 +53,9 @@ struct ProcessState
         {
             return error->message;
         }
-        if (exit_code && exit_code.value() != 0)
+        if (exit_code && *exit_code != 0)
         {
-            return QString("Process returned exit code: %1").arg(exit_code.value());
+            return QString("Process returned exit code: %1").arg(*exit_code);
         }
         return QString();
     }

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -510,7 +510,7 @@ bool mp::DefaultVMImageVault::has_record_for(const std::string& name)
 void mp::DefaultVMImageVault::prune_expired_images()
 {
     std::vector<decltype(prepared_image_records)::key_type> expired_keys;
-    std::lock_guard lock{fetch_mutex};
+    std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
 
     for (const auto& record : prepared_image_records)
     {
@@ -582,7 +582,7 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
             fetch_image(fetch_type, record.query, prepare, monitor);
 
             // Remove old image
-            std::lock_guard lock{fetch_mutex};
+            std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
             delete_image_dir(record.image.image_path);
             prepared_image_records.erase(key);
             persist_image_records();

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -99,7 +99,7 @@ void check_status(const QSettings& settings, const QString& attempted_operation)
 
 QString checked_get(QSettings& settings, const QString& key, const QString& fallback, std::mutex& mutex)
 {
-    std::scoped_lock lock{mutex};
+    std::lock_guard<std::mutex> lock{mutex};
 
     auto ret = settings.value(key, fallback).toString();
 
@@ -109,7 +109,7 @@ QString checked_get(QSettings& settings, const QString& key, const QString& fall
 
 void checked_set(QSettings& settings, const QString& key, const QString& val, std::mutex& mutex)
 {
-    std::scoped_lock lock{mutex};
+    std::lock_guard<std::mutex> lock{mutex};
 
     settings.setValue(key, val);
 

--- a/tests/mock_process_factory.cpp
+++ b/tests/mock_process_factory.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<mp::Process> mpt::MockProcessFactory::create_process(std::unique
     auto process = std::make_unique<NiceMock<mpt::MockProcess>>(std::move(spec),
                                                                 const_cast<std::vector<ProcessInfo>&>(process_list));
     if (callback)
-        callback.value()(process.get());
+        (*callback)(process.get());
     return process;
 }
 

--- a/tests/test_basic_process.cpp
+++ b/tests/test_basic_process.cpp
@@ -63,7 +63,7 @@ TEST_F(BasicProcessTest, execute_good_command_with_positive_exit_code)
 
     EXPECT_FALSE(process_state.completed_successfully());
     EXPECT_TRUE(process_state.exit_code);
-    EXPECT_EQ(exit_code, process_state.exit_code.value());
+    EXPECT_EQ(exit_code, *process_state.exit_code);
     EXPECT_EQ("Process returned exit code: 7", process_state.failure_message());
 
     EXPECT_FALSE(process_state.error);
@@ -77,7 +77,7 @@ TEST_F(BasicProcessTest, execute_good_command_with_zero_exit_code)
 
     EXPECT_TRUE(process_state.completed_successfully());
     EXPECT_TRUE(process_state.exit_code);
-    EXPECT_EQ(exit_code, process_state.exit_code.value());
+    EXPECT_EQ(exit_code, *process_state.exit_code);
     EXPECT_EQ(QString(), process_state.failure_message());
 
     EXPECT_FALSE(process_state.error);
@@ -100,7 +100,7 @@ TEST_F(BasicProcessTest, process_state_when_runs_and_stops_ok)
 
     process_state = process.process_state();
     EXPECT_TRUE(process_state.exit_code);
-    EXPECT_EQ(exit_code, process_state.exit_code.value());
+    EXPECT_EQ(exit_code, *process_state.exit_code);
 
     EXPECT_FALSE(process_state.error);
 }
@@ -186,7 +186,7 @@ TEST_F(BasicProcessTest, process_state_when_runs_and_stops_immediately)
 
     process_state = process.process_state();
     EXPECT_TRUE(process_state.exit_code);
-    EXPECT_EQ(exit_code, process_state.exit_code.value());
+    EXPECT_EQ(exit_code, *process_state.exit_code);
 
     EXPECT_FALSE(process_state.error);
 }

--- a/tests/test_basic_process.cpp
+++ b/tests/test_basic_process.cpp
@@ -62,7 +62,7 @@ TEST_F(BasicProcessTest, execute_good_command_with_positive_exit_code)
     auto process_state = process.execute();
 
     EXPECT_FALSE(process_state.completed_successfully());
-    EXPECT_TRUE(process_state.exit_code);
+    ASSERT_TRUE(process_state.exit_code);
     EXPECT_EQ(exit_code, *process_state.exit_code);
     EXPECT_EQ("Process returned exit code: 7", process_state.failure_message());
 
@@ -76,7 +76,7 @@ TEST_F(BasicProcessTest, execute_good_command_with_zero_exit_code)
     auto process_state = process.execute();
 
     EXPECT_TRUE(process_state.completed_successfully());
-    EXPECT_TRUE(process_state.exit_code);
+    ASSERT_TRUE(process_state.exit_code);
     EXPECT_EQ(exit_code, *process_state.exit_code);
     EXPECT_EQ(QString(), process_state.failure_message());
 
@@ -99,7 +99,7 @@ TEST_F(BasicProcessTest, process_state_when_runs_and_stops_ok)
     EXPECT_TRUE(process.wait_for_finished());
 
     process_state = process.process_state();
-    EXPECT_TRUE(process_state.exit_code);
+    ASSERT_TRUE(process_state.exit_code);
     EXPECT_EQ(exit_code, *process_state.exit_code);
 
     EXPECT_FALSE(process_state.error);
@@ -185,7 +185,7 @@ TEST_F(BasicProcessTest, process_state_when_runs_and_stops_immediately)
     EXPECT_TRUE(process.wait_for_finished());
 
     process_state = process.process_state();
-    EXPECT_TRUE(process_state.exit_code);
+    ASSERT_TRUE(process_state.exit_code);
     EXPECT_EQ(exit_code, *process_state.exit_code);
 
     EXPECT_FALSE(process_state.error);


### PR DESCRIPTION
To keep our minimal macOS version lower, we need to work around some limitations of their c++17 support. What we know so far:
- `std::optional::value()` and `::reset()` are not supported
- `std::bad_optional_access` has no d'tor (so we mustn't throw it manually either)
- `std::optional::emplace` non-conformant (returns `void` rather than `T&`)
- `std::scoped_lock` is not supported
- `std::lock_guard` needs to be templated

Fixes #1258 