### PR TITLE
[qemu] pass --conf-file to dnsmasq (Fixes #1468)

### DIFF
--- a/src/platform/backends/qemu/dnsmasq_process_spec.h
+++ b/src/platform/backends/qemu/dnsmasq_process_spec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@ class DNSMasqProcessSpec : public ProcessSpec
 {
 public:
     explicit DNSMasqProcessSpec(const Path& data_dir, const QString& bridge_name, const QString& pid_file_path,
-                                const std::string& subnet);
+                                const std::string& subnet, const QString& conf_file_path);
 
     QString program() const override;
     QStringList arguments() const override;
@@ -45,6 +45,7 @@ private:
     const QString bridge_name;
     const QString pid_file_path;
     const std::string subnet;
+    const QString conf_file_path;
 };
 
 } // namespace multipass

--- a/src/platform/backends/qemu/dnsmasq_server.h
+++ b/src/platform/backends/qemu/dnsmasq_server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Canonical, Ltd.
+ * Copyright (C) 2018-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,8 @@
 #include <multipass/ip_address.h>
 #include <multipass/optional.h>
 #include <multipass/path.h>
+
+#include <QTemporaryFile>
 
 #include <memory>
 #include <string>
@@ -48,6 +50,7 @@ private:
     const QString pid_file_path;
     const std::string subnet;
     std::unique_ptr<Process> dnsmasq_cmd;
+    QTemporaryFile conf_file;
 };
 } // namespace multipass
 #endif // MULTIPASS_DNSMASQ_SERVER_H

--- a/tests/qemu/test_dnsmasq_process_spec.cpp
+++ b/tests/qemu/test_dnsmasq_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,39 +34,41 @@ struct TestDnsmasqProcessSpec : public Test
     const QString bridge_name{"bridgey"};
     const QString pid_file_path{"/path/to/file.pid"};
     const std::string subnet{"1.2.3"};
+    const QString conf_file_path{"/path/to/file.conf"};
 };
 
 TEST_F(TestDnsmasqProcessSpec, default_arguments_correct)
 {
     mpt::SetEnvScope e1("SNAP", "/something");
-    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet);
-    EXPECT_EQ(
-        spec.arguments(),
-        QStringList({"--strict-order", "--bind-interfaces", "--pid-file=/path/to/file.pid", "--domain=multipass",
-                     "--local=/multipass/", "--except-interface=lo", "--interface=bridgey", "--listen-address=1.2.3.1",
-                     "--dhcp-no-override", "--dhcp-authoritative", "--dhcp-leasefile=/data/dnsmasq.leases",
-                     "--dhcp-hostsfile=/data/dnsmasq.hosts", "--dhcp-range", "1.2.3.2,1.2.3.254,infinite"}));
+    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet, conf_file_path);
+    EXPECT_EQ(spec.arguments(),
+              QStringList({"--strict-order", "--bind-interfaces", "--pid-file=/path/to/file.pid", "--domain=multipass",
+                           "--local=/multipass/", "--except-interface=lo", "--interface=bridgey",
+                           "--listen-address=1.2.3.1", "--dhcp-no-override", "--dhcp-authoritative",
+                           "--dhcp-leasefile=/data/dnsmasq.leases", "--dhcp-hostsfile=/data/dnsmasq.hosts",
+                           "--dhcp-range", "1.2.3.2,1.2.3.254,infinite", "--conf-file=/path/to/file.conf"}));
 }
 
 TEST_F(TestDnsmasqProcessSpec, apparmor_profile_has_correct_name)
 {
-    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet);
+    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet, conf_file_path);
 
     EXPECT_TRUE(spec.apparmor_profile().contains("profile multipass.dnsmasq"));
 }
 
 TEST_F(TestDnsmasqProcessSpec, apparmor_profile_permits_data_dirs)
 {
-    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet);
+    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet, conf_file_path);
 
     EXPECT_TRUE(spec.apparmor_profile().contains("/data/dnsmasq.leases rw,"));
     EXPECT_TRUE(spec.apparmor_profile().contains("/data/dnsmasq.hosts r,"));
     EXPECT_TRUE(spec.apparmor_profile().contains("/path/to/file.pid w,"));
+    EXPECT_TRUE(spec.apparmor_profile().contains("/path/to/file.conf r,"));
 }
 
 TEST_F(TestDnsmasqProcessSpec, apparmor_profile_identifier)
 {
-    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet);
+    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet, conf_file_path);
 
     EXPECT_EQ(spec.identifier(), "");
 }
@@ -76,7 +78,7 @@ TEST_F(TestDnsmasqProcessSpec, apparmor_profile_running_as_snap_correct)
     QTemporaryDir snap_dir;
 
     mpt::SetEnvScope e1("SNAP", snap_dir.path().toUtf8());
-    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet);
+    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet, conf_file_path);
 
     EXPECT_TRUE(spec.apparmor_profile().contains("signal (receive) peer=snap.multipass.multipassd"));
     EXPECT_TRUE(spec.apparmor_profile().contains(QString("%1/usr/sbin/dnsmasq ixr,").arg(snap_dir.path())));
@@ -89,7 +91,7 @@ TEST_F(TestDnsmasqProcessSpec, apparmor_profile_running_as_symlinked_snap_correc
     QFile::link(snap_dir.path(), link_dir.path());
 
     mpt::SetEnvScope e1("SNAP", link_dir.path().toUtf8());
-    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet);
+    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet, conf_file_path);
 
     EXPECT_TRUE(spec.apparmor_profile().contains(QString("%1/usr/sbin/dnsmasq ixr,").arg(snap_dir.path())));
 }
@@ -97,7 +99,7 @@ TEST_F(TestDnsmasqProcessSpec, apparmor_profile_running_as_symlinked_snap_correc
 TEST_F(TestDnsmasqProcessSpec, apparmor_profile_not_running_as_snap_correct)
 {
     mpt::UnsetEnvScope e("SNAP");
-    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet);
+    mp::DNSMasqProcessSpec spec(data_dir, bridge_name, pid_file_path, subnet, conf_file_path);
 
     EXPECT_TRUE(spec.apparmor_profile().contains("signal (receive) peer=unconfined"));
     EXPECT_TRUE(spec.apparmor_profile().contains(" /usr/sbin/dnsmasq ixr,")); // space wanted

--- a/tests/qemu/test_dnsmasq_server.cpp
+++ b/tests/qemu/test_dnsmasq_server.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Canonical, Ltd.
+ * Copyright (C) 2018-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -153,4 +153,11 @@ TEST_F(DNSMasqServer, dnsmasq_fails_and_throws)
     mp::DNSMasqServer dns{data_dir.path(), bridge_name, error_subnet};
 
     EXPECT_THROW(dns.check_dnsmasq_running(), std::runtime_error);
+}
+
+TEST_F(DNSMasqServer, dnsmasq_creates_conf_file)
+{
+    mp::DNSMasqServer dns{data_dir.path(), bridge_name, subnet};
+
+    EXPECT_FALSE(QDir(data_dir.path()).entryList({"dnsmasq-??????.conf"}, QDir::Files).isEmpty());
 }


### PR DESCRIPTION
Otherwise it may try (and fail) to read /etc/dnsmasq.conf, when it exists, and die.

---

To test:
```
$ sudo touch /etc/dnsmasq.conf
$ snap restart multipass
$ systemctl status snap.multipass.multipassd.service
# ensure dnsmasq is running under CGroup
$ sudo rm /etc/dnsmasq.conf
```