### PR TITLE
Fix inconsistencies in mount/umount parameters.

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -79,6 +79,7 @@ void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseco
                          const SSHKeyProvider& key_provider);
 void link_autostart_file(const QDir& link_dir, const QString& autostart_subdir, const QString& autostart_filename);
 void check_and_create_config_file(const QString& config_file_path);
+std::string normalize_absolute_path(const std::string& path);
 
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>
 void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds timeout, TryAction&& try_action,

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -341,4 +341,11 @@ void mp::utils::check_and_create_config_file(const QString& config_file_path)
         make_dir({}, QFileInfo{config_file_path}.dir().path()); // make sure parent dir is there
         config_file.open(QIODevice::WriteOnly);
     }
+}
+
+// Given an absolute path, removes trailing slash, multiple slashes and
+// redundant "." and "..".
+std::string mp::utils::normalize_absolute_path(const std::string& path)
+{
+    return QDir::cleanPath(QString::fromStdString(path)).toStdString();
 }


### PR DESCRIPTION
Path names are now normalized before mounting or unmounting.

This way, directories can be mounted using relative paths and unmounted using absolute paths or viceversa. Also, the final slash in the path can be omitted.

The fix works in the multipass client, so the daemon always receives an absolute mountpoint as parameter.

---

Actual diff: https://github.com/canonical/multipass/compare/fix-mount-dir-permissions...fix-mount-umount-inconsistencies