### PR TITLE
[lxd] Add try/catch around updating and pruning images

### DIFF
--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -193,53 +193,73 @@ bool mp::LXDVMImageVault::has_record_for(const std::string& name)
 
 void mp::LXDVMImageVault::prune_expired_images()
 {
+    QJsonObject json_reply;
+
     try
     {
-        auto json_reply = lxd_request(manager, "GET", QUrl(QString("%1/images?recursion=1").arg(base_url.toString())));
-        auto images = json_reply["metadata"].toArray();
-
-        for (const auto image : images)
-        {
-            auto image_info = image.toObject();
-            auto last_used = std::chrono::system_clock::time_point(std::chrono::milliseconds(
-                QDateTime::fromString(image_info["last_used_at"].toString(), Qt::ISODateWithMs).toMSecsSinceEpoch()));
-
-            if (last_used + days_to_expire <= std::chrono::system_clock::now())
-            {
-                mpl::log(mpl::Level::info, category,
-                         fmt::format("Source image \'{}\' is expired. Removing it…",
-                                     image_info["properties"].toObject()["release"].toString()));
-
-                lxd_request(
-                    manager, "DELETE",
-                    QUrl(QString("%1/images/%2").arg(base_url.toString()).arg(image_info["fingerprint"].toString())));
-            }
-        }
+        json_reply = lxd_request(manager, "GET", QUrl(QString("%1/images?recursion=1").arg(base_url.toString())));
     }
     catch (const LXDNotFoundException&)
     {
         return;
+    }
+
+    auto images = json_reply["metadata"].toArray();
+
+    for (const auto image : images)
+    {
+        auto image_info = image.toObject();
+        auto last_used = std::chrono::system_clock::time_point(std::chrono::milliseconds(
+            QDateTime::fromString(image_info["last_used_at"].toString(), Qt::ISODateWithMs).toMSecsSinceEpoch()));
+
+        if (last_used + days_to_expire <= std::chrono::system_clock::now())
+        {
+            mpl::log(mpl::Level::info, category,
+                     fmt::format("Source image \'{}\' is expired. Removing it…",
+                                 image_info["properties"].toObject()["release"].toString()));
+
+            try
+            {
+                lxd_request(
+                    manager, "DELETE",
+                    QUrl(QString("%1/images/%2").arg(base_url.toString()).arg(image_info["fingerprint"].toString())));
+            }
+            catch (const LXDNotFoundException&)
+            {
+                continue;
+            }
+        }
     }
 }
 
 void mp::LXDVMImageVault::update_images(const FetchType& fetch_type, const PrepareAction& prepare,
                                         const ProgressMonitor& monitor)
 {
+    QJsonObject json_reply;
+
     try
     {
-        auto json_reply = lxd_request(manager, "GET", QUrl(QString("%1/images?recursion=1").arg(base_url.toString())));
-        auto images = json_reply["metadata"].toArray();
+        json_reply = lxd_request(manager, "GET", QUrl(QString("%1/images?recursion=1").arg(base_url.toString())));
+    }
+    catch (const LXDNotFoundException&)
+    {
+        return;
+    }
 
-        for (const auto image : images)
+    auto images = json_reply["metadata"].toArray();
+
+    for (const auto image : images)
+    {
+        auto image_info = image.toObject();
+        if (image_info.contains("update_source"))
         {
-            auto image_info = image.toObject();
-            if (image_info.contains("update_source"))
+            auto release = image_info["properties"].toObject()["release"].toString();
+            mpl::log(mpl::Level::debug, category, fmt::format("Checking if \'{}\' needs updating…", release));
+
+            auto id = image_info["fingerprint"].toString();
+
+            try
             {
-                auto release = image_info["properties"].toObject()["release"].toString();
-                mpl::log(mpl::Level::debug, category, fmt::format("Checking if \'{}\' needs updating…", release));
-
-                auto id = image_info["fingerprint"].toString();
-
                 auto json_reply = lxd_request(manager, "POST",
                                               QUrl(QString("%1/images/%2/refresh").arg(base_url.toString()).arg(id)));
 
@@ -256,11 +276,11 @@ void mp::LXDVMImageVault::update_images(const FetchType& fetch_type, const Prepa
 
                 poll_download_operation(json_reply, monitor, task_complete);
             }
+            catch (const LXDNotFoundException&)
+            {
+                continue;
+            }
         }
-    }
-    catch (const LXDNotFoundException&)
-    {
-        return;
     }
 }
 

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -535,6 +535,45 @@ TEST_F(LXDImageVault, update_image_no_project_does_not_throw)
     EXPECT_NO_THROW(image_vault.update_images(mp::FetchType::ImageOnly, stub_prepare, stub_monitor));
 }
 
