### PR TITLE
[lxd] Use a single NetworkAccessManager object

### DIFF
--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -55,8 +55,6 @@ QString daemon_config_home();                      // temporary
 
 bool is_backend_supported(const QString& backend); // temporary
 VirtualMachineFactory::UPtr vm_backend(const Path& data_dir);
-std::unique_ptr<VMImageVault> make_image_vault(std::vector<VMImageHost*> image_host, URLDownloader* downloader,
-                                               Path cache_dir_path, Path data_dir_path, days days_to_expire);
 logging::Logger::UPtr make_logger(logging::Level level);
 UpdatePrompt::UPtr make_update_prompt();
 std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& config);

--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -18,9 +18,12 @@
 #ifndef MULTIPASS_VIRTUAL_MACHINE_FACTORY_H
 #define MULTIPASS_VIRTUAL_MACHINE_FACTORY_H
 
+#include <multipass/days.h>
 #include <multipass/fetch_type.h>
+#include <multipass/path.h>
 #include <multipass/virtual_machine.h>
 #include <multipass/vm_image.h>
+#include <multipass/vm_image_vault.h>
 
 namespace YAML
 {
@@ -29,9 +32,11 @@ class Node;
 
 namespace multipass
 {
+class URLDownloader;
 class VirtualMachineDescription;
 class VMImageHost;
 class VMStatusMonitor;
+
 class VirtualMachineFactory
 {
 public:
@@ -53,6 +58,9 @@ public:
     virtual void hypervisor_health_check() = 0;
     virtual QString get_backend_directory_name() = 0;
     virtual QString get_backend_version_string() = 0;
+    virtual VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
+                                                  const Path& cache_dir_path, const Path& data_dir_path,
+                                                  const days& days_to_expire) = 0;
 
 protected:
     VirtualMachineFactory() = default;

--- a/include/multipass/vm_image_vault.h
+++ b/include/multipass/vm_image_vault.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@
 #include <multipass/progress_monitor.h>
 
 #include <functional>
+#include <memory>
 
 namespace multipass
 {
@@ -31,8 +32,10 @@ class VMImage;
 class VMImageVault
 {
 public:
-    virtual ~VMImageVault() = default;
+    using UPtr = std::unique_ptr<VMImageVault>;
     using PrepareAction = std::function<VMImage(const VMImage&)>;
+
+    virtual ~VMImageVault() = default;
     virtual VMImage fetch_image(const FetchType& fetch_type, const Query& query, const PrepareAction& prepare,
                                 const ProgressMonitor& monitor) = 0;
     virtual void remove(const std::string& name) = 0;

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -132,7 +132,7 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
             hosts.push_back(image.get());
         }
 
-        vault = platform::make_image_vault(
+        vault = factory->create_image_vault(
             hosts, url_downloader.get(),
             mp::utils::backend_directory_path(cache_directory, factory->get_backend_directory_name()),
             mp::utils::backend_directory_path(data_directory, factory->get_backend_directory_name()), days_to_expire);

--- a/src/platform/backends/libvirt/CMakeLists.txt
+++ b/src/platform/backends/libvirt/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Copyright © 2018-2019 Canonical Ltd.
+#Copyright © 2018-2020 Canonical Ltd.
 #
 #This program is free software : you can redistribute it and / or modify
 #it under the terms of the GNU General Public License version 3 as
@@ -24,6 +24,7 @@ function(add_libvirt_target TARGET_NAME)
 
   target_include_directories(${TARGET_NAME} PRIVATE ${LIBVIRT_INCLUDE_DIRS})
   target_link_libraries(${TARGET_NAME}
+    daemon
     fmt
     ip_address
     Qt5::Core

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -17,6 +17,7 @@
 
 #include "lxd_virtual_machine_factory.h"
 #include "lxd_virtual_machine.h"
+#include "lxd_vm_image_vault.h"
 
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
@@ -108,4 +109,13 @@ void mp::LXDVirtualMachineFactory::hypervisor_health_check()
                  fmt::format("{}: {}", base_url.toString(), QJsonDocument(reply).toJson(QJsonDocument::Compact)));
         throw std::runtime_error("Failed to authenticate to LXD.");
     }
+}
+
+mp::VMImageVault::UPtr mp::LXDVirtualMachineFactory::create_image_vault(std::vector<mp::VMImageHost*> image_hosts,
+                                                                        mp::URLDownloader* downloader,
+                                                                        const mp::Path& cache_dir_path,
+                                                                        const mp::Path& data_dir_path,
+                                                                        const mp::days& days_to_expire)
+{
+    return std::make_unique<mp::LXDVMImageVault>(image_hosts, manager.get(), base_url);
 }

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -51,6 +51,9 @@ public:
     {
         return "lxd";
     };
+    VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
+                                          const Path& cache_dir_path, const Path& data_dir_path,
+                                          const days& days_to_expire) override;
 
 private:
     NetworkAccessManager::UPtr manager;

--- a/src/platform/backends/lxd/lxd_vm_image_vault.h
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.h
@@ -18,9 +18,6 @@
 #ifndef MULTIPASS_LXD_VM_IMAGE_VAULT_H
 #define MULTIPASS_LXD_VM_IMAGE_VAULT_H
 
-#include "lxd_request.h"
-
-#include <multipass/network_access_manager.h>
 #include <multipass/query.h>
 #include <multipass/vm_image_host.h>
 #include <multipass/vm_image_vault.h>
@@ -31,10 +28,12 @@
 
 namespace multipass
 {
+class NetworkAccessManager;
+
 class LXDVMImageVault final : public VMImageVault
 {
 public:
-    LXDVMImageVault(std::vector<VMImageHost*> image_host, const QUrl& base_url = lxd_socket_url);
+    LXDVMImageVault(std::vector<VMImageHost*> image_host, NetworkAccessManager* manager, const QUrl& base_url);
 
     VMImage fetch_image(const FetchType& fetch_type, const Query& query, const PrepareAction& prepare,
                         const ProgressMonitor& monitor) override;
@@ -48,8 +47,8 @@ private:
     VMImageInfo info_for(const Query& query);
 
     std::vector<VMImageHost*> image_hosts;
+    NetworkAccessManager* manager;
     const QUrl base_url;
-    std::unique_ptr<NetworkAccessManager> manager;
     std::unordered_map<std::string, VMImageHost*> remote_image_host_map;
 };
 } // namespace multipass

--- a/src/platform/backends/qemu/CMakeLists.txt
+++ b/src/platform/backends/qemu/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(qemu_backend STATIC
   qemu_virtual_machine.cpp)
 
 target_link_libraries(qemu_backend
+  daemon
   fmt
   logger
   Qt5::Core

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -22,6 +22,8 @@
 #include <multipass/logging/log.h>
 #include <multipass/virtual_machine_factory.h>
 
+#include <daemon/default_vm_image_vault.h>
+
 namespace multipass
 {
 constexpr auto log_category = "base factory";
@@ -44,6 +46,14 @@ public:
     QString get_backend_directory_name() override
     {
         return {};
+    };
+
+    VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
+                                          const Path& cache_dir_path, const Path& data_dir_path,
+                                          const days& days_to_expire) override
+    {
+        return std::make_unique<DefaultVMImageVault>(image_hosts, downloader, cache_dir_path, data_dir_path,
+                                                     days_to_expire);
     };
 };
 } // namespace multipass

