### PR TITLE
[args] Enable debug verbosity on more than 3 vs

### DIFF
--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -72,7 +72,7 @@ auto verbosity_level_in(const QStringList& arguments)
             return 1;
         if (arg == QStringLiteral("-vv"))
             return 2;
-        if (arg == QStringLiteral("-vvv"))
+        if (QRegExp{"-vvv+"}.exactMatch(arg))
             return 3;
     }
     return 0;

--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -72,8 +72,10 @@ auto verbosity_level_in(const QStringList& arguments)
             return 1;
         if (arg == QStringLiteral("-vv"))
             return 2;
-        if (QRegExp{"-vvv+"}.exactMatch(arg))
+        if (arg == QStringLiteral("-vvv"))
             return 3;
+        if (QRegExp{"-vvvv+"}.exactMatch(arg))
+            return 4;
     }
     return 0;
 }
@@ -89,7 +91,8 @@ mp::ParseCode mp::ArgParser::parse()
 {
     QCommandLineOption help_option = parser.addHelpOption();
     QCommandLineOption verbose_option({"v", "verbose"},
-                                      "Increase logging verbosity, repeat up to three times for more detail");
+                                      "Increase logging verbosity. Repeat the 'v' in the short option for more detail. "
+                                      "Maximum verbosity is obtained with 4 (or more) v's, i.e. -vvvv.");
     QCommandLineOption version_option({"V", "version"}, "Show version details");
     version_option.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(verbose_option);

--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -40,11 +40,18 @@ namespace
 {
 auto max_command_string_length(const std::vector<cmd::Command::UPtr>& commands)
 {
-    auto string_len_compare = [](const cmd::Command::UPtr& a, const cmd::Command::UPtr& b) {
-        return a->name().length() < b->name().length();
-    };
-    const auto& max_elem = *std::max_element(commands.begin(), commands.end(), string_len_compare);
-    return max_elem->name().length();
+    auto ret = 0ul;
+
+    if (!commands.empty())
+    {
+        auto string_len_compare = [](const cmd::Command::UPtr& a, const cmd::Command::UPtr& b) {
+            return a->name().length() < b->name().length();
+        };
+        const auto& max_elem = *std::max_element(commands.begin(), commands.end(), string_len_compare);
+        ret = max_elem->name().length();
+    }
+
+    return ret;
 }
 
 auto format_into_column(const std::string& name, std::string::size_type column_size)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(multipass_tests
   stub_process_factory.cpp
   temp_dir.cpp
   temp_file.cpp
+  test_argparser.cpp
   test_basic_process.cpp
   test_cli_client.cpp
   test_client_cert_store.cpp

--- a/tests/test_argparser.cpp
+++ b/tests/test_argparser.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/cli/argparser.h>
+#include <multipass/cli/command.h>
+
+#include <QString>
+#include <QStringList>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <vector>
+
+namespace mp = multipass;
+using namespace testing;
+
+struct TestVerbosity : public TestWithParam<int>
+{
+};
+
+TEST_P(TestVerbosity, test_various_vs)
+{
+    std::ostringstream oss;
+    const auto cmds = std::vector<mp::cmd::Command::UPtr>{};
+    const auto v = GetParam();
+    auto args = QStringList{"multipass_tests"};
+
+    if (v)
+    {
+        auto arg = QString{v, 'v'};
+        arg.prepend('-');
+        args << arg;
+    }
+
+    auto parser = mp::ArgParser{args, cmds, oss, oss};
+    parser.parse();
+
+    const auto expect = v > 4 ? 4 : v;
+    EXPECT_EQ(parser.verbosityLevel(), expect);
+}
+
+INSTANTIATE_TEST_SUITE_P(ArgParser, TestVerbosity, Range(0, 10));


### PR DESCRIPTION
Multipass accepted more than 3 vs in `-v` but kept the verbosity as error. This sets it to debug on 3 or more vs.

I couldn't find tests for arg parsing or verbosity. I am not sure if this is the PR to add them, so I just tested manually by editing code to print the configured verbosity.