### PR TITLE
[network] Implement Qt classes to communicate with a Unix socket

### DIFF
--- a/include/multipass/network_access_manager.h
+++ b/include/multipass/network_access_manager.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_NETWORK_ACCESS_MANAGER_H
+#define MULTIPASS_NETWORK_ACCESS_MANAGER_H
+
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+
+namespace multipass
+{
+class NetworkAccessManager final : public QNetworkAccessManager
+{
+    Q_OBJECT
+public:
+    NetworkAccessManager(QObject* parent = nullptr);
+
+protected:
+    QNetworkReply* createRequest(Operation op, const QNetworkRequest& orig_request,
+                                 QIODevice* outgoingData = nullptr) override;
+};
+} // namespace multipass
+
+#endif // MULTIPASS_NETWORK_ACCESS_MANAGER_H

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017 Canonical Ltd.
+# Copyright © 2017-2020 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -11,11 +11,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Authored by: Chris Townsend <christopher.townsend@canonical.com>
+
+set(CMAKE_AUTOMOC ON)
 
 add_library(network STATIC
-            url_downloader.cpp)
+            local_socket_reply.cpp
+            network_access_manager.cpp
+            url_downloader.cpp
+            ${CMAKE_SOURCE_DIR}/include/multipass/network_access_manager.h
+            local_socket_reply.h)
 
 add_library(ip_address STATIC
             ip_address.cpp)

