### PR TITLE
[lxd] Add 60 seconds timeout for state operations

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -356,7 +356,7 @@ const QUrl mp::LXDVirtualMachine::network_leases_url()
 
 void mp::LXDVirtualMachine::request_state(const QString& new_state)
 {
-    const QJsonObject state_json{{"action", new_state}};
+    const QJsonObject state_json{{"action", new_state}, {"timeout", 60}};
 
     auto state_task = lxd_request(manager, "PUT", state_url(), state_json, 5000);
 


### PR DESCRIPTION
If no timeout is set, LXD uses a hardcoded 30 second timeout when waiting on
operations to complete and if the wait timeout occurs, it can lead to incorrect
behavior in the LXD backend.

Fixes #1777