### PR TITLE
Dnsmasq server fix

### DIFF
--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -70,10 +70,12 @@ mp::DNSMasqServer::DNSMasqServer(const Path& data_dir, const QString& bridge_nam
 
     try
     {
+        mpl::log(mpl::Level::debug, "dnsmasq", "Looking for dnsmasq");
         check_dnsmasq_running();
     }
     catch (const std::exception&)
     {
+        mpl::log(logging::Level::warning, "dnsmasq", "Could not confirm dnsmasq is running");
         // Ignore
     }
 }

--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -51,6 +51,7 @@ auto get_dnsmasq_pid(const mp::Path& pid_file_path)
     std::string pid;
 
     getline(pid_file, pid);
+    mpl::log(mpl::Level::debug, "dnsmasq", fmt::format("Read pid \"{}\" from file \"{}\"", pid, pid_file_path));
 
     // std::stoi will throw if pid doesn't exist or is invalid
     return static_cast<unsigned int>(std::stoi(pid));
@@ -149,15 +150,17 @@ void mp::DNSMasqServer::check_dnsmasq_running()
         auto dnsmasq_pid = get_dnsmasq_pid(pid_file_path);
         if (kill(dnsmasq_pid, 0) == 0)
         {
+            mpl::log(mpl::Level::debug, "dnsmasq", fmt::format("existing dnsmasq found with pid {}", dnsmasq_pid));
             return;
         }
     }
-    catch (const std::exception&)
+    catch (const std::exception& e)
     {
+        mpl::log(mpl::Level::debug, "dnsmasq", fmt::format("Exception caught while looking for dnsmasq: {}", e.what()));
         // Ignore and fall-through
     }
 
-    // Try starting dnsmasq since it's not running
+    mpl::log(mpl::Level::debug, "dnsmasq", "Starting dnsmasq");
     start_dnsmasq();
 }
 

--- a/src/platform/backends/qemu/dnsmasq_server.h
+++ b/src/platform/backends/qemu/dnsmasq_server.h
@@ -35,7 +35,6 @@ class DNSMasqServer
 {
 public:
     DNSMasqServer(const Path& data_dir, const QString& bridge_name, const std::string& subnet);
-    DNSMasqServer(DNSMasqServer&& other) = default;
     ~DNSMasqServer();
 
     optional<IPAddress> get_ip_for(const std::string& hw_addr);
@@ -43,6 +42,9 @@ public:
     void check_dnsmasq_running();
 
 private:
+    DNSMasqServer(const DNSMasqServer&) = delete;
+    DNSMasqServer& operator=(const DNSMasqServer&) = delete;
+
     void start_dnsmasq();
 
     const QString data_dir;


### PR DESCRIPTION
Remove an explicitly-defaulted move ctor that actually gets implicitly deleted because the QTemporaryFile member is non-copyable. Make the class non-copyable instead (since it owns a dnsmasq process resource).

The class should still have been non-copyable, but just to be sure, since an unintentional copy could explain the behavior I experienced yesterday, where dnsmasq seemingly failed to come up. That's kind of what I would expect if a) dnsmasq was found to be running and b) a temporary dtor immediately killed it.

Also add some debug logging to help untangle problems in the future.