### PR TITLE
[network_manager] Generalize requests and support chunked uploads

### DIFF
--- a/include/multipass/exceptions/http_local_socket_exception.h
+++ b/include/multipass/exceptions/http_local_socket_exception.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_HTTP_LOCAL_SOCKET_EXCEPTION_H
+#define MULTIPASS_HTTP_LOCAL_SOCKET_EXCEPTION_H
+
+#include <stdexcept>
+
+namespace multipass
+{
+class HttpLocalSocketException : public std::runtime_error
+{
+public:
+    HttpLocalSocketException(const std::string& what) : runtime_error(what)
+    {
+    }
+};
+} // namespace multipass
+#endif // MULTIPASS_HTTP_LOCAL_SOCKET_EXCEPTION_H

--- a/src/network/local_socket_reply.cpp
+++ b/src/network/local_socket_reply.cpp
@@ -177,7 +177,7 @@ void mp::LocalSocketReply::send_request(const QNetworkRequest& request, QIODevic
     {
         http_data = "Content-Type: " + request.header(QNetworkRequest::ContentTypeHeader).toByteArray() + "\r\n";
 
-        if (outgoingData)
+        if (outgoingData && outgoingData->size() > 0)
         {
             auto content_length = request.header(QNetworkRequest::ContentLengthHeader).toByteArray();
             auto transfer_encoding = request.rawHeader("Transfer-Encoding");

--- a/src/network/local_socket_reply.h
+++ b/src/network/local_socket_reply.h
@@ -52,6 +52,7 @@ private:
     void send_request(const QNetworkRequest& request, QIODevice* outgoingData);
     void parse_reply();
     void parse_status(const QByteArray& status);
+    bool local_socket_write(const QByteArray& data);
 
     LocalSocketUPtr local_socket;
     QByteArray reply_data;

--- a/src/network/network_access_manager.cpp
+++ b/src/network/network_access_manager.cpp
@@ -57,6 +57,8 @@ QNetworkReply* mp::NetworkAccessManager::createRequest(QNetworkAccessManager::Op
         QNetworkRequest request{orig_request};
 
         QUrl url(QString("/%1").arg(server_path));
+        url.setHost(orig_request.url().host());
+
         request.setUrl(url);
 
         // The caller needs to be responsible for freeing the allocated memory

--- a/tests/linux/mock_q_buffer.h
+++ b/tests/linux/mock_q_buffer.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_Q_BUFFER_H
+#define MULTIPASS_MOCK_Q_BUFFER_H
+
+#include <QBuffer>
+
+namespace multipass
+{
+namespace test
+{
+class MockQBuffer : public QBuffer
+{
+public:
+    MockQBuffer(QByteArray* byteArray) : QBuffer(byteArray){};
+
+    virtual qint64 readData(char* data, qint64 len) override
+    {
+        read_called = true;
+
+        return -1;
+    };
+
+    bool read_attempted()
+    {
+        return read_called;
+    }
+
+private:
+    bool read_called{false};
+};
+} // namespace test
+} // namespace multipass
+
+#endif // MULTIPASS_MOCK_Q_BUFFER_H

--- a/tests/linux/mock_q_local_socket.h
+++ b/tests/linux/mock_q_local_socket.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_Q_LOCAL_SOCKET_H
+#define MULTIPASS_MOCK_Q_LOCAL_SOCKET_H
+
+#include <QLocalSocket>
+
+namespace multipass
+{
+namespace test
+{
+class MockQLocalSocket : public QLocalSocket
+{
+public:
+    MockQLocalSocket(int writes_before_failure) : writes_before_failure{writes_before_failure}
+    {
+        QIODevice::open(QIODevice::ReadWrite);
+    };
+
+    virtual qint64 writeData(const char* data, qint64 c) override
+    {
+        ++num_writes;
+
+        if (writes_before_failure-- > 0)
+            return c;
+        else
+            return -1;
+    };
+
+    virtual bool waitForBytesWritten(int msecs = 30000) override
+    {
+        return true;
+    };
+
+    int num_writes_called()
+    {
+        return num_writes;
+    };
+
+private:
+    int writes_before_failure;
+    int num_writes{0};
+};
+} // namespace test
+} // namespace multipass
+
+#endif // MULTIPASS_MOCK_Q_LOCAL_SOCKET_H

--- a/tests/linux/test_local_network_access_manager.cpp
+++ b/tests/linux/test_local_network_access_manager.cpp
@@ -164,7 +164,7 @@ TEST_F(LocalNetworkAccessManager, client_posts_correct_data)
                              "User-Agent: Test\r\n"
                              "Content-Type: application/x-www-form-urlencoded\r\n"
                              "Content-Length: 11\r\n\r\n"
-                             "Hello World\r\n"};
+                             "Hello World\r\n\r\n\r\n"};
 
     QByteArray http_response{"HTTP/1.1 200 OK\r\n\r\n"};
 

--- a/tests/linux/test_local_network_access_manager.cpp
+++ b/tests/linux/test_local_network_access_manager.cpp
@@ -194,7 +194,7 @@ TEST_F(LocalNetworkAccessManager, client_posts_correct_data)
                              "User-Agent: Test\r\n"
                              "Content-Type: application/x-www-form-urlencoded\r\n"
                              "Content-Length: 11\r\n\r\n"
-                             "Hello World\r\n\r\n\r\n"};
+                             "Hello World\r\n\r\n"};
 
     QByteArray http_response{"HTTP/1.1 200 OK\r\n\r\n"};
 

