### PR TITLE
Mockable standard paths

### DIFF
--- a/include/multipass/standard_paths.h
+++ b/include/multipass/standard_paths.h
@@ -20,12 +20,23 @@
 
 #include "singleton.h"
 
+#include <QStandardPaths>
+
 namespace multipass
 {
 class StandardPaths : public Singleton<StandardPaths>
 {
 public:
+    using LocateOption = QStandardPaths::LocateOption;
+    using LocateOptions = QStandardPaths::LocateOptions;
+    using StandardLocation = QStandardPaths::StandardLocation;
+
     StandardPaths(const Singleton<StandardPaths>::PrivatePass&);
+
+    virtual QString locate(StandardLocation type, const QString& fileName,
+                           LocateOptions options = LocateOption::LocateFile) const;
+    virtual QStringList standardLocations(StandardLocation type) const;
+    virtual QString writableLocation(StandardLocation type) const;
 };
 } // namespace multipass
 #endif // MULTIPASS_STANDARD_PATHS_H

--- a/include/multipass/standard_paths.h
+++ b/include/multipass/standard_paths.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_STANDARD_PATHS_H
+#define MULTIPASS_STANDARD_PATHS_H
+
+#include "singleton.h"
+
+namespace multipass
+{
+class StandardPaths : public Singleton<StandardPaths>
+{
+public:
+    StandardPaths(const Singleton<StandardPaths>::PrivatePass&);
+};
+} // namespace multipass
+#endif // MULTIPASS_STANDARD_PATHS_H

