### PR TITLE
Enable auto cache and disable compression on sshfs mounts

### DIFF
--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -90,7 +90,7 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
 
     auto version_info{run_cmd(session, fmt::format("sudo {} -V", sshfs_exec))};
 
-    sshfs_exec += " -o slave -o transform_symlinks -o allow_other";
+    sshfs_exec += " -o slave -o transform_symlinks -o allow_other -o auto_cache -o Compression=no";
 
     auto fuse_version_line = mp::utils::match_line_for(version_info, fuse_version_string);
     if (!fuse_version_line.empty())

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -203,7 +203,7 @@ struct SshfsMount : public mp::test::SftpServerTest
          "/home/ubuntu/\n"},
         {"id -u", "1000\n"},
         {"id -g", "1000\n"},
-        {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o allow_other :\"source\" "
+        {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o allow_other  -o auto_cache -o Compression=no :\"source\" "
          "\"target\"",
          "don't care\n"}};
 };

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -203,8 +203,8 @@ struct SshfsMount : public mp::test::SftpServerTest
          "/home/ubuntu/\n"},
         {"id -u", "1000\n"},
         {"id -g", "1000\n"},
-        {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o allow_other  -o auto_cache -o Compression=no :\"source\" "
-         "\"target\"",
+        {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o allow_other  -o "
+         "auto_cache -o Compression=no :\"source\" \"target\"",
          "don't care\n"}};
 };
 

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -298,7 +298,7 @@ INSTANTIATE_TEST_SUITE_P(SshfsMountThrowWhenError, SshfsMountFail,
 // Commands to check that a version of FUSE smaller that 3 gives a correct answer.
 CommandVector old_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 2.9.0\n"},
                                {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-                                "allow_other -o nonempty -o auto_cache -o Compression=no :\"source\" \"/home/ubuntu/target\"",
+                                "allow_other -o auto_cache -o Compression=no -o nonempty :\"source\" \"/home/ubuntu/target\"",
                                 "don't care\n"}};
 
 // Commands to check that a version of FUSE at least 3.0.0 gives a correct answer.

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -298,7 +298,7 @@ INSTANTIATE_TEST_SUITE_P(SshfsMountThrowWhenError, SshfsMountFail,
 // Commands to check that a version of FUSE smaller that 3 gives a correct answer.
 CommandVector old_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 2.9.0\n"},
                                {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-                                "allow_other -o auto_cache -o Compression=no :\"source\" \"/home/ubuntu/target\"",
+                                "allow_other -o nonempty -o auto_cache -o Compression=no :\"source\" \"/home/ubuntu/target\"",
                                 "don't care\n"}};
 
 // Commands to check that a version of FUSE at least 3.0.0 gives a correct answer.

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -296,10 +296,11 @@ INSTANTIATE_TEST_SUITE_P(SshfsMountThrowWhenError, SshfsMountFail,
                          testing::Values("mkdir", "chown", "id -u", "id -g", "cd", "echo $PWD"));
 
 // Commands to check that a version of FUSE smaller that 3 gives a correct answer.
-CommandVector old_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 2.9.0\n"},
-                               {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-                                "allow_other -o auto_cache -o Compression=no -o nonempty :\"source\" \"/home/ubuntu/target\"",
-                                "don't care\n"}};
+CommandVector old_fuse_cmds = {
+    {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 2.9.0\n"},
+    {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
+     "allow_other -o auto_cache -o Compression=no -o nonempty :\"source\" \"/home/ubuntu/target\"",
+     "don't care\n"}};
 
 // Commands to check that a version of FUSE at least 3.0.0 gives a correct answer.
 CommandVector new_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -298,19 +298,19 @@ INSTANTIATE_TEST_SUITE_P(SshfsMountThrowWhenError, SshfsMountFail,
 // Commands to check that a version of FUSE smaller that 3 gives a correct answer.
 CommandVector old_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 2.9.0\n"},
                                {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-                                "allow_other -o nonempty :\"source\" \"/home/ubuntu/target\"",
+                                "allow_other -o auto_cache -o Compression=no :\"source\" \"/home/ubuntu/target\"",
                                 "don't care\n"}};
 
 // Commands to check that a version of FUSE at least 3.0.0 gives a correct answer.
 CommandVector new_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},
                                {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-                                "allow_other :\"source\" \"/home/ubuntu/target\"",
+                                "allow_other -o auto_cache -o Compression=no :\"source\" \"/home/ubuntu/target\"",
                                 "don't care\n"}};
 
 // Commands to check that an unknown version of FUSE gives a correct answer.
 CommandVector unk_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "weird fuse version\n"},
                                {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-                                "allow_other :\"source\" \"/home/ubuntu/target\"",
+                                "allow_other -o auto_cache -o Compression=no :\"source\" \"/home/ubuntu/target\"",
                                 "don't care\n"}};
 
 // Commands to check that the server correctly creates the mount target.


### PR DESCRIPTION
This is related to #1502 

sshfs has a default cache duration of 20 seconds. Since multipass is a local virtual machine, it might make sense to disable compression (as we are less worried about the network traffic) and auto caching enables caching based on modification times. 

> Note: this came out of research and trial and error based on this SE post: https://superuser.com/a/1359783/215387

Happy to discuss the options in further detail, but the default 20 second cache is rather noticeable in our project.