### PR TITLE
[grpc] Changes needed to support updating gRPC to version 1.30.2

### DIFF
--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -43,12 +43,6 @@ function(generate_grpc_cpp SRCS DEST)
   endforeach ()
 
   set_source_files_properties(${${SRCS}} ${HDRS} PROPERTIES GENERATED TRUE)
-  # Also protobuf uses a compiler extension (namely extended-offsetof), which -Wall can warn about
-  # See https://github.com/google/protobuf/issues/1947
-  CHECK_CXX_COMPILER_FLAG("-Wno-extended-offsetof" COMPILER_SUPPORTS_NO_EXT_OFFSETOF)
-  if(COMPILER_SUPPORTS_NO_EXT_OFFSETOF)
-    set_source_files_properties(${${SRCS}} PROPERTIES COMPILE_FLAGS "-Wno-extended-offsetof")
-  endif()
   set(${SRCS} ${${SRCS}} PARENT_SCOPE)
 endfunction()
 

--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -24,7 +24,7 @@ set(OPENSSL_VERSION "1.1.1")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-int-conversion")
 
-set(OPENSSL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../grpc/third_party/boringssl/include)
+set(OPENSSL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../grpc/third_party/boringssl-with-bazel/src/include)
 set(LIBSSH_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libssh/include)
 
 # Needed only because of libssh install target
@@ -48,7 +48,7 @@ configure_file(libssh/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh/config.h
 
 # Must be set after configure checks as crypto has not been built yet
 # but will be included in the final libssh shared library
-set(OPENSSL_CRYPTO_LIBRARY crypto decrepit ssh-boringssl-compat)
+set(OPENSSL_CRYPTO_LIBRARY crypto ssh-boringssl-compat)
 
 message(STATUS "Checking for 'libssh' version")
 

--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018 Canonical Ltd.
+# Copyright © 2018-2020 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -20,7 +20,7 @@ add_library(cert
 )
 
 target_include_directories(cert PRIVATE
-  ${CMAKE_SOURCE_DIR}/3rd-party/grpc/third_party/boringssl/include)
+  ${CMAKE_SOURCE_DIR}/3rd-party/grpc/third_party/boringssl-with-bazel/src/include)
 
 foreach(flag -Wno-nested-anon-types -Wno-gnu -Wno-pedantic -Wno-ignored-qualifiers)
   check_cxx_compiler_flag(${flag} SUPPORTED)
@@ -30,6 +30,7 @@ foreach(flag -Wno-nested-anon-types -Wno-gnu -Wno-pedantic -Wno-ignored-qualifie
 endforeach()
 
 target_link_libraries(cert
+  ssl
   crypto
   fmt
   utils

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017 Canonical Ltd.
+# Copyright © 2017-2020 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -11,12 +11,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-# Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
 
 set(MULTIPASS_PROTOCOL_SPEC multipass.proto)
 set(GRPC_GENERATED_SOURCE_DIR ${MULTIPASS_GENERATED_SOURCE_DIR}/multipass/rpc)
 file(MAKE_DIRECTORY ${GRPC_GENERATED_SOURCE_DIR})
+
+add_compile_options(-Wno-error)
 
 generate_grpc_cpp(GRPC_GENERATED_SOURCES ${GRPC_GENERATED_SOURCE_DIR} ${MULTIPASS_PROTOCOL_SPEC})
 

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -16,7 +16,7 @@ set(MULTIPASS_PROTOCOL_SPEC multipass.proto)
 set(GRPC_GENERATED_SOURCE_DIR ${MULTIPASS_GENERATED_SOURCE_DIR}/multipass/rpc)
 file(MAKE_DIRECTORY ${GRPC_GENERATED_SOURCE_DIR})
 
-add_compile_options(-Wno-error)
+add_compile_options(-Wno-error=pedantic)
 
 generate_grpc_cpp(GRPC_GENERATED_SOURCES ${GRPC_GENERATED_SOURCE_DIR} ${MULTIPASS_PROTOCOL_SPEC})
 


### PR DESCRIPTION
- boringssl-with-bazel
  - boringssl itself has been dropped.
  - Point openssl includes to boringssl-with-bazel directory.
  - Drop libssh link to decrepit library is this is no longer built.
  - Explicitly link the cert library to the ssl library.
- protobuf
  - Drop '-Wno-extended-offsetof' check as this is no longer used by protobuf.
  - Add '-Wno-error' for rpc builds since new protobuf uses the zero byte array extension
    and ISO C++ forbids causing -pendantic to issue a warning that gets treated like an error.