### PR TITLE
[gui] Refuse session restoring

### DIFF
--- a/src/client/gui/main.cpp
+++ b/src/client/gui/main.cpp
@@ -29,6 +29,9 @@ namespace
 int main_impl(int argc, char* argv[])
 {
     QApplication app(argc, argv);
+    if (app.isSessionRestored())
+        throw std::runtime_error{"Session restoring is not supported"};
+
     app.setApplicationName("multipass-gui");
 
     mp::ClientConfig config{mp::client::get_server_address(), mp::RpcConnectionType::ssl,


### PR DESCRIPTION
Hopefully fixes #1770.

Qt consumes `-session <id>` from the command line before we have a chance to parse it. When we parse the `QApplication::arguments()`, it's no longer there, so we continued happily. But then we were not running with a proper environment, so no luck reaching the daemon.

Since we don't implement session restoring, we need to explicitly refuse the attempt. 

This is only applicable to `QGuiApplication`s, so it does not affect our other binaries.

References:
  - https://doc.qt.io/qt-5/qguiapplication.html#supported-command-line-options
  - https://code.woboq.org/qt5/qtbase/src/gui/kernel/qguiapplication.cpp.html#1547
  - https://code.woboq.org/qt5/qtbase/src/gui/kernel/qguiapplication.cpp.html#1573
  - https://doc.qt.io/qt-5/session.html