+TEST_F(LXDImageVault, update_image_refresh_image_fails_does_no_throw)
+{
+    bool refresh_requested{false}, operation_requested{false};
+
+    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+        .WillByDefault([&refresh_requested, &operation_requested](auto, auto request, auto) {
+            auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
+            auto url = request.url().toString();
+
+            if (op == "GET")
+            {
+                if (url.contains("1.0/images"))
+                {
+                    return new mpt::MockLocalSocketReply(mpt::image_info_update_source_info);
+                }
+                else if (url.contains("1.0/operations/b4d2419f-61c7-44ff-9d17-68cd13e7c6df"))
+                {
+                    // Should not be called
+                    operation_requested = true;
+                }
+            }
+            else if (op == "POST" &&
+                     url.contains(
+                         "1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/refresh"))
+            {
+                refresh_requested = true;
+            }
+
+            return new mpt::MockLocalSocketReply(mpt::not_found_data, QNetworkReply::ContentNotFoundError);
+        });
+
+    mp::LXDVMImageVault image_vault{hosts, mock_network_access_manager.get(), base_url, mp::days{0}};
+
+    EXPECT_NO_THROW(image_vault.update_images(mp::FetchType::ImageOnly, stub_prepare, stub_monitor));
+
+    EXPECT_TRUE(refresh_requested);
+    EXPECT_FALSE(operation_requested);
+}
+
 TEST_F(LXDImageVault, image_update_source_delete_requested_on_expiration)
 {
     bool delete_requested{false};
@@ -611,4 +650,33 @@ TEST_F(LXDImageVault, prune_expired_image_no_project_does_not_throw)
     mp::LXDVMImageVault image_vault{hosts, mock_network_access_manager.get(), base_url, mp::days{0}};
 
     EXPECT_NO_THROW(image_vault.prune_expired_images());
+}
+
+TEST_F(LXDImageVault, prune_expired_image_delete_fails_does_no_throw)
+{
+    bool delete_requested{false};
+
+    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+        .WillByDefault([&delete_requested](auto, auto request, auto) {
+            auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
+            auto url = request.url().toString();
+
+            if (op == "GET" && url.contains("1.0/images"))
+            {
+                return new mpt::MockLocalSocketReply(mpt::image_info_data);
+            }
+            else if (op == "DELETE" &&
+                     url.contains("1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+            {
+                delete_requested = true;
+            }
+
+            return new mpt::MockLocalSocketReply(mpt::not_found_data, QNetworkReply::ContentNotFoundError);
+        });
+
+    mp::LXDVMImageVault image_vault{hosts, mock_network_access_manager.get(), base_url, mp::days{0}};
+
+    EXPECT_NO_THROW(image_vault.prune_expired_images());
+
+    EXPECT_TRUE(delete_requested);
 }

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -521,6 +521,20 @@ TEST_F(LXDImageVault, update_image_not_refreshed_logs_expected_message)
     EXPECT_TRUE(refresh_requested);
 }
 
+TEST_F(LXDImageVault, update_image_no_project_does_not_throw)
+{
+    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+        auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
+        auto url = request.url().toString();
+
+        return new mpt::MockLocalSocketReply(mpt::not_found_data, QNetworkReply::ContentNotFoundError);
+    });
+
+    mp::LXDVMImageVault image_vault{hosts, mock_network_access_manager.get(), base_url, mp::days{0}};
+
+    EXPECT_NO_THROW(image_vault.update_images(mp::FetchType::ImageOnly, stub_prepare, stub_monitor));
+}
+
 TEST_F(LXDImageVault, image_update_source_delete_requested_on_expiration)
 {
     bool delete_requested{false};
@@ -583,4 +597,18 @@ TEST_F(LXDImageVault, image_hash_delete_requested_on_expiration)
     image_vault.prune_expired_images();
 
     EXPECT_TRUE(delete_requested);
+}
+
+TEST_F(LXDImageVault, prune_expired_image_no_project_does_not_throw)
+{
+    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+        auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
+        auto url = request.url().toString();
+
+        return new mpt::MockLocalSocketReply(mpt::not_found_data, QNetworkReply::ContentNotFoundError);
+    });
+
+    mp::LXDVMImageVault image_vault{hosts, mock_network_access_manager.get(), base_url, mp::days{0}};
+
+    EXPECT_NO_THROW(image_vault.prune_expired_images());
 }


### PR DESCRIPTION
Previously, when the "multipass" project didn't exist on daemon start, there would be an unhandled exception and the daemon would exit.

Fixes #1689