### PR TITLE
[snap] Set 'build-environment' PATH

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,6 +87,8 @@ parts:
     plugin: cmake
     build-snaps:
     - cmake
+    build-environment:
+    - PATH: /snap/bin:$PATH
     build-packages:
     - on arm64: [libgles2-mesa-dev]
     - on armhf: [libgles2-mesa-dev]


### PR DESCRIPTION
This fixes launchpad-buildd builds where Snapcraft does not set the /snap/bin at beginning of $PATH.