--- a/tests/linux/test_local_network_access_manager.cpp
+++ b/tests/linux/test_local_network_access_manager.cpp
@@ -123,7 +123,7 @@ struct LocalSocketWriteErrorTestSuite : LocalNetworkAccessManager, WithParamInte
 {
 };
 
-const std::vector<int> local_socket_write_error_suite_inputs{0, 1, 2, 3, 4, 5};
+const std::vector<int> local_socket_write_error_suite_inputs{0, 1, 2, 3, 4, 5, 6};
 
 const std::vector<HTTPErrorParamType> http_error_suite_inputs{
     {"HTTP/1.1 400 Bad Request\r\n\r\n", QNetworkReply::ProtocolInvalidOperationError},
@@ -205,7 +205,7 @@ TEST_F(LocalNetworkAccessManager, client_posts_correct_data)
                              "User-Agent: Test\r\n"
                              "Content-Type: application/x-www-form-urlencoded\r\n"
                              "Content-Length: 11\r\n\r\n"
-                             "Hello World\r\n\r\n"};
+                             "Hello World\r\n"};
 
     QByteArray http_response{"HTTP/1.1 200 OK\r\n\r\n"};
 

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -865,6 +865,7 @@ TEST_F(LXDBackend, lxd_request_timeout_aborts_and_throws)
         return reply;
     });
 
+    base_url.setHost("test");
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url, mp::nullopt, 3),
                          std::runtime_error,
                          Property(&std::runtime_error::what, AllOf(HasSubstr(base_url.toString().toStdString()),
@@ -881,6 +882,7 @@ TEST_F(LXDBackend, lxd_request_invalid_json_throws)
         return new mpt::MockLocalSocketReply(invalid_json);
     });
 
+    base_url.setHost("test");
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url), std::runtime_error,
                          Property(&std::runtime_error::what,
                                   AllOf(HasSubstr(base_url.toString().toStdString()), HasSubstr("illegal value"))));
@@ -898,6 +900,7 @@ TEST_F(LXDBackend, lxd_request_wrong_json_throws)
             return new mpt::MockLocalSocketReply(invalid_json);
         });
 
+    base_url.setHost("test");
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url), std::runtime_error,
                          Property(&std::runtime_error::what, AllOf(HasSubstr(base_url.toString().toStdString()),
                                                                    HasSubstr(invalid_json.toStdString()))));


### PR DESCRIPTION
Don't set "Multipass" specific data in the NetworkAccessManager and LocalSocketReply.
Support chunked transfers for uploading data.