### PR TITLE
[daemon] Prefer `admin` over `wheel` group and remove `adm`

### DIFF
--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -50,7 +50,7 @@ namespace mpp = multipass::platform;
 
 namespace
 {
-const std::vector<std::string> supported_socket_groups{"sudo", "admin", "wheel", "adm"};
+const std::vector<std::string> supported_socket_groups{"sudo", "admin", "wheel"};
 
 void set_server_permissions(const std::string& server_address)
 {

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -50,7 +50,7 @@ namespace mpp = multipass::platform;
 
 namespace
 {
-const std::vector<std::string> supported_socket_groups{"sudo", "wheel", "adm", "admin"};
+const std::vector<std::string> supported_socket_groups{"sudo", "admin", "wheel", "adm"};
 
 void set_server_permissions(const std::string& server_address)
 {


### PR DESCRIPTION
macOS has a `wheel` group, but admin users are not part of it…

In support:
- [Debian](https://wiki.debian.org/sudo)/[Ubuntu](https://wiki.ubuntu.com/QuantalQuetzal/TechnicalOverview/Alpha1#General): `sudo`
- [Fedora](https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/basic-system-configuration/Gaining_Privileges/)/[CentOS/RHEL](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/chap-gaining_privileges)/[Arch](https://wiki.archlinux.org/index.php/Users_and_Groups#Group_list)/[SuSE](https://en.opensuse.org/SDB:Administer_with_sudo): `wheel`

Fixes #1563