### PR TITLE
Windows Terminal integration

### DIFF
--- a/include/multipass/cli/client_common.h
+++ b/include/multipass/cli/client_common.h
@@ -53,6 +53,7 @@ std::unique_ptr<SSLCertProvider> get_cert_provider();
 void set_logger();
 void set_logger(multipass::logging::Level verbosity); // full param qualification makes sure msvc is happy
 void preliminary_setup();
+void final_adjustments();
 }
 } // namespace multipass
 #endif // MULTIPASS_CLIENT_COMMON_H

--- a/include/multipass/cli/client_common.h
+++ b/include/multipass/cli/client_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/multipass/cli/client_common.h
+++ b/include/multipass/cli/client_common.h
@@ -52,8 +52,8 @@ std::string get_server_address();
 std::unique_ptr<SSLCertProvider> get_cert_provider();
 void set_logger();
 void set_logger(multipass::logging::Level verbosity); // full param qualification makes sure msvc is happy
-void preliminary_setup();
-void final_adjustments();
+void pre_setup();
+void post_setup();
 }
 } // namespace multipass
 #endif // MULTIPASS_CLIENT_COMMON_H

--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -22,14 +22,22 @@ namespace multipass
 {
 constexpr auto client_name = "multipass";
 constexpr auto daemon_name = "multipassd";
+
 constexpr auto min_memory_size = "128M";
 constexpr auto min_disk_size = "512M";
 constexpr auto min_cpu_cores = "1";
+
 constexpr auto default_memory_size = "1G";
 constexpr auto default_disk_size = "5G";
 constexpr auto default_cpu_cores = min_cpu_cores;
+
 constexpr auto home_automount_dir = "Home";
+
 constexpr auto driver_env_var = "MULTIPASS_VM_DRIVER";
+
+constexpr auto winterm_profile_guid =
+    "{aaaa9e6d-1e09-4be6-b76c-82b4ba1885fb}"; // identifies the primary Multipass profile in Windows Terminal
+
 constexpr auto petenv_key = "client.primary-name";     // This will eventually be moved to some dynamic settings schema
 constexpr auto driver_key = "local.driver";            // idem
 constexpr auto autostart_key = "client.gui.autostart"; // idem

--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -33,6 +33,7 @@ constexpr auto driver_env_var = "MULTIPASS_VM_DRIVER";
 constexpr auto petenv_key = "client.primary-name";     // This will eventually be moved to some dynamic settings schema
 constexpr auto driver_key = "local.driver";            // idem
 constexpr auto autostart_key = "client.gui.autostart"; // idem
+constexpr auto winterm_key = "client.windows-terminal.add-profiles"; // idem
 } // namespace multipass
 
 #endif // MULTIPASS_CONSTANTS_H

--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -41,7 +41,7 @@ constexpr auto winterm_profile_guid =
 constexpr auto petenv_key = "client.primary-name";     // This will eventually be moved to some dynamic settings schema
 constexpr auto driver_key = "local.driver";            // idem
 constexpr auto autostart_key = "client.gui.autostart"; // idem
-constexpr auto winterm_key = "client.windows-terminal.add-profiles"; // idem
+constexpr auto winterm_key = "client.apps.windows-terminal.profiles"; // idem
 } // namespace multipass
 
 #endif // MULTIPASS_CONSTANTS_H

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -39,6 +39,7 @@ namespace platform
 std::map<QString, QString> extra_settings_defaults();
 
 QString interpret_winterm_integration(const QString& val);
