### PR TITLE
Expand `~` in mount target (Fixes #1230)

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -72,6 +72,7 @@ std::string run_cmd_for_output(const QString& cmd, const QStringList& args, cons
 std::string& trim_end(std::string& s);
 std::string& trim_newline(std::string& s);
 std::string escape_char(const std::string& s, char c);
+std::string escape_for_shell(const std::string& s);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
 std::string generate_mac_address();
 std::string timestamp();

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -154,6 +154,26 @@ std::string mp::utils::escape_char(const std::string& in, char c)
     return std::regex_replace(in, std::regex({c}), fmt::format("\\{}", c));
 }
 
+// Escape all characters which need to be escaped in the shell.
+std::string mp::utils::escape_for_shell(const std::string& in)
+{
+    std::string ret;
+    std::back_insert_iterator<std::string> ret_insert = std::back_inserter(ret);
+
+    for (char c : in)
+    {
+        // If the character is in one of these code ranges, then it must be escaped.
+        if (c < 0x25 || c > 0x7a || (c > 0x25 && c < 0x2b) || (c > 0x5a && c < 0x5f) || 0x2c == c || 0x3b == c ||
+            0x3c == c || 0x3e == c || 0x3f == c || 0x60 == c)
+        {
+            *ret_insert++ = '\\';
+        }
+        *ret_insert++ = c;
+    }
+
+    return ret;
+}
+
 std::vector<std::string> mp::utils::split(const std::string& string, const std::string& delimiter)
 {
     std::regex regex(delimiter);

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -218,6 +218,13 @@ TEST(Utils, escape_char_actually_escapes)
     EXPECT_THAT(res, ::testing::StrEq("I've got \\\"quotes\\\""));
 }
 
+TEST(Utils, escape_for_shell_actually_escapes)
+{
+    std::string s{"I've got \"quotes\""};
+    auto res = mp::utils::escape_for_shell(s);
+    EXPECT_THAT(res, ::testing::StrEq("I\\'ve\\ got\\ \\\"quotes\\\""));
+}
+
 TEST(Utils, try_action_actually_times_out)
 {
     bool on_timeout_called{false};


### PR DESCRIPTION
This commit adds support for specifying mount points starting with ~.
It also handles the case on which mount points or home paths end with a space character.