### PR TITLE
[qemu] pass --conf-file to dnsmasq (Fixes #1468)

### DIFF
--- a/src/platform/backends/qemu/dnsmasq_process_spec.cpp
+++ b/src/platform/backends/qemu/dnsmasq_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,7 +50,9 @@ QStringList mp::DNSMasqProcessSpec::arguments() const
                          << QString("--dhcp-hostsfile=%1/dnsmasq.hosts").arg(data_dir) << "--dhcp-range"
                          << QString("%1,%2,infinite")
                                 .arg(QString::fromStdString(start_ip.as_string()))
-                                .arg(QString::fromStdString(end_ip.as_string()));
+                                .arg(QString::fromStdString(end_ip.as_string()))
+                         // This is to prevent it trying to read /etc/dnsmasq.conf
+                         << QString("--conf-file=%1/dnsmasq.conf").arg(data_dir);
 }
 
 mp::logging::Level mp::DNSMasqProcessSpec::error_log_level() const
@@ -93,6 +95,7 @@ profile %1 flags=(attach_disconnected) {
   # CLASSIC ONLY: need to specify required libs from core snap
   /{,var/lib/snapd/}snap/core18/*/{,usr/}lib/@{multiarch}/{,**/}*.so* rm,
 
+  %5/dnsmasq.conf r,              # Config file
   %5/dnsmasq.leases rw,           # Leases file
   %5/dnsmasq.hosts r,             # Hosts file
 

--- a/tests/qemu/test_dnsmasq_process_spec.cpp
+++ b/tests/qemu/test_dnsmasq_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,12 +40,12 @@ TEST_F(TestDnsmasqProcessSpec, default_arguments_correct)
 {
     mpt::SetEnvScope e1("SNAP", "/something");
     mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet);
-    EXPECT_EQ(
-        spec.arguments(),
-        QStringList({"--strict-order", "--bind-interfaces", "--pid-file=/path/to/file.pid", "--domain=multipass",
-                     "--local=/multipass/", "--except-interface=lo", "--interface=bridgey", "--listen-address=1.2.3.1",
-                     "--dhcp-no-override", "--dhcp-authoritative", "--dhcp-leasefile=/data/dnsmasq.leases",
-                     "--dhcp-hostsfile=/data/dnsmasq.hosts", "--dhcp-range", "1.2.3.2,1.2.3.254,infinite"}));
+    EXPECT_EQ(spec.arguments(),
+              QStringList({"--strict-order", "--bind-interfaces", "--pid-file=/path/to/file.pid", "--domain=multipass",
+                           "--local=/multipass/", "--except-interface=lo", "--interface=bridgey",
+                           "--listen-address=1.2.3.1", "--dhcp-no-override", "--dhcp-authoritative",
+                           "--dhcp-leasefile=/data/dnsmasq.leases", "--dhcp-hostsfile=/data/dnsmasq.hosts",
+                           "--dhcp-range", "1.2.3.2,1.2.3.254,infinite", "--conf-file=/data/dnsmasq.conf"}));
 }
 
 TEST_F(TestDnsmasqProcessSpec, apparmor_profile_has_correct_name)


### PR DESCRIPTION
Otherwise it may try (and fail) to read /etc/dnsmasq.conf, when it exists, and die.