+void sync_winterm_profiles();
 
 QString autostart_test_data(); // returns a platform-specific string, for testing purposes
 void setup_gui_autostart_prerequisites();

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -36,6 +36,7 @@ namespace multipass
 {
 namespace platform
 {
+QString interpret_winterm_integration(const QString& val);
 QString autostart_test_data(); // returns a platform-specific string, for testing purposes
 void setup_gui_autostart_prerequisites();
 std::string default_server_address();

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -36,14 +36,21 @@ namespace multipass
 {
 namespace platform
 {
+std::map<QString, QString> extra_settings_defaults();
+
 QString interpret_winterm_integration(const QString& val);
+
 QString autostart_test_data(); // returns a platform-specific string, for testing purposes
 void setup_gui_autostart_prerequisites();
+
 std::string default_server_address();
 QString default_driver();
+
 QString daemon_config_home();                      // temporary
+
 bool is_backend_supported(const QString& backend); // temporary
 VirtualMachineFactory::UPtr vm_backend(const Path& data_dir);
+
 logging::Logger::UPtr make_logger(logging::Level level);
 UpdatePrompt::UPtr make_update_prompt();
 std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& config);

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -38,7 +38,7 @@ namespace platform
 {
 std::map<QString, QString> extra_settings_defaults();
 
-QString interpret_winterm_integration(const QString& val);
+QString interpret_setting(const QString& key, const QString& val);
 void sync_winterm_profiles();
 
 QString autostart_test_data(); // returns a platform-specific string, for testing purposes

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -99,10 +99,10 @@ int mp::Client::run(const QStringList& arguments)
     mp::client::set_logger(mpl::level_from(parser.verbosityLevel())); // we need logging for...
     mp::client::preliminary_setup(); // ... something we want to do even if the command was wrong
 
-    if (parse_status != ParseCode::Ok)
-    {
-        return parser.returnCodeFrom(parse_status);
-    }
+    const auto ret =
+        parse_status == ParseCode::Ok ? parser.chosenCommand()->run(&parser) : parser.returnCodeFrom(parse_status);
 
-    return parser.chosenCommand()->run(&parser);
+    mp::client::final_adjustments();
+
+    return ret;
 }

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -97,12 +97,12 @@ int mp::Client::run(const QStringList& arguments)
     ParseCode parse_status = parser.parse();
 
     mp::client::set_logger(mpl::level_from(parser.verbosityLevel())); // we need logging for...
-    mp::client::preliminary_setup(); // ... something we want to do even if the command was wrong
+    mp::client::pre_setup(); // ... something we want to do even if the command was wrong
 
     const auto ret =
         parse_status == ParseCode::Ok ? parser.chosenCommand()->run(&parser) : parser.returnCodeFrom(parse_status);
 
-    mp::client::final_adjustments();
+    mp::client::post_setup();
 
     return ret;
 }

--- a/src/client/common/client_common.cpp
+++ b/src/client/common/client_common.cpp
@@ -117,3 +117,8 @@ void mp::client::preliminary_setup()
         mpl::log(mpl::Level::debug, "client", e.get_detail());
     }
 }
+
+void mp::client::final_adjustments()
+{
+    platform::sync_winterm_profiles();
+}

--- a/src/client/common/client_common.cpp
+++ b/src/client/common/client_common.cpp
@@ -105,7 +105,7 @@ void mp::client::set_logger(mpl::Level verbosity)
     mpl::set_logger(std::make_shared<mpl::StandardLogger>(verbosity));
 }
 
-void mp::client::preliminary_setup()
+void mp::client::pre_setup()
 {
     try
     {
@@ -118,7 +118,7 @@ void mp::client::preliminary_setup()
     }
 }
 
-void mp::client::final_adjustments()
+void mp::client::post_setup()
 {
     platform::sync_winterm_profiles();
 }

--- a/src/client/gui/client_gui.cpp
+++ b/src/client/gui/client_gui.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,7 +37,7 @@ mp::ClientGui::ClientGui(ClientConfig& config)
 int mp::ClientGui::run(const QStringList& arguments)
 {
     mp::client::set_logger();        // we need logging for...
-    mp::client::preliminary_setup(); // ... something we want to do even if the command was wrong
+    mp::client::pre_setup();         // ... something we want to do even if the command was wrong
 
     ArgParser parser;
 

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -17,6 +17,7 @@
 
 #include <multipass/constants.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
+#include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
@@ -44,6 +45,12 @@ namespace
 constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
 } // namespace
+
+QString mp::platform::interpret_winterm_integration(const QString& val)
+{
+    // this should not happen (settings would have found it to be an invalid key)
+    throw InvalidSettingsException(winterm_key, val, "Windows Terminal is not available on Linux");
+}
 
 QString mp::platform::autostart_test_data()
 {

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -46,6 +46,11 @@ constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
 } // namespace
 