--- a/src/network/local_socket_reply.cpp
+++ b/src/network/local_socket_reply.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "local_socket_reply.h"
+
+#include <multipass/format.h>
+
+namespace mp = multipass;
+
+namespace
+{
+constexpr int len = 65536;
+
+// The following is mostly "borrowed" from Qt src/network/access/qhttpthreaddelegate.cpp
+QNetworkReply::NetworkError statusCodeFromHttp(int httpStatusCode)
+{
+    QNetworkReply::NetworkError code;
+
+    // Only switch on the HTTP errors LXD will respond with for now
+    switch (httpStatusCode)
+    {
+    case 400: // Bad Request
+        code = QNetworkReply::ProtocolInvalidOperationError;
+        break;
+
+    case 401: // Authorization required
+        code = QNetworkReply::AuthenticationRequiredError;
+        break;
+
+    case 403: // Access denied
+        code = QNetworkReply::ContentAccessDenied;
+        break;
+
+    case 404: // Not Found
+        code = QNetworkReply::ContentNotFoundError;
+        break;
+
+    case 409: // Resource Conflict
+        code = QNetworkReply::ContentConflictError;
+        break;
+
+    case 500: // Internal Server Error
+        code = QNetworkReply::InternalServerError;
+        break;
+
+    default:
+        if (httpStatusCode > 500)
+        {
+            // some kind of server error
+            code = QNetworkReply::UnknownServerError;
+        }
+        else
+        {
+            // content error we did not handle above
+            code = QNetworkReply::UnknownContentError;
+        }
+    }
+
+    return code;
+}
+} // namespace
+
+mp::LocalSocketReply::LocalSocketReply(const QString& socket_path, const QNetworkRequest& request,
+                                       QIODevice* outgoingData)
+    : QNetworkReply(), local_socket{std::make_unique<QLocalSocket>(this)}, reply_data{QByteArray(len, '\0')}
+{
+    QIODevice::open(QIODevice::ReadOnly);
+
+    local_socket->connectToServer(socket_path);
+
+    if (!local_socket->waitForConnected(5000))
+    {
+        throw std::runtime_error(fmt::format("Cannot connect to {}: {}", socket_path, local_socket->error()));
+    }
+
+    QObject::connect(local_socket.get(), &QLocalSocket::readyRead, this, &LocalSocketReply::read_reply);
+
+    send_request(request, outgoingData);
+}
+
+mp::LocalSocketReply::~LocalSocketReply()
+{
+    local_socket->disconnectFromServer();
+}
+
+void mp::LocalSocketReply::abort()
+{
+}
+
+qint64 mp::LocalSocketReply::readData(char* data, qint64 maxSize)
+{
+    if (offset < content_data.size())
+    {
+        qint64 number = qMin(maxSize, content_data.size() - offset);
+        memcpy(data, content_data.constData() + offset, number);
+        offset += number;
+
+        return number;
+    }
+
+    return -1;
+}
+
+void mp::LocalSocketReply::send_request(const QNetworkRequest& request, QIODevice* outgoingData)
+{
+    QByteArray http_data;
+    http_data.reserve(1024);
+
+    auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toByteArray();
+
+    // Build the HTTP method part
+    http_data += op;
+    http_data += ' ';
+    http_data += request.url().path();
+    http_data += " HTTP/1.1\r\n";
+
+    // Build the HTTP Host header
+    // Host can be anything, so we'll use 'multipass'
+    http_data += "Host: multipass\r\n";
+
+    // Build the HTTP User-Agent header
+    // We'll just use what Qt uses
+    http_data += "User-Agent: Mozilla/5.0\r\n";
+
+    // Build the HTTP Accept header
+    // Default to accept everything
+    http_data += "Accept: */*\r\n";
+
+    if (op == "POST" || op == "PUT")
+    {
+        http_data += "Content-Type: application/x-www-form-urlencoded\r\n";
+
+        if (outgoingData)
+        {
+            outgoingData->open(QIODevice::ReadOnly);
+
+            http_data += "Content-Length: ";
+            http_data += QByteArray::number(outgoingData->size());
+            http_data += "\r\n\r\n";
+            http_data += outgoingData->readAll();
+        }
+    }
+
+    http_data += "\r\n";
+
+    local_socket->write(http_data);
+    local_socket->flush();
+}
+
+void mp::LocalSocketReply::read_reply()
+{
+    local_socket->read(reply_data.data(), len);
+
+    parse_reply();
+
+    emit finished();
+}
+
+void mp::LocalSocketReply::parse_reply()
+{
+    auto reply_lines = reply_data.split('\n');
+    auto it = reply_lines.constBegin();
+
+    parse_status(*it);
+
+    for (++it; it != reply_lines.constEnd(); ++it)
+    {
+        if ((*it).contains("Transfer-Encoding") && (*it).contains("chunked"))
+            chunked_transfer_encoding = true;
+
+        if ((*it).isEmpty() || (*it).startsWith('\r'))
+        {
+            // Advance to the body
+            // Chunked transfer encoding also includes a line with the amount of
+            // bytes (in hex) in the chunk. We just skip it for now.
+            it = chunked_transfer_encoding ? it + 2 : it + 1;
+
+            content_data = (*it).trimmed();
+
+            break;
+        }
+    }
+}
+
+// Some of this logic is taken from Qt src/network/access/qhttpnetworkreply.cpp
+void mp::LocalSocketReply::parse_status(const QByteArray& status)
+{
+    const int minLength = 11;
+    const int dotPos = 6;
+    const int spacePos = 8;
+    const char httpMagic[] = "HTTP/";
+
+    if (status.length() < minLength || !status.startsWith(httpMagic) || status.at(dotPos) != '.' ||
+        status.at(spacePos) != ' ')
+    {
+        setError(QNetworkReply::ProtocolFailure, "Malformed HTTP response from server");
+
+        emit error(QNetworkReply::ProtocolFailure);
+
+        return;
+    }
+
+    int i = spacePos;
+    int j = status.indexOf(' ', i + 1); // j == -1 || at(j) == ' ' so j+1 == 0 && j+1 <= length()
+    const QByteArray code = status.mid(i + 1, j - i - 1);
+
+    bool ok;
+    auto statusCode = code.toInt(&ok);
+
+    if (statusCode >= 400)
+    {
+        auto error_code = statusCodeFromHttp(statusCode);
+
+        setError(error_code, QString::fromLatin1(status.constData() + j + 1));
+
+        emit error(error_code);
+    }
+}

