### PR TITLE
virtual_machine_factory: Introduce new base class common implementation

### DIFF
--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Canonical, Ltd.
+ * Copyright (C) 2018-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ namespace mpl = multipass::logging;
 namespace
 {
 constexpr auto multipass_bridge_name = "mpvirtbr0";
-constexpr auto logging_category = "libvirt-factory";
+constexpr auto logging_category = "libvirt factory";
 
 auto generate_libvirt_bridge_xml_config(const mp::Path& data_dir, const std::string& bridge_name)
 {
@@ -107,7 +107,8 @@ auto make_libvirt_wrapper(const std::string& libvirt_object_path)
 
 mp::LibVirtVirtualMachineFactory::LibVirtVirtualMachineFactory(const mp::Path& data_dir,
                                                                const std::string& libvirt_object_path)
-    : libvirt_wrapper{make_libvirt_wrapper(libvirt_object_path)},
+    : BaseVirtualMachineFactory(logging_category),
+      libvirt_wrapper{make_libvirt_wrapper(libvirt_object_path)},
       data_dir{data_dir},
       bridge_name{enable_libvirt_network(data_dir, libvirt_wrapper)},
       libvirt_object_path{libvirt_object_path}
@@ -147,11 +148,6 @@ void mp::LibVirtVirtualMachineFactory::remove_resources_for(const std::string& n
     libvirt_wrapper->virDomainUndefine(libvirt_wrapper->virDomainLookupByName(connection.get(), name.c_str()));
 }
 
-mp::FetchType mp::LibVirtVirtualMachineFactory::fetch_type()
-{
-    return mp::FetchType::ImageOnly;
-}
-
 mp::VMImage mp::LibVirtVirtualMachineFactory::prepare_source_image(const VMImage& source_image)
 {
     VMImage image{source_image};
@@ -163,11 +159,6 @@ void mp::LibVirtVirtualMachineFactory::prepare_instance_image(const VMImage& ins
                                                               const VirtualMachineDescription& desc)
 {
     mp::backend::resize_instance_image(desc.disk_space, instance_image.image_path);
-}
-
-void mp::LibVirtVirtualMachineFactory::configure(const std::string& /*name*/, YAML::Node& /*meta_config*/,
-                                                 YAML::Node& /*user_config*/)
-{
 }
 
 void mp::LibVirtVirtualMachineFactory::hypervisor_health_check()

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
@@ -107,8 +107,7 @@ auto make_libvirt_wrapper(const std::string& libvirt_object_path)
 
 mp::LibVirtVirtualMachineFactory::LibVirtVirtualMachineFactory(const mp::Path& data_dir,
                                                                const std::string& libvirt_object_path)
-    : BaseVirtualMachineFactory(logging_category),
-      libvirt_wrapper{make_libvirt_wrapper(libvirt_object_path)},
+    : libvirt_wrapper{make_libvirt_wrapper(libvirt_object_path)},
       data_dir{data_dir},
       bridge_name{enable_libvirt_network(data_dir, libvirt_wrapper)},
       libvirt_object_path{libvirt_object_path}

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Canonical, Ltd.
+ * Copyright (C) 2018-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
 
 #include "libvirt_wrapper.h"
 
-#include <multipass/virtual_machine_factory.h>
+#include <shared/base_virtual_machine_factory.h>
 
 #include <memory>
 #include <string>
@@ -28,7 +28,7 @@ namespace multipass
 {
 class ProcessFactory;
 
-class LibVirtVirtualMachineFactory final : public VirtualMachineFactory
+class LibVirtVirtualMachineFactory final : public BaseVirtualMachineFactory
 {
 public:
     explicit LibVirtVirtualMachineFactory(const Path& data_dir, const std::string& libvirt_object_path); // For testing
@@ -38,15 +38,9 @@ public:
     VirtualMachine::UPtr create_virtual_machine(const VirtualMachineDescription& desc,
                                                 VMStatusMonitor& monitor) override;
     void remove_resources_for(const std::string& name) override;
-    FetchType fetch_type() override;
     VMImage prepare_source_image(const VMImage& source_image) override;
     void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) override;
-    void configure(const std::string& name, YAML::Node& meta_config, YAML::Node& user_config) override;
     void hypervisor_health_check() override;
-    QString get_backend_directory_name() override
-    {
-        return {};
-    };
     QString get_backend_version_string() override;
 
     // Making this public makes this modifiable which is necessary for testing

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -36,7 +36,8 @@ const QString multipass_bridge_name = "mpbr0";
 
 mp::LXDVirtualMachineFactory::LXDVirtualMachineFactory(NetworkAccessManager::UPtr manager, const mp::Path& data_dir,
                                                        const QUrl& base_url)
-    : manager{std::move(manager)},
+    : BaseVirtualMachineFactory(category),
+      manager{std::move(manager)},
       data_dir{mp::utils::make_dir(data_dir, get_backend_directory_name())},
       base_url{base_url}
 {
@@ -91,26 +92,10 @@ void mp::LXDVirtualMachineFactory::remove_resources_for(const std::string& name)
     mpl::log(mpl::Level::trace, category, fmt::format("No resources to remove for \"{}\"", name));
 }
 
-mp::FetchType mp::LXDVirtualMachineFactory::fetch_type()
-{
-    return mp::FetchType::ImageOnly;
-}
-
-mp::VMImage mp::LXDVirtualMachineFactory::prepare_source_image(const mp::VMImage& source_image)
-{
-    return source_image;
-}
-
 void mp::LXDVirtualMachineFactory::prepare_instance_image(const mp::VMImage& /* instance_image */,
                                                           const VirtualMachineDescription& /* desc */)
 {
     mpl::log(mpl::Level::trace, category, "No driver preparation for instance image");
-}
-
-void mp::LXDVirtualMachineFactory::configure(const std::string& name, YAML::Node& /* meta_config */,
-                                             YAML::Node& /* user_config */)
-{
-    mpl::log(mpl::Level::trace, category, fmt::format("No driver configuration for \"{}\"", name));
 }
 
 void mp::LXDVirtualMachineFactory::hypervisor_health_check()

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -36,8 +36,7 @@ const QString multipass_bridge_name = "mpbr0";
 
 mp::LXDVirtualMachineFactory::LXDVirtualMachineFactory(NetworkAccessManager::UPtr manager, const mp::Path& data_dir,
                                                        const QUrl& base_url)
-    : BaseVirtualMachineFactory(category),
-      manager{std::move(manager)},
+    : manager{std::move(manager)},
       data_dir{mp::utils::make_dir(data_dir, get_backend_directory_name())},
       base_url{base_url}
 {

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -21,13 +21,13 @@
 #include "lxd_request.h"
 
 #include <multipass/network_access_manager.h>
-#include <multipass/virtual_machine_factory.h>
+#include <shared/base_virtual_machine_factory.h>
 
 #include <QUrl>
 
 namespace multipass
 {
-class LXDVirtualMachineFactory final : public VirtualMachineFactory
+class LXDVirtualMachineFactory final : public BaseVirtualMachineFactory
 {
 public:
     explicit LXDVirtualMachineFactory(const Path& data_dir, const QUrl& base_url = lxd_socket_url);
@@ -37,10 +37,11 @@ public:
     VirtualMachine::UPtr create_virtual_machine(const VirtualMachineDescription& desc,
                                                 VMStatusMonitor& monitor) override;
     void remove_resources_for(const std::string& name) override;
-    FetchType fetch_type() override;
-    VMImage prepare_source_image(const VMImage& source_image) override;
+    VMImage prepare_source_image(const VMImage& source_image) override
+    {
+        return source_image;
+    };
     void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) override;
-    void configure(const std::string& name, YAML::Node& meta_config, YAML::Node& user_config) override;
     void hypervisor_health_check() override;
     QString get_backend_directory_name() override
     {

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -120,8 +120,7 @@ mp::DNSMasqServer create_dnsmasq_server(const mp::Path& network_dir, const QStri
 } // namespace
 
 mp::QemuVirtualMachineFactory::QemuVirtualMachineFactory(const mp::Path& data_dir)
-    : BaseVirtualMachineFactory(category),
-      bridge_name{QString::fromStdString(multipass_bridge_name)},
+    : bridge_name{QString::fromStdString(multipass_bridge_name)},
       network_dir{mp::utils::make_dir(QDir(data_dir), "network")},
       subnet{mp::backend::get_subnet(network_dir, bridge_name)},
       dnsmasq_server{create_dnsmasq_server(network_dir, bridge_name, subnet)},

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
 #include "iptables_config.h"
 
 #include <multipass/path.h>
-#include <multipass/virtual_machine_factory.h>
+#include <shared/base_virtual_machine_factory.h>
 
 #include <QString>
 
@@ -30,7 +30,7 @@
 
 namespace multipass
 {
-class QemuVirtualMachineFactory final : public VirtualMachineFactory
+class QemuVirtualMachineFactory final : public BaseVirtualMachineFactory
 {
 public:
     explicit QemuVirtualMachineFactory(const Path& data_dir);
@@ -39,15 +39,9 @@ public:
     VirtualMachine::UPtr create_virtual_machine(const VirtualMachineDescription& desc,
                                                 VMStatusMonitor& monitor) override;
     void remove_resources_for(const std::string& name) override;
-    FetchType fetch_type() override;
     VMImage prepare_source_image(const VMImage& source_image) override;
     void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) override;
-    void configure(const std::string& name, YAML::Node& meta_config, YAML::Node& user_config) override;
     void hypervisor_health_check() override;
-    QString get_backend_directory_name() override
-    {
-        return {};
-    };
     QString get_backend_version_string() override;
 
 private:

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_BASE_VIRTUAL_MACHINE_FACTORY_H
+#define MULTIPASS_BASE_VIRTUAL_MACHINE_FACTORY_H
+
+#include <multipass/format.h>
+#include <multipass/logging/log.h>
+#include <multipass/virtual_machine_factory.h>
+
+namespace multipass
+{
+class BaseVirtualMachineFactory : public VirtualMachineFactory
+{
+public:
+    BaseVirtualMachineFactory(const logging::CString& category) : log_category{category} {};
+
+    FetchType fetch_type() override
+    {
+        return FetchType::ImageOnly;
+    };
+
+    void configure(const std::string& name, YAML::Node& /*meta_config*/, YAML::Node& /*user_config*/) override
+    {
+        log(logging::Level::trace, log_category, fmt::format("No driver configuration for \"{}\"", name));
+    };
+
+    QString get_backend_directory_name() override
+    {
+        return {};
+    };
+
+protected:
+    const logging::CString log_category;
+};
+} // namespace multipass
+
+#endif // MULTIPASS_BASE_VIRTUAL_MACHINE_FACTORY_H

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -24,11 +24,11 @@
 
 namespace multipass
 {
+constexpr auto category = "base factory";
+
 class BaseVirtualMachineFactory : public VirtualMachineFactory
 {
 public:
-    BaseVirtualMachineFactory(const logging::CString& category) : log_category{category} {};
-
     FetchType fetch_type() override
     {
         return FetchType::ImageOnly;
@@ -36,16 +36,13 @@ public:
 
     void configure(const std::string& name, YAML::Node& /*meta_config*/, YAML::Node& /*user_config*/) override
     {
-        log(logging::Level::trace, log_category, fmt::format("No driver configuration for \"{}\"", name));
+        log(logging::Level::trace, category, fmt::format("No driver configuration for \"{}\"", name));
     };
 
     QString get_backend_directory_name() override
     {
         return {};
     };
-
-protected:
-    const logging::CString log_category;
 };
 } // namespace multipass
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(multipass_tests
   temp_dir.cpp
   temp_file.cpp
   test_argparser.cpp
+  test_base_virtual_machine_factory.cpp
   test_basic_process.cpp
   test_cli_client.cpp
   test_client_cert_store.cpp

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -31,12 +31,8 @@ using namespace testing;
 
 namespace
 {
-constexpr auto category = "testing";
-
 struct MockBaseFactory : mp::BaseVirtualMachineFactory
 {
-    MockBaseFactory() : mp::BaseVirtualMachineFactory(category){};
-
     MOCK_METHOD2(create_virtual_machine,
                  mp::VirtualMachine::UPtr(const mp::VirtualMachineDescription&, mp::VMStatusMonitor&));
     MOCK_METHOD1(remove_resources_for, void(const std::string&));
@@ -69,7 +65,7 @@ TEST_F(BaseFactory, configure_logs_trace_message)
     const std::string name{"foo"};
     MockBaseFactory factory;
 
-    EXPECT_CALL(*logger, log(Eq(mpl::Level::trace), mpt::MockLogger::make_cstring_matcher(StrEq(category)),
+    EXPECT_CALL(*logger, log(Eq(mpl::Level::trace), mpt::MockLogger::make_cstring_matcher(StrEq("base factory")),
                              mpt::MockLogger::make_cstring_matcher(
                                  StrEq(fmt::format("No driver configuration for \"{}\"", name)))));
 

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/virtual_machine_description.h>
+#include <multipass/vm_status_monitor.h>
+#include <shared/base_virtual_machine_factory.h>
+
+#include "mock_logger.h"
+
+#include <gmock/gmock.h>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+namespace mpt = multipass::test;
+
+using namespace testing;
+
+namespace
+{
+constexpr auto category = "testing";
+
+struct MockBaseFactory : mp::BaseVirtualMachineFactory
+{
+    MockBaseFactory() : mp::BaseVirtualMachineFactory(category){};
+
+    MOCK_METHOD2(create_virtual_machine,
+                 mp::VirtualMachine::UPtr(const mp::VirtualMachineDescription&, mp::VMStatusMonitor&));
+    MOCK_METHOD1(remove_resources_for, void(const std::string&));
+    MOCK_METHOD1(prepare_source_image, mp::VMImage(const mp::VMImage&));
+    MOCK_METHOD2(prepare_instance_image, void(const mp::VMImage&, const mp::VirtualMachineDescription&));
+    MOCK_METHOD0(hypervisor_health_check, void());
+    MOCK_METHOD0(get_backend_version_string, QString());
+};
+
+struct BaseFactory : public Test
+{
+    BaseFactory()
+    {
+        mpl::set_logger(logger);
+    }
+
+    std::shared_ptr<NiceMock<mpt::MockLogger>> logger = std::make_shared<NiceMock<mpt::MockLogger>>();
+};
+} // namespace
+
+TEST_F(BaseFactory, returns_image_only_fetch_type)
+{
+    MockBaseFactory factory;
+
+    EXPECT_EQ(factory.fetch_type(), mp::FetchType::ImageOnly);
+}
+
+TEST_F(BaseFactory, configure_logs_trace_message)
+{
+    const std::string name{"foo"};
+    MockBaseFactory factory;
+
+    EXPECT_CALL(*logger, log(Eq(mpl::Level::trace), mpt::MockLogger::make_cstring_matcher(StrEq(category)),
+                             mpt::MockLogger::make_cstring_matcher(
+                                 StrEq(fmt::format("No driver configuration for \"{}\"", name)))));
+
+    YAML::Node node;
+
+    factory.configure(name, node, node);
+}
+
+TEST_F(BaseFactory, dir_name_returns_empty_string)
+{
+    MockBaseFactory factory;
+
+    const auto dir_name = factory.get_backend_directory_name();
+
+    EXPECT_TRUE(dir_name.isEmpty());
+}


### PR DESCRIPTION
This allows for the various virtual machine factories to use a base class implementation
for defaults to cut down on code reuse.