+std::map<QString, QString> mp::platform::extra_settings_defaults()
+{
+    return {};
+}
+
 QString mp::platform::interpret_winterm_integration(const QString& val)
 {
     // this should not happen (settings would have found it to be an invalid key)

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -57,6 +57,11 @@ QString mp::platform::interpret_winterm_integration(const QString& val)
     throw InvalidSettingsException(winterm_key, val, "Windows Terminal is not available on Linux");
 }
 
+void mp::platform::sync_winterm_profiles()
+{
+    // NOOP on Linux
+}
+
 QString mp::platform::autostart_test_data()
 {
     return autostart_filename;

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -51,10 +51,10 @@ std::map<QString, QString> mp::platform::extra_settings_defaults()
     return {};
 }
 
-QString mp::platform::interpret_winterm_integration(const QString& val)
+QString mp::platform::interpret_setting(const QString& key, const QString& val)
 {
-    // this should not happen (settings would have found it to be an invalid key)
-    throw InvalidSettingsException(winterm_key, val, "Windows Terminal is not available on Linux");
+    // this should not happen (settings should have found it to be an invalid key)
+    throw InvalidSettingsException(key, val, "Setting unavailable on Linux");
 }
 
 void mp::platform::sync_winterm_profiles()

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -188,12 +188,15 @@ QString mp::Settings::get_client_settings_file_path() // idem
 
 void multipass::Settings::set_aux(const QString& key, QString val) // work with a copy of val
 {
+    // TODO we should have handler callbacks instead
     if (key == petenv_key && !mp::utils::valid_hostname(val.toStdString()))
-        throw InvalidSettingsException{key, val, "Invalid hostname"}; // TODO move checking logic out
+        throw InvalidSettingsException{key, val, "Invalid hostname"};
     else if (key == driver_key && !mp::platform::is_backend_supported(val))
-        throw InvalidSettingsException(key, val, "Invalid driver"); // TODO idem
+        throw InvalidSettingsException(key, val, "Invalid driver");
     else if (key == autostart_key && (val = interpret_bool(val)) != "true" && val != "false")
         throw InvalidSettingsException(key, val, "Invalid flag, try \"true\" or \"false\"");
+    else if (key == winterm_key)
+        val = mp::platform::interpret_winterm_integration(val);
 
     auto settings = persistent_settings(key);
     checked_set(settings, key, val, mutex);

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -41,14 +41,17 @@ const auto daemon_root = QStringLiteral("local");
 const auto client_root = QStringLiteral("client");
 const auto petenv_name = QStringLiteral("primary");
 const auto autostart_default = QStringLiteral("true");
-const auto winterm_default = QStringLiteral("none");
 
 std::map<QString, QString> make_defaults()
 { // clang-format off
-    return {{mp::petenv_key, petenv_name},
-            {mp::driver_key, mp::platform::default_driver()},
-            {mp::autostart_key, autostart_default},
-            {mp::winterm_key, winterm_default}};
+    auto ret = std::map<QString, QString>{{mp::petenv_key, petenv_name},
+                                          {mp::driver_key, mp::platform::default_driver()},
+                                          {mp::autostart_key, autostart_default}};
+
+    for(const auto& [k, v] : mp::platform::extra_settings_defaults())
+        ret.insert_or_assign(k, v);
+
+    return ret;
 } // clang-format on
 
 /*

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -41,12 +41,14 @@ const auto daemon_root = QStringLiteral("local");
 const auto client_root = QStringLiteral("client");
 const auto petenv_name = QStringLiteral("primary");
 const auto autostart_default = QStringLiteral("true");
+const auto winterm_default = QStringLiteral("none");
 
 std::map<QString, QString> make_defaults()
 { // clang-format off
     return {{mp::petenv_key, petenv_name},
             {mp::driver_key, mp::platform::default_driver()},
-            {mp::autostart_key, autostart_default}};
+            {mp::autostart_key, autostart_default},
+            {mp::winterm_key, winterm_default}};
 } // clang-format on
 
 /*

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -199,7 +199,7 @@ void multipass::Settings::set_aux(const QString& key, QString val) // work with 
     else if (key == autostart_key && (val = interpret_bool(val)) != "true" && val != "false")
         throw InvalidSettingsException(key, val, "Invalid flag, try \"true\" or \"false\"");
     else if (key == winterm_key)
-        val = mp::platform::interpret_winterm_integration(val);
+        val = mp::platform::interpret_setting(winterm_key, val);
 
     auto settings = persistent_settings(key);
     checked_set(settings, key, val, mutex);

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -26,6 +26,7 @@
 
 #include <multipass/constants.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
+#include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/platform.h>
 
 #include <QDir>
@@ -34,6 +35,7 @@
 
 #include <scope_guard.hpp>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <stdexcept>
@@ -157,6 +159,17 @@ struct PlatformLinux : public mpt::TestWithMockedBinPath
     mpt::UnsetEnvScope unset_env_scope{mp::driver_env_var};
     mpt::SetEnvScope disable_apparmor{"DISABLE_APPARMOR", "1"};
 };
+
+TEST_F(PlatformLinux, test_no_extra_settings)
+{
+    EXPECT_THAT(mp::platform::extra_settings_defaults(), IsEmpty());
+}
+
+TEST_F(PlatformLinux, test_winterm_setting_not_supported)
+{
+    for (const auto x : {"no", "matter", "what"})
+        EXPECT_THROW(mp::platform::interpret_winterm_integration(x), mp::InvalidSettingsException);
+}
 
 TEST_F(PlatformLinux, test_autostart_desktop_file_properly_placed)
 {

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -171,6 +171,11 @@ TEST_F(PlatformLinux, test_winterm_setting_not_supported)
         EXPECT_THROW(mp::platform::interpret_winterm_integration(x), mp::InvalidSettingsException);
 }
 
+TEST_F(PlatformLinux, test_empty_sync_winterm_profiles)
+{
+    EXPECT_NO_THROW(mp::platform::sync_winterm_profiles());
+}
+
 TEST_F(PlatformLinux, test_autostart_desktop_file_properly_placed)
 {
     try

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -165,10 +165,17 @@ TEST_F(PlatformLinux, test_no_extra_settings)
     EXPECT_THAT(mp::platform::extra_settings_defaults(), IsEmpty());
 }
 
-TEST_F(PlatformLinux, test_winterm_setting_not_supported)
+TEST_F(PlatformLinux, test_interpretation_of_winterm_setting_not_supported)
 {
     for (const auto x : {"no", "matter", "what"})
-        EXPECT_THROW(mp::platform::interpret_winterm_integration(x), mp::InvalidSettingsException);
+        EXPECT_THROW(mp::platform::interpret_setting(mp::winterm_key, x), mp::InvalidSettingsException);
+}
+
+TEST_F(PlatformLinux, test_interpretation_of_unknown_settings_not_supported)
+{
+    for (const auto k : {"unimaginable", "katxama", "katxatxa"})
+        for (const auto v : {"no", "matter", "what"})
+            EXPECT_THROW(mp::platform::interpret_setting(k, v), mp::InvalidSettingsException);
 }
 
 TEST_F(PlatformLinux, test_empty_sync_winterm_profiles)

--- a/tests/mock_logger.h
+++ b/tests/mock_logger.h
@@ -32,6 +32,12 @@ public:
     MockLogger() = default;
     MOCK_CONST_METHOD3(log, void(multipass::logging::Level level, multipass::logging::CString category,
                                  multipass::logging::CString message));
+
+    template <typename Matcher>
+    static auto make_cstring_matcher(const Matcher& matcher)
+    {
+        return Property(&multipass::logging::CString::c_str, matcher);
+    }
 };
 } // namespace test
 } // namespace multipass

--- a/tests/mock_logger.h
+++ b/tests/mock_logger.h
@@ -18,9 +18,13 @@
 #ifndef MULTIPASS_MOCK_LOGGER_H
 #define MULTIPASS_MOCK_LOGGER_H
 
+#include <multipass/logging/log.h>
 #include <multipass/logging/logger.h>
 
+#include <scope_guard.hpp>
+
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 namespace multipass
 {
@@ -39,6 +43,25 @@ public:
         return Property(&multipass::logging::CString::c_str, matcher);
     }
 };
+
+inline auto guarded_mock_logger()
+{
+    auto guard = sg::make_scope_guard([] { multipass::logging::set_logger(nullptr); });
+    auto mock_logger = std::make_shared<testing::StrictMock<MockLogger>>();
+    multipass::logging::set_logger(mock_logger);
+
+    return std::make_pair(mock_logger, std::move(guard)); // needs to be moved into the pair first (NRVO does not apply)
+}
+
+inline auto expect_log(multipass::logging::Level lvl, const std::string& substr)
+{
+    auto [mock_logger, guard] = guarded_mock_logger();
+
+    EXPECT_CALL(*mock_logger, log(lvl, testing::_, MockLogger::make_cstring_matcher(testing::HasSubstr(substr))));
+
+    return std::move(guard); // needs to be moved because it's only part of an implicit local var (NRVO does not apply)
+}
+
 } // namespace test
 } // namespace multipass
 

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1644,6 +1644,20 @@ INSTANTIATE_TEST_SUITE_P(Client, TestSetDriverWithInstances, ValuesIn(set_driver
 
 #endif // MULTIPASS_PLATFORM_LINUX
 
+#ifndef MULTIPASS_PLATFORM_WINDOWS // Test Windows Terminal setting not recognized outside Windows
+
+TEST_F(Client, get_and_set_do_not_know_about_winterm_integration)
+{
+    const auto val = "asdf";
+    EXPECT_CALL(mock_settings, get(Eq(mp::winterm_key)));
+    EXPECT_THAT(send_command({"get", mp::winterm_key}), Eq(mp::ReturnCode::CommandLineError));
+
+    EXPECT_CALL(mock_settings, set(Eq(mp::winterm_key), Eq(val)));
+    EXPECT_THAT(send_command({"set", keyval_arg(mp::winterm_key, val)}), Eq(mp::ReturnCode::CommandLineError));
+}
+
+#endif // #ifndef MULTIPASS_PLATFORM_WINDOWS
+
 // general help tests
 TEST_F(Client, help_returns_ok_return_code)
 {

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1661,6 +1661,19 @@ TEST_F(Client, get_and_set_do_not_know_about_winterm_integration)
     EXPECT_THAT(send_command({"set", keyval_arg(mp::winterm_key, val)}), Eq(mp::ReturnCode::CommandLineError));
 }
 
+#else
+
+TEST_F(Client, get_and_set_can_read_and_write_winterm_integration)
+{
+    const auto orig = get_setting((mp::winterm_key));
+    const auto novel = "asdf";
+
+    EXPECT_THAT(get_setting(mp::winterm_key), Not(IsEmpty()));
+
+    EXPECT_CALL(mock_settings, set(Eq(mp::winterm_key), Eq(QString::fromStdString(novel))));
+    EXPECT_THAT(send_command({"set", keyval_arg(mp::winterm_key, novel)}), Eq(mp::ReturnCode::Ok));
+}
+
 #endif // #ifndef MULTIPASS_PLATFORM_WINDOWS
 
 // general help tests

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -92,6 +92,13 @@ struct MockDaemonRpc : public mp::DaemonRpc
 
 struct Client : public Test
 {
+    void SetUp() override
+    {
+        EXPECT_CALL(mock_settings, get(_)).Times(AnyNumber()); /* Admit get calls beyond explicitly expected in tests.
+                                                                  This allows general actions to consult settings
+                                                                  (e.g. Windows Terminal profile sync) */
+    }
+
     void TearDown() override
     {
         Mock::VerifyAndClearExpectations(&mock_daemon); /* We got away without this before because, being a strict mock
@@ -1443,7 +1450,6 @@ INSTANTIATE_TEST_SUITE_P(Client, TestBasicGetSetOptions, Values(mp::petenv_key, 
 
 TEST_F(Client, get_cmd_fails_with_no_arguments)
 {
-    EXPECT_CALL(mock_settings, get(_)).Times(0);
     EXPECT_THAT(send_command({"get"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
@@ -1455,7 +1461,6 @@ TEST_F(Client, set_cmd_fails_with_no_arguments)
 
 TEST_F(Client, get_cmd_fails_with_multiple_arguments)
 {
-    EXPECT_CALL(mock_settings, get(_)).Times(0);
     EXPECT_THAT(send_command({"get", mp::petenv_key, mp::driver_key}), Eq(mp::ReturnCode::CommandLineError));
 }
 

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -17,6 +17,7 @@
 
 #include "mock_environment_helpers.h"
 #include "mock_settings.h"
+#include "mock_standard_paths.h"
 #include "mock_stdcin.h"
 #include "path.h"
 #include "stub_cert_store.h"
@@ -97,6 +98,13 @@ struct Client : public Test
         EXPECT_CALL(mock_settings, get(_)).Times(AnyNumber()); /* Admit get calls beyond explicitly expected in tests.
                                                                   This allows general actions to consult settings
                                                                   (e.g. Windows Terminal profile sync) */
+        EXPECT_CALL(mpt::MockStandardPaths::mock_instance(), locate(_, _, _))
+            .Times(AnyNumber()); // needed to allow general calls once we have added the specific expectation below
+        EXPECT_CALL(mpt::MockStandardPaths::mock_instance(),
+                    locate(_, Property(&QString::toStdString, EndsWith("settings.json")), _))
+            .Times(AnyNumber())
+            .WillRepeatedly(Return("")); /* Avoid writing to Windows Terminal settings. We use an "expectation" so that
+                                            it gets reset at the end of each test (by VerifyAndClearExpectations) */
     }
 
     void TearDown() override

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +31,7 @@
 #include <multipass/vm_image_vault.h>
 
 #include "mock_environment_helpers.h"
