### PR TITLE
[lxd] Set state to "unknown" if ssh_hostname() times out

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -325,7 +325,11 @@ std::string mp::LXDVirtualMachine::ssh_hostname()
                 return mpu::TimeoutAction::retry;
             }
         };
-        auto on_timeout = [] { throw std::runtime_error("failed to determine IP address"); };
+        auto on_timeout = [this] {
+            state = State::unknown;
+            throw std::runtime_error("failed to determine IP address");
+        };
+
         mpu::try_action_for(on_timeout, std::chrono::minutes(2), action);
     }
 


### PR DESCRIPTION
Fixes #1719

---

I would like to have a test, but it will require changing `ssh_hostname()` in the base class to accept a timeout parameter and then change all inherited implementations to use this parameter since the default timeout (2 minutes) is baked into the function itself.  Doing this will then touch other unrelated parts of the code.