### PR TITLE
[snap_utils] Throw exception when snap dir env vars are not found

### DIFF
--- a/include/multipass/exceptions/snap_environment_exception.h
+++ b/include/multipass/exceptions/snap_environment_exception.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,18 +15,22 @@
  *
  */
 
-#ifndef MULTIPASS_SNAP_UTILS_H
-#define MULTIPASS_SNAP_UTILS_H
+#ifndef MULTIPASS_SNAP_ENVIRONMENT_EXCEPTION_H
+#define MULTIPASS_SNAP_ENVIRONMENT_EXCEPTION_H
 
-#include <QByteArray>
+#include <stdexcept>
+
+#include <multipass/format.h>
 
 namespace multipass
 {
-namespace utils
+class SnapEnvironmentException : public std::runtime_error
 {
-QByteArray snap_dir();
-QByteArray snap_common_dir();
-} // namespace utils
+public:
+    SnapEnvironmentException(const std::string& env_var)
+        : runtime_error(fmt::format("The \'{}\' environment variable is not set.", env_var))
+    {
+    }
+};
 } // namespace multipass
-
-#endif // MULTIPASS_SNAP_UTILS_H
+#endif // MULTIPASS_SNAP_ENVIRONMENT_EXCEPTION_H

--- a/include/multipass/exceptions/snap_environment_exception.h
+++ b/include/multipass/exceptions/snap_environment_exception.h
@@ -31,6 +31,11 @@ public:
         : runtime_error(fmt::format("The \'{}\' environment variable is not set.", env_var))
     {
     }
+
+    SnapEnvironmentException(const std::string& env_var, const std::string& expected_value)
+        : runtime_error(fmt::format("The \'{}\' environment variable is not set to \'{}\'.", env_var, expected_value))
+    {
+    }
 };
 } // namespace multipass
 #endif // MULTIPASS_SNAP_ENVIRONMENT_EXCEPTION_H

--- a/src/platform/backends/qemu/dnsmasq_process_spec.cpp
+++ b/src/platform/backends/qemu/dnsmasq_process_spec.cpp
@@ -17,6 +17,7 @@
 
 #include "dnsmasq_process_spec.h"
 
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/format.h>
 #include <multipass/snap_utils.h>
 
