### PR TITLE
console/unix: Only set terminal attributes when stdin & stdout are live

### DIFF
--- a/src/platform/console/unix_console.cpp
+++ b/src/platform/console/unix_console.cpp
@@ -83,7 +83,7 @@ void mp::UnixConsole::setup_environment()
 
 void mp::UnixConsole::setup_console()
 {
-    if (term->cin_is_live())
+    if (term->is_live())
     {
         struct termios terminal_local;
 
@@ -96,7 +96,7 @@ void mp::UnixConsole::setup_console()
 
 void mp::UnixConsole::restore_console()
 {
-    if (term->cin_is_live())
+    if (term->is_live())
     {
         tcsetattr(term->cin_fd(), TCSANOW, &saved_terminal);
     }


### PR DESCRIPTION
Fixes #1310