### PR TITLE
Use net info in backend

### DIFF
--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -61,7 +61,7 @@ public:
     virtual VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                                   const Path& cache_dir_path, const Path& data_dir_path,
                                                   const days& days_to_expire) = 0;
-    virtual std::vector<NetworkInterfaceInfo> list_networks() = 0;
+    virtual std::vector<NetworkInterfaceInfo> list_networks() const = 0;
 
 protected:
     VirtualMachineFactory() = default;

--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -36,6 +36,7 @@ class URLDownloader;
 class VirtualMachineDescription;
 class VMImageHost;
 class VMStatusMonitor;
+struct NetworkInterfaceInfo;
 
 class VirtualMachineFactory
 {
@@ -60,7 +61,7 @@ public:
     virtual VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                                   const Path& cache_dir_path, const Path& data_dir_path,
                                                   const days& days_to_expire) = 0;
-    virtual std::vector<std::tuple<std::string, std::string, std::string>> list_networks() = 0;
+    virtual std::vector<NetworkInterfaceInfo> list_networks() = 0;
 
 protected:
     VirtualMachineFactory() = default;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1273,9 +1273,9 @@ try // clang-format on
     for (auto iface : iface_list)
     {
         auto entry = response.add_interfaces();
-        entry->set_name(std::get<0>(iface));
-        entry->set_type(std::get<1>(iface));
-        entry->set_description(std::get<2>(iface));
+        entry->set_name(iface.id);
+        entry->set_type(iface.type);
+        entry->set_description(iface.description);
     }
 
     server->Write(response);

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
@@ -19,6 +19,7 @@
 #include "libvirt_virtual_machine.h"
 
 #include <multipass/logging/log.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/utils.h>
 #include <multipass/virtual_machine_description.h>
 #include <shared/linux/backend_utils.h>
@@ -196,4 +197,9 @@ QString mp::LibVirtVirtualMachineFactory::get_backend_version_string()
 
     mpl::log(mpl::Level::error, logging_category, "Failed to determine libvirtd version.");
     return QString("libvirt-unknown");
+}
+
+auto multipass::LibVirtVirtualMachineFactory::list_networks() -> std::vector<NetworkInterfaceInfo>
+{
+    return {}; // TODO
 }

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
@@ -199,7 +199,7 @@ QString mp::LibVirtVirtualMachineFactory::get_backend_version_string()
     return QString("libvirt-unknown");
 }
 
-auto multipass::LibVirtVirtualMachineFactory::list_networks() -> std::vector<NetworkInterfaceInfo>
+auto multipass::LibVirtVirtualMachineFactory::list_networks() const -> std::vector<NetworkInterfaceInfo>
 {
     return {}; // TODO
 }

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
@@ -42,7 +42,7 @@ public:
     void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) override;
     void hypervisor_health_check() override;
     QString get_backend_version_string() override;
-    std::vector<NetworkInterfaceInfo> list_networks() override;
+    std::vector<NetworkInterfaceInfo> list_networks() const override;
 
     // Making this public makes this modifiable which is necessary for testing
     LibvirtWrapper::UPtr libvirt_wrapper;

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
@@ -42,6 +42,7 @@ public:
     void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) override;
     void hypervisor_health_check() override;
     QString get_backend_version_string() override;
+    std::vector<NetworkInterfaceInfo> list_networks() override;
 
     // Making this public makes this modifiable which is necessary for testing
     LibvirtWrapper::UPtr libvirt_wrapper;

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -21,6 +21,7 @@
 
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/utils.h>
 
 #include <QJsonDocument>
@@ -125,4 +126,9 @@ mp::VMImageVault::UPtr mp::LXDVirtualMachineFactory::create_image_vault(std::vec
                                                                         const mp::days& days_to_expire)
 {
     return std::make_unique<mp::LXDVMImageVault>(image_hosts, manager.get(), base_url, days_to_expire);
+}
+
+auto multipass::LXDVirtualMachineFactory::list_networks() -> std::vector<NetworkInterfaceInfo>
+{
+    return {}; // TODO
 }

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -128,7 +128,7 @@ mp::VMImageVault::UPtr mp::LXDVirtualMachineFactory::create_image_vault(std::vec
     return std::make_unique<mp::LXDVMImageVault>(image_hosts, manager.get(), base_url, days_to_expire);
 }
 