--- a/include/multipass/standard_paths.h
+++ b/include/multipass/standard_paths.h
@@ -27,9 +27,33 @@ namespace multipass
 class StandardPaths : public Singleton<StandardPaths>
 {
 public:
+    // TODO try to replace all the stuff below with `using enum` in C++20 (P1099R5)
     using LocateOption = QStandardPaths::LocateOption;
+    static constexpr auto LocateFile = LocateOption::LocateFile;
+    static constexpr auto LocateDirectory = LocateOption::LocateDirectory;
     using LocateOptions = QStandardPaths::LocateOptions;
+
     using StandardLocation = QStandardPaths::StandardLocation;
+    static constexpr auto DesktopLocation = StandardLocation::DesktopLocation;
+    static constexpr auto DocumentsLocation = StandardLocation::DocumentsLocation;
+    static constexpr auto FontsLocation = StandardLocation::FontsLocation;
+    static constexpr auto ApplicationsLocation = StandardLocation::ApplicationsLocation;
+    static constexpr auto MusicLocation = StandardLocation::MusicLocation;
+    static constexpr auto MoviesLocation = StandardLocation::MoviesLocation;
+    static constexpr auto PicturesLocation = StandardLocation::PicturesLocation;
+    static constexpr auto TempLocation = StandardLocation::TempLocation;
+    static constexpr auto HomeLocation = StandardLocation::HomeLocation;
+    static constexpr auto DataLocation = StandardLocation::DataLocation;
+    static constexpr auto CacheLocation = StandardLocation::CacheLocation;
+    static constexpr auto GenericCacheLocation = StandardLocation::GenericCacheLocation;
+    static constexpr auto GenericDataLocation = StandardLocation::GenericDataLocation;
+    static constexpr auto RuntimeLocation = StandardLocation::RuntimeLocation;
+    static constexpr auto ConfigLocation = StandardLocation::ConfigLocation;
+    static constexpr auto DownloadLocation = StandardLocation::DownloadLocation;
+    static constexpr auto GenericConfigLocation = StandardLocation::GenericConfigLocation;
+    static constexpr auto AppDataLocation = StandardLocation::AppDataLocation;
+    static constexpr auto AppLocalDataLocation = StandardLocation::AppLocalDataLocation;
+    static constexpr auto AppConfigLocation = StandardLocation::AppConfigLocation;
 
     StandardPaths(const Singleton<StandardPaths>::PrivatePass&);
 

--- a/src/client/common/client_common.cpp
+++ b/src/client/common/client_common.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/client/common/client_common.cpp
+++ b/src/client/common/client_common.cpp
@@ -17,9 +17,8 @@
 
 #include <multipass/cli/client_common.h>
 #include <multipass/platform.h>
+#include <multipass/standard_paths.h>
 #include <multipass/utils.h>
-
-#include <QStandardPaths>
 
 #include <fmt/ostream.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
@@ -91,7 +90,7 @@ std::string mp::client::get_server_address()
 
 std::unique_ptr<mp::SSLCertProvider> mp::client::get_cert_provider()
 {
-    auto data_dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    auto data_dir = StandardPaths::instance().writableLocation(StandardPaths::AppDataLocation);
     auto client_cert_dir = mp::utils::make_dir(data_dir, "client-certificate");
     return std::make_unique<mp::SSLCertProvider>(client_cert_dir);
 }

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -291,7 +291,7 @@ void cmd::GuiCmd::create_menu()
 
     about_client_version.setEnabled(false);
     about_daemon_version.setEnabled(false);
-    about_copyright.setText("Copyright © 2017-2019 Canonical Ltd.");
+    about_copyright.setText("Copyright © 2017-2020 Canonical Ltd.");
     about_copyright.setEnabled(false);
 
     about_menu.insertActions(0, {&autostart_option, &about_client_version, &about_daemon_version, &about_copyright});

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -23,6 +23,7 @@
 #include <multipass/cli/format_utils.h>
 #include <multipass/format.h>
 #include <multipass/settings.h>
+#include <multipass/standard_paths.h>
 #include <multipass/version.h>
 
 #include <QHotkey>
@@ -116,7 +117,7 @@ mp::ReturnCode cmd::GuiCmd::run(mp::ArgParser* parser)
     create_menu();
     tray_icon.show();
 
-    QFile first_run_file(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/first_run");
+    QFile first_run_file(StandardPaths::instance().writableLocation(StandardPaths::AppDataLocation) + "/first_run");
 
     if (!first_run_file.exists())
     {

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -28,9 +28,9 @@
 #include <multipass/platform.h>
 #include <multipass/ssh/openssh_key_provider.h>
 #include <multipass/ssl_cert_provider.h>
+#include <multipass/standard_paths.h>
 #include <multipass/utils.h>
 
-#include <QStandardPaths>
 #include <QString>
 #include <QUrl>
 
@@ -106,9 +106,9 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
     mpl::set_logger(multiplexing_logger);
 
     if (cache_directory.isEmpty())
-        cache_directory = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+        cache_directory = StandardPaths::instance().writableLocation(StandardPaths::CacheLocation);
     if (data_directory.isEmpty())
-        data_directory = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        data_directory = StandardPaths::instance().writableLocation(StandardPaths::AppDataLocation);
     if (url_downloader == nullptr)
         url_downloader = std::make_unique<URLDownloader>(cache_directory, std::chrono::seconds{10});
     if (factory == nullptr)

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -21,6 +21,7 @@
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
 #include <multipass/snap_utils.h>
+#include <multipass/standard_paths.h>
 #include <multipass/utils.h>
 #include <multipass/virtual_machine_factory.h>
 
@@ -30,8 +31,6 @@
 #include "shared/linux/process_factory.h"
 #include "shared/sshfs_server_process_spec.h"
 #include <disabled_update_prompt.h>
-
-#include <QStandardPaths>
 
 #include <signal.h>
 #include <sys/prctl.h>
@@ -53,7 +52,7 @@ QString mp::platform::autostart_test_data()
 
 void mp::platform::setup_gui_autostart_prerequisites()
 {
-    const auto config_dir = QDir{QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)};
+    const auto config_dir = QDir{StandardPaths::instance().writableLocation(StandardPaths::GenericConfigLocation)};
     const auto link_dir = QDir{config_dir.absoluteFilePath("autostart")};
     mu::link_autostart_file(link_dir, mp::client_name, autostart_filename);
 }

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -15,10 +15,10 @@
  *
  */
 
-#include <multipass/ssh/ssh_session.h>
-
 #include <multipass/ssh/ssh_key_provider.h>
+#include <multipass/ssh/ssh_session.h>
 #include <multipass/ssh/throw_on_error.h>
+#include <multipass/standard_paths.h>
 
 #include <libssh/callbacks.h>
 #include <libssh/socket.h>
@@ -26,7 +26,6 @@
 #include <multipass/format.h>
 
 #include <QDir>
-#include <QStandardPaths>
 
 #include <sstream>
 #include <stdexcept>
@@ -43,8 +42,9 @@ mp::SSHSession::SSHSession(const std::string& host, int port, const std::string&
 
     const long timeout_secs = std::chrono::duration_cast<std::chrono::seconds>(timeout).count();
     const int nodelay{1};
-    auto ssh_dir =
-        QDir(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation)).filePath("ssh").toStdString();
+    auto ssh_dir = QDir(StandardPaths::instance().writableLocation(StandardPaths::AppConfigLocation))
+                       .filePath("ssh")
+                       .toStdString();
 
     set_option(SSH_OPTIONS_HOST, host.c_str());
     set_option(SSH_OPTIONS_PORT, &port);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(utils STATIC
   memory_size.cpp
   settings.cpp
   snap_utils.cpp
+  standard_paths.cpp
   utils.cpp)
 
 target_link_libraries(utils

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -18,11 +18,11 @@
 #include <multipass/constants.h>
 #include <multipass/platform.h>
 #include <multipass/settings.h>
+#include <multipass/standard_paths.h>
 #include <multipass/utils.h> // TODO move out
 
 #include <QDir>
 #include <QSettings>
-#include <QStandardPaths>
 
 #include <algorithm>
 #include <array>
@@ -61,7 +61,8 @@ QString file_for(const QString& key) // the key should have passed checks at thi
 {
     // static consts ensure these stay fixed
     static const auto file_pattern = QStringLiteral("%2.%1").arg(file_extension); // note the order
-    static const auto user_config_path = QDir{QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)};
+    static const auto user_config_path =
+        QDir{mp::StandardPaths::instance().writableLocation(mp::StandardPaths::GenericConfigLocation)};
     static const auto cli_client_dir_path = QDir{user_config_path.absoluteFilePath(mp::client_name)};
     static const auto daemon_dir_path = QDir{mp::platform::daemon_config_home()}; // temporary, replace w/ AppConfigLoc
     static const auto client_file_path = cli_client_dir_path.absoluteFilePath(file_pattern.arg(mp::client_name));

--- a/src/utils/standard_paths.cpp
+++ b/src/utils/standard_paths.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/standard_paths.h>
+
+namespace mp = multipass;
+
+mp::StandardPaths::StandardPaths(const Singleton<StandardPaths>::PrivatePass& pass)
+    : Singleton<StandardPaths>::Singleton{pass}
+{
+}

--- a/src/utils/standard_paths.cpp
+++ b/src/utils/standard_paths.cpp
@@ -23,3 +23,18 @@ mp::StandardPaths::StandardPaths(const Singleton<StandardPaths>::PrivatePass& pa
     : Singleton<StandardPaths>::Singleton{pass}
 {
 }
+
+QString mp::StandardPaths::locate(StandardLocation type, const QString& fileName, LocateOptions options) const
+{
+    return QStandardPaths::locate(type, fileName, options);
+}
+
+QStringList mp::StandardPaths::standardLocations(StandardLocation type) const
+{
+    return QStandardPaths::standardLocations(type);
+}
+
+QString mp::StandardPaths::writableLocation(StandardLocation type) const
+{
+    return QStandardPaths::writableLocation(type);
+}

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -23,13 +23,13 @@
 #include <multipass/logging/log.h>
 #include <multipass/settings.h>
 #include <multipass/ssh/ssh_session.h>
+#include <multipass/standard_paths.h>
 #include <multipass/utils.h>
 
 #include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
 #include <QProcess>
-#include <QStandardPaths>
 #include <QUuid>
 #include <QtGlobal>
 
@@ -59,12 +59,13 @@ auto quote_for(const std::string& arg, mp::utils::QuoteType quote_type)
 QString find_autostart_target(const QString& subdir, const QString& autostart_filename)
 {
     const auto target_subpath = QDir{subdir}.filePath(autostart_filename);
-    const auto target_path = QStandardPaths::locate(QStandardPaths::GenericDataLocation, target_subpath);
+    const auto target_path =
+        mp::StandardPaths::instance().locate(mp::StandardPaths::GenericDataLocation, target_subpath);
 
     if (target_path.isEmpty())
     {
         QString detail{};
-        for (const auto& path : QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation))
+        for (const auto& path : mp::StandardPaths::instance().standardLocations(mp::StandardPaths::GenericDataLocation))
             detail += QStringLiteral("\n  ") + path + "/" + target_subpath;
 
         throw mp::AutostartSetupException{fmt::format("could not locate the autostart file '{}'", autostart_filename),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(multipass_tests
   test_petname.cpp
   test_private_pass_provider.cpp
   test_mock_settings.cpp
+  test_mock_standard_paths.cpp
   test_simple_streams_index.cpp
   test_simple_streams_manifest.cpp
   test_singleton.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(multipass_tests
   mischievous_url_downloader.cpp
   mock_process_factory.cpp
   mock_settings.cpp
+  mock_standard_paths.cpp
   mock_sftp.cpp
   mock_sftpserver.cpp
   mock_ssh.cpp

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/mock_settings.cpp
+++ b/tests/mock_settings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/mock_settings.cpp
+++ b/tests/mock_settings.cpp
@@ -23,7 +23,7 @@ using namespace testing;
 
 void mpt::MockSettings::mockit()
 {
-    mpt::MockSingletonHelper<Settings, MockSettings>::mockit();
+    mpt::MockSingletonHelper<Settings, MockSettings, NiceMock>::mockit();
 }
 
 auto mpt::MockSettings::mock_instance() -> MockSettings&

--- a/tests/mock_settings.cpp
+++ b/tests/mock_settings.cpp
@@ -17,20 +17,21 @@
 
 #include "mock_settings.h"
 
+namespace mpt = multipass::test;
+
 using namespace testing;
 
-void multipass::test::MockSettings::mockit()
+void mpt::MockSettings::mockit()
 {
-    AddGlobalTestEnvironment(
-        new multipass::test::MockSingletonHelper<Settings, MockSettings>{}); // takes pointer ownership o_O
+    AddGlobalTestEnvironment(new mpt::MockSingletonHelper<Settings, MockSettings>{}); // takes pointer ownership o_O
 }
 
-auto multipass::test::MockSettings::mock_instance() -> MockSettings&
+auto mpt::MockSettings::mock_instance() -> MockSettings&
 {
     return dynamic_cast<MockSettings&>(instance());
 }
 
-void multipass::test::MockSettings::setup_mock_defaults()
+void mpt::MockSettings::setup_mock_defaults()
 {
     ON_CALL(*this, get(_)).WillByDefault(Invoke(this, &MockSettings::get_default));
     ON_CALL(*this, set(_, _)).WillByDefault(Invoke([this](const auto& a, const auto& /*ignored*/) {

--- a/tests/mock_settings.cpp
+++ b/tests/mock_settings.cpp
@@ -33,8 +33,6 @@ auto mpt::MockSettings::mock_instance() -> MockSettings&
 
 void mpt::MockSettings::setup_mock_defaults()
 {
-    ON_CALL(*this, get(_)).WillByDefault(Invoke(this, &MockSettings::get_default));
-    ON_CALL(*this, set(_, _)).WillByDefault(Invoke([this](const auto& a, const auto& /*ignored*/) {
-        get_default(a);
-    })); // using lambda instead of gmock actions because old VC++ chokes on `WithArg`
+    ON_CALL(*this, get(_)).WillByDefault([this](const auto& a) { return get_default(a); });
+    ON_CALL(*this, set(_, _)).WillByDefault([this](const auto& a, const auto& /*ignored*/) { get_default(a); });
 }

--- a/tests/mock_settings.cpp
+++ b/tests/mock_settings.cpp
@@ -23,7 +23,7 @@ using namespace testing;
 
 void mpt::MockSettings::mockit()
 {
-    AddGlobalTestEnvironment(new mpt::MockSingletonHelper<Settings, MockSettings>{}); // takes pointer ownership o_O
+    mpt::MockSingletonHelper<Settings, MockSettings>::mockit();
 }
 
 auto mpt::MockSettings::mock_instance() -> MockSettings&

--- a/tests/mock_settings.cpp
+++ b/tests/mock_settings.cpp
@@ -23,7 +23,7 @@ using namespace testing;
 
 void mpt::MockSettings::mockit()
 {
-    mpt::MockSingletonHelper<Settings, MockSettings, NiceMock>::mockit();
+    mpt::MockSingletonHelper<MockSettings, NiceMock>::mockit();
 }
 
 auto mpt::MockSettings::mock_instance() -> MockSettings&

--- a/tests/mock_settings.h
+++ b/tests/mock_settings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/mock_settings.h
+++ b/tests/mock_settings.h
@@ -18,6 +18,8 @@
 #ifndef MULTIPASS_MOCK_SETTINGS_H
 #define MULTIPASS_MOCK_SETTINGS_H
 
+#include "mock_singleton_helper.h"
+
 #include <multipass/settings.h>
 
 #include <gmock/gmock.h>
@@ -39,24 +41,9 @@ public:
     MOCK_METHOD2(set, void(const QString&, const QString&));
 
 private:
-    class Accountant : public ::testing::EmptyTestEventListener
-    {
-    public:
-        void OnTestEnd(const ::testing::TestInfo&) override;
-    };
+    void setup_mock_defaults();
 
-    class TestEnv : public ::testing::Environment
-    {
-    public:
-        void SetUp() override;
-        void TearDown() override;
-
-    private:
-        void register_accountant();
-        void release_accountant();
-
-        Accountant* accountant = nullptr; // non-owning ptr
-    };
+    friend class MockSingletonHelper<Settings, MockSettings>;
 };
 } // namespace test
 } // namespace multipass

--- a/tests/mock_settings.h
+++ b/tests/mock_settings.h
@@ -43,7 +43,7 @@ public:
 private:
     void setup_mock_defaults();
 
-    friend class MockSingletonHelper<Settings, MockSettings, ::testing::NiceMock>;
+    friend class MockSingletonHelper<MockSettings, ::testing::NiceMock>;
 };
 } // namespace test
 } // namespace multipass

--- a/tests/mock_settings.h
+++ b/tests/mock_settings.h
@@ -43,7 +43,7 @@ public:
 private:
     void setup_mock_defaults();
 
-    friend class MockSingletonHelper<Settings, MockSettings>;
+    friend class MockSingletonHelper<Settings, MockSettings, ::testing::NiceMock>;
 };
 } // namespace test
 } // namespace multipass

--- a/tests/mock_singleton_helper.h
+++ b/tests/mock_singleton_helper.h
@@ -59,7 +59,7 @@ void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockC
 template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::SetUp()
 {
-    ConcreteSingleton::template mock<MockCharacter<ConcreteMock>>(); // Register mock as the singleton instance
+    ConcreteMock::template mock<MockCharacter<ConcreteMock>>(); // Register mock as the singleton instance
 
     auto& mock = ConcreteMock::mock_instance();
     mock.setup_mock_defaults(); // setup any custom actions for calls on the mock
@@ -71,12 +71,10 @@ template <typename ConcreteSingleton, typename ConcreteMock, template <typename 
 void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::TearDown()
 {
     release_accountant();       // release this mock's test observer
-    ConcreteSingleton::reset(); /*
-    We need to make sure this runs before gtest unwinds because this is a mock and otherwise
-      a) the mock would leak,
-      b) expectations would not be checked,
-      c) it would refer to stuff that was deleted by then.
-    */
+    ConcreteMock::reset();      /* Make sure this runs before gtest unwinds, so that:
+                                   - the mock doesn't leak
+                                   - expectations are checked
+                                   - it doesn't refer to stuff that was already deleted */
 }
 
 template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>

--- a/tests/mock_singleton_helper.h
+++ b/tests/mock_singleton_helper.h
@@ -25,8 +25,7 @@
 namespace multipass::test
 {
 
-template <typename ConcreteSingleton, typename ConcreteMock,
-          template <typename MockClass> typename MockCharacter = ::testing::NaggyMock>
+template <typename ConcreteMock, template <typename MockClass> typename MockCharacter = ::testing::NaggyMock>
 class MockSingletonHelper : public ::testing::Environment
 {
 public:
@@ -49,15 +48,15 @@ private:
 };
 } // namespace multipass::test
 
-template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::mockit()
+template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::mockit()
 {
     ::testing::AddGlobalTestEnvironment(
-        new MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>{}); // takes pointer ownership o_O
+        new MockSingletonHelper<ConcreteMock, MockCharacter>{}); // takes pointer ownership o_O
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::SetUp()
+template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::SetUp()
 {
     ConcreteMock::template mock<MockCharacter<ConcreteMock>>(); // Register mock as the singleton instance
 
@@ -67,8 +66,8 @@ void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockC
     register_accountant(); // register a test observer to verify and clear mock expectations
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::TearDown()
+template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::TearDown()
 {
     release_accountant();       // release this mock's test observer
     ConcreteMock::reset();      /* Make sure this runs before gtest unwinds, so that:
@@ -77,15 +76,15 @@ void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockC
                                    - it doesn't refer to stuff that was already deleted */
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::register_accountant()
+template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::register_accountant()
 {
     accountant = new Accountant{};
     ::testing::UnitTest::GetInstance()->listeners().Append(accountant); // takes ownership
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::release_accountant()
+template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::release_accountant()
 {
     [[maybe_unused]] auto* listener =
         ::testing::UnitTest::GetInstance()->listeners().Release(accountant); // releases ownership
@@ -95,8 +94,8 @@ void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockC
     accountant = nullptr;
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::Accountant::OnTestEnd(
+template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::Accountant::OnTestEnd(
     const ::testing::TestInfo& /*unused*/)
 {
     ::testing::Mock::VerifyAndClearExpectations(&ConcreteMock::mock_instance());

--- a/tests/mock_singleton_helper.h
+++ b/tests/mock_singleton_helper.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_SINGLETON_HELPER_H
+#define MULTIPASS_MOCK_SINGLETON_HELPER_H
+
+#include <gmock/gmock.h>
+
+#include <cassert>
+
+namespace multipass::test
+{
+
+template <typename ConcreteSingleton, typename ConcreteMock>
+class MockSingletonHelper : public ::testing::Environment
+{
+public:
+    void SetUp() override;
+
+    void TearDown() override;
+
+private:
+    class Accountant : public ::testing::EmptyTestEventListener
+    {
+    public:
+        void OnTestEnd(const ::testing::TestInfo&) override;
+    };
+
+    void register_accountant();
+    void release_accountant();
+
+    Accountant* accountant = nullptr; // non-owning ptr
+};
+} // namespace multipass::test
+
+template <typename ConcreteSingleton, typename ConcreteMock>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::SetUp()
+{
+    ConcreteSingleton::template mock<testing::NiceMock<ConcreteMock>>(); // Register mock as the singleton instance
+
+    auto& mock = ConcreteMock::mock_instance();
+    mock.setup_mock_defaults(); // setup any custom actions for calls on the mock
+
+    register_accountant(); // register a test observer to verify and clear mock expectations
+}
+
+template <typename ConcreteSingleton, typename ConcreteMock>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::TearDown()
+{
+    release_accountant();       // release this mock's test observer
+    ConcreteSingleton::reset(); /*
+    We need to make sure this runs before gtest unwinds because this is a mock and otherwise
+      a) the mock would leak,
+      b) expectations would not be checked,
+      c) it would refer to stuff that was deleted by then.
+    */
+}
+
+template <typename ConcreteSingleton, typename ConcreteMock>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::register_accountant()
+{
+    accountant = new Accountant{};
+    testing::UnitTest::GetInstance()->listeners().Append(accountant); // takes ownership
+}
+
+template <typename ConcreteSingleton, typename ConcreteMock>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::release_accountant()
+{
+    [[maybe_unused]] auto* listener =
+        testing::UnitTest::GetInstance()->listeners().Release(accountant); // releases ownership
+    assert(listener == accountant);
+
+    delete accountant; // no prob if already null
+    accountant = nullptr;
+}
+
+template <typename ConcreteSingleton, typename ConcreteMock>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::Accountant::OnTestEnd(
+    const testing::TestInfo& /*unused*/)
+{
+    testing::Mock::VerifyAndClearExpectations(&ConcreteMock::mock_instance());
+}
+
+#endif // MULTIPASS_MOCK_SINGLETON_HELPER_H

--- a/tests/mock_singleton_helper.h
+++ b/tests/mock_singleton_helper.h
@@ -26,7 +26,7 @@ namespace multipass::test
 {
 
 template <typename ConcreteSingleton, typename ConcreteMock,
-          template <typename MockClass> typename MockCharacter = testing::NaggyMock>
+          template <typename MockClass> typename MockCharacter = ::testing::NaggyMock>
 class MockSingletonHelper : public ::testing::Environment
 {
 public:
@@ -52,7 +52,7 @@ private:
 template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::mockit()
 {
-    testing::AddGlobalTestEnvironment(
+    ::testing::AddGlobalTestEnvironment(
         new MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>{}); // takes pointer ownership o_O
 }
 
@@ -83,14 +83,14 @@ template <typename ConcreteSingleton, typename ConcreteMock, template <typename 
 void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::register_accountant()
 {
     accountant = new Accountant{};
-    testing::UnitTest::GetInstance()->listeners().Append(accountant); // takes ownership
+    ::testing::UnitTest::GetInstance()->listeners().Append(accountant); // takes ownership
 }
 
 template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::release_accountant()
 {
     [[maybe_unused]] auto* listener =
-        testing::UnitTest::GetInstance()->listeners().Release(accountant); // releases ownership
+        ::testing::UnitTest::GetInstance()->listeners().Release(accountant); // releases ownership
     assert(listener == accountant);
 
     delete accountant; // no prob if already null
@@ -99,9 +99,9 @@ void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockC
 
 template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::Accountant::OnTestEnd(
-    const testing::TestInfo& /*unused*/)
+    const ::testing::TestInfo& /*unused*/)
 {
-    testing::Mock::VerifyAndClearExpectations(&ConcreteMock::mock_instance());
+    ::testing::Mock::VerifyAndClearExpectations(&ConcreteMock::mock_instance());
 }
 
 #endif // MULTIPASS_MOCK_SINGLETON_HELPER_H

--- a/tests/mock_singleton_helper.h
+++ b/tests/mock_singleton_helper.h
@@ -25,7 +25,8 @@
 namespace multipass::test
 {
 
-template <typename ConcreteSingleton, typename ConcreteMock>
+template <typename ConcreteSingleton, typename ConcreteMock,
+          template <typename MockClass> typename MockCharacter = testing::NaggyMock>
 class MockSingletonHelper : public ::testing::Environment
 {
 public:
@@ -48,17 +49,17 @@ private:
 };
 } // namespace multipass::test
 
-template <typename ConcreteSingleton, typename ConcreteMock>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::mockit()
+template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::mockit()
 {
     testing::AddGlobalTestEnvironment(
-        new MockSingletonHelper<ConcreteSingleton, ConcreteMock>{}); // takes pointer ownership o_O
+        new MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>{}); // takes pointer ownership o_O
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::SetUp()
+template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::SetUp()
 {
-    ConcreteSingleton::template mock<testing::NiceMock<ConcreteMock>>(); // Register mock as the singleton instance
+    ConcreteSingleton::template mock<MockCharacter<ConcreteMock>>(); // Register mock as the singleton instance
 
     auto& mock = ConcreteMock::mock_instance();
     mock.setup_mock_defaults(); // setup any custom actions for calls on the mock
@@ -66,8 +67,8 @@ void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::SetU
     register_accountant(); // register a test observer to verify and clear mock expectations
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::TearDown()
+template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::TearDown()
 {
     release_accountant();       // release this mock's test observer
     ConcreteSingleton::reset(); /*
@@ -78,15 +79,15 @@ void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::Tear
     */
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::register_accountant()
+template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::register_accountant()
 {
     accountant = new Accountant{};
     testing::UnitTest::GetInstance()->listeners().Append(accountant); // takes ownership
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::release_accountant()
+template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::release_accountant()
 {
     [[maybe_unused]] auto* listener =
         testing::UnitTest::GetInstance()->listeners().Release(accountant); // releases ownership
@@ -96,8 +97,8 @@ void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::rele
     accountant = nullptr;
 }
 
-template <typename ConcreteSingleton, typename ConcreteMock>
-void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::Accountant::OnTestEnd(
+template <typename ConcreteSingleton, typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock, MockCharacter>::Accountant::OnTestEnd(
     const testing::TestInfo& /*unused*/)
 {
     testing::Mock::VerifyAndClearExpectations(&ConcreteMock::mock_instance());

--- a/tests/mock_singleton_helper.h
+++ b/tests/mock_singleton_helper.h
@@ -29,8 +29,9 @@ template <typename ConcreteSingleton, typename ConcreteMock>
 class MockSingletonHelper : public ::testing::Environment
 {
 public:
-    void SetUp() override;
+    static void mockit();
 
+    void SetUp() override;
     void TearDown() override;
 
 private:
@@ -46,6 +47,13 @@ private:
     Accountant* accountant = nullptr; // non-owning ptr
 };
 } // namespace multipass::test
+
+template <typename ConcreteSingleton, typename ConcreteMock>
+void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::mockit()
+{
+    testing::AddGlobalTestEnvironment(
+        new MockSingletonHelper<ConcreteSingleton, ConcreteMock>{}); // takes pointer ownership o_O
+}
 
 template <typename ConcreteSingleton, typename ConcreteMock>
 void multipass::test::MockSingletonHelper<ConcreteSingleton, ConcreteMock>::SetUp()

--- a/tests/mock_standard_paths.cpp
+++ b/tests/mock_standard_paths.cpp
@@ -23,7 +23,7 @@ using namespace testing;
 
 void mpt::MockStandardPaths::mockit()
 {
-    mpt::MockSingletonHelper<StandardPaths, MockStandardPaths>::mockit();
+    mpt::MockSingletonHelper<StandardPaths, MockStandardPaths, NiceMock>::mockit();
 }
 
 auto mpt::MockStandardPaths::mock_instance() -> MockStandardPaths&

--- a/tests/mock_standard_paths.cpp
+++ b/tests/mock_standard_paths.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,25 +15,18 @@
  *
  */
 
-#include "mock_settings.h"
 #include "mock_standard_paths.h"
 
-#include <gtest/gtest.h>
+namespace mpt = multipass::test;
 
-#include <QCoreApplication>
+using namespace testing;
 
-namespace mp = multipass;
-
-// Normally one would just use libgtest_main but our static library dependencies
-// also define main... DAMN THEM!
-int main(int argc, char* argv[])
+void mpt::MockStandardPaths::mockit()
 {
-    QCoreApplication app(argc, argv);
-    QCoreApplication::setApplicationName("multipass_tests");
+    // TODO@ricab
+}
 
-    ::testing::InitGoogleTest(&argc, argv);
-    mp::test::MockStandardPaths::mockit();
-    mp::test::MockSettings::mockit();
-
-    return RUN_ALL_TESTS();
+auto mpt::MockStandardPaths::mock_instance() -> MockStandardPaths&
+{
+    return dynamic_cast<MockStandardPaths&>(instance());
 }

--- a/tests/mock_standard_paths.cpp
+++ b/tests/mock_standard_paths.cpp
@@ -23,8 +23,7 @@ using namespace testing;
 
 void mpt::MockStandardPaths::mockit()
 {
-    AddGlobalTestEnvironment(
-        new mpt::MockSingletonHelper<StandardPaths, MockStandardPaths>{}); // takes pointer ownership o_O
+    mpt::MockSingletonHelper<StandardPaths, MockStandardPaths>::mockit();
 }
 
 auto mpt::MockStandardPaths::mock_instance() -> MockStandardPaths&

--- a/tests/mock_standard_paths.cpp
+++ b/tests/mock_standard_paths.cpp
@@ -23,7 +23,7 @@ using namespace testing;
 
 void mpt::MockStandardPaths::mockit()
 {
-    mpt::MockSingletonHelper<StandardPaths, MockStandardPaths, NiceMock>::mockit();
+    mpt::MockSingletonHelper<MockStandardPaths, NiceMock>::mockit();
 }
 
 auto mpt::MockStandardPaths::mock_instance() -> MockStandardPaths&

--- a/tests/mock_standard_paths.cpp
+++ b/tests/mock_standard_paths.cpp
@@ -23,10 +23,16 @@ using namespace testing;
 
 void mpt::MockStandardPaths::mockit()
 {
-    // TODO@ricab
+    AddGlobalTestEnvironment(
+        new mpt::MockSingletonHelper<StandardPaths, MockStandardPaths>{}); // takes pointer ownership o_O
 }
 
 auto mpt::MockStandardPaths::mock_instance() -> MockStandardPaths&
 {
     return dynamic_cast<MockStandardPaths&>(instance());
+}
+
+void mpt::MockStandardPaths::setup_mock_defaults()
+{
+    // TODO@ricab
 }

--- a/tests/mock_standard_paths.cpp
+++ b/tests/mock_standard_paths.cpp
@@ -33,5 +33,11 @@ auto mpt::MockStandardPaths::mock_instance() -> MockStandardPaths&
 
 void mpt::MockStandardPaths::setup_mock_defaults()
 {
-    // TODO@ricab
+    // see https://github.com/google/googletest/issues/2794
+    ON_CALL(*this, standardLocations(_)).WillByDefault([this](const auto& loc) {
+        return StandardPaths::standardLocations(loc); // call the parent (this implicit)
+    });
+    ON_CALL(*this, writableLocation(_)).WillByDefault([this](const auto& loc) {
+        return StandardPaths::writableLocation(loc); // call the parent (this implicit)
+    });
 }

--- a/tests/mock_standard_paths.cpp
+++ b/tests/mock_standard_paths.cpp
@@ -34,6 +34,9 @@ auto mpt::MockStandardPaths::mock_instance() -> MockStandardPaths&
 void mpt::MockStandardPaths::setup_mock_defaults()
 {
     // see https://github.com/google/googletest/issues/2794
+    ON_CALL(*this, locate(_, _, _)).WillByDefault([this](const auto& a, const auto& b, const auto& c) {
+        return StandardPaths::locate(a, b, c); // call the parent (this implicit)
+    });
     ON_CALL(*this, standardLocations(_)).WillByDefault([this](const auto& loc) {
         return StandardPaths::standardLocations(loc); // call the parent (this implicit)
     });

--- a/tests/mock_standard_paths.h
+++ b/tests/mock_standard_paths.h
@@ -42,7 +42,7 @@ public:
 private:
     void setup_mock_defaults();
 
-    friend class MockSingletonHelper<StandardPaths, MockStandardPaths, ::testing::NiceMock>;
+    friend class MockSingletonHelper<MockStandardPaths, ::testing::NiceMock>;
 };
 } // namespace multipass::test
 

--- a/tests/mock_standard_paths.h
+++ b/tests/mock_standard_paths.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,25 +15,24 @@
  *
  */
 
-#include "mock_settings.h"
-#include "mock_standard_paths.h"
+#ifndef MULTIPASS_MOCK_STANDARD_PATHS_H
+#define MULTIPASS_MOCK_STANDARD_PATHS_H
 
-#include <gtest/gtest.h>
+#include <multipass/standard_paths.h>
 
-#include <QCoreApplication>
+#include <gmock/gmock.h>
 
-namespace mp = multipass;
-
-// Normally one would just use libgtest_main but our static library dependencies
-// also define main... DAMN THEM!
-int main(int argc, char* argv[])
+namespace multipass::test
 {
-    QCoreApplication app(argc, argv);
-    QCoreApplication::setApplicationName("multipass_tests");
+// This will automatically verify expectations set upon it at the end of each test
+class MockStandardPaths : public StandardPaths
+{
+public:
+    using StandardPaths::StandardPaths;
 
-    ::testing::InitGoogleTest(&argc, argv);
-    mp::test::MockStandardPaths::mockit();
-    mp::test::MockSettings::mockit();
+    static void mockit();
+    static MockStandardPaths& mock_instance();
+};
+} // namespace multipass::test
 
-    return RUN_ALL_TESTS();
-}
+#endif // MULTIPASS_MOCK_STANDARD_PATHS_H

--- a/tests/mock_standard_paths.h
+++ b/tests/mock_standard_paths.h
@@ -42,7 +42,7 @@ public:
 private:
     void setup_mock_defaults();
 
-    friend class MockSingletonHelper<StandardPaths, MockStandardPaths>;
+    friend class MockSingletonHelper<StandardPaths, MockStandardPaths, ::testing::NiceMock>;
 };
 } // namespace multipass::test
 

--- a/tests/mock_standard_paths.h
+++ b/tests/mock_standard_paths.h
@@ -18,6 +18,8 @@
 #ifndef MULTIPASS_MOCK_STANDARD_PATHS_H
 #define MULTIPASS_MOCK_STANDARD_PATHS_H
 
+#include "mock_singleton_helper.h"
+
 #include <multipass/standard_paths.h>
 
 #include <gmock/gmock.h>
@@ -32,6 +34,11 @@ public:
 
     static void mockit();
     static MockStandardPaths& mock_instance();
+
+private:
+    void setup_mock_defaults();
+
+    friend class MockSingletonHelper<StandardPaths, MockStandardPaths>;
 };
 } // namespace multipass::test
 

--- a/tests/mock_standard_paths.h
+++ b/tests/mock_standard_paths.h
@@ -35,6 +35,10 @@ public:
     static void mockit();
     static MockStandardPaths& mock_instance();
 
+    MOCK_CONST_METHOD3(locate, QString(StandardLocation, const QString&, LocateOptions));
+    MOCK_CONST_METHOD1(standardLocations, QStringList(StandardLocation type));
+    MOCK_CONST_METHOD1(writableLocation, QString(StandardLocation type));
+
 private:
     void setup_mock_defaults();
 

--- a/tests/test_mock_settings.cpp
+++ b/tests/test_mock_settings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/test_mock_settings.cpp
+++ b/tests/test_mock_settings.cpp
@@ -31,7 +31,12 @@ using namespace testing;
 namespace
 {
 
-TEST(Settings, can_be_mocked)
+TEST(Settings, provides_get_default_as_get_by_default)
+{
+    // TODO@ricab
+}
+
+TEST(Settings, can_have_get_mocked)
 {
     const auto test = QStringLiteral("abc"), proof = QStringLiteral("xyz");
     const auto& mock = mpt::MockSettings::mock_instance();

--- a/tests/test_mock_settings.cpp
+++ b/tests/test_mock_settings.cpp
@@ -17,6 +17,7 @@
 
 #include "mock_settings.h"
 
+#include <multipass/constants.h>
 #include <multipass/settings.h>
 
 #include <QString>
@@ -33,7 +34,8 @@ namespace
 
 TEST(Settings, provides_get_default_as_get_by_default)
 {
-    // TODO@ricab
+    const auto& key = mp::driver_key;
+    ASSERT_EQ(mp::Settings::instance().get(key), mpt::MockSettings::mock_instance().get_default(key));
 }
 
 TEST(Settings, can_have_get_mocked)

--- a/tests/test_mock_settings.cpp
+++ b/tests/test_mock_settings.cpp
@@ -41,7 +41,7 @@ TEST(Settings, can_have_get_mocked)
     const auto test = QStringLiteral("abc"), proof = QStringLiteral("xyz");
     const auto& mock = mpt::MockSettings::mock_instance();
 
-    EXPECT_CALL(mock, get(_)).WillOnce(Return(proof));
+    EXPECT_CALL(mock, get(test)).WillOnce(Return(proof));
     ASSERT_EQ(mp::Settings::instance().get(test), proof);
 }
 

--- a/tests/test_mock_settings.cpp
+++ b/tests/test_mock_settings.cpp
@@ -39,7 +39,7 @@ TEST(Settings, provides_get_default_as_get_by_default)
 TEST(Settings, can_have_get_mocked)
 {
     const auto test = QStringLiteral("abc"), proof = QStringLiteral("xyz");
-    const auto& mock = mpt::MockSettings::mock_instance();
+    auto& mock = mpt::MockSettings::mock_instance();
 
     EXPECT_CALL(mock, get(test)).WillOnce(Return(proof));
     ASSERT_EQ(mp::Settings::instance().get(test), proof);

--- a/tests/test_mock_standard_paths.cpp
+++ b/tests/test_mock_standard_paths.cpp
@@ -34,11 +34,18 @@ namespace
 
 TEST(StandardPaths, provides_regular_locate_by_default)
 {
-    const auto location_type = mp::StandardPaths::HomeLocation;
+    const auto location_type = mp::StandardPaths::TempLocation;
+    const auto find = QStringLiteral("o_o");
     const auto locate_options = mp::StandardPaths::LocateOptions{mp::StandardPaths::LocateDirectory};
-    const auto find = QStringLiteral("Desktop");
-    const auto proof = QStandardPaths::locate(location_type, find, locate_options);
 
+    // Create a subdir in the standard temp dir, for locate to find
+    QDir aux{QStandardPaths::writableLocation(location_type)};
+    ASSERT_TRUE(aux.exists());
+    aux.mkdir(find);
+    ASSERT_TRUE(aux.exists(find));
+
+    // Confirm the subdir is properly located
+    const auto proof = QStandardPaths::locate(location_type, find, locate_options);
     ASSERT_TRUE(proof.endsWith(find));
     ASSERT_EQ(mp::StandardPaths::instance().locate(location_type, find, locate_options), proof);
 }

--- a/tests/test_mock_standard_paths.cpp
+++ b/tests/test_mock_standard_paths.cpp
@@ -20,6 +20,7 @@
 #include <multipass/standard_paths.h>
 
 #include <QStandardPaths>
+#include <QTemporaryDir>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -33,7 +34,13 @@ namespace
 
 TEST(StandardPaths, provides_regular_locate_by_default)
 {
-    // TODO@ricab
+    const auto location_type = mp::StandardPaths::HomeLocation;
+    const auto locate_options = mp::StandardPaths::LocateOptions{mp::StandardPaths::LocateDirectory};
+    const auto find = QStringLiteral("Desktop");
+    const auto proof = QStandardPaths::locate(location_type, find, locate_options);
+
+    ASSERT_TRUE(proof.endsWith(find));
+    ASSERT_EQ(mp::StandardPaths::instance().locate(location_type, find, locate_options), proof);
 }
 
 TEST(StandardPaths, can_have_locate_mocked)

--- a/tests/test_mock_standard_paths.cpp
+++ b/tests/test_mock_standard_paths.cpp
@@ -36,11 +36,11 @@ TEST(StandardPaths, provides_regular_locate_by_default)
 
 TEST(StandardPaths, can_have_locate_mocked)
 {
-    const auto& mock = mpt::MockStandardPaths::mock_instance();
     const auto location_type = mp::StandardPaths::HomeLocation;
     const auto locate_options = mp::StandardPaths::LocateOptions{mp::StandardPaths::LocateFile};
     const auto find = QStringLiteral("abc");
     const auto proof = QStringLiteral("xyz");
+    auto& mock = mpt::MockStandardPaths::mock_instance();
 
     EXPECT_CALL(mock, locate(location_type, find, locate_options)).WillOnce(Return(proof));
     ASSERT_EQ(mp::StandardPaths::instance().locate(location_type, find, locate_options), proof);
@@ -53,9 +53,9 @@ TEST(StandardPaths, provides_regular_standard_locations_by_default)
 
 TEST(StandardPaths, can_have_standard_locations_mocked)
 {
-    const auto& mock = mpt::MockStandardPaths::mock_instance();
     const auto test = mp::StandardPaths::AppConfigLocation;
     const auto proof = QStringList{QStringLiteral("abc"), QStringLiteral("xyz")};
+    auto& mock = mpt::MockStandardPaths::mock_instance();
 
     EXPECT_CALL(mock, standardLocations(test)).WillOnce(Return(proof));
     ASSERT_EQ(mp::StandardPaths::instance().standardLocations(test), proof);
@@ -68,9 +68,9 @@ TEST(StandardPaths, provides_regular_writable_location_by_default)
 
 TEST(StandardPaths, can_have_writable_location_mocked)
 {
-    const auto& mock = mpt::MockStandardPaths::mock_instance();
     const auto test = mp::StandardPaths::ConfigLocation;
     const auto proof = QStringLiteral("xyz");
+    auto& mock = mpt::MockStandardPaths::mock_instance();
 
     EXPECT_CALL(mock, writableLocation(test)).WillOnce(Return(proof));
     ASSERT_EQ(mp::StandardPaths::instance().writableLocation(test), proof);

--- a/tests/test_mock_standard_paths.cpp
+++ b/tests/test_mock_standard_paths.cpp
@@ -19,6 +19,8 @@
 
 #include <multipass/standard_paths.h>
 
+#include <QStandardPaths>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -48,7 +50,8 @@ TEST(StandardPaths, can_have_locate_mocked)
 
 TEST(StandardPaths, provides_regular_standard_locations_by_default)
 {
-    // TODO@ricab
+    const auto& test = mp::StandardPaths::MusicLocation;
+    ASSERT_EQ(mp::StandardPaths::instance().standardLocations(test), QStandardPaths::standardLocations(test));
 }
 
 TEST(StandardPaths, can_have_standard_locations_mocked)
@@ -63,7 +66,8 @@ TEST(StandardPaths, can_have_standard_locations_mocked)
 
 TEST(StandardPaths, provides_regular_writable_location_by_default)
 {
-    // TODO@ricab
+    const auto test = mp::StandardPaths::MoviesLocation;
+    ASSERT_EQ(mp::StandardPaths::instance().writableLocation(test), QStandardPaths::writableLocation(test));
 }
 
 TEST(StandardPaths, can_have_writable_location_mocked)

--- a/tests/test_mock_standard_paths.cpp
+++ b/tests/test_mock_standard_paths.cpp
@@ -29,12 +29,50 @@ using namespace testing;
 namespace
 {
 
-TEST(StandardPaths, can_be_mocked)
+TEST(StandardPaths, provides_regular_locate_by_default)
 {
-    [[maybe_unused]] // TODO@ricab remove
-    const auto& mock = mpt::MockStandardPaths::mock_instance();
-
-    // TODO@ricab actually test
+    // TODO@ricab
 }
 
+TEST(StandardPaths, can_have_locate_mocked)
+{
+    const auto& mock = mpt::MockStandardPaths::mock_instance();
+    const auto location_type = mp::StandardPaths::HomeLocation;
+    const auto locate_options = mp::StandardPaths::LocateOptions{mp::StandardPaths::LocateFile};
+    const auto find = QStringLiteral("abc");
+    const auto proof = QStringLiteral("xyz");
+
+    EXPECT_CALL(mock, locate(location_type, find, locate_options)).WillOnce(Return(proof));
+    ASSERT_EQ(mp::StandardPaths::instance().locate(location_type, find, locate_options), proof);
+}
+
+TEST(StandardPaths, provides_regular_standard_locations_by_default)
+{
+    // TODO@ricab
+}
+
+TEST(StandardPaths, can_have_standard_locations_mocked)
+{
+    const auto& mock = mpt::MockStandardPaths::mock_instance();
+    const auto test = mp::StandardPaths::AppConfigLocation;
+    const auto proof = QStringList{QStringLiteral("abc"), QStringLiteral("xyz")};
+
+    EXPECT_CALL(mock, standardLocations(test)).WillOnce(Return(proof));
+    ASSERT_EQ(mp::StandardPaths::instance().standardLocations(test), proof);
+}
+
+TEST(StandardPaths, provides_regular_writable_location_by_default)
+{
+    // TODO@ricab
+}
+
+TEST(StandardPaths, can_have_writable_location_mocked)
+{
+    const auto& mock = mpt::MockStandardPaths::mock_instance();
+    const auto test = mp::StandardPaths::ConfigLocation;
+    const auto proof = QStringLiteral("xyz");
+
+    EXPECT_CALL(mock, writableLocation(test)).WillOnce(Return(proof));
+    ASSERT_EQ(mp::StandardPaths::instance().writableLocation(test), proof);
+}
 } // namespace

--- a/tests/test_mock_standard_paths.cpp
+++ b/tests/test_mock_standard_paths.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mock_standard_paths.h"
+
+#include <multipass/standard_paths.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace mp = multipass;
+namespace mpt = mp::test;
+using namespace testing;
+
+namespace
+{
+
+TEST(StandardPaths, can_be_mocked)
+{
+    [[maybe_unused]] // TODO@ricab remove
+    const auto& mock = mpt::MockStandardPaths::mock_instance();
+
+    // TODO@ricab actually test
+}
+
+} // namespace


### PR DESCRIPTION
Adds a mockable `StandardPaths` singleton, as a thin wrapper around `QStandardPaths`. Implements the corresponding mock with the same approach as `MockSettings`, that is, via:
1. a test environment, to run custom code during test setup and tear down
2. a test event listener, to verify and clear mock expectations on the singleton at the end of each test
3. default operations delegating on the parent

To achieve that, this PR also extracts common stuff into a `MockSingletonHelper`.

This approach enforces accounting of mock expectations in the respective test. It also avoids singleton state leaking from test to test and affecting the results based on execution order. Finally, it ensures that tests only deal with the mock. They use only parent operations that are deemed safe for testing, indirectly, via the mock itself.