+#include "mock_standard_paths.h"
 #include "mock_virtual_machine_factory.h"
 #include "stub_cert_store.h"
 #include "stub_certprovider.h"
@@ -233,6 +234,17 @@ struct Daemon : public Test
         config_builder.connection_type = mp::RpcConnectionType::insecure;
         config_builder.logger = std::make_unique<mpt::StubLogger>();
         config_builder.update_prompt = std::make_unique<mp::DisabledUpdatePrompt>();
+    }
+
+    void SetUp() override
+    {
+        EXPECT_CALL(mpt::MockStandardPaths::mock_instance(), locate(_, _, _))
+            .Times(AnyNumber()); // needed to allow general calls once we have added the specific expectation below
+        EXPECT_CALL(mpt::MockStandardPaths::mock_instance(),
+                    locate(_, Property(&QString::toStdString, EndsWith("settings.json")), _))
+            .Times(AnyNumber())
+            .WillRepeatedly(Return("")); /* Avoid writing to Windows Terminal settings. We use an "expectation" so that
+                                            it gets reset at the end of each test (by VerifyAndClearExpectations) */
     }
 
     mpt::MockVirtualMachineFactory* use_a_mock_vm_factory()

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -185,12 +185,6 @@ struct SshfsMount : public mp::test::SftpServerTest
         EXPECT_TRUE(next_expected_cmd == commands.end()) << "\"" << next_expected_cmd->first << "\" not executed";
     }
 
