### PR TITLE
Top level catch all

### DIFF
--- a/include/multipass/logging/cstring.h
+++ b/include/multipass/logging/cstring.h
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    const char* c_str()
+    const char* c_str() const
     {
         return data;
     }

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -23,12 +23,12 @@
 
 namespace multipass
 {
-template <typename F, typename... Args>                           // F needs to return int
-int top_catch_all(const char* log_category, F f, Args&&... args); // not noexcept because logging isn't
+template <typename F, typename... Args>                                      // F needs to return int
+int top_catch_all(const logging::CString log_category, F f, Args&&... args); // not noexcept because logging isn't
 }
 
 template <typename F, typename... Args>
-inline int multipass::top_catch_all(const char* log_category, F f, Args&&... args)
+inline int multipass::top_catch_all(const logging::CString log_category, F f, Args&&... args)
 {
     namespace mpl = multipass::logging;
     try

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_TOP_CATCH_ALL_H
+#define MULTIPASS_TOP_CATCH_ALL_H
+
+#include <multipass/format.h>
+#include <multipass/logging/log.h>
+
+namespace multipass
+{
+template <typename F, typename... Args>                           // F needs to return int
+int top_catch_all(const char* log_category, F f, Args&&... args); // not noexcept because logging isn't
+}
+
+template <typename F, typename... Args>
+inline int multipass::top_catch_all(const char* log_category, F f, Args&&... args)
+{
+    namespace mpl = multipass::logging;
+    try
+    {
+        return f(std::forward<Args>(args)...);
+    }
+    catch (const std::exception& e)
+    {
+        mpl::log(mpl::Level::error, log_category, fmt::format("Caught an unhandled exception: {}", e.what()));
+        return EXIT_FAILURE;
+    }
+    catch (...)
+    {
+        mpl::log(mpl::Level::error, log_category, "Caught an unknown exception");
+        return EXIT_FAILURE;
+    }
+}
+
+#endif // MULTIPASS_TOP_CATCH_ALL_H

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -23,6 +23,16 @@
 
 namespace multipass
 {
+/**
+ * Call f within a try-catch, catching and logging anything that it throws.
+ *
+ * @tparam F The type of the callable f. It must be callable and return int.
+ * @tparam Args The types of f's arguments
+ * @param log_category The category to use when logging exceptions
+ * @param f The int-returning function to protect with a catch-all
+ * @param args The arguments to pass to the function f
+ * @return The result of f when no exception is thrown, EXIT_FAILURE (from cstdlib) otherwise
+ */
 template <typename F, typename... Args>                                      // F needs to return int
 int top_catch_all(const logging::CString log_category, F f, Args&&... args); // not noexcept because logging isn't
 }

--- a/src/client/cli/main.cpp
+++ b/src/client/cli/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,12 +20,15 @@
 #include <multipass/cli/client_common.h>
 #include <multipass/console.h>
 #include <multipass/constants.h>
+#include <multipass/top_catch_all.h>
 
 #include <QCoreApplication>
 
 namespace mp = multipass;
 
-int main(int argc, char* argv[])
+namespace
+{
+int main_impl(int argc, char* argv[])
 {
     QCoreApplication app(argc, argv);
     QCoreApplication::setApplicationName(mp::client_name);
@@ -38,4 +41,10 @@ int main(int argc, char* argv[])
     mp::Client client{config};
 
     return client.run(QCoreApplication::arguments());
+}
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    return mp::top_catch_all("client", main_impl, argc, argv);
 }

--- a/src/client/gui/main.cpp
+++ b/src/client/gui/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,12 +18,15 @@
 #include "client_gui.h"
 
 #include <multipass/cli/client_common.h>
+#include <multipass/top_catch_all.h>
 
 #include <QApplication>
 
 namespace mp = multipass;
 
-int main(int argc, char* argv[])
+namespace
+{
+int main_impl(int argc, char* argv[])
 {
     QApplication app(argc, argv);
     app.setApplicationName("multipass-gui");
@@ -33,4 +36,10 @@ int main(int argc, char* argv[])
     mp::ClientGui client{config};
 
     return client.run(app.arguments());
+}
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    return mp::top_catch_all("client", main_impl, argc, argv);
 }

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -131,6 +131,11 @@ try // clang-format on
 }
 catch (const std::exception& e)
 {
-    mpl::log(mpl::Level::error, "daemon", e.what());
+    mpl::log(mpl::Level::error, "daemon", fmt::format("Caught an unhandled exception: {}", e.what()));
+    return EXIT_FAILURE;
+}
+catch (...)
+{
+    mpl::log(mpl::Level::error, "daemon", "Caught an unknown exception");
     return EXIT_FAILURE;
 }

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -27,6 +27,7 @@
 #include <multipass/name_generator.h>
 #include <multipass/platform.h>
 #include <multipass/platform_unix.h>
