### PR TITLE
Windows Terminal profile for primary - take2

### DIFF
--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -22,14 +22,22 @@ namespace multipass
 {
 constexpr auto client_name = "multipass";
 constexpr auto daemon_name = "multipassd";
+
 constexpr auto min_memory_size = "128M";
 constexpr auto min_disk_size = "512M";
 constexpr auto min_cpu_cores = "1";
+
 constexpr auto default_memory_size = "1G";
 constexpr auto default_disk_size = "5G";
 constexpr auto default_cpu_cores = min_cpu_cores;
+
 constexpr auto home_automount_dir = "Home";
+
 constexpr auto driver_env_var = "MULTIPASS_VM_DRIVER";
+
+constexpr auto winterm_profile_guid =
+    "{aaaa9e6d-1e09-4be6-b76c-82b4ba1885fb}"; // identifies the primary Multipass profile in Windows Terminal
+
 constexpr auto petenv_key = "client.primary-name";     // This will eventually be moved to some dynamic settings schema
 constexpr auto driver_key = "local.driver";            // idem
 constexpr auto autostart_key = "client.gui.autostart"; // idem

--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -33,6 +33,7 @@ constexpr auto driver_env_var = "MULTIPASS_VM_DRIVER";
 constexpr auto petenv_key = "client.primary-name";     // This will eventually be moved to some dynamic settings schema
 constexpr auto driver_key = "local.driver";            // idem
 constexpr auto autostart_key = "client.gui.autostart"; // idem
+constexpr auto winterm_key = "client.windows-terminal.add-profiles"; // idem
 } // namespace multipass
 
 #endif // MULTIPASS_CONSTANTS_H

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -36,6 +36,7 @@ namespace multipass
 {
 namespace platform
 {
+void apply_winterm_integration(const QString&);
 QString autostart_test_data(); // returns a platform-specific string, for testing purposes
 void setup_gui_autostart_prerequisites();
 std::string default_server_address();

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -36,14 +36,21 @@ namespace multipass
 {
 namespace platform
 {
+std::map<QString, QString> extra_settings_defaults();
+
 void apply_winterm_integration(const QString&);
+
 QString autostart_test_data(); // returns a platform-specific string, for testing purposes
 void setup_gui_autostart_prerequisites();
+
 std::string default_server_address();
 QString default_driver();
+
 QString daemon_config_home();                      // temporary
+
 bool is_backend_supported(const QString& backend); // temporary
 VirtualMachineFactory::UPtr vm_backend(const Path& data_dir);
+
 logging::Logger::UPtr make_logger(logging::Level level);
 UpdatePrompt::UPtr make_update_prompt();
 std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& config);

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -46,6 +46,11 @@ constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
 } // namespace
 
+void mp::platform::apply_winterm_integration(const QString&)
+{
+    throw std::runtime_error("Windows Terminal is not available on Linux");
+}
+
 QString mp::platform::autostart_test_data()
 {
     return autostart_filename;

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -46,6 +46,11 @@ constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
 } // namespace
 
+std::map<QString, QString> mp::platform::extra_settings_defaults()
+{
+    return {};
+}
+
 void mp::platform::apply_winterm_integration(const QString&)
 {
     throw std::runtime_error("Windows Terminal is not available on Linux");

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -41,14 +41,17 @@ const auto daemon_root = QStringLiteral("local");
 const auto client_root = QStringLiteral("client");
 const auto petenv_name = QStringLiteral("primary");
 const auto autostart_default = QStringLiteral("true");
-const auto winterm_default = QStringLiteral("none");
 
 std::map<QString, QString> make_defaults()
 { // clang-format off
-    return {{mp::petenv_key, petenv_name},
-            {mp::driver_key, mp::platform::default_driver()},
-            {mp::autostart_key, autostart_default},
-            {mp::winterm_key, winterm_default}};
+    auto ret = std::map<QString, QString>{{mp::petenv_key, petenv_name},
+                                          {mp::driver_key, mp::platform::default_driver()},
+                                          {mp::autostart_key, autostart_default}};
+
+    for(const auto& [k, v] : mp::platform::extra_settings_defaults())
+        ret.insert_or_assign(k, v);
+
+    return ret;
 } // clang-format on
 
 /*

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -41,12 +41,14 @@ const auto daemon_root = QStringLiteral("local");
 const auto client_root = QStringLiteral("client");
 const auto petenv_name = QStringLiteral("primary");
 const auto autostart_default = QStringLiteral("true");
+const auto winterm_default = QStringLiteral("none");
 
 std::map<QString, QString> make_defaults()
 { // clang-format off
     return {{mp::petenv_key, petenv_name},
             {mp::driver_key, mp::platform::default_driver()},
-            {mp::autostart_key, autostart_default}};
+            {mp::autostart_key, autostart_default},
+            {mp::winterm_key, winterm_default}};
 } // clang-format on
 
 /*

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -193,6 +193,8 @@ void multipass::Settings::set_aux(const QString& key, QString val) // work with 
         throw InvalidSettingsException(key, val, "Invalid driver"); // TODO idem
     else if (key == autostart_key && (val = interpret_bool(val)) != "true" && val != "false")
         throw InvalidSettingsException(key, val, "Invalid flag, try \"true\" or \"false\"");
+    else if (key == winterm_key)
+        mp::platform::apply_winterm_integration(val);
 
     auto settings = persistent_settings(key);
     checked_set(settings, key, val, mutex);


### PR DESCRIPTION
New approach, following change of plans requested in #1427. 

The setting is stored and retrieved in a regular fashion, but has platform-dependent side effects upon switching.