-    template <typename Matcher>
-    auto make_cstring_matcher(const Matcher& matcher)
-    {
-        return Property(&mpl::CString::c_str, matcher);
-    }
-
     mpt::ExitStatusMock exit_status_mock;
     decltype(MOCK(ssh_channel_read_timeout)) channel_read{MOCK(ssh_channel_read_timeout)};
     decltype(MOCK(ssh_channel_is_closed)) channel_is_closed{MOCK(ssh_channel_is_closed)};
@@ -424,11 +418,11 @@ TEST_F(SshfsMount, blank_fuse_version_logs_error)
     EXPECT_CALL(*logger, log(Matcher<multipass::logging::Level>(_), Matcher<multipass::logging::CString>(_),
                              Matcher<multipass::logging::CString>(_)))
         .WillRepeatedly(Return());
-    EXPECT_CALL(*logger, log(Eq(mpl::Level::warning), make_cstring_matcher(StrEq("sshfs mount")),
-                             make_cstring_matcher(StrEq("Unable to parse the FUSE library version"))));
-    EXPECT_CALL(*logger,
-                log(Eq(mpl::Level::debug), make_cstring_matcher(StrEq("sshfs mount")),
-                    make_cstring_matcher(StrEq("Unable to parse the FUSE library version: FUSE library version:"))));
+    EXPECT_CALL(*logger, log(Eq(mpl::Level::warning), mpt::MockLogger::make_cstring_matcher(StrEq("sshfs mount")),
+                             mpt::MockLogger::make_cstring_matcher(StrEq("Unable to parse the FUSE library version"))));
+    EXPECT_CALL(*logger, log(Eq(mpl::Level::debug), mpt::MockLogger::make_cstring_matcher(StrEq("sshfs mount")),
+                             mpt::MockLogger::make_cstring_matcher(
+                                 StrEq("Unable to parse the FUSE library version: FUSE library version:"))));
 
     test_command_execution(commands);
 }
