### PR TITLE
[factory] Remove configure() as it's not used by any factory

### DIFF
--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -54,7 +54,6 @@ public:
     virtual FetchType fetch_type() = 0;
     virtual VMImage prepare_source_image(const VMImage& source_image) = 0;
     virtual void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) = 0;
-    virtual void configure(const std::string& name, YAML::Node& meta_config, YAML::Node& user_config) = 0;
     virtual void hypervisor_health_check() = 0;
     virtual QString get_backend_directory_name() = 0;
     virtual QString get_backend_version_string() = 0;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2032,7 +2032,6 @@ void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriter<Crea
                 auto meta_data_cloud_init_config = make_cloud_init_meta_config(name);
                 auto user_data_cloud_init_config = YAML::Load(request->cloud_init_user_data());
                 prepare_user_data(user_data_cloud_init_config, vendor_data_cloud_init_config);
-                config->factory->configure(name, meta_data_cloud_init_config, vendor_data_cloud_init_config);
 
                 std::string mac_addr;
                 while (true)

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -38,11 +38,6 @@ public:
         return FetchType::ImageOnly;
     };
 
-    void configure(const std::string& name, YAML::Node& /*meta_config*/, YAML::Node& /*user_config*/) override
-    {
-        log(logging::Level::trace, log_category, fmt::format("No driver configuration for \"{}\"", name));
-    };
-
     QString get_backend_directory_name() override
     {
         return {};

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -36,7 +36,6 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD0(fetch_type, FetchType());
     MOCK_METHOD1(prepare_source_image, VMImage(const VMImage&));
     MOCK_METHOD2(prepare_instance_image, void(const VMImage&, const VirtualMachineDescription&));
-    MOCK_METHOD3(configure, void(const std::string&, YAML::Node&, YAML::Node&));
     MOCK_METHOD0(hypervisor_health_check, void());
     MOCK_METHOD0(get_backend_directory_name, QString());
     MOCK_METHOD0(get_backend_version_string, QString());

--- a/tests/stub_virtual_machine_factory.h
+++ b/tests/stub_virtual_machine_factory.h
@@ -54,10 +54,6 @@ struct StubVirtualMachineFactory : public multipass::VirtualMachineFactory
     {
     }
 
-    void configure(const std::string&, YAML::Node&, YAML::Node&) override
-    {
-    }
-
     void hypervisor_health_check() override
     {
     }

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -62,20 +62,6 @@ TEST_F(BaseFactory, returns_image_only_fetch_type)
     EXPECT_EQ(factory.fetch_type(), mp::FetchType::ImageOnly);
 }
 
-TEST_F(BaseFactory, configure_logs_trace_message)
-{
-    const std::string name{"foo"};
-    MockBaseFactory factory;
-
-    EXPECT_CALL(*logger, log(Eq(mpl::Level::trace), mpt::MockLogger::make_cstring_matcher(StrEq("base factory")),
-                             mpt::MockLogger::make_cstring_matcher(
-                                 StrEq(fmt::format("No driver configuration for \"{}\"", name)))));
-
-    YAML::Node node;
-
-    factory.configure(name, node, node);
-}
-
 TEST_F(BaseFactory, dir_name_returns_empty_string)
 {
     MockBaseFactory factory;


### PR DESCRIPTION
---

The factory configure() method is a no-op for all backends and I see no reason to keep it around.