### PR TITLE
[lxd] Drop saving stream_location as this is only needed for LXDVMImageVault

### DIFF
--- a/include/multipass/vm_image.h
+++ b/include/multipass/vm_image.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -33,7 +31,6 @@ public:
     Path kernel_path;
     Path initrd_path;
     std::string id;
-    std::string stream_location;
     std::string original_release;
     std::string current_release;
     std::string release_date;

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -153,8 +153,8 @@ auto full_image_info_for(const QMap<QString, CustomImageInfo>& custom_image_info
                                         image_url, // image_location
                                         image_info.second.kernel_location,
                                         image_info.second.initrd_location,
-                                        base_image_info.hash,          // id
-                                        prefix,                        // stream_location
+                                        base_image_info.hash, // id
+                                        "",
                                         base_image_info.last_modified, // version
                                         0,
                                         true};

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -73,7 +73,6 @@ auto image_to_json(const mp::VMImage& image)
     json.insert("kernel_path", image.kernel_path);
     json.insert("initrd_path", image.initrd_path);
     json.insert("id", QString::fromStdString(image.id));
-    json.insert("stream_location", QString::fromStdString(image.stream_location));
     json.insert("original_release", QString::fromStdString(image.original_release));
     json.insert("current_release", QString::fromStdString(image.current_release));
     json.insert("release_date", QString::fromStdString(image.release_date));
@@ -134,7 +133,6 @@ std::unordered_map<std::string, mp::VaultRecord> load_db(const QString& db_name)
         auto kernel_path = image["kernel_path"].toString();
         auto initrd_path = image["initrd_path"].toString();
         auto image_id = image["id"].toString().toStdString();
-        auto stream_location = image["stream_location"].toString().toStdString();
         auto original_release = image["original_release"].toString().toStdString();
         auto current_release = image["current_release"].toString().toStdString();
         auto release_date = image["release_date"].toString().toStdString();
@@ -170,8 +168,7 @@ std::unordered_map<std::string, mp::VaultRecord> load_db(const QString& db_name)
         }
 
         reconstructed_records[key] = {
-            {image_path, kernel_path, initrd_path, image_id, stream_location, original_release, current_release,
-             release_date, aliases},
+            {image_path, kernel_path, initrd_path, image_id, original_release, current_release, release_date, aliases},
             {"", release.toStdString(), persistent.toBool(), remote_name.toStdString(), query_type},
             last_accessed};
     }
@@ -613,7 +610,6 @@ mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
     else
     {
         source_image.id = id;
-        source_image.stream_location = info.stream_location.toStdString();
         source_image.image_path = image_dir.filePath(filename_for(info.image_location));
         source_image.original_release = info.release_title.toStdString();
         source_image.release_date = info.version.toStdString();
@@ -704,7 +700,6 @@ mp::VMImage mp::DefaultVMImageVault::image_instance_from(const std::string& inst
             copy(prepared_image.kernel_path, output_dir),
             copy(prepared_image.initrd_path, output_dir),
             prepared_image.id,
-            prepared_image.stream_location,
             prepared_image.original_release,
             prepared_image.current_release,
             prepared_image.release_date,

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -127,7 +127,7 @@ mp::LXDVirtualMachine::LXDVirtualMachine(const VirtualMachineDescription& desc, 
     catch (const LXDNotFoundException& e)
     {
         mpl::log(mpl::Level::debug, name.toStdString(),
-                 fmt::format("Creating container with stream: {}, id: {}", desc.image.stream_location, desc.image.id));
+                 fmt::format("Creating instance with image id: {}", desc.image.id));
 
         QJsonObject config{{"limits.cpu", QString::number(desc.num_cores)},
                            {"limits.memory", QString::number(desc.mem_size.in_bytes())}};

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -93,7 +93,6 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type, const 
             VMImage source_image;
 
             source_image.id = id.toStdString();
-            source_image.stream_location = info.stream_location.toStdString();
             source_image.original_release = info.release_title.toStdString();
             source_image.release_date = info.version.toStdString();
 
@@ -123,7 +122,6 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type, const 
     VMImage source_image;
 
     source_image.id = id.toStdString();
-    source_image.stream_location = info.stream_location.toStdString();
     source_image.original_release = info.release_title.toStdString();
     source_image.release_date = info.version.toStdString();
 

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -49,7 +49,7 @@ struct LibVirtBackend : public Test
                                                       "pied-piper-valley",
                                                       "",
                                                       "",
-                                                      {dummy_image.name(), "", "", "", "", "", "", "", {}},
+                                                      {dummy_image.name(), "", "", "", "", "", "", {}},
                                                       dummy_cloud_init_iso.name(),
                                                       {},
                                                       {},

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -628,8 +628,8 @@ TEST_F(LXDBackend, posts_expected_data_including_disk_size_when_creating_instanc
 TEST_F(LXDBackend, prepare_source_image_does_not_modify)
 {
     mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
-    const mp::VMImage original_image{
-        "/path/to/image", "", "", "deadbeef", "http://foo.bar", "bin", "baz", "the past", {"fee", "fi", "fo", "fum"}};
+    const mp::VMImage original_image{"/path/to/image",          "", "", "deadbeef", "bin", "baz", "the past",
+                                     {"fee", "fi", "fo", "fum"}};
 
     auto source_image = backend.prepare_source_image(original_image);
 
@@ -637,7 +637,6 @@ TEST_F(LXDBackend, prepare_source_image_does_not_modify)
     EXPECT_EQ(source_image.kernel_path, original_image.kernel_path);
     EXPECT_EQ(source_image.initrd_path, original_image.initrd_path);
     EXPECT_EQ(source_image.id, original_image.id);
-    EXPECT_EQ(source_image.stream_location, original_image.stream_location);
     EXPECT_EQ(source_image.original_release, original_image.original_release);
     EXPECT_EQ(source_image.current_release, original_image.current_release);
     EXPECT_EQ(source_image.release_date, original_image.release_date);

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -99,7 +99,6 @@ TEST_F(LXDImageVault, instance_exists_fetch_returns_expected_image_info)
                         image_vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor));
 
     EXPECT_EQ(image.id, mpt::default_id);
-    EXPECT_EQ(image.stream_location, mpt::default_stream_location);
     EXPECT_EQ(image.original_release, "18.04 LTS");
     EXPECT_EQ(image.release_date, mpt::default_version);
 }
@@ -129,7 +128,6 @@ TEST_F(LXDImageVault, returns_expected_info_with_valid_remote)
     EXPECT_NO_THROW(image = image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor));
 
     EXPECT_EQ(image.id, mpt::default_id);
-    EXPECT_EQ(image.stream_location, mpt::default_stream_location);
     EXPECT_EQ(image.original_release, "18.04 LTS");
     EXPECT_EQ(image.release_date, mpt::default_version);
 }

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -58,7 +58,7 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
                                                       "pied-piper-valley",
                                                       "",
                                                       "",
-                                                      {dummy_image.name(), "", "", "", "", "", "", {}, {}},
+                                                      {dummy_image.name(), "", "", "", "", "", {}, {}},
                                                       dummy_cloud_init_iso.name(),
                                                       {},
                                                       {},

--- a/tests/qemu/test_qemu_vm_process_spec.cpp
+++ b/tests/qemu/test_qemu_vm_process_spec.cpp
@@ -34,7 +34,7 @@ struct TestQemuVMProcessSpec : public Test
                                              "vm_name",
                                              "00:11:22:33:44:55",
                                              "ssh_username",
-                                             {"/path/to/image", "", "", "", "", "", "", "", {}}, // VMImage
+                                             {"/path/to/image", "", "", "", "", "", "", {}}, // VMImage
                                              mp::Path{"/path/to/cloud_init.iso"},
                                              {},
                                              {},

--- a/tests/stub_vm_image_vault.h
+++ b/tests/stub_vm_image_vault.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -32,7 +30,7 @@ struct StubVMImageVault final : public multipass::VMImageVault
     multipass::VMImage fetch_image(const multipass::FetchType&, const multipass::Query&, const PrepareAction& prepare,
                                    const multipass::ProgressMonitor&) override
     {
-        return prepare({dummy_image.name(), dummy_image.name(), dummy_image.name(), {}, {}, {}, {}, {}, {}});
+        return prepare({dummy_image.name(), dummy_image.name(), dummy_image.name(), {}, {}, {}, {}, {}});
     };
 
     void remove(const std::string&) override{};

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -289,7 +289,7 @@ TEST_F(ImageVault, uses_image_from_prepare)
     mpt::make_file_with_content(file_name, expected_data);
 
     auto prepare = [&file_name](const mp::VMImage& source_image) -> mp::VMImage {
-        return {file_name, "", "", source_image.id, "", "", "", "", {}};
+        return {file_name, "", "", source_image.id, "", "", "", {}};
     };
 
     mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
@@ -309,7 +309,7 @@ TEST_F(ImageVault, image_purged_expired)
 
     auto prepare = [&file_name](const mp::VMImage& source_image) -> mp::VMImage {
         mpt::make_file_with_content(file_name);
-        return {file_name, "", "", source_image.id, "", "", "", "", {}};
+        return {file_name, "", "", source_image.id, "", "", "", {}};
     };
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, prepare, stub_monitor);
 
@@ -329,7 +329,7 @@ TEST_F(ImageVault, image_exists_not_expired)
 
     auto prepare = [&file_name](const mp::VMImage& source_image) -> mp::VMImage {
         mpt::make_file_with_content(file_name);
-        return {file_name, "", "", source_image.id, "", "", "", "", {}};
+        return {file_name, "", "", source_image.id, "", "", "", {}};
     };
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, prepare, stub_monitor);
 
@@ -450,7 +450,6 @@ TEST_F(ImageVault, http_download_returns_expected_image_info)
     // Hash is based on image url
     EXPECT_THAT(image.id, Eq("7404f51c9b4f40312fa048a0ad36e07b74b718a2d3a5a08e8cca906c69059ddf"));
     EXPECT_THAT(image.release_date, Eq(default_last_modified.toString().toStdString()));
-    EXPECT_TRUE(image.stream_location.empty());
 }
 
 TEST_F(ImageVault, image_update_creates_new_dir_and_removes_old)


### PR DESCRIPTION
The LXDVMImageVault is the only class that needs stream_location as provide by the ImageHost. There is no need to save this or make it available for LXDVirtualMachine.