@@ -112,12 +113,13 @@ profile %1 flags=(attach_disconnected) {
     QString root_dir;    // root directory: either "" or $SNAP
     QString signal_peer; // who can send kill signal to dnsmasq
 
-    if (mu::is_snap()) // if snap confined, specify only multipassd can kill dnsmasq
+    try
     {
+        // if snap confined, specify only multipassd can kill dnsmasq
         root_dir = mu::snap_dir();
         signal_peer = "snap.multipass.multipassd";
     }
-    else
+    catch (const mp::SnapEnvironmentException&)
     {
         signal_peer = "unconfined";
     }

--- a/src/platform/backends/qemu/qemu_base_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_base_process_spec.cpp
@@ -17,6 +17,7 @@
 
 #include "qemu_base_process_spec.h"
 
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/snap_utils.h>
 #include <shared/linux/backend_utils.h>
 
@@ -30,9 +31,14 @@ QString mp::QemuBaseProcessSpec::program() const
 
 QString mp::QemuBaseProcessSpec::working_directory() const
 {
-    if (mu::is_snap())
+    try
+    {
         return mu::snap_dir().append("/qemu");
-    return QString();
+    }
+    catch (const mp::SnapEnvironmentException&)
+    {
+        return QString();
+    }
 }
 
 QString mp::QemuBaseProcessSpec::apparmor_profile() const

--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -17,6 +17,7 @@
 
 #include "qemu_vm_process_spec.h"
 
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/snap_utils.h>
@@ -230,13 +231,13 @@ profile %1 flags=(attach_disconnected) {
     QString signal_peer; // who can send kill signal to qemu
     QString firmware;    // location of bootloader firmware needed by qemu
 
-    if (mu::is_snap())
+    try
     {
         root_dir = mu::snap_dir();
         signal_peer = "snap.multipass.multipassd"; // only multipassd can send qemu signals
         firmware = root_dir + "/qemu/*";           // if snap confined, firmware in $SNAP/qemu
     }
-    else
+    catch (const mp::SnapEnvironmentException&)
     {
         signal_peer = "unconfined";
         firmware = "/usr/share/seabios/*";

--- a/src/platform/backends/shared/linux/CMakeLists.txt
+++ b/src/platform/backends/shared/linux/CMakeLists.txt
@@ -15,17 +15,25 @@
 include(FindPkgConfig)
 pkg_search_module(APPARMOR libapparmor REQUIRED)
 
-add_library(shared_linux STATIC
-  apparmor.cpp
-  backend_utils.cpp
-  process_factory.cpp)
+function(add_target TARGET_NAME)
+  add_library(${TARGET_NAME} STATIC
+    apparmor.cpp
+    backend_utils.cpp
+    process_factory.cpp)
+
+  target_link_libraries(${TARGET_NAME}
+    apparmor
+    fmt
+    shared
+    utils
+    Qt5::Core)
+endfunction()
+
+add_target(shared_linux)
+if(MULTIPASS_ENABLE_TESTS)
+  add_target(shared_linux_test)
+endif()
 
 include_directories(shared_linux
   ..)
 
-target_link_libraries(shared_linux
-  apparmor
-  fmt
-  shared
-  utils
-  Qt5::Core)

--- a/src/platform/backends/shared/linux/apparmor.cpp
+++ b/src/platform/backends/shared/linux/apparmor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 
 #include "apparmor.h"
 
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/snap_utils.h>
@@ -48,7 +49,7 @@ void throw_if_binary_fails(const char* binary_name, const QStringList& arguments
 
 QStringList generate_extra_apparmor_args()
 {
-    if (mp::utils::is_snap())
+    try
     {
         QString apparmor_cache_dir = mp::utils::snap_common_dir() + "/apparmor.d/cache/multipass";
         QDir cache_dir;
@@ -61,6 +62,11 @@ QStringList generate_extra_apparmor_args()
             mpl::log(mpl::Level::debug, "daemon", "Failed to create cache directory for AppArmor - disabling caching");
         }
     }
+    catch (const mp::SnapEnvironmentException&)
+    {
+        // Ignore
+    }
+
     return {"-W"};
 }
 

--- a/src/platform/backends/shared/linux/apparmor.cpp
+++ b/src/platform/backends/shared/linux/apparmor.cpp
@@ -75,7 +75,7 @@ QStringList generate_extra_apparmor_args()
 mp::AppArmor::AppArmor() : apparmor_args{generate_extra_apparmor_args()}
 {
     int ret = aa_is_enabled();
-    if (ret < 0)
+    if (ret <= 0)
     {
         throw mp::AppArmorException("AppArmor is not enabled");
     }

--- a/src/platform/backends/shared/linux/process_factory.cpp
+++ b/src/platform/backends/shared/linux/process_factory.cpp
@@ -64,7 +64,7 @@ private:
 
 mp::optional<mp::AppArmor> create_apparmor()
 {
-    if (!mp::utils::is_snap() && qEnvironmentVariableIsSet("DISABLE_APPARMOR"))
+    if (!qEnvironmentVariableIsSet("SNAP") && qEnvironmentVariableIsSet("DISABLE_APPARMOR"))
     {
         mpl::log(mpl::Level::warning, "apparmor", "AppArmor disabled by environment variable");
         return mp::nullopt;

--- a/src/platform/backends/shared/linux/process_factory.cpp
+++ b/src/platform/backends/shared/linux/process_factory.cpp
@@ -16,13 +16,14 @@
  */
 
 #include "process_factory.h"
+
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/process/basic_process.h>
 #include <multipass/process/process_spec.h>
 #include <multipass/process/simple_process_spec.h>
 #include <multipass/snap_utils.h>
-#include <multipass/utils.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -64,23 +65,28 @@ private:
 
 mp::optional<mp::AppArmor> create_apparmor()
 {
-    if (!qEnvironmentVariableIsSet("SNAP") && qEnvironmentVariableIsSet("DISABLE_APPARMOR"))
+    try
     {
-        mpl::log(mpl::Level::warning, "apparmor", "AppArmor disabled by environment variable");
-        return mp::nullopt;
+        mp::utils::snap_dir();
     }
-    else
+    catch (const mp::SnapEnvironmentException&)
     {
-        try
+        if (qEnvironmentVariableIsSet("DISABLE_APPARMOR"))
         {
-            mpl::log(mpl::Level::info, "apparmor", "Using AppArmor support");
-            return mp::AppArmor{};
-        }
-        catch (mp::AppArmorException& e)
-        {
-            mpl::log(mpl::Level::warning, "apparmor", fmt::format("Failed to enable AppArmor: {}", e.what()));
+            mpl::log(mpl::Level::warning, "apparmor", "AppArmor disabled by environment variable");
             return mp::nullopt;
         }
+    }
+
+    try
+    {
+        mpl::log(mpl::Level::info, "apparmor", "Using AppArmor support");
+        return mp::AppArmor{};
+    }
+    catch (mp::AppArmorException& e)
+    {
+        mpl::log(mpl::Level::warning, "apparmor", fmt::format("Failed to enable AppArmor: {}", e.what()));
+        return mp::nullopt;
     }
 }
 } // namespace

--- a/src/platform/backends/shared/sshfs_server_process_spec.cpp
+++ b/src/platform/backends/shared/sshfs_server_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 
 #include "sshfs_server_process_spec.h"
 
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/snap_utils.h>
 
 #include <QCoreApplication>
@@ -123,12 +124,12 @@ profile %1 flags=(attach_disconnected) {
                       // snap. If snapped, is located relative to $SNAP
     QString signal_peer; // if snap confined, specify only multipassd can kill dnsmasq
 
-    if (mu::is_snap())
+    try
     {
         root_dir = mu::snap_dir();
         signal_peer = "snap.multipass.multipassd";
     }
-    else
+    catch (const mp::SnapEnvironmentException&)
     {
         QDir application_dir(QCoreApplication::applicationDirPath());
         application_dir.cdUp();

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -18,6 +18,7 @@
 #include <multipass/constants.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
 #include <multipass/exceptions/settings_exceptions.h>
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
@@ -81,12 +82,12 @@ std::string mp::platform::default_server_address()
 {
     std::string base_dir;
 
-    if (mu::is_snap())
+    try
     {
         // if Snap, client and daemon can both access $SNAP_COMMON so can put socket there
         base_dir = mu::snap_common_dir().toStdString();
     }
-    else
+    catch (const mp::SnapEnvironmentException&)
     {
         base_dir = "/run";
     }

--- a/src/process/qemuimg_process_spec.cpp
+++ b/src/process/qemuimg_process_spec.cpp
@@ -15,6 +15,7 @@
  *
  */
 
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/process/qemuimg_process_spec.h>
 #include <multipass/snap_utils.h>
 
@@ -65,13 +66,13 @@ profile %1 flags=(attach_disconnected) {
     QString extra_capabilities;
     QString signal_peer; // who can send kill signal to qemu-img
 
-    if (mu::is_snap())
+    try
     {
         root_dir = mu::snap_dir();
         image_dir = mu::snap_common_dir();         // FIXME - am guessing we work inside this directory
         signal_peer = "snap.multipass.multipassd"; // only multipassd can send qemu-img signals
     }
-    else
+    catch (mp::SnapEnvironmentException&)
     {
         extra_capabilities =
             "capability dac_read_search,\n    capability dac_override,"; // FIXME - unclear why this is required when

--- a/src/utils/snap_utils.cpp
+++ b/src/utils/snap_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,27 +15,32 @@
  *
  */
 
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/snap_utils.h>
 
 #include <QFileInfo>
 
+namespace mp = multipass;
 namespace mu = multipass::utils;
-
-bool mu::is_snap()
-{
-    // Decide if Snap based on if $SNAP env var is set.
-    // TODO: can this be better?
-    return !snap_dir().isEmpty();
-}
 
 QByteArray mu::snap_dir()
 {
     auto snap_dir = qgetenv("SNAP");                         // Inside snap, this can be trusted.
+    if (snap_dir.isEmpty())
+    {
+        throw mp::SnapEnvironmentException("SNAP");
+    }
+
     return QFileInfo(snap_dir).canonicalFilePath().toUtf8(); // To resolve any symlinks
 }
 
 QByteArray mu::snap_common_dir()
 {
     auto snap_common = qgetenv("SNAP_COMMON");                  // Inside snap, this can be trusted
+    if (snap_common.isEmpty())
+    {
+        throw mp::SnapEnvironmentException("SNAP_COMMON");
+    }
+
     return QFileInfo(snap_common).canonicalFilePath().toUtf8(); // To resolve any symlinks
 }

--- a/src/utils/snap_utils.cpp
+++ b/src/utils/snap_utils.cpp
@@ -19,12 +19,26 @@
 #include <multipass/snap_utils.h>
 
 #include <QFileInfo>
+#include <QString>
 
 namespace mp = multipass;
 namespace mu = multipass::utils;
 
+namespace
+{
+const QString snap_name{"multipass"};
+
+void verify_snap_name()
+{
+    if (qgetenv("SNAP_NAME") != snap_name)
+        throw mp::SnapEnvironmentException("SNAP_NAME", snap_name.toStdString());
+}
+} // namespace
+
 QByteArray mu::snap_dir()
 {
+    verify_snap_name();
+
     auto snap_dir = qgetenv("SNAP");                         // Inside snap, this can be trusted.
     if (snap_dir.isEmpty())
     {
@@ -36,6 +50,8 @@ QByteArray mu::snap_dir()
 
 QByteArray mu::snap_common_dir()
 {
+    verify_snap_name();
+
     auto snap_common = qgetenv("SNAP_COMMON");                  // Inside snap, this can be trusted
     if (snap_common.isEmpty())
     {

--- a/tests/linux/CMakeLists.txt
+++ b/tests/linux/CMakeLists.txt
@@ -5,7 +5,14 @@ target_sources(multipass_tests
     ${CMAKE_CURRENT_LIST_DIR}/test_local_network_access_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_platform_linux.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_snap_utils.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mock_aa_is_enabled.cpp
 )
+
+target_compile_definitions(shared_linux_test PRIVATE
+  -Daa_is_enabled=ut_aa_is_enabled)
+
+target_link_libraries(multipass_tests
+  shared_linux_test)
 
 add_executable(apparmor_parser
   mock_apparmor_parser.cpp)

--- a/tests/linux/CMakeLists.txt
+++ b/tests/linux/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(multipass_tests
     ${CMAKE_CURRENT_LIST_DIR}/test_local_network_access_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_platform_linux.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_snap_utils.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/mock_aa_is_enabled.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mock_aa_syscalls.cpp
 )
 
 target_compile_definitions(shared_linux_test PRIVATE

--- a/tests/linux/mock_aa_syscalls.cpp
+++ b/tests/linux/mock_aa_syscalls.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mock_aa_syscalls.h"
+
+extern "C" IMPL_MOCK_DEFAULT(0, aa_is_enabled);

--- a/tests/linux/mock_aa_syscalls.h
+++ b/tests/linux/mock_aa_syscalls.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_AA_IS_ENABLED_H
+#define MULTIPASS_AA_IS_ENABLED_H
+
+#include <premock.hpp>
+
+#include <sys/apparmor.h>
+
+DECL_MOCK(aa_is_enabled);
+
+#endif // MULTIPASS_AA_IS_ENABLED_H

--- a/tests/linux/mock_aa_syscalls.h
+++ b/tests/linux/mock_aa_syscalls.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef MULTIPASS_AA_IS_ENABLED_H
-#define MULTIPASS_AA_IS_ENABLED_H
+#ifndef MULTIPASS_MOCK_AA_SYSCALLS_H
+#define MULTIPASS_MOCK_AA_SYSCALLS_H
 
 #include <premock.hpp>
 
@@ -24,4 +24,4 @@
 
 DECL_MOCK(aa_is_enabled);
 
-#endif // MULTIPASS_AA_IS_ENABLED_H
+#endif // MULTIPASS_MOCK_AA_SYSCALLS_H

--- a/tests/linux/test_apparmored_process.cpp
+++ b/tests/linux/test_apparmored_process.cpp
@@ -101,7 +101,10 @@ TEST_F(ApparmoredProcessTest, loads_profile_with_apparmor)
 TEST_F(ApparmoredProcessNoFactoryTest, snap_enables_cache_with_expected_args)
 {
     mpt::TempDir cache_dir;
+    const QByteArray snap_name{"multipass"};
+
     mpt::SetEnvScope env_scope("SNAP_COMMON", cache_dir.path().toUtf8());
+    mpt::SetEnvScope env_scope2("SNAP_NAME", snap_name);
 
     const mp::ProcessFactory& process_factory{mp::ProcessFactory::instance()};
     auto process = process_factory.create_process(std::make_unique<TestProcessSpec>());

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -328,6 +328,22 @@ TEST_F(PlatformLinux, test_is_remote_supported_lxd_driver)
     EXPECT_FALSE(mp::platform::is_remote_supported("appliance"));
 }
 
+TEST_F(PlatformLinux, test_snap_returns_expected_default_address)
+{
+    const QByteArray base_dir{"/tmp"};
+
+    mpt::SetEnvScope env("SNAP_COMMON", base_dir);
+
+    EXPECT_EQ(mp::platform::default_server_address(), fmt::format("unix:{}/multipass_socket", base_dir.toStdString()));
+}
+
+TEST_F(PlatformLinux, test_not_snap_returns_expected_default_address)
+{
+    mpt::UnsetEnvScope unset_env("SNAP_COMMON");
+
+    EXPECT_EQ(mp::platform::default_server_address(), fmt::format("unix:/run/multipass_socket"));
+}
+
 struct TestUnsupportedDrivers : public TestWithParam<QString>
 {
 };

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -331,15 +331,20 @@ TEST_F(PlatformLinux, test_is_remote_supported_lxd_driver)
 TEST_F(PlatformLinux, test_snap_returns_expected_default_address)
 {
     const QByteArray base_dir{"/tmp"};
+    const QByteArray snap_name{"multipass"};
 
     mpt::SetEnvScope env("SNAP_COMMON", base_dir);
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
 
     EXPECT_EQ(mp::platform::default_server_address(), fmt::format("unix:{}/multipass_socket", base_dir.toStdString()));
 }
 
 TEST_F(PlatformLinux, test_not_snap_returns_expected_default_address)
 {
+    const QByteArray snap_name{"multipass"};
+
     mpt::UnsetEnvScope unset_env("SNAP_COMMON");
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
 
     EXPECT_EQ(mp::platform::default_server_address(), fmt::format("unix:/run/multipass_socket"));
 }

--- a/tests/linux/test_snap_utils.cpp
+++ b/tests/linux/test_snap_utils.cpp
@@ -15,6 +15,7 @@
  *
  */
 
+#include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/snap_utils.h>
 
 #include <QFile>
@@ -34,14 +35,14 @@ TEST(SnapUtils, test_is_confined_when_snap_dir_set)
 {
     mpt::SetEnvScope env("SNAP", "/tmp");
 
-    EXPECT_TRUE(mu::is_snap());
+    EXPECT_NO_THROW(mu::snap_dir());
 }
 
 TEST(SnapUtils, test_is_not_confined_when_snap_dir_not_set)
 {
     mpt::UnsetEnvScope env("SNAP");
 
-    EXPECT_FALSE(mu::is_snap());
+    EXPECT_THROW(mu::snap_dir(), mp::SnapEnvironmentException);
 }
 
 TEST(SnapUtils, test_snap_dir_read_ok)
@@ -50,13 +51,6 @@ TEST(SnapUtils, test_snap_dir_read_ok)
     mpt::SetEnvScope env("SNAP", snap_dir.path().toUtf8());
 
     EXPECT_EQ(snap_dir.path(), mu::snap_dir());
-}
-
-TEST(SnapUtils, test_snap_dir_null_if_not_set)
-{
-    mpt::UnsetEnvScope env("SNAP");
-
-    EXPECT_EQ(QByteArray(), mu::snap_dir());
 }
 
 TEST(SnapUtils, test_snap_dir_resolves_links)
@@ -77,11 +71,11 @@ TEST(SnapUtils, test_snap_common_dir_read_ok)
     EXPECT_EQ(snap_dir.path(), mu::snap_common_dir());
 }
 
-TEST(SnapUtils, test_snap_common_dir_null_if_not_set)
+TEST(SnapUtils, test_snap_common_dir_throws_if_not_set)
 {
     mpt::UnsetEnvScope env("SNAP_COMMON");
 
-    EXPECT_EQ(QByteArray(), mu::snap_common_dir());
+    EXPECT_THROW(mu::snap_common_dir(), mp::SnapEnvironmentException);
 }
 
 TEST(SnapUtils, test_snap_common_resolves_links)

--- a/tests/linux/test_snap_utils.cpp
+++ b/tests/linux/test_snap_utils.cpp
@@ -71,6 +71,14 @@ TEST(SnapUtils, test_snap_common_dir_read_ok)
     EXPECT_EQ(snap_dir.path(), mu::snap_common_dir());
 }
 
+TEST(SnapUtils, test_snap_common_dir_no_throw_if_set)
+{
+    QTemporaryDir snap_dir;
+    mpt::SetEnvScope env("SNAP_COMMON", snap_dir.path().toUtf8());
+
+    EXPECT_NO_THROW(mu::snap_common_dir());
+}
+
 TEST(SnapUtils, test_snap_common_dir_throws_if_not_set)
 {
     mpt::UnsetEnvScope env("SNAP_COMMON");

--- a/tests/linux/test_snap_utils.cpp
+++ b/tests/linux/test_snap_utils.cpp
@@ -31,9 +31,15 @@ namespace mu = multipass::utils;
 
 using namespace testing;
 
+namespace
+{
+const QByteArray snap_name{"multipass"};
+} // namespace
+
 TEST(SnapUtils, test_is_confined_when_snap_dir_set)
 {
     mpt::SetEnvScope env("SNAP", "/tmp");
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
 
     EXPECT_NO_THROW(mu::snap_dir());
 }
@@ -41,6 +47,16 @@ TEST(SnapUtils, test_is_confined_when_snap_dir_set)
 TEST(SnapUtils, test_is_not_confined_when_snap_dir_not_set)
 {
     mpt::UnsetEnvScope env("SNAP");
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
+
+    EXPECT_THROW(mu::snap_dir(), mp::SnapEnvironmentException);
+}
+
+TEST(SnapUtils, test_is_not_confined_when_snap_name_not_set_snap_dir_set)
+{
+    QTemporaryDir snap_dir;
+    mpt::SetEnvScope env("SNAP", snap_dir.path().toUtf8());
+    mpt::UnsetEnvScope env2("SNAP_NAME");
 
     EXPECT_THROW(mu::snap_dir(), mp::SnapEnvironmentException);
 }
@@ -49,6 +65,7 @@ TEST(SnapUtils, test_snap_dir_read_ok)
 {
     QTemporaryDir snap_dir;
     mpt::SetEnvScope env("SNAP", snap_dir.path().toUtf8());
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
 
     EXPECT_EQ(snap_dir.path(), mu::snap_dir());
 }
@@ -59,6 +76,7 @@ TEST(SnapUtils, test_snap_dir_resolves_links)
     link_dir.remove();
     QFile::link(snap_dir.path(), link_dir.path());
     mpt::SetEnvScope env("SNAP", link_dir.path().toUtf8());
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
 
     EXPECT_EQ(snap_dir.path(), mu::snap_dir());
 }
@@ -67,6 +85,7 @@ TEST(SnapUtils, test_snap_common_dir_read_ok)
 {
     QTemporaryDir snap_dir;
     mpt::SetEnvScope env("SNAP_COMMON", snap_dir.path().toUtf8());
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
 
     EXPECT_EQ(snap_dir.path(), mu::snap_common_dir());
 }
@@ -75,6 +94,7 @@ TEST(SnapUtils, test_snap_common_dir_no_throw_if_set)
 {
     QTemporaryDir snap_dir;
     mpt::SetEnvScope env("SNAP_COMMON", snap_dir.path().toUtf8());
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
 
     EXPECT_NO_THROW(mu::snap_common_dir());
 }
@@ -82,6 +102,16 @@ TEST(SnapUtils, test_snap_common_dir_no_throw_if_set)
 TEST(SnapUtils, test_snap_common_dir_throws_if_not_set)
 {
     mpt::UnsetEnvScope env("SNAP_COMMON");
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
+
+    EXPECT_THROW(mu::snap_common_dir(), mp::SnapEnvironmentException);
+}
+
+TEST(SnapUtils, test_is_not_confined_when_snap_name_not_set_snap_common_set)
+{
+    QTemporaryDir snap_dir;
+    mpt::SetEnvScope env("SNAP_COMMON", snap_dir.path().toUtf8());
+    mpt::UnsetEnvScope env2("SNAP_NAME");
 
     EXPECT_THROW(mu::snap_common_dir(), mp::SnapEnvironmentException);
 }
@@ -92,6 +122,17 @@ TEST(SnapUtils, test_snap_common_resolves_links)
     link_dir.remove();
     QFile::link(common_dir.path(), link_dir.path());
     mpt::SetEnvScope env("SNAP_COMMON", link_dir.path().toUtf8());
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
 
     EXPECT_EQ(common_dir.path(), mu::snap_common_dir());
+}
+
+TEST(SnapUtils, test_snap_name_not_multipass_throws)
+{
+    QByteArray snap_name{"foo"};
+    QTemporaryDir snap_dir;
+    mpt::SetEnvScope env("SNAP_COMMON", snap_dir.path().toUtf8());
+    mpt::SetEnvScope env2("SNAP_NAME", snap_name);
+
+    EXPECT_THROW(mu::snap_common_dir(), mp::SnapEnvironmentException);
 }

--- a/tests/qemu/test_qemu_vm_process_spec.cpp
+++ b/tests/qemu/test_qemu_vm_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -185,9 +185,11 @@ TEST_F(TestQemuVMProcessSpec, apparmor_profile_identifier)
 
 TEST_F(TestQemuVMProcessSpec, apparmor_profile_running_as_snap_correct)
 {
+    const QByteArray snap_name{"multipass"};
     QTemporaryDir snap_dir;
 
     mpt::SetEnvScope e("SNAP", snap_dir.path().toUtf8());
+    mpt::SetEnvScope e2("SNAP_NAME", snap_name);
     mp::QemuVMProcessSpec spec(desc, tap_device_name, mp::nullopt);
 
     EXPECT_TRUE(spec.apparmor_profile().contains("signal (receive) peer=snap.multipass.multipassd"));
@@ -197,11 +199,14 @@ TEST_F(TestQemuVMProcessSpec, apparmor_profile_running_as_snap_correct)
 
 TEST_F(TestQemuVMProcessSpec, apparmor_profile_running_as_symlinked_snap_correct)
 {
+    const QByteArray snap_name{"multipass"};
     QTemporaryDir snap_dir, link_dir;
+
     link_dir.remove();
     QFile::link(snap_dir.path(), link_dir.path());
 
     mpt::SetEnvScope e("SNAP", link_dir.path().toUtf8());
+    mpt::SetEnvScope e2("SNAP_NAME", snap_name);
     mp::QemuVMProcessSpec spec(desc, tap_device_name, mp::nullopt);
 
     EXPECT_TRUE(spec.apparmor_profile().contains(QString("%1/qemu/* r,").arg(snap_dir.path())));
@@ -210,7 +215,10 @@ TEST_F(TestQemuVMProcessSpec, apparmor_profile_running_as_symlinked_snap_correct
 
 TEST_F(TestQemuVMProcessSpec, apparmor_profile_not_running_as_snap_correct)
 {
+    const QByteArray snap_name{"multipass"};
+
     mpt::UnsetEnvScope e("SNAP");
+    mpt::SetEnvScope e2("SNAP_NAME", snap_name);
     mp::QemuVMProcessSpec spec(desc, tap_device_name, mp::nullopt);
 
     EXPECT_TRUE(spec.apparmor_profile().contains("signal (receive) peer=unconfined"));

--- a/tests/test_qemuimg_process_spec.cpp
+++ b/tests/test_qemuimg_process_spec.cpp
@@ -65,9 +65,12 @@ TEST(TestQemuImgProcessSpec, no_apparmor_profile_identifier)
 
 TEST(TestQemuImgProcessSpec, apparmor_profile_running_as_snap_correct)
 {
+    const QByteArray snap_name{"multipass"};
     QTemporaryDir snap_dir, common_dir;
+
     mpt::SetEnvScope e("SNAP", snap_dir.path().toUtf8());
     mpt::SetEnvScope e2("SNAP_COMMON", common_dir.path().toUtf8());
+    mpt::SetEnvScope e3("SNAP_NAME", snap_name);
     mp::QemuImgProcessSpec spec({});
 
     EXPECT_TRUE(spec.apparmor_profile().contains(QString("%1/usr/bin/qemu-img ixr,").arg(snap_dir.path())));
@@ -76,7 +79,9 @@ TEST(TestQemuImgProcessSpec, apparmor_profile_running_as_snap_correct)
 
 TEST(TestQemuImgProcessSpec, apparmor_profile_running_as_symlinked_snap_correct)
 {
+    const QByteArray snap_name{"multipass"};
     QTemporaryDir snap_dir, snap_link_dir, common_dir, common_link_dir;
+
     snap_link_dir.remove();
     common_link_dir.remove();
     QFile::link(snap_dir.path(), snap_link_dir.path());
@@ -84,6 +89,7 @@ TEST(TestQemuImgProcessSpec, apparmor_profile_running_as_symlinked_snap_correct)
 
     mpt::SetEnvScope e("SNAP", snap_link_dir.path().toUtf8());
     mpt::SetEnvScope e2("SNAP_COMMON", common_link_dir.path().toUtf8());
+    mpt::SetEnvScope e3("SNAP_NAME", snap_name);
     mp::QemuImgProcessSpec spec({});
 
     EXPECT_TRUE(spec.apparmor_profile().contains(QString("%1/usr/bin/qemu-img ixr,").arg(snap_dir.path())));
@@ -92,7 +98,10 @@ TEST(TestQemuImgProcessSpec, apparmor_profile_running_as_symlinked_snap_correct)
 
 TEST(TestQemuImgProcessSpec, apparmor_profile_not_running_as_snap_correct)
 {
+    const QByteArray snap_name{"multipass"};
+
     mpt::UnsetEnvScope e("SNAP");
+    mpt::SetEnvScope e2("SNAP_NAME", snap_name);
     mp::QemuImgProcessSpec spec({});
 
     EXPECT_TRUE(spec.apparmor_profile().contains("capability dac_read_search,"));

--- a/tests/test_sshfs_server_process_spec.cpp
+++ b/tests/test_sshfs_server_process_spec.cpp
@@ -74,7 +74,10 @@ TEST_F(TestSSHFSServerProcessSpec, environment_correct)
 TEST_F(TestSSHFSServerProcessSpec, snap_confined_apparmor_profile_returns_expected_data)
 {
     mpt::TempDir bin_dir;
+    const QByteArray snap_name{"multipass"};
+
     mpt::SetEnvScope env_scope("SNAP", bin_dir.path().toUtf8());
+    mpt::SetEnvScope env_scope2("SNAP_NAME", snap_name);
     mp::SSHFSServerProcessSpec spec(config);
 
     const auto apparmor_profile = spec.apparmor_profile();
@@ -86,7 +89,10 @@ TEST_F(TestSSHFSServerProcessSpec, snap_confined_apparmor_profile_returns_expect
 
 TEST_F(TestSSHFSServerProcessSpec, unconfined_apparmor_profile_returns_expected_data)
 {
+    const QByteArray snap_name{"multipass"};
+
     mpt::UnsetEnvScope env_scope("SNAP");
+    mpt::SetEnvScope env_scope2("SNAP_NAME", snap_name);
     mp::SSHFSServerProcessSpec spec(config);
     QDir current_dir(QCoreApplication::applicationDirPath());
     const auto apparmor_profile = spec.apparmor_profile();


### PR DESCRIPTION
- When a snap-related directory environment variable is not found, throw the new SnapEnvironmentException exception.