@@ -512,8 +506,9 @@ TEST_F(SshfsMount, install_sshfs_timeout_logs_info)
     EXPECT_CALL(*logger, log(Matcher<multipass::logging::Level>(_), Matcher<multipass::logging::CString>(_),
                              Matcher<multipass::logging::CString>(_)))
         .WillRepeatedly(Return());
-    EXPECT_CALL(*logger, log(Eq(mpl::Level::info), make_cstring_matcher(StrEq("utils")),
-                             make_cstring_matcher(StrEq("Timeout while installing 'sshfs' in 'foo'"))));
+    EXPECT_CALL(*logger,
+                log(Eq(mpl::Level::info), mpt::MockLogger::make_cstring_matcher(StrEq("utils")),
+                    mpt::MockLogger::make_cstring_matcher(StrEq("Timeout while installing 'sshfs' in 'foo'"))));
 
     mp::SSHSession session{"a", 42};
 

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -48,15 +48,9 @@ struct TopCatchAll : public Test
         mpl::set_logger(mock_logger);
     }
 
-    template <typename Matcher>
-    auto make_cstring_matcher(const Matcher& matcher)
-    {
-        return Property(&mpl::CString::c_str, matcher);
-    }
-
     auto make_category_matcher()
     {
-        return make_cstring_matcher(StrEq(category.c_str()));
+        return mpt::MockLogger::make_cstring_matcher(StrEq(category.c_str()));
     }
 
     const std::string category = "testing";
