### PR TITLE
Add common ensure_vm_is_running_for() function

### DIFF
--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -74,6 +74,7 @@ public:
     std::condition_variable state_wait;
     std::mutex state_mutex;
     optional<IPAddress> ip;
+    bool shutdown_while_starting{false};
 
 protected:
     VirtualMachine(VirtualMachine::State state, const std::string& vm_name) : state{state}, vm_name{vm_name} {};


### PR DESCRIPTION
Also, instead of changing the instance state to detect if an instance is shutdown while starting, use a flag.