--- a/src/platform/backends/shared/linux/CMakeLists.txt
+++ b/src/platform/backends/shared/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018-2019 Canonical Ltd.
+# Copyright © 2018-2020 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -27,5 +27,6 @@ include_directories(shared_linux
 target_link_libraries(shared_linux
   apparmor
   fmt
+  shared
   utils
   Qt5::Core)

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -28,12 +28,10 @@
 
 #include "backends/libvirt/libvirt_virtual_machine_factory.h"
 #include "backends/lxd/lxd_virtual_machine_factory.h"
-#include "backends/lxd/lxd_vm_image_vault.h"
 #include "backends/qemu/qemu_virtual_machine_factory.h"
 #include "logger/journald_logger.h"
 #include "shared/linux/process_factory.h"
 #include "shared/sshfs_server_process_spec.h"
-#include <daemon/default_vm_image_vault.h>
 #include <disabled_update_prompt.h>
 
 #include <signal.h>
@@ -124,18 +122,6 @@ mp::VirtualMachineFactory::UPtr mp::platform::vm_backend(const mp::Path& data_di
         return std::make_unique<LXDVirtualMachineFactory>(data_dir);
     else
         throw std::runtime_error(fmt::format("Unsupported virtualization driver: {}", driver));
-}
-
-std::unique_ptr<mp::VMImageVault> mp::platform::make_image_vault(std::vector<mp::VMImageHost*> image_hosts,
-                                                                 mp::URLDownloader* downloader, mp::Path cache_dir_path,
-                                                                 mp::Path data_dir_path, mp::days days_to_expire)
-{
-    const auto& driver = utils::get_driver_str();
-    if (driver == QStringLiteral("lxd"))
-        return std::make_unique<LXDVMImageVault>(image_hosts);
-    else
-        return std::make_unique<DefaultVMImageVault>(image_hosts, downloader, cache_dir_path, data_dir_path,
-                                                     days_to_expire);
 }
 
 std::unique_ptr<mp::Process> mp::platform::make_sshfs_server_process(const mp::SSHFSServerConfig& config)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(multipass_tests
 
 target_include_directories(multipass_tests
   PRIVATE ${CMAKE_SOURCE_DIR}
+  PRIVATE ${CMAKE_SOURCE_DIR}/src
   PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/backends
   PRIVATE ${MULTIPASS_GTEST_DIR}
   PRIVATE ${MULTIPASS_GTEST_DIR}/include

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -40,6 +40,8 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD0(hypervisor_health_check, void());
     MOCK_METHOD0(get_backend_directory_name, QString());
     MOCK_METHOD0(get_backend_version_string, QString());
+    MOCK_METHOD5(create_image_vault,
+                 VMImageVault::UPtr(std::vector<VMImageHost*>, URLDownloader*, const Path&, const Path&, const days&));
 };
 }
 }