@@ -95,8 +89,8 @@ TEST_F(TopCatchAll, handles_unknown_error)
 {
     int got = 0;
 
-    EXPECT_CALL(*mock_logger,
-                log(Eq(mpl::Level::error), make_category_matcher(), make_cstring_matcher(HasSubstr("unknown"))));
+    EXPECT_CALL(*mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
+                                  mpt::MockLogger::make_cstring_matcher(HasSubstr("unknown"))));
     EXPECT_NO_THROW(got = mp::top_catch_all(category, [] {
                         throw 123;
                         return 0;
@@ -110,7 +104,8 @@ TEST_F(TopCatchAll, handles_standard_exception)
     const std::string emsg = "some error";
     const auto msg_matcher = AllOf(HasSubstr("exception"), HasSubstr(emsg.c_str()));
 
-    EXPECT_CALL(*mock_logger, log(Eq(mpl::Level::error), make_category_matcher(), make_cstring_matcher(msg_matcher)));
+    EXPECT_CALL(*mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
+                                  mpt::MockLogger::make_cstring_matcher(msg_matcher)));
     EXPECT_NO_THROW(got = mp::top_catch_all(category, [&emsg] {
                         throw std::runtime_error{emsg};
                         return 0;
@@ -123,7 +118,8 @@ TEST_F(TopCatchAll, handles_custom_exception)
     int got = 0;
     const auto msg_matcher = AllOf(HasSubstr("exception"), HasSubstr(CustomExceptionForTesting::msg));
 
-    EXPECT_CALL(*mock_logger, log(Eq(mpl::Level::error), make_category_matcher(), make_cstring_matcher(msg_matcher)));
+    EXPECT_CALL(*mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
+                                  mpt::MockLogger::make_cstring_matcher(msg_matcher)));
     EXPECT_NO_THROW(got = mp::top_catch_all(category, [] {
                         throw CustomExceptionForTesting{};
                         return 42;


### PR DESCRIPTION
Yet another approach. Addresses #1449 .

The setting is checked upon set, but applied separately.

Depends on #1467. Diff against that: https://github.com/canonical/multipass/compare/mockable-standard-paths...winterm-integration-take3