### PR TITLE
[snap] Remove golang build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,6 @@
 Source: multipass
 Build-Depends: build-essential,
                cmake,
-               golang,
                google-mock,
                libapparmor-dev,
                libqt5x11extras5-dev,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,7 +86,6 @@ parts:
     - on armhf: [libgles2-mesa-dev]
     - build-essential
     - git
-    - golang
     - libapparmor-dev
     - libqt5x11extras5-dev
     - libsystemd-dev


### PR DESCRIPTION
boringssl is no longer built and that is what required golang.