--- a/tests/stub_virtual_machine_factory.h
+++ b/tests/stub_virtual_machine_factory.h
@@ -19,6 +19,7 @@
 #define MULTIPASS_STUB_VIRTUAL_MACHINE_FACTORY_H
 
 #include "stub_virtual_machine.h"
+#include "stub_vm_image_vault.h"
 
 #include <multipass/virtual_machine_factory.h>
 
@@ -69,6 +70,13 @@ struct StubVirtualMachineFactory : public multipass::VirtualMachineFactory
     QString get_backend_version_string() override
     {
         return "stub-5678";
+    }
+
+    multipass::VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
+                                                     const Path& cache_dir_path, const Path& data_dir_path,
+                                                     const days& days_to_expire) override
+    {
+        return std::make_unique<StubVMImageVault>();
     }
 };
 }

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -20,6 +20,8 @@
 #include <shared/base_virtual_machine_factory.h>
 
 #include "mock_logger.h"
+#include "stub_url_downloader.h"
+#include "temp_dir.h"
 
 #include <gmock/gmock.h>
 
@@ -81,4 +83,17 @@ TEST_F(BaseFactory, dir_name_returns_empty_string)
     const auto dir_name = factory.get_backend_directory_name();
 
     EXPECT_TRUE(dir_name.isEmpty());
+}
+
+TEST_F(BaseFactory, create_image_vault_returns_default_vault)
+{
+    mpt::StubURLDownloader stub_downloader;
+    mpt::TempDir cache_dir;
+    mpt::TempDir data_dir;
+    std::vector<mp::VMImageHost*> hosts;
+    MockBaseFactory factory;
+
+    auto vault = factory.create_image_vault(hosts, &stub_downloader, cache_dir.path(), data_dir.path(), mp::days{0});
+
+    EXPECT_TRUE(dynamic_cast<mp::DefaultVMImageVault*>(vault.get()));
 }


### PR DESCRIPTION
- All LXD backend classes will share a single NetworkAccessManager object owned by LXDVirtualMachineFactory.