--- a/src/network/local_socket_reply.h
+++ b/src/network/local_socket_reply.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_LOCAL_SOCKET_REPLY_H
+#define MULTIPASS_LOCAL_SOCKET_REPLY_H
+
+#include <QLocalSocket>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QString>
+
+#include <memory>
+
+namespace multipass
+{
+class LocalSocketReply final : public QNetworkReply
+{
+    Q_OBJECT
+public:
+    LocalSocketReply(const QString& socket_path, const QNetworkRequest& request, QIODevice* outgoingData);
+    virtual ~LocalSocketReply();
+
+public Q_SLOTS:
+    void abort() override;
+
+protected:
+    qint64 readData(char* data, qint64 maxSize) override;
+
+private slots:
+    void read_reply();
+
+private:
+    void send_request(const QNetworkRequest& request, QIODevice* outgoingData);
+    void parse_reply();
+    void parse_status(const QByteArray& status);
+
+    std::unique_ptr<QLocalSocket> local_socket;
+    QByteArray reply_data;
+    QByteArray content_data;
+    qint64 offset{0};
+    bool chunked_transfer_encoding{false};
+};
+} // namespace multipass
+
+#endif // MULTIPASS_LOCAL_SOCKET_REPLY_H

--- a/src/network/local_socket_reply.h
+++ b/src/network/local_socket_reply.h
@@ -18,6 +18,7 @@
 #ifndef MULTIPASS_LOCAL_SOCKET_REPLY_H
 #define MULTIPASS_LOCAL_SOCKET_REPLY_H
 
+#include <QByteArray>
 #include <QLocalSocket>
 #include <QNetworkReply>
 #include <QNetworkRequest>