-auto multipass::LXDVirtualMachineFactory::list_networks() -> std::vector<NetworkInterfaceInfo>
+auto multipass::LXDVirtualMachineFactory::list_networks() const -> std::vector<NetworkInterfaceInfo>
 {
     return {}; // TODO
 }

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -51,7 +51,7 @@ public:
     VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                           const Path& cache_dir_path, const Path& data_dir_path,
                                           const days& days_to_expire) override;
-    std::vector<NetworkInterfaceInfo> list_networks() override;
+    std::vector<NetworkInterfaceInfo> list_networks() const override;
 
 private:
     NetworkAccessManager::UPtr manager;

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -51,6 +51,7 @@ public:
     VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                           const Path& cache_dir_path, const Path& data_dir_path,
                                           const days& days_to_expire) override;
+    std::vector<NetworkInterfaceInfo> list_networks() override;
 
 private:
     NetworkAccessManager::UPtr manager;

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -20,6 +20,7 @@
 
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/optional.h>
 #include <multipass/utils.h>
 #include <multipass/virtual_machine_description.h>
@@ -211,4 +212,9 @@ QString mp::QemuVirtualMachineFactory::get_backend_version_string()
     }
 
     return QString("qemu-unknown");
+}
+
+auto multipass::QemuVirtualMachineFactory::list_networks() -> std::vector<NetworkInterfaceInfo>
+{
+    return {}; // TODO
 }

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -214,7 +214,7 @@ QString mp::QemuVirtualMachineFactory::get_backend_version_string()
     return QString("qemu-unknown");
 }
 
-auto multipass::QemuVirtualMachineFactory::list_networks() -> std::vector<NetworkInterfaceInfo>
+auto multipass::QemuVirtualMachineFactory::list_networks() const -> std::vector<NetworkInterfaceInfo>
 {
     return {}; // TODO
 }

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -43,7 +43,7 @@ public:
     void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) override;
     void hypervisor_health_check() override;
     QString get_backend_version_string() override;
-    std::vector<NetworkInterfaceInfo> list_networks() override;
+    std::vector<NetworkInterfaceInfo> list_networks() const override;
 
 private:
     const QString bridge_name;

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -43,6 +43,7 @@ public:
     void prepare_instance_image(const VMImage& instance_image, const VirtualMachineDescription& desc) override;
     void hypervisor_health_check() override;
     QString get_backend_version_string() override;
+    std::vector<NetworkInterfaceInfo> list_networks() override;
 
 private:
     const QString bridge_name;

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -20,7 +20,6 @@
 
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
-#include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_factory.h>
 
 #include <daemon/default_vm_image_vault.h>
@@ -50,11 +49,6 @@ public:
     {
         return std::make_unique<DefaultVMImageVault>(image_hosts, downloader, cache_dir_path, data_dir_path,
                                                      days_to_expire);
-    };
-
-    std::vector<NetworkInterfaceInfo> list_networks() override
-    {
-        return {}; // TODO@ricab do we really need this
     };
 };
 } // namespace multipass

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -20,6 +20,7 @@
 
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_factory.h>
 
 #include <daemon/default_vm_image_vault.h>
@@ -51,9 +52,9 @@ public:
                                                      days_to_expire);
     };
 
-    std::vector<std::tuple<std::string, std::string, std::string>> list_networks() override
+    std::vector<NetworkInterfaceInfo> list_networks() override
     {
-        return std::vector<std::tuple<std::string, std::string, std::string>>();
+        return {}; // TODO@ricab do we really need this
     };
 };
 } // namespace multipass

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -41,7 +41,7 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD0(get_backend_version_string, QString());
     MOCK_METHOD5(create_image_vault,
                  VMImageVault::UPtr(std::vector<VMImageHost*>, URLDownloader*, const Path&, const Path&, const days&));
