### PR TITLE
[snap] pass daemon arguments in `launch-multipassd`

### DIFF
--- a/snap-wrappers/bin/launch-multipassd
+++ b/snap-wrappers/bin/launch-multipassd
@@ -14,4 +14,4 @@ fi
 
 export MULTIPASS_VM_DRIVER
 
-exec "$SNAP/bin/multipassd" --verbosity debug --logger platform
+exec "$SNAP/bin/multipassd" --verbosity debug --logger platform "${@}"


### PR DESCRIPTION
This is so that you can override `--verbosity` with a systemd `.override` file.