### PR TITLE
Disable failing tests

### DIFF
--- a/tests/disabling_macros.h
+++ b/tests/disabling_macros.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_DISABLING_MACROS_H
+#define MULTIPASS_DISABLING_MACROS_H
+
+// Macros to disable tests - prepend to test or test suite names
+// Use like this: TEST_F(TestSuite, DISABLE_ON_XXX(test_name))
+// See https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#temporarily-disabling-tests
+
+#ifdef MULTIPASS_PLATFORM_WINDOWS
+
+#define DISABLE_ON_WINDOWS(test_name) DISABLED_##test_name
+#define DISABLE_ON_WINDOWS_AND_MACOS(test_name) DISABLED_##test_name
+#define DISABLE_ON_MACOS(test_name) test_name
+
+#elif MULTIPASS_PLATFORM_APPLE
+
+#define DISABLE_ON_WINDOWS(test_name) test_name
+#define DISABLE_ON_WINDOWS_AND_MACOS(test_name) DISABLED_##test_name
+#define DISABLE_ON_MACOS(test_name) DISABLED_##test_name
+
+#else // Linux
+
+#define DISABLE_ON_WINDOWS(test_name) test_name
+#define DISABLE_ON_WINDOWS_AND_MACOS(test_name) test_name
+#define DISABLE_ON_MACOS(test_name) test_name
+
+#endif
+
+#endif // MULTIPASS_DISABLING_MACROS_H

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -15,6 +15,7 @@
  *
  */
 
+#include "disabling_macros.h"
 #include "mock_environment_helpers.h"
 #include "mock_settings.h"
 #include "mock_standard_paths.h"
@@ -562,13 +563,13 @@ TEST_F(Client, launch_cmd_cpu_option_fails_no_value)
     EXPECT_THAT(send_command({"launch", "-c"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
-TEST_F(Client, launch_cmd_custom_image_file_ok)
+TEST_F(Client, DISABLE_ON_MACOS(launch_cmd_custom_image_file_ok)) // TODO
 {
     EXPECT_CALL(mock_daemon, launch(_, _, _));
     EXPECT_THAT(send_command({"launch", "file://foo"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, launch_cmd_custom_image_http_ok)
+TEST_F(Client, DISABLE_ON_MACOS(launch_cmd_custom_image_http_ok)) // TODO
 {
     EXPECT_CALL(mock_daemon, launch(_, _, _));
     EXPECT_THAT(send_command({"launch", "http://foo"}), Eq(mp::ReturnCode::Ok));

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -563,13 +563,13 @@ TEST_F(Client, launch_cmd_cpu_option_fails_no_value)
     EXPECT_THAT(send_command({"launch", "-c"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
-TEST_F(Client, DISABLE_ON_MACOS(launch_cmd_custom_image_file_ok)) // TODO
+TEST_F(Client, DISABLE_ON_MACOS(launch_cmd_custom_image_file_ok))
 {
     EXPECT_CALL(mock_daemon, launch(_, _, _));
     EXPECT_THAT(send_command({"launch", "file://foo"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, DISABLE_ON_MACOS(launch_cmd_custom_image_http_ok)) // TODO
+TEST_F(Client, DISABLE_ON_MACOS(launch_cmd_custom_image_http_ok))
 {
     EXPECT_CALL(mock_daemon, launch(_, _, _));
     EXPECT_THAT(send_command({"launch", "http://foo"}), Eq(mp::ReturnCode::Ok));

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -17,6 +17,7 @@
 
 #include "src/daemon/default_vm_image_vault.h"
 
+#include "disabling_macros.h"
 #include "file_operations.h"
 #include "mock_image_host.h"
 #include "path.h"
@@ -342,7 +343,7 @@ TEST_F(ImageVault, invalid_custom_image_file_throws)
     EXPECT_THROW(vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor), std::runtime_error);
 }
 
-TEST_F(ImageVault, custom_image_url_downloads)
+TEST_F(ImageVault, DISABLE_ON_WINDOWS_AND_MACOS(custom_image_url_downloads))
 {
     mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
     auto query = default_query;
@@ -383,7 +384,7 @@ TEST_F(ImageVault, invalid_remote_throws)
     EXPECT_THROW(vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor), std::runtime_error);
 }
 
-TEST_F(ImageVault, invalid_image_alias_throw)
+TEST_F(ImageVault, DISABLE_ON_WINDOWS_AND_MACOS(invalid_image_alias_throw))
 {
     mpt::StubURLDownloader stub_url_downloader;
     mp::DefaultVMImageVault vault{hosts, &stub_url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
@@ -410,7 +411,7 @@ TEST_F(ImageVault, valid_remote_and_alias_returns_valid_image_info)
     EXPECT_THAT(image.id, Eq("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
 }
 
-TEST_F(ImageVault, http_download_returns_expected_image_info)
+TEST_F(ImageVault, DISABLE_ON_WINDOWS_AND_MACOS(http_download_returns_expected_image_info))
 {
     HttpURLDownloader http_url_downloader;
     mp::DefaultVMImageVault vault{hosts, &http_url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};

--- a/tests/test_qemuimg_process_spec.cpp
+++ b/tests/test_qemuimg_process_spec.cpp
@@ -15,9 +15,11 @@
  *
  */
 
+#include "disabling_macros.h"
+#include "mock_environment_helpers.h"
+
 #include <multipass/process/qemuimg_process_spec.h>
 
-#include "tests/mock_environment_helpers.h"
 #include <gmock/gmock.h>
 
 #include <QFile>
@@ -106,7 +108,9 @@ TEST(TestQemuImgProcessSpec, apparmor_profile_running_as_snap_with_only_target_c
     EXPECT_TRUE(spec.apparmor_profile().contains(QString("%1 rwk,").arg(target_image)));
 }
 
-TEST(TestQemuImgProcessSpec, apparmor_profile_running_as_symlinked_snap_correct)
+TEST(TestQemuImgProcessSpec,
+     DISABLE_ON_WINDOWS(apparmor_profile_running_as_symlinked_snap_correct)) // TODO tests involving apparmor should
+                                                                             // probably be moved elsewhere
 {
     const QByteArray snap_name{"multipass"};
     QTemporaryDir snap_dir, snap_link_dir, common_dir, common_link_dir;


### PR DESCRIPTION
Disable failing tests on Windows and macOS. This is meant as a temporary measure, so that we can otherwise fail CI on failing tests, thereby avoiding pile up of further test failures.

Addresses #1515.