### PR TITLE
[lxd] Fix slow startup of daemon when getting image info

### DIFF
--- a/src/daemon/common_image_host.h
+++ b/src/daemon/common_image_host.h
@@ -20,7 +20,7 @@
 
 #include "multipass/vm_image_host.h"
 
-#include <QTimer>
+#include <QFuture>
 
 #include <chrono>
 
@@ -48,7 +48,7 @@ private:
     std::chrono::seconds manifest_time_to_live;
     std::chrono::steady_clock::time_point last_update;
     bool need_extra_update = true;
-    QTimer manifest_single_shot;
+    QFuture<void> manifest_update_future;
 };
 
 }


### PR DESCRIPTION
- Use LXD's store image info instead of querying SimpleStreams.
- Make getting SimpleStreams manifest updates run in a separate thread.