+#include <multipass/top_catch_all.h>
 #include <multipass/utils.h>
 #include <multipass/version.h>
 #include <multipass/virtual_machine_factory.h>
@@ -104,10 +105,7 @@ private:
     mp::AutoJoinThread signal_handling_thread;
 };
 
-} // namespace
-
-int main(int argc, char* argv[]) // clang-format off
-try // clang-format on
+int main_impl(int argc, char* argv[])
 {
     QCoreApplication app(argc, argv);
     QCoreApplication::setApplicationName(mp::daemon_name);
@@ -129,13 +127,9 @@ try // clang-format on
     mpl::log(mpl::Level::info, "daemon", "Goodbye!");
     return ret;
 }
-catch (const std::exception& e)
+} // namespace
+
+int main(int argc, char* argv[])
 {
-    mpl::log(mpl::Level::error, "daemon", fmt::format("Caught an unhandled exception: {}", e.what()));
-    return EXIT_FAILURE;
-}
-catch (...)
-{
-    mpl::log(mpl::Level::error, "daemon", "Caught an unknown exception");
-    return EXIT_FAILURE;
+    return mp::top_catch_all("daemon", main_impl, argc, argv);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2019 Canonical Ltd.
+# Copyright © 2017-2020 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -67,6 +67,7 @@ add_executable(multipass_tests
   test_ssh_key_provider.cpp
   test_ssh_process.cpp
   test_ssh_session.cpp
+  test_top_catch_all.cpp
   test_ubuntu_image_host.cpp
   test_utils.cpp
   test_with_mocked_bin_path.cpp

--- a/tests/mock_logger.h
+++ b/tests/mock_logger.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_LOGGER_H
+#define MULTIPASS_MOCK_LOGGER_H
+
+#include <multipass/logging/logger.h>
+
+#include <gmock/gmock.h>
+
+namespace multipass
+{
+namespace test
+{
+class MockLogger : public multipass::logging::Logger
+{
+public:
+    MockLogger() = default;
+    MOCK_CONST_METHOD3(log, void(multipass::logging::Level level, multipass::logging::CString category,
+                                 multipass::logging::CString message));
+};
+} // namespace test
+} // namespace multipass
+
+#endif // MULTIPASS_MOCK_LOGGER_H

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -25,6 +25,7 @@
 
 #include <functional>
 #include <memory>
+#include <stdexcept>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -85,6 +86,20 @@ TEST_F(TopCatchAll, handles_unknown_error)
                 log(Eq(mpl::Level::error), make_category_matcher(), make_cstring_matcher(HasSubstr("unknown"))));
     EXPECT_NO_THROW(got = mp::top_catch_all(category, [] {
                         throw 123;
+                        return 0;
+                    }););
+    EXPECT_EQ(got, EXIT_FAILURE);
+}
+
+TEST_F(TopCatchAll, handles_standard_exception)
+{
+    int got = 0;
+    const std::string emsg = "some error";
+    const auto msg_matcher = AllOf(HasSubstr("exception"), HasSubstr(emsg.c_str()));
+
+    EXPECT_CALL(*mock_logger, log(Eq(mpl::Level::error), make_category_matcher(), make_cstring_matcher(msg_matcher)));
+    EXPECT_NO_THROW(got = mp::top_catch_all(category, [&emsg] {
+                        throw std::runtime_error{emsg};
                         return 0;
                     }););
     EXPECT_EQ(got, EXIT_FAILURE);

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/top_catch_all.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <functional>
+
+namespace mp = multipass;
+
+TEST(TopCatchAll, calls_function_with_no_args)
+{
+    int ret = 123, got = 0;
+    EXPECT_NO_THROW(got = mp::top_catch_all("", [ret] { return ret; }););
+    EXPECT_EQ(got, ret);
+}
+
+TEST(TopCatchAll, calls_function_with_args)
+{
+    int a = 5, b = 7, got = 0;
+    EXPECT_NO_THROW(got = mp::top_catch_all("", std::plus<int>{}, a, b););
+    EXPECT_EQ(got, a + b);
+}


### PR DESCRIPTION
Fixes #1429.

---

Manual test examples (beyond unit tests):

- Daemon :
```console
$ ./bin/multipassd --logger=stderr -V debug  # non-admin user, no sudo
```
- CLI client:
```console
$ chmod -r ~/.local/share/multipass/client-certificate/multipass_cert.pem  # don't forget to revert
$ multipass
```
- GUI client:
```console
$ echo asdf > ~/.config/multipass/multipass.conf  # don't forget to revert
$ multipass.gui
```