### PR TITLE
[default_image_vault] Fix regression for file-based launches

### DIFF
--- a/include/multipass/vm_image_vault.h
+++ b/include/multipass/vm_image_vault.h
@@ -37,6 +37,7 @@ namespace vault
 // Helper functions and classes for all image vault types
 QString filename_for(const Path& path);
 void delete_file(const Path& path);
+QString compute_image_hash(const Path& image_path);
 void verify_image_download(const Path& image_path, const QString& image_hash);
 QString extract_image(const Path& image_path, const ProgressMonitor& monitor, const bool delete_file = false);
 

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -583,15 +583,25 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
 
 mp::MemorySize mp::DefaultVMImageVault::minimum_image_size_for(const std::string& id)
 {
-    auto entry = prepared_image_records.find(id);
-    if (entry == prepared_image_records.end())
+    auto prepared_image_entry = prepared_image_records.find(id);
+    if (prepared_image_entry != prepared_image_records.end())
     {
-        throw std::runtime_error(fmt::format("Cannot find prepared image with id \'{}\'", id));
+        const auto& record = prepared_image_entry->second;
+
+        return get_image_size(record.image.image_path);
     }
 
-    const auto& record = entry->second;
+    for (const auto& instance_image_entry : instance_image_records)
+    {
+        const auto& record = instance_image_entry.second;
 
-    return get_image_size(record.image.image_path);
+        if (record.image.id == id)
+        {
+            return get_image_size(record.image.image_path);
+        }
+    }
+
+    throw std::runtime_error(fmt::format("Cannot determine minimum image size for id \'{}\'", id));
 }
 
 mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -313,6 +313,8 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
         }
 
         vm_image = prepare(source_image);
+        vm_image.id = mp::vault::compute_image_hash(vm_image.image_path).toStdString();
+
         remove_source_images(source_image, vm_image);
 
         {

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -37,7 +37,7 @@ void mp::vault::delete_file(const mp::Path& path)
     file.remove();
 }
 
-void mp::vault::verify_image_download(const mp::Path& image_path, const QString& image_hash)
+QString mp::vault::compute_image_hash(const mp::Path& image_path)
 {
     QFile image_file(image_path);
     if (!image_file.open(QFile::ReadOnly))
@@ -51,7 +51,14 @@ void mp::vault::verify_image_download(const mp::Path& image_path, const QString&
         throw std::runtime_error("Cannot read image file to compute hash");
     }
 
-    if (hash.result().toHex() != image_hash)
+    return hash.result().toHex();
+}
+
+void mp::vault::verify_image_download(const mp::Path& image_path, const QString& image_hash)
+{
+    auto computed_hash = compute_image_hash(image_path);
+
+    if (computed_hash != image_hash)
     {
         throw std::runtime_error("Downloaded image hash does not match");
     }

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -524,9 +524,9 @@ TEST_F(ImageVault, minimum_image_size_throws_when_not_cached)
     mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{1}};
 
     const std::string id{"12345"};
-    MP_EXPECT_THROW_THAT(
-        vault.minimum_image_size_for(id), std::runtime_error,
-        Property(&std::runtime_error::what, StrEq(fmt::format("Cannot find prepared image with id \'{}\'", id))));
+    MP_EXPECT_THROW_THAT(vault.minimum_image_size_for(id), std::runtime_error,
+                         Property(&std::runtime_error::what,
+                                  StrEq(fmt::format("Cannot determine minimum image size for id \'{}\'", id))));
 }
 
 TEST_F(ImageVault, minimum_image_size_throws_when_qemuimg_info_crashes)


### PR DESCRIPTION
Check the instance_image_records map if an image is not found in the prepared_image_records map.

Fixes #1818 