--- a/src/network/network_access_manager.cpp
+++ b/src/network/network_access_manager.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "local_socket_reply.h"
+
+#include <multipass/network_access_manager.h>
+
+namespace mp = multipass;
+
+mp::NetworkAccessManager::NetworkAccessManager(QObject* parent) : QNetworkAccessManager(parent)
+{
+}
+
+QNetworkReply* mp::NetworkAccessManager::createRequest(QNetworkAccessManager::Operation operation,
+                                                       const QNetworkRequest& orig_request, QIODevice* device)
+{
+    auto scheme = orig_request.url().scheme();
+
+    // To support http requests over Unix sockets, the initial URL needs to be in the form of:
+    // unix:///path/to/unix_socket@path/in/server (or 'local' instead of 'unix')
+    //
+    // For example, to get the general LXD configuration when LXD is installed as a snap:
+    // unix:////var/snap/lxd/common/lxd/unix.socket@1.0
+    if (scheme == "unix" || scheme == "local")
+    {
+        const auto url_parts = orig_request.url().path().split('@');
+        if (url_parts.count() != 2)
+        {
+            throw std::runtime_error("The local socket scheme is malformed.");
+        }
+
+        const auto socket_path = url_parts[0];
+        const auto server_path = url_parts[1];
+        QNetworkRequest request{orig_request};
+
+        QUrl url(QString("/%1").arg(server_path));
+        request.setUrl(url);
+
+        // The caller needs to be responsible for freeing the allocated memory
+        return new LocalSocketReply(socket_path, request, device);
+    }
+    else
+    {
+        return QNetworkAccessManager::createRequest(operation, orig_request, device);
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(multipass_tests
   test_output_formatter.cpp
   test_image_vault.cpp
   test_ip_address.cpp
+  test_local_network_access_manager.cpp
   test_memory_size.cpp
   test_metrics_provider.cpp
   test_new_release_monitor.cpp
@@ -105,6 +106,7 @@ target_link_libraries(multipass_tests
   ip_address
   iso
   metrics
+  network
   petname
   simplestreams
   sftp_test

--- a/tests/test_local_network_access_manager.cpp
+++ b/tests/test_local_network_access_manager.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "temp_dir.h"
+
+#include <multipass/network_access_manager.h>
+
+#include <QEventLoop>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QNetworkReply>
+#include <QTimer>
+
+#include <gmock/gmock.h>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+using namespace testing;
+
+namespace
+{
+using HTTPErrorParamType = std::pair<QByteArray, QNetworkReply::NetworkError>;
+
+struct LocalNetworkAccessManager : public Test
+{
+    LocalNetworkAccessManager()
+    {
+        socket_path = QString("%1/test_socket").arg(temp_dir.path());
+        test_server.listen(socket_path);
+        base_url = QString("unix://%1@1.0").arg(socket_path);
+    }
+
+    void local_socket_server_handler(const QByteArray& http_response, const QByteArray& expected_data = QByteArray())
+    {
+        QObject::connect(&test_server, &QLocalServer::newConnection, [&] {
+            auto client_connection = test_server.nextPendingConnection();
+
+            client_connection->waitForReadyRead();
+            auto data = client_connection->readAll();
+
+            if (!expected_data.isEmpty())
+            {
+                EXPECT_THAT(data, Eq(expected_data));
+            }
+
+            client_connection->write(http_response);
+        });
+    }
+
+    auto handle_request(const QUrl& url, const QByteArray& verb, const QByteArray& data = QByteArray())
+    {
+        QNetworkRequest request{url};
+
+        std::unique_ptr<QNetworkReply> reply{manager.sendCustomRequest(request, verb, data)};
+
+        QObject::connect(reply.get(), &QNetworkReply::finished, &event_loop, &QEventLoop::quit);
+        QObject::connect(&download_timeout, &QTimer::timeout, [&] {
+            download_timeout.stop();
+            reply->abort();
+        });
+
+        download_timeout.start();
+        event_loop.exec();
+
+        return reply;
+    }
+
+    mp::NetworkAccessManager manager;
+    QLocalServer test_server;
+    mpt::TempDir temp_dir;
+    QString socket_path;
+    QUrl base_url;
+    QEventLoop event_loop;
+    QTimer download_timeout;
+};
+
+struct HTTPErrorsTestSuite : LocalNetworkAccessManager, WithParamInterface<HTTPErrorParamType>
+{
+};
+
+const std::vector<HTTPErrorParamType> http_error_suite_inputs{
+    {"HTTP/1.1 400 Bad Request\r\n\r\n", QNetworkReply::ProtocolInvalidOperationError},
+    {"HTTP/1.1 401 Authorization Required\r\n\r\n", QNetworkReply::AuthenticationRequiredError},
+    {"HTTP/1.1 403 Access Denied\r\n\r\n", QNetworkReply::ContentAccessDenied},
+    {"HTTP/1.1 404 Not Found\r\n\r\n", QNetworkReply::ContentNotFoundError},
+    {"HTTP/1.1 409 Resource Conflict\r\n\r\n", QNetworkReply::ContentConflictError},
+    {"HTTP/1.1 500 Internal Server Error\r\n\r\n", QNetworkReply::InternalServerError},
+    {"HTTP/1.1 501 Unknown Server Error\r\n\r\n", QNetworkReply::UnknownServerError},
+    {"HTTP/1.1 412 Precondition Failed\r\n\r\n", QNetworkReply::UnknownContentError}};
+} // namespace
+
+TEST_F(LocalNetworkAccessManager, no_error_returns_good_reply)
+{
+    QByteArray http_response;
+    http_response += "HTTP/1.1 200 OK\r\n";
+    http_response += "Content-Type: text/plain\r\n";
+    http_response += "\r\n";
+
+    local_socket_server_handler(http_response);
+
+    auto reply = handle_request(base_url, "GET");
+
+    EXPECT_THAT(reply->error(), Eq(QNetworkReply::NoError));
+}
+
+TEST_F(LocalNetworkAccessManager, reads_expected_data_not_chunked)
+{
+    QByteArray reply_data{"Hello"};
+
+    QByteArray http_response;
+    http_response += "HTTP/1.1 200 OK\r\n";
+    http_response += "Content-Type: text/plain\r\n";
+    http_response += "Content-Length: 5\r\n";
+    http_response += "\r\n";
+    http_response += reply_data;
+    http_response += "\r\n";
+
+    local_socket_server_handler(http_response);
+
+    auto reply = handle_request(base_url, "GET");
+
+    ASSERT_THAT(reply->error(), Eq(QNetworkReply::NoError));
+
+    auto data = reply->readAll();
+
+    EXPECT_THAT(data, Eq(reply_data));
+}
+
+TEST_F(LocalNetworkAccessManager, reads_expected_data_chunked)
+{
+    QByteArray reply_data{"What's up?"};
+
+    QByteArray http_response;
+    http_response += "HTTP/1.1 200 OK\r\n";
+    http_response += "Content-Type: text/plain\r\n";
+    http_response += "Content-Length: 5\r\n";
+    http_response += "Transfer-Encoding: chunked\r\n";
+    http_response += "\r\n";
+    http_response += "5\r\n";
+    http_response += reply_data;
+    http_response += "\r\n";
+
+    local_socket_server_handler(http_response);
+
+    auto reply = handle_request(base_url, "GET");
+
+    ASSERT_THAT(reply->error(), Eq(QNetworkReply::NoError));
+
+    auto data = reply->readAll();
+
+    EXPECT_THAT(data, Eq(reply_data));
+}
+
+TEST_F(LocalNetworkAccessManager, client_posts_correct_data)
+{
+    QByteArray expected_data{"POST /1.0 HTTP/1.1\r\n"
+                             "Host: multipass\r\n"
+                             "User-Agent: Mozilla/5.0\r\n"
+                             "Accept: */*\r\n"
+                             "Content-Type: application/x-www-form-urlencoded\r\n"
+                             "Content-Length: 11\r\n\r\n"
+                             "Hello World\r\n"};
+
+    QByteArray http_response;
+    http_response += "HTTP/1.1 200 OK\r\n";
+    http_response += "Content-Type: text/plain\r\n";
+    http_response += "\r\n";
+
+    // The actual test is in the QObject::connect's lambda slot
+    local_socket_server_handler(http_response, expected_data);
+
+    handle_request(base_url, "POST", "Hello World");
+}
+
+TEST_F(LocalNetworkAccessManager, bad_http_server_response_has_error)
+{
+    QByteArray malformed_http_response{"FOO/1.4 42 Yo\r\n"};
+
+    local_socket_server_handler(malformed_http_response);
+
+    auto reply = handle_request(base_url, "GET");
+
+    EXPECT_THAT(reply->error(), Eq(QNetworkReply::ProtocolFailure));
+}
+
+TEST_F(LocalNetworkAccessManager, malformed_unix_schema_throws)
+{
+    base_url = "unix:///foo";
+
+    QNetworkRequest request{base_url};
+
+    EXPECT_THROW(manager.sendCustomRequest(request, "GET"), std::runtime_error);
+}
+
+TEST_F(LocalNetworkAccessManager, unable_to_connect_throws)
+{
+    base_url = "unix:///invalid/path@1.0";
+
+    QNetworkRequest request{base_url};
+
+    EXPECT_THROW(manager.sendCustomRequest(request, "GET"), std::runtime_error);
+}
+
+TEST_P(HTTPErrorsTestSuite, returns_expected_error)
+{
+    const auto http_response = GetParam().first;
+    const auto expected_error = GetParam().second;
+
+    local_socket_server_handler(http_response);
+
+    auto reply = handle_request(base_url, "GET");
+
+    EXPECT_THAT(reply->error(), Eq(expected_error));
+}
+
+INSTANTIATE_TEST_SUITE_P(LocalNetworkAccessManager, HTTPErrorsTestSuite, ValuesIn(http_error_suite_inputs));


### PR DESCRIPTION
This is needed to communicate with the LXD Unix socket.
    
This is a minimal implementation and can be modified later for more/better functionality.

---
We should be able to replace anywhere we use `QNetworkAccessManager` with this class and have just one implementation.