### PR TITLE
[lxd] Do not send unnecessary source info on instance creation

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -153,9 +153,6 @@ mp::LXDVirtualMachine::LXDVirtualMachine(const VirtualMachineDescription& desc, 
             {"config", config},
             {"devices", devices},
             {"source", QJsonObject{{"type", "image"},
-                                   {"mode", "pull"},
-                                   {"server", QString::fromStdString(desc.image.stream_location)},
-                                   {"protocol", "simplestreams"},
                                    {"fingerprint", QString::fromStdString(desc.image.id)}}}};
 
         auto json_reply = lxd_request(manager, "POST", QUrl(QString("%1/virtual-machines").arg(base_url.toString())),

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -513,9 +513,6 @@ TEST_F(LXDBackend, posts_expected_data_when_creating_instance)
                              "\"name\":\"pied-piper-valley\","
                              "\"source\":{"
                              "\"fingerprint\":\"\","
-                             "\"mode\":\"pull\","
-                             "\"protocol\":\"simplestreams\","
-                             "\"server\":\"\","
                              "\"type\":\"image\""
                              "}"
                              "}"};
@@ -588,9 +585,6 @@ TEST_F(LXDBackend, posts_expected_data_including_disk_size_when_creating_instanc
                              "\"name\":\"pied-piper-valley\","
                              "\"source\":{"
                              "\"fingerprint\":\"\","
-                             "\"mode\":\"pull\","
-                             "\"protocol\":\"simplestreams\","
-                             "\"server\":\"\","
                              "\"type\":\"image\""
                              "}"
                              "}"};


### PR DESCRIPTION
The image is downloaded separately, so there is no need to send source info that tells LXD where to download an image during instance creation.