-    MOCK_METHOD0(list_networks, std::vector<std::tuple<std::string, std::string, std::string>>());
+    MOCK_METHOD0(list_networks, std::vector<NetworkInterfaceInfo>());
 };
 }
 }

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -41,7 +41,7 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD0(get_backend_version_string, QString());
     MOCK_METHOD5(create_image_vault,
                  VMImageVault::UPtr(std::vector<VMImageHost*>, URLDownloader*, const Path&, const Path&, const days&));
-    MOCK_METHOD0(list_networks, std::vector<NetworkInterfaceInfo>());
+    MOCK_CONST_METHOD0(list_networks, std::vector<NetworkInterfaceInfo>());
 };
 }
 }

--- a/tests/stub_virtual_machine_factory.h
+++ b/tests/stub_virtual_machine_factory.h
@@ -76,7 +76,7 @@ struct StubVirtualMachineFactory : public multipass::VirtualMachineFactory
         return std::make_unique<StubVMImageVault>();
     }
 
-    std::vector<NetworkInterfaceInfo> list_networks() override
+    std::vector<NetworkInterfaceInfo> list_networks() const override
     {
         return {};
     }

--- a/tests/stub_virtual_machine_factory.h
+++ b/tests/stub_virtual_machine_factory.h
@@ -21,6 +21,7 @@
 #include "stub_virtual_machine.h"
 #include "stub_vm_image_vault.h"
 
+#include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_factory.h>
 
 namespace multipass
@@ -75,9 +76,9 @@ struct StubVirtualMachineFactory : public multipass::VirtualMachineFactory
         return std::make_unique<StubVMImageVault>();
     }
 
-    std::vector<std::tuple<std::string, std::string, std::string>> list_networks() override
+    std::vector<NetworkInterfaceInfo> list_networks() override
     {
-        return std::vector<std::tuple<std::string, std::string, std::string>>();
+        return {};
     }
 };
 }

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -15,6 +15,7 @@
  *
  */
 
+#include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_description.h>
 #include <multipass/vm_status_monitor.h>
 #include <shared/base_virtual_machine_factory.h>
@@ -42,6 +43,7 @@ struct MockBaseFactory : mp::BaseVirtualMachineFactory
     MOCK_METHOD2(prepare_instance_image, void(const mp::VMImage&, const mp::VirtualMachineDescription&));
     MOCK_METHOD0(hypervisor_health_check, void());
     MOCK_METHOD0(get_backend_version_string, QString());
+    MOCK_METHOD0(list_networks, std::vector<mp::NetworkInterfaceInfo>());
 };
 
 struct BaseFactory : public Test

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -43,7 +43,7 @@ struct MockBaseFactory : mp::BaseVirtualMachineFactory
     MOCK_METHOD2(prepare_instance_image, void(const mp::VMImage&, const mp::VirtualMachineDescription&));
     MOCK_METHOD0(hypervisor_health_check, void());
     MOCK_METHOD0(get_backend_version_string, QString());
-    MOCK_METHOD0(list_networks, std::vector<mp::NetworkInterfaceInfo>());
+    MOCK_CONST_METHOD0(list_networks, std::vector<mp::NetworkInterfaceInfo>());
 };
 
 struct BaseFactory : public Test


### PR DESCRIPTION
Hey @luis4a0, I added a few tweaks to the backends' `list_networks`. 

I am not entirely sure about the middle commit, because it's still not clear to me how we'll want to integrate the info from the platform and the backends, how to handle overlaps, etc. If it turns out that multiple backends just get everything from the platform and need nothing else, then it would make sense to call that in the base factory. 

For the time being, the empty impl was just a placeholder, so I thought we'd better have placeholders for each backend, to avoid forgetting the placeholder in the base and proper implementation in the backends. Let's discuss this later today :slightly_smiling_face: 