### PR TITLE
Validate network names

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -394,7 +394,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
 
         if (result == factory_networks.cend())
         {
-            mpl::log(mpl::Level::debug, category, fmt::format("Invalid network id \"{}\"", net.id()));
+            mpl::log(mpl::Level::warning, category, fmt::format("Invalid network id \"{}\"", net.id()));
             option_errors.add_error_codes(mp::LaunchError::INVALID_NETWORK);
         }
 
@@ -405,7 +405,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
                 mp::NetworkInterface{net.id(), mac, net.mode() != multipass::LaunchRequest_NetworkOptions_Mode_MANUAL});
         else
         {
-            mpl::log(mpl::Level::debug, category, fmt::format("Repeated MAC address \"{}\"", mac));
+            mpl::log(mpl::Level::warning, category, fmt::format("Repeated MAC address \"{}\"", mac));
             option_errors.add_error_codes(mp::LaunchError::INVALID_NETWORK);
         }
     }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -398,14 +398,14 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
             option_errors.add_error_codes(mp::LaunchError::INVALID_NETWORK);
         }
 
-        // Check that the MAC the user specified is not repeated.
+        // In case the user specified a MAC address, check it is valid.
         if (const auto& mac = QString::fromStdString(net.mac_address()).toLower().toStdString();
             mac.empty() || mpu::valid_mac_address(mac))
             interfaces.push_back(
                 mp::NetworkInterface{net.id(), mac, net.mode() != multipass::LaunchRequest_NetworkOptions_Mode_MANUAL});
         else
         {
-            mpl::log(mpl::Level::warning, category, fmt::format("Repeated MAC address \"{}\"", mac));
+            mpl::log(mpl::Level::warning, category, fmt::format("Invalid MAC address \"{}\"", mac));
             option_errors.add_error_codes(mp::LaunchError::INVALID_NETWORK);
         }
     }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -366,7 +366,7 @@ auto try_mem_size(const std::string& val) -> mp::optional<mp::MemorySize>
 }
 
 std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequest* request,
-                                                            const std::unique_ptr<mp::VirtualMachineFactory>& factory,
+                                                            const mp::VirtualMachineFactory& factory,
                                                             mp::LaunchError& option_errors)
 {
     std::vector<mp::NetworkInterfaceInfo> factory_networks;
@@ -375,7 +375,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
     {
         try
         {
-            factory_networks = factory->list_networks();
+            factory_networks = factory.list_networks();
         }
         catch (const mp::NotImplementedOnThisBackendException&)
         {
@@ -413,8 +413,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
     return interfaces;
 }
 
-auto validate_create_arguments(const mp::LaunchRequest* request,
-                               const std::unique_ptr<mp::VirtualMachineFactory>& factory)
+auto validate_create_arguments(const mp::LaunchRequest* request, const mp::VirtualMachineFactory& factory)
 {
     static const auto min_mem = try_mem_size(mp::min_memory_size);
     static const auto min_disk = try_mem_size(mp::min_disk_size);
@@ -2071,7 +2070,7 @@ std::string mp::Daemon::check_instance_exists(const std::string& instance_name) 
 void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriter<CreateReply>* server,
                            std::promise<grpc::Status>* status_promise, bool start)
 {
-    auto checked_args = validate_create_arguments(request, config->factory);
+    auto checked_args = validate_create_arguments(request, *config->factory);
 
     if (!checked_args.option_errors.error_codes().empty())
     {

--- a/tests/stub_virtual_machine_factory.h
+++ b/tests/stub_virtual_machine_factory.h
@@ -74,11 +74,6 @@ struct StubVirtualMachineFactory : public multipass::BaseVirtualMachineFactory
     {
         return std::make_unique<StubVMImageVault>();
     }
-
-    std::vector<multipass::NetworkInterfaceInfo> list_networks() const
-    {
-        throw multipass::NotImplementedOnThisBackendException("list-networks");
-    }
 };
 }
 }

--- a/tests/stub_virtual_machine_factory.h
+++ b/tests/stub_virtual_machine_factory.h
@@ -74,6 +74,11 @@ struct StubVirtualMachineFactory : public multipass::BaseVirtualMachineFactory
     {
         return std::make_unique<StubVMImageVault>();
     }
+
+    std::vector<multipass::NetworkInterfaceInfo> list_networks() const
+    {
+        throw multipass::NotImplementedOnThisBackendException("list-networks");
+    }
 };
 }
 }

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -266,7 +266,7 @@ struct Daemon : public Test
 
         ON_CALL(*mock_factory_ptr, get_backend_version_string()).WillByDefault(Return("mock-1234"));
 
-        ON_CALL(*mock_factory, list_networks())
+        ON_CALL(*mock_factory_ptr, list_networks())
             .WillByDefault(Return(std::vector<mp::NetworkInterfaceInfo>{{"eth0", "ethernet", "wired adapter"},
                                                                         {"wlan0", "wi-fi", "wireless adapter"}}));
 


### PR DESCRIPTION
This PR includes code to validate the network names given as argument to `--networks`.

This address one of the first concerns in the review of https://github.com/canonical/multipass/pull/1745 and implements what is described in https://github.com/canonical/multipass/projects/12#card-47746768
