### PR TITLE
Log the command-line of the command being executed

### DIFF
--- a/src/process/basic_process.cpp
+++ b/src/process/basic_process.cpp
@@ -181,7 +181,7 @@ mp::ProcessState mp::BasicProcess::execute(const int timeout)
     start();
 
     mpl::log(mpl::Level::debug, "basic_process",
-             fmt::format("executing {} {}", qUtf8Printable(process_spec->program()),
+             fmt::format("executing: {} {}", qUtf8Printable(process_spec->program()),
                          qUtf8Printable(process_spec->arguments().join(' '))));
 
     if (!process.waitForStarted(timeout) || !process.waitForFinished(timeout) ||

--- a/src/process/basic_process.cpp
+++ b/src/process/basic_process.cpp
@@ -180,7 +180,7 @@ mp::ProcessState mp::BasicProcess::execute(const int timeout)
     mp::ProcessState exit_state;
     start();
 
-    mpl::log(mpl::Level::trace, "basic_process",
+    mpl::log(mpl::Level::debug, "basic_process",
              fmt::format("executing {} {}", qUtf8Printable(process_spec->program()),
                          qUtf8Printable(process_spec->arguments().join(' '))));
 

--- a/src/process/basic_process.cpp
+++ b/src/process/basic_process.cpp
@@ -18,6 +18,8 @@
 #include <multipass/logging/log.h>
 #include <multipass/process/basic_process.h>
 
+#include <fmt/format.h>
+
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 
@@ -177,6 +179,10 @@ mp::ProcessState mp::BasicProcess::execute(const int timeout)
 {
     mp::ProcessState exit_state;
     start();
+
+    mpl::log(mpl::Level::trace, "basic_process",
+             fmt::format("executing {} {}", qUtf8Printable(process_spec->program()),
+                         qUtf8Printable(process_spec->arguments().join(' '))));
 
     if (!process.waitForStarted(timeout) || !process.waitForFinished(timeout) ||
         process.exitStatus() != QProcess::NormalExit)


### PR DESCRIPTION
This logging is implemented in BasicProcess, thus it will work for all processes launched as a ProcessSpec.

The feature was discussed in https://github.com/canonical/multipass-private/pull/273