### PR TITLE
[snap] Allow CLI client to use the "all-home" interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ apps:
     command: bin/launch-multipass
     completer: etc/bash_completion.d/snap.multipass
     plugs:
-      - home
+      - all-home
       - network
   gui:
     environment: *client-environment


### PR DESCRIPTION
- This will ease the restriction a bit of where the client can mount and copy-files.

---

This is just partial fix for where user's can mount and copy-files.  The better long term solution is to use `multipass-support` for the clients.