### PR TITLE
[build] Require cmake version 3.13 or higher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2019 Canonical Ltd.
+# Copyright © 2017-2020 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -12,7 +12,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
+cmake_policy(SET CMP0079 NEW) # Allow target_link_libraries() in subdirs
 
 project(Multipass)
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,11 +85,12 @@ apps:
 parts:
   multipass:
     plugin: cmake
+    build-snaps:
+    - cmake
     build-packages:
     - on arm64: [libgles2-mesa-dev]
     - on armhf: [libgles2-mesa-dev]
     - build-essential
-    - cmake-extras
     - git
     - golang
     - libapparmor-dev

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,7 +151,8 @@ target_include_directories(multipass_tests
   BEFORE
     PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/backends/shared/linux
 )
+
+add_subdirectory(libvirt)
 add_subdirectory(linux)
 add_subdirectory(qemu)
 add_subdirectory(lxd)
-include(libvirt/CMakeLists.txt) # with add_subdirectory it's not possible to target_link_libraries

--- a/tests/libvirt/CMakeLists.txt
+++ b/tests/libvirt/CMakeLists.txt
@@ -7,11 +7,7 @@ target_sources(multipass_tests
 add_library(broken_libvirt SHARED
     ${CMAKE_CURRENT_LIST_DIR}/broken_libvirt_library.cpp)
 
-if(${CMAKE_VERSION} VERSION_LESS "3.13")
-    target_link_libraries(multipass_tests -rdynamic)
-else()
-    target_link_options(multipass_tests PRIVATE -rdynamic)
-endif()
+target_link_options(multipass_tests PRIVATE -rdynamic)
 
 target_compile_definitions(libvirt_backend_test PRIVATE
     ${c_mock_defines})

--- a/tests/travis-Clang.patch
+++ b/tests/travis-Clang.patch
@@ -1,16 +1,14 @@
-diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
-index 99b6312c..bb68596d 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -68,6 +68,7 @@ parts:
+@@ -92,6 +92,7 @@ parts:
+     - on armhf: [libgles2-mesa-dev]
      - build-essential
      - ccache
-     - cmake-extras
 +    - clang-10
      - git
      - golang
      - libapparmor-dev
-@@ -97,6 +98,8 @@ parts:
+@@ -122,6 +123,8 @@ parts:
      - -DCMAKE_INSTALL_PREFIX=/
      - -DMULTIPASS_ENABLE_TESTS=off
      - -DMULTIPASS_UPSTREAM=origin

--- a/tests/travis.patch
+++ b/tests/travis.patch
@@ -1,16 +1,16 @@
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -196,6 +196,7 @@ parts:
+@@ -91,6 +91,7 @@ parts:
      - on arm64: [libgles2-mesa-dev]
      - on armhf: [libgles2-mesa-dev]
      - build-essential
 +    - ccache
-     - cmake-extras
      - git
      - golang
-@@ -213,6 +214,7 @@ parts:
-     - -DCMAKE_INSTALL_PREFIX=/
+     - libapparmor-dev
+@@ -122,6 +123,7 @@ parts:
      - -DMULTIPASS_ENABLE_TESTS=off
+     - -DMULTIPASS_UPSTREAM=origin
      override-build: |
 +      update-ccache-symlinks
        snapcraftctl build


### PR DESCRIPTION
- Add "build-snaps" for specifying cmake snap for building snap.
- target_link_libraries() will now work in subdirectories so get rid of libvirt test hack.

---

This will allow for better gRPC build handling: https://grpc.io/blog/cmake-improvements/