### PR TITLE
[dnsmasq_server] Increase wait timeout to 100ms

### DIFF
--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -33,7 +33,7 @@ namespace mpl = multipass::logging;
 
 namespace
 {
-constexpr auto immediate_wait = 25; // period to wait for immediate dnsmasq failures, in ms
+constexpr auto immediate_wait = 100; // period to wait for immediate dnsmasq failures, in ms
 
 auto make_dnsmasq_process(const mp::Path& data_dir, const QString& bridge_name, const std::string& subnet,
                           const QString& conf_file_path)


### PR DESCRIPTION
There are still some occasional CI test failures due to the timeout being a little short.