### PR TITLE
[github] add a link to documentation in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Documentation
+    url: https://multipass.run/docs
+    about: See here about potential solutions to some common problems
   - name: Forums
     url: https://discourse.ubuntu.com/c/multipass
     about: Please ask and answer questions here.


### PR DESCRIPTION
---
Result: https://github.com/Saviq/multipass/issues/new/choose