### PR TITLE
Refactor SSH tests

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -70,6 +70,7 @@ std::string to_cmd(const std::vector<std::string>& args, QuoteType type);
 bool run_cmd_for_status(const QString& cmd, const QStringList& args, const int timeout=30000);
 std::string run_cmd_for_output(const QString& cmd, const QStringList& args, const int timeout=30000);
 std::string& trim_end(std::string& s);
+std::string& trim_newline(std::string& s);
 std::string escape_char(const std::string& s, char c);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
 std::string generate_mac_address();

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -147,8 +147,7 @@ std::pair<std::string, std::string> get_path_split(mp::SSHSession& session, cons
 // Create a directory on a given root folder.
 void make_target_dir(mp::SSHSession& session, const std::string& root, const std::string& relative_target)
 {
-    if (!relative_target.empty())
-        run_cmd(session, fmt::format("sudo /bin/bash -c 'cd \"{}\" && mkdir -p \"{}\"'", root, relative_target));
+    run_cmd(session, fmt::format("sudo /bin/bash -c 'cd \"{}\" && mkdir -p \"{}\"'", root, relative_target));
 }
 
 // Set ownership of all directories on a path starting on a given root.
@@ -160,7 +159,7 @@ void set_owner_for(mp::SSHSession& session, const std::string& root, const std::
     mp::utils::trim_newline(vm_user);
     mp::utils::trim_newline(vm_group);
 
-    run_cmd(session, fmt::format("sudo /bin/bash -c 'cd \"{}\" && chown -R {}:{} {}'", root, vm_user, vm_group,
+    run_cmd(session, fmt::format("sudo /bin/bash -c 'cd \"{}\" && chown -R {}:{} \"{}\"'", root, vm_user, vm_group,
                                  relative_target.substr(0, relative_target.find_first_of('/'))));
 }
 
@@ -177,8 +176,11 @@ auto make_sftp_server(mp::SSHSession&& session, const std::string& source, const
 
     // We need to create the part of the path which does not still exist,
     // and set then the correct ownership.
-    make_target_dir(session, leading, missing);
-    set_owner_for(session, leading, missing);
+    if (missing != ".")
+    {
+        make_target_dir(session, leading, missing);
+        set_owner_for(session, leading, missing);
+    }
 
     auto output = run_cmd(session, "id -u");
     mpl::log(mpl::Level::debug, category,

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -142,6 +142,13 @@ std::string& mp::utils::trim_end(std::string& s)
     return s;
 }
 
+std::string& mp::utils::trim_newline(std::string& s)
+{
+    assert(!s.empty() && '\n' == s.back());
+    s.pop_back();
+    return s;
+}
+
 std::string mp::utils::escape_char(const std::string& in, char c)
 {
     return std::regex_replace(in, std::regex({c}), fmt::format("\\{}", c));

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -290,49 +290,9 @@ TEST_F(SshfsMount, throws_when_unable_to_obtain_user_id)
 
 TEST_F(SshfsMount, throws_when_uid_is_not_an_integer)
 {
-    bool cmd_invoked{false};
-    bool uid_invoked{false};
-    std::string output;
-    std::string::size_type remaining;
+    CommandVector commands = {{"id -u", "1000\n"}, {"id -u", "ubuntu\n"}};
 
-    auto request_exec = [&cmd_invoked, &uid_invoked, &remaining, &output](ssh_channel, const char* raw_cmd) {
-        std::string cmd{raw_cmd};
-
-        if (cmd.find("id -u") != std::string::npos)
-        {
-            output = "ubuntu\n";
-            remaining = output.size();
-            uid_invoked = true;
-        }
-        if (cmd.find("id -g") != std::string::npos)
-        {
-            output = "1000\n";
-            remaining = output.size();
-            cmd_invoked = true;
-        }
-        else if (cmd.find("pwd") != std::string::npos)
-        {
-            output = "/home/ubuntu\n";
-            remaining = output.size();
-            cmd_invoked = true;
-        }
-        else if (cmd.find("P=") != std::string::npos)
-        {
-            output = "/home/ubuntu/\n";
-            remaining = output.size();
-            cmd_invoked = true;
-        }
-
-        return SSH_OK;
-    };
-
-    REPLACE(ssh_channel_request_exec, request_exec);
-
-    auto channel_read = make_channel_read_return(output, remaining, cmd_invoked);
-    REPLACE(ssh_channel_read_timeout, channel_read);
-
-    EXPECT_THROW(make_sshfsmount(), std::invalid_argument);
-    EXPECT_TRUE(uid_invoked);
+    EXPECT_THROW(test_command_execution(commands), std::invalid_argument);
 }
 
 TEST_F(SshfsMount, throws_when_unable_to_obtain_group_id)
@@ -342,49 +302,9 @@ TEST_F(SshfsMount, throws_when_unable_to_obtain_group_id)
 
 TEST_F(SshfsMount, throws_when_gid_is_not_an_integer)
 {
-    bool cmd_invoked{false};
-    bool gid_invoked{false};
-    std::string output;
-    std::string::size_type remaining;
+    CommandVector commands = {{"id -g", "1000\n"}, {"id -g", "ubuntu\n"}};
 
-    auto request_exec = [&cmd_invoked, &gid_invoked, &remaining, &output](ssh_channel, const char* raw_cmd) {
-        std::string cmd{raw_cmd};
-
-        if (cmd.find("id -u") != std::string::npos)
-        {
-            output = "1000\n";
-            remaining = output.size();
-            cmd_invoked = true;
-        }
-        if (cmd.find("id -g") != std::string::npos)
-        {
-            output = "ubuntu\n";
-            remaining = output.size();
-            gid_invoked = true;
-        }
-        else if (cmd.find("pwd") != std::string::npos)
-        {
-            output = "/home/ubuntu\n";
-            remaining = output.size();
-            cmd_invoked = true;
-        }
-        else if (cmd.find("P=") != std::string::npos)
-        {
-            output = "/home/ubuntu/\n";
-            remaining = output.size();
-            cmd_invoked = true;
-        }
-
-        return SSH_OK;
-    };
-
-    REPLACE(ssh_channel_request_exec, request_exec);
-
-    auto channel_read = make_channel_read_return(output, remaining, cmd_invoked);
-    REPLACE(ssh_channel_read_timeout, channel_read);
-
-    EXPECT_THROW(make_sshfsmount(), std::invalid_argument);
-    EXPECT_TRUE(gid_invoked);
+    EXPECT_THROW(test_command_execution(commands), std::invalid_argument);
 }
 
 TEST_F(SshfsMount, unblocks_when_sftpserver_exits)

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -26,9 +26,11 @@
 #include <multipass/sshfs_mount/sshfs_mount.h>
 #include <multipass/utils.h>
 
+#include "extra_assertions.h"
 #include <algorithm>
 #include <gmock/gmock.h>
 #include <iterator>
+#include <tuple>
 #include <unordered_set>
 #include <vector>
 
@@ -84,15 +86,25 @@ struct SshfsMount : public mp::test::SftpServerTest
     // cooperate better, i.e., make the reader read only when a command was issued.
     auto make_exec_to_check_commands(const CommandVector& commands, std::string::size_type& remaining,
                                      CommandVector::const_iterator& next_expected_cmd, std::string& output,
-                                     bool& invoked)
+                                     bool& invoked, mp::optional<std::string>& fail_cmd, mp::optional<bool>& fail_bool)
     {
-        auto request_exec = [this, &commands, &remaining, &next_expected_cmd, &output, &invoked](ssh_channel,
-                                                                                                 const char* raw_cmd) {
+        *fail_bool = false;
+
+        auto request_exec = [this, &commands, &remaining, &next_expected_cmd, &output, &invoked, &fail_cmd,
+                             &fail_bool](ssh_channel, const char* raw_cmd) {
             invoked = false;
 
             std::string cmd{raw_cmd};
 
-            if (next_expected_cmd != commands.end())
+            if (fail_cmd && cmd.find(*fail_cmd) != std::string::npos)
+            {
+                if (fail_bool)
+                {
+                    *fail_bool = true;
+                }
+                exit_status_mock.return_exit_code(SSH_ERROR);
+            }
+            else if (next_expected_cmd != commands.end())
             {
                 // Check if the first element of the given commands list is what we are expecting. In that case,
                 // give the correct answer. If not, check the rest of the list to see if we broke the execution
@@ -121,53 +133,13 @@ struct SshfsMount : public mp::test::SftpServerTest
             }
 
             // If the command list was entirely checked or if the executed command is not on the list, check the
-            // default commands to see if there is an answer to the current command. If not, answer with a
-            // newline, because all strings returned by the server we are mocking end in newline.
+            // default commands to see if there is an answer to the current command.
             auto it = default_cmds.find(cmd);
             if (it != default_cmds.end())
             {
                 output = it->second;
                 remaining = output.size();
                 invoked = true;
-            }
-
-            return SSH_OK;
-        };
-
-        return request_exec;
-    }
-
-    // Mock that fails after executing some commands.
-    auto make_exec_that_executes_and_fails(const CommandVector& commands, const std::string& fail_cmd,
-                                           std::string::size_type& remaining,
-                                           CommandVector::const_iterator& next_expected_cmd, std::string& output,
-                                           bool& invoked_cmd, bool& invoked_fail)
-    {
-        auto request_exec = [this, &commands, &fail_cmd, &remaining, &next_expected_cmd, &output, &invoked_cmd,
-                             &invoked_fail](ssh_channel, const char* raw_cmd) {
-            std::string cmd{raw_cmd};
-
-            if (cmd.find(fail_cmd) != std::string::npos)
-            {
-                invoked_fail = true;
-                exit_status_mock.return_exit_code(SSH_ERROR);
-            }
-            else if (next_expected_cmd != commands.end() && cmd == next_expected_cmd->first)
-            {
-                output = next_expected_cmd->second;
-                remaining = output.size();
-                invoked_cmd = true;
-                ++next_expected_cmd;
-            }
-            else
-            {
-                auto it = default_cmds.find(cmd);
-                if (it != default_cmds.end())
-                {
-                    output = it->second;
-                    remaining = output.size();
-                    invoked_cmd = true;
-                }
             }
 
             return SSH_OK;
@@ -191,33 +163,9 @@ struct SshfsMount : public mp::test::SftpServerTest
         return channel_read;
     }
 
-    // Check that a given command is invoked and that it throws when failing.
-    void test_failed_invocation(const std::string& fail_cmd)
-    {
-        CommandVector commands = {
-            {"snap run multipass-sshfs.env", "LD_LIBRARY_PATH=/foo/bar\nSNAP=/baz\n"},
-            {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},
-            {"pwd", "/home/ubuntu\n"},
-            {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
-             "/home/ubuntu/\n"}};
-
-        bool invoked_cmd{false}, invoked_fail{false};
-        std::string output;
-        std::string::size_type remaining;
-        CommandVector::const_iterator next_expected_cmd = commands.begin();
-
-        auto channel_read = make_channel_read_return(output, remaining, invoked_cmd);
-        REPLACE(ssh_channel_read_timeout, channel_read);
-
-        auto request_exec = make_exec_that_executes_and_fails(commands, fail_cmd, remaining, next_expected_cmd, output,
-                                                              invoked_cmd, invoked_fail);
-        REPLACE(ssh_channel_request_exec, request_exec);
-
-        EXPECT_THROW(make_sshfsmount(), std::runtime_error);
-        EXPECT_TRUE(invoked_fail);
-    }
-
-    void test_command_execution(const CommandVector& commands, mp::optional<std::string> target = mp::nullopt)
+    void test_command_execution(const CommandVector& commands, mp::optional<std::string> target = mp::nullopt,
+                                mp::optional<std::string> fail_cmd = mp::nullopt,
+                                mp::optional<bool> fail_bool = mp::nullopt)
     {
         bool invoked{false};
         std::string output;
@@ -227,7 +175,8 @@ struct SshfsMount : public mp::test::SftpServerTest
         auto channel_read = make_channel_read_return(output, remaining, invoked);
         REPLACE(ssh_channel_read_timeout, channel_read);
 
-        auto request_exec = make_exec_to_check_commands(commands, remaining, next_expected_cmd, output, invoked);
+        auto request_exec =
+            make_exec_to_check_commands(commands, remaining, next_expected_cmd, output, invoked, fail_cmd, fail_bool);
         REPLACE(ssh_channel_request_exec, request_exec);
 
         make_sshfsmount(target.value_or(default_target));
@@ -254,14 +203,172 @@ struct SshfsMount : public mp::test::SftpServerTest
     const std::unordered_map<std::string, std::string> default_cmds{
         {"snap run multipass-sshfs.env", "LD_LIBRARY_PATH=/foo/bar\nSNAP=/baz\n"},
         {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},
+        {"pwd", "/home/ubuntu\n"},
+        {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
+         "/home/ubuntu/\n"},
         {"id -u", "1000\n"},
         {"id -g", "1000\n"},
-        {"pwd", "/home/ubuntu\n"},
         {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o allow_other :\"source\" "
          "\"target\"",
          "don't care\n"}};
 };
+
+// Mocks an incorrect return from a given command.
+struct SshfsMountFail : public SshfsMount, public testing::WithParamInterface<std::string>
+{
+};
+
+// Mocks correct execution of a given vector of commands/answers. The first string specifies the parameter with
+// which make_sshfsmount mock is called.
+struct SshfsMountExecute : public SshfsMount, public testing::WithParamInterface<std::pair<std::string, CommandVector>>
+{
+};
+
+struct SshfsMountExecuteAndFail
+    : public SshfsMount,
+      public testing::WithParamInterface<std::tuple<std::string, CommandVector, std::string>>
+{
+};
+
+// Mocks the server raising a std::invalid_argument.
+struct SshfsMountExecuteThrowInvArg : public SshfsMount, public testing::WithParamInterface<CommandVector>
+{
+};
+
+// Mocks the server raising a std::runtime_error.
+struct SshfsMountExecuteThrowRuntErr : public SshfsMount, public testing::WithParamInterface<CommandVector>
+{
+};
+
 } // namespace
+
+//
+// Define some parameterized test fixtures.
+//
+
+TEST_P(SshfsMountFail, test_failed_invocation)
+{
+    bool invoked_cmd{false};
+    std::string output;
+    std::string::size_type remaining;
+
+    auto channel_read = make_channel_read_return(output, remaining, invoked_cmd);
+    REPLACE(ssh_channel_read_timeout, channel_read);
+
+    CommandVector empty;
+    CommandVector::const_iterator it = empty.end();
+    mp::optional<std::string> fail_cmd = mp::make_optional(GetParam());
+    mp::optional<bool> invoked_fail = mp::make_optional(false);
+    auto request_exec = make_exec_to_check_commands(empty, remaining, it, output, invoked_cmd, fail_cmd, invoked_fail);
+    REPLACE(ssh_channel_request_exec, request_exec);
+
+    EXPECT_THROW(make_sshfsmount(), std::runtime_error);
+    EXPECT_TRUE(*invoked_fail);
+}
+
+TEST_P(SshfsMountExecute, test_succesful_invocation)
+{
+    std::string target = GetParam().first;
+    CommandVector commands = GetParam().second;
+
+    test_command_execution(commands, target);
+}
+
+TEST_P(SshfsMountExecuteAndFail, test_succesful_invocation_and_fail)
+{
+    std::string target = std::get<0>(GetParam());
+    CommandVector commands = std::get<1>(GetParam());
+    std::string fail_command = std::get<2>(GetParam());
+
+    ASSERT_NO_THROW(test_command_execution(commands, target, fail_command));
+}
+
+TEST_P(SshfsMountExecuteThrowInvArg, test_invalid_arg_when_executing)
+{
+    EXPECT_THROW(test_command_execution(GetParam()), std::invalid_argument);
+}
+
+TEST_P(SshfsMountExecuteThrowRuntErr, test_runtime_error_when_executing)
+{
+    EXPECT_THROW(test_command_execution(GetParam()), std::runtime_error);
+}
+
+//
+// Instantiate the parameterized tests suites from above.
+//
+
+INSTANTIATE_TEST_SUITE_P(SshfsMountThrowWhenError, SshfsMountFail,
+                         testing::Values("mkdir", "chown", "id -u", "id -g", "cd", "pwd"));
+
+// Commands to check that a version of FUSE smaller that 3 gives a correct answer.
+CommandVector old_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 2.9.0\n"},
+                               {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
+                                "allow_other -o nonempty :\"source\" \"target\"",
+                                "don't care\n"}};
+
+// Commands to check that a version of FUSE at least 3.0.0 gives a correct answer.
+CommandVector new_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},
+                               {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
+                                "allow_other :\"source\" \"target\"",
+                                "don't care\n"}};
+
+// Commands to check that an unknown version of FUSE gives a correct answer.
+CommandVector unk_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "weird fuse version\n"},
+                               {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
+                                "allow_other :\"source\" \"target\"",
+                                "don't care\n"}};
+
+// Commands to check that the server correctly creates the mount target.
+CommandVector exec_cmds = {
+    {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
+     "/home/ubuntu/\n"},
+    {"sudo /bin/bash -c 'cd \"/home/ubuntu/\" && mkdir -p \"target\"'", "\n"},
+    {"sudo /bin/bash -c 'cd \"/home/ubuntu/\" && chown -R 1000:1000 \"target\"'", "\n"}};
+
+// Commands to check that the server works if an absolute path is given.
+CommandVector absolute_cmds = {
+    {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
+     "/home/ubuntu/\n"},
+    {"sudo /bin/bash -c 'cd \"/home/ubuntu/\" && mkdir -p \"target\"'", "\n"},
+    {"sudo /bin/bash -c 'cd \"/home/ubuntu/\" && chown -R 1000:1000 \"target\"'", "\n"}};
+
+// Commands to check that it works for a nonexisting path.
+CommandVector nonexisting_path_cmds = {
+    {"sudo /bin/bash -c 'P=\"/nonexisting/path\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'", "/\n"},
+    {"sudo /bin/bash -c 'cd \"/\" && mkdir -p \"nonexisting/path\"'", "\n"},
+    {"sudo /bin/bash -c 'cd \"/\" && chown -R 1000:1000 \"nonexisting\"'", "\n"}};
+
+// Check the execution of the CommandVector's above.
+INSTANTIATE_TEST_SUITE_P(SshfsMountSuccess, SshfsMountExecute,
+                         testing::Values(std::make_pair("target", old_fuse_cmds), std::make_pair("target", exec_cmds),
+                                         std::make_pair("target", new_fuse_cmds), std::make_pair("target", exec_cmds),
+                                         std::make_pair("target", unk_fuse_cmds), std::make_pair("target", exec_cmds),
+                                         std::make_pair("/home/ubuntu/target", absolute_cmds),
+                                         std::make_pair("/nonexisting/path", nonexisting_path_cmds)));
+
+// Commands to test that when a mount path already exists, no mkdir nor chown is ran.
+CommandVector execute_no_mkdir_cmds = {
+    {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
+     "/home/ubuntu/target/\n"}};
+
+INSTANTIATE_TEST_SUITE_P(SshfsMountSuccessAndAvoidCommands, SshfsMountExecuteAndFail,
+                         testing::Values(std::make_tuple("target", execute_no_mkdir_cmds, "mkdir"),
+                                         std::make_tuple("target", execute_no_mkdir_cmds, "chown")));
+
+// Check that some commands throw some exceptions.
+CommandVector non_int_uid_cmds = {{"id -u", "1000\n"}, {"id -u", "ubuntu\n"}};
+CommandVector non_int_gid_cmds = {{"id -g", "1000\n"}, {"id -g", "ubuntu\n"}};
+CommandVector invalid_fuse_ver_cmds = {
+    {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: fu.man.chu\n"}};
+
+INSTANTIATE_TEST_SUITE_P(SshfsMountThrowInvArg, SshfsMountExecuteThrowInvArg,
+                         testing::Values(non_int_uid_cmds, non_int_gid_cmds));
+
+INSTANTIATE_TEST_SUITE_P(SshfsMountThrowRuntErr, SshfsMountExecuteThrowRuntErr, testing::Values(invalid_fuse_ver_cmds));
+
+//
+// Finally, individual test fixtures.
+//
 
 TEST_F(SshfsMount, throws_when_sshfs_does_not_exist)
 {
@@ -273,72 +380,8 @@ TEST_F(SshfsMount, throws_when_sshfs_does_not_exist)
     EXPECT_TRUE(invoked);
 }
 
-TEST_F(SshfsMount, throws_when_unable_to_make_target_dir)
-{
-    test_failed_invocation("mkdir");
-}
-
-TEST_F(SshfsMount, throws_when_unable_to_chown)
-{
-    test_failed_invocation("chown");
-}
-
-TEST_F(SshfsMount, throws_when_unable_to_obtain_user_id)
-{
-    test_failed_invocation("id -u");
-}
-
-TEST_F(SshfsMount, throws_when_uid_is_not_an_integer)
-{
-    CommandVector commands = {{"id -u", "1000\n"}, {"id -u", "ubuntu\n"}};
-
-    EXPECT_THROW(test_command_execution(commands), std::invalid_argument);
-}
-
-TEST_F(SshfsMount, throws_when_unable_to_obtain_group_id)
-{
-    test_failed_invocation("id -g");
-}
-
-TEST_F(SshfsMount, throws_when_gid_is_not_an_integer)
-{
-    CommandVector commands = {{"id -g", "1000\n"}, {"id -g", "ubuntu\n"}};
-
-    EXPECT_THROW(test_command_execution(commands), std::invalid_argument);
-}
-
 TEST_F(SshfsMount, unblocks_when_sftpserver_exits)
 {
-    bool invoked{false};
-    std::string output{"1000\n"};
-    auto remaining = output.size();
-    auto channel_read = make_channel_read_return(output, remaining, invoked);
-    REPLACE(ssh_channel_read_timeout, channel_read);
-
-    auto request_exec = [&invoked, &remaining, &output](ssh_channel, const char* raw_cmd) {
-        std::string cmd{raw_cmd};
-        if (cmd.find("id -") != std::string::npos)
-        {
-            invoked = true;
-            output = "1000\n";
-            remaining = output.size();
-        }
-        else if (cmd.find("pwd") != std::string::npos)
-        {
-            invoked = true;
-            output = "/home/ubuntu\n";
-            remaining = output.size();
-        }
-        else if (cmd.find("P=") != std::string::npos)
-        {
-            invoked = true;
-            output = "/home/ubuntu/\n";
-            remaining = output.size();
-        }
-        return SSH_OK;
-    };
-    REPLACE(ssh_channel_request_exec, request_exec);
-
     mpt::Signal client_message;
     auto get_client_msg = [&client_message](sftp_session) {
         client_message.wait();
@@ -348,7 +391,7 @@ TEST_F(SshfsMount, unblocks_when_sftpserver_exits)
 
     bool stopped_ok = false;
     std::thread mount([&] {
-        auto sshfs_mount = make_sshfsmount(); // blocks until it asked to quit
+        test_command_execution(CommandVector());
         stopped_ok = true;
     });
 
@@ -358,27 +401,9 @@ TEST_F(SshfsMount, unblocks_when_sftpserver_exits)
     EXPECT_TRUE(stopped_ok);
 }
 
-TEST_F(SshfsMount, throws_when_unable_to_change_dir)
-{
-    test_failed_invocation("cd");
-}
-
-TEST_F(SshfsMount, invalid_fuse_version_throws)
-{
-    CommandVector commands = {
-        {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: fu.man.chu\n"},
-        {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
-         "/home/ubuntu/\n"}};
-
-    EXPECT_THROW(test_command_execution(commands), std::runtime_error);
-}
-
 TEST_F(SshfsMount, blank_fuse_version_logs_error)
 {
-    CommandVector commands = {
-        {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version:\n"},
-        {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
-         "/home/ubuntu\n"}};
+    CommandVector commands = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version:\n"}};
 
     EXPECT_CALL(*logger, log(Matcher<multipass::logging::Level>(_), Matcher<multipass::logging::CString>(_),
                              Matcher<multipass::logging::CString>(_)))
@@ -390,44 +415,6 @@ TEST_F(SshfsMount, blank_fuse_version_logs_error)
                     make_cstring_matcher(StrEq("Unable to parse the FUSE library version: FUSE library version:"))));
 
     test_command_execution(commands);
-}
-
-TEST_F(SshfsMount, fuse_version_less_than_3_nonempty)
-{
-    CommandVector commands = {
-        {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 2.9.0\n"},
-        {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
-         "/home/ubuntu/\n"},
-        {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-         "allow_other -o nonempty :\"source\" \"target\"",
-         "don't care\n"}};
-
-    test_command_execution(commands);
-}
-
-TEST_F(SshfsMount, throws_when_unable_to_get_current_dir)
-{
-    test_failed_invocation("pwd");
-}
-
-TEST_F(SshfsMount, executes_commands)
-{
-    CommandVector commands = {
-        {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
-         "/home/ubuntu/\n"},
-        {"sudo /bin/bash -c 'cd \"/home/ubuntu/\" && mkdir -p \"target\"'", "\n"},
-        {"sudo /bin/bash -c 'cd \"/home/ubuntu/\" && chown -R 1000:1000 target'", "\n"}};
-
-    test_command_execution(commands, std::string("target"));
-}
-
-TEST_F(SshfsMount, works_with_absolute_paths)
-{
-    CommandVector commands = {
-        {"sudo /bin/bash -c 'P=\"/home/ubuntu/target\"; while [ ! -d \"$P/\" ]; do P=${P%/*}; done; echo $P/'",
-         "/home/ubuntu/\n"}};
-
-    test_command_execution(commands, std::string("/home/ubuntu/target"));
 }
 
 TEST_F(SshfsMount, throws_install_sshfs_which_snap_fails)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -25,6 +25,7 @@
 #include <QRegExp>
 
 #include <gmock/gmock.h>
+#include <gtest/gtest-death-test.h>
 #include <gtest/gtest.h>
 
 #include <sstream>
@@ -194,6 +195,20 @@ TEST(Utils, trim_end_actually_trims_end)
     mp::utils::trim_end(s);
 
     EXPECT_THAT(s, ::testing::StrEq("I'm a great\n\t string"));
+}
+
+TEST(Utils, trim_newline_works)
+{
+    std::string s{"correct\n"};
+    mp::utils::trim_newline(s);
+
+    EXPECT_THAT(s, ::testing::StrEq("correct"));
+}
+
+TEST(Utils, trim_newline_assertion_works)
+{
+    std::string s{"wrong"};
+    ASSERT_DEBUG_DEATH(mp::utils::trim_newline(s), "[Aa]ssert");
 }
 
 TEST(Utils, escape_char_actually_escapes)


### PR DESCRIPTION
1. refactor `make_exec_to_check_commands()`, using `std::find_if()`;
2. add `\n` to all answers of the sshfs mock, because the real server always returns the newline and we were missing this behavior in the mock;
3. enforce newline checks in sshfs server code; and
4. use parameterized tests.