### PR TITLE
Move ps to proc factory

### DIFF
--- a/include/multipass/process/basic_process.h
+++ b/include/multipass/process/basic_process.h
@@ -47,16 +47,18 @@ public:
 
     bool wait_for_started(int msecs = 30000) override;
     bool wait_for_finished(int msecs = 30000) override;
+    bool wait_for_ready_read(int msecs = 30000) override;
 
     bool running() const override;
     ProcessState process_state() const override;
-    QString error_string() const;
+    QString error_string() const override;
 
     QByteArray read_all_standard_output() override;
     QByteArray read_all_standard_error() override;
 
     qint64 write(const QByteArray& data) override;
     void close_write_channel() override;
+    void set_process_channel_mode(QProcess::ProcessChannelMode mode) override;
 
     ProcessState execute(const int timeout = 30000) override;
 

--- a/include/multipass/process/process.h
+++ b/include/multipass/process/process.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -90,15 +90,18 @@ public:
 
     virtual bool wait_for_started(int msecs = 30000) = 0;
     virtual bool wait_for_finished(int msecs = 30000) = 0;
+    virtual bool wait_for_ready_read(int msecs = 30000) = 0;
 
     virtual bool running() const = 0;
     virtual ProcessState process_state() const = 0;
+    virtual QString error_string() const = 0;
 
     virtual QByteArray read_all_standard_output() = 0;
     virtual QByteArray read_all_standard_error() = 0;
 
     virtual qint64 write(const QByteArray& data) = 0;
     virtual void close_write_channel() = 0;
+    virtual void set_process_channel_mode(QProcess::ProcessChannelMode mode) = 0;
 
     virtual ProcessState execute(const int timeout = 30000) = 0;
 

--- a/src/process/basic_process.cpp
+++ b/src/process/basic_process.cpp
@@ -132,6 +132,11 @@ bool mp::BasicProcess::wait_for_finished(int msecs)
     return process.waitForFinished(msecs);
 }
 
+bool mp::BasicProcess::wait_for_ready_read(int msecs)
+{
+    return process.waitForReadyRead(msecs);
+}
+
 mp::ProcessState mp::BasicProcess::process_state() const
 {
     mp::ProcessState state;
@@ -176,6 +181,11 @@ qint64 mp::BasicProcess::write(const QByteArray& data)
 void mp::BasicProcess::close_write_channel()
 {
     process.closeWriteChannel();
+}
+
+void mp::BasicProcess::set_process_channel_mode(QProcess::ProcessChannelMode mode)
+{
+    process.setProcessChannelMode(mode);
 }
 
 mp::ProcessState mp::BasicProcess::execute(const int timeout)

--- a/tests/mock_process_factory.cpp
+++ b/tests/mock_process_factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -114,7 +114,13 @@ bool mpt::MockProcess::wait_for_started(int)
 {
     return true;
 }
+
 bool mpt::MockProcess::wait_for_finished(int)
+{
+    return true;
+}
+
+bool mpt::MockProcess::wait_for_ready_read(int)
 {
     return true;
 }
@@ -125,6 +131,10 @@ qint64 mpt::MockProcess::write(const QByteArray&)
 }
 
 void mpt::MockProcess::close_write_channel()
+{
+}
+
+void mpt::MockProcess::set_process_channel_mode(QProcess::ProcessChannelMode)
 {
 }
 

--- a/tests/mock_process_factory.cpp
+++ b/tests/mock_process_factory.cpp
@@ -115,19 +115,9 @@ bool mpt::MockProcess::wait_for_started(int)
     return true;
 }
 
-bool mpt::MockProcess::wait_for_finished(int)
-{
-    return true;
-}
-
 bool mpt::MockProcess::wait_for_ready_read(int)
 {
     return true;
-}
-
-qint64 mpt::MockProcess::write(const QByteArray&)
-{
-    return 0;
 }
 
 void mpt::MockProcess::close_write_channel()

--- a/tests/mock_process_factory.h
+++ b/tests/mock_process_factory.h
@@ -80,6 +80,8 @@ public:
     MOCK_CONST_METHOD0(process_state, ProcessState());
     MOCK_CONST_METHOD0(error_string, QString());
     MOCK_METHOD1(execute, ProcessState(int));
+    MOCK_METHOD1(write, qint64(const QByteArray&));
+    MOCK_METHOD1(wait_for_finished, bool(int msecs));
 
     MockProcess(std::unique_ptr<ProcessSpec>&& spec, std::vector<MockProcessFactory::ProcessInfo>& process_list);
 
@@ -89,11 +91,9 @@ public:
     QProcessEnvironment process_environment() const override;
 
     bool wait_for_started(int msecs = 30000) override;
-    bool wait_for_finished(int msecs = 30000) override;
     bool wait_for_ready_read(int msecs = 30000) override;
     MOCK_METHOD0(read_all_standard_output, QByteArray());
     MOCK_METHOD0(read_all_standard_error, QByteArray());
-    qint64 write(const QByteArray& data) override;
     void close_write_channel() override;
     void set_process_channel_mode(QProcess::ProcessChannelMode) override;
     void setup_child_process() override;

--- a/tests/mock_process_factory.h
+++ b/tests/mock_process_factory.h
@@ -78,6 +78,7 @@ public:
     MOCK_METHOD0(kill, void());
     MOCK_CONST_METHOD0(running, bool());
     MOCK_CONST_METHOD0(process_state, ProcessState());
+    MOCK_CONST_METHOD0(error_string, QString());
     MOCK_METHOD1(execute, ProcessState(int));
 
     MockProcess(std::unique_ptr<ProcessSpec>&& spec, std::vector<MockProcessFactory::ProcessInfo>& process_list);
@@ -89,10 +90,12 @@ public:
 
     bool wait_for_started(int msecs = 30000) override;
     bool wait_for_finished(int msecs = 30000) override;
+    bool wait_for_ready_read(int msecs = 30000) override;
     MOCK_METHOD0(read_all_standard_output, QByteArray());
     MOCK_METHOD0(read_all_standard_error, QByteArray());
     qint64 write(const QByteArray& data) override;
     void close_write_channel() override;
+    void set_process_channel_mode(QProcess::ProcessChannelMode) override;
     void setup_child_process() override;
 
 private:

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2020 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -71,7 +71,13 @@ public:
     {
         return true;
     }
+
     bool wait_for_finished(int msecs = 30000) override
+    {
+        return true;
+    }
+
+    bool wait_for_ready_read(int msecs = 30000) override
     {
         return true;
     }
@@ -84,6 +90,11 @@ public:
     mp::ProcessState process_state() const override
     {
         return mp::ProcessState();
+    }
+
+    QString error_string() const override
+    {
+        return {};
     }
 
     QByteArray read_all_standard_output() override
@@ -101,6 +112,10 @@ public:
     }
 
     void close_write_channel() override
+    {
+    }
+
+    void set_process_channel_mode(QProcess::ProcessChannelMode) override
     {
     }
 


### PR DESCRIPTION
Public pre-requisites to move PS to `mp::Process`.