### PR TITLE
Add suggested command when 'exec' gets an unrecognized option

### DIFF
--- a/include/multipass/cli/argparser.h
+++ b/include/multipass/cli/argparser.h
@@ -53,6 +53,8 @@ public:
 
     QStringList positionalArguments() const;
 
+    QStringList unknownOptionNames() const;
+
     ParseCode commandParse(cmd::Command* command);
 
     ReturnCode returnCodeFrom(ParseCode parse_code) const;
@@ -62,6 +64,8 @@ public:
 
     void setVerbosityLevel(int verbosity);
     int verbosityLevel() const;
+
+    bool containsArgument(const QString& argument) const;
 
 private:
     QString generalHelpText();

--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -156,6 +156,18 @@ mp::ParseCode mp::ArgParser::commandParse(cmd::Command* command)
     if (!parsedOk)
     {
         cerr << qUtf8Printable(parser.errorText()) << '\n';
+
+        if (parser.errorText().contains("Unknown option"))
+        {
+            cerr << "\nYou need to separate the options to be passed to the command with \"--\", like this: \n";
+            QStringList suggestedCommand(arguments);
+            suggestedCommand.insert(3, "--");
+            foreach (auto& argument, suggestedCommand)
+            {
+                cerr << argument.toStdString() << " ";
+            }
+            cerr << '\n';
+        }
         return ParseCode::CommandLineError;
     }
 

--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -156,18 +156,6 @@ mp::ParseCode mp::ArgParser::commandParse(cmd::Command* command)
     if (!parsedOk)
     {
         cerr << qUtf8Printable(parser.errorText()) << '\n';
-
-        if (parser.errorText().contains("Unknown option"))
-        {
-            cerr << "\nYou need to separate the options to be passed to the command with \"--\", like this: \n";
-            QStringList suggestedCommand(arguments);
-            suggestedCommand.insert(3, "--");
-            foreach (auto& argument, suggestedCommand)
-            {
-                cerr << argument.toStdString() << " ";
-            }
-            cerr << '\n';
-        }
         return ParseCode::CommandLineError;
     }
 
@@ -351,6 +339,11 @@ QStringList mp::ArgParser::positionalArguments() const
     return positionalArguments;
 }
 
+QStringList mp::ArgParser::unknownOptionNames() const
+{
+    return parser.unknownOptionNames();
+}
+
 void mp::ArgParser::setVerbosityLevel(int verbosity)
 {
     if (verbosity > 4 || verbosity < 0)
@@ -366,4 +359,9 @@ void mp::ArgParser::setVerbosityLevel(int verbosity)
 int mp::ArgParser::verbosityLevel() const
 {
     return verbosity_level;
+}
+
+bool mp::ArgParser::containsArgument(const QString& argument) const
+{
+    return arguments.contains(argument);
 }

--- a/src/client/cli/cmd/exec.cpp
+++ b/src/client/cli/cmd/exec.cpp
@@ -95,6 +95,11 @@ mp::ParseCode cmd::Exec::parse_args(mp::ArgParser* parser)
 
     if (status != ParseCode::Ok)
     {
+        if (!parser->unknownOptionNames().empty() && !parser->containsArgument("--"))
+        {
+            cerr << "\nOptions to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
+                    "<command> <arguments>\n";
+        }
         return status;
     }
 

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -718,35 +718,31 @@ TEST_F(Client, exec_cmd_no_double_dash_unknown_option_fails_print_suggested_comm
     std::stringstream cerr_stream;
     EXPECT_THAT(send_command({"exec", "foo", "cmd", "--unknownOption"}, trash_stream, cerr_stream),
                 Eq(mp::ReturnCode::CommandLineError));
-    EXPECT_NE(std::string::npos,
-              cerr_stream.str().find(
-                  "Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
-                  "<command> <arguments>\n"))
-        << "cerr has: " << cerr_stream.str();
+    EXPECT_THAT(
+        cerr_stream.str(),
+        HasSubstr("Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
+                  "<command> <arguments>\n"));
 }
 
 TEST_F(Client, exec_cmd_double_dash_unknown_option_fails_does_not_print_suggested_command)
 {
     std::stringstream cerr_stream;
-    EXPECT_THAT(send_command({"exec", "foo", "--", "cmd", "--unknownOption"}, trash_stream, cerr_stream),
+    EXPECT_THAT(send_command({"exec", "foo", "--unknownOption", "--", "cmd"}, trash_stream, cerr_stream),
                 Eq(mp::ReturnCode::CommandLineError));
-    EXPECT_EQ(std::string::npos,
-              cerr_stream.str().find(
-                  "Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
-                  "<command> <arguments>\n"))
-        << "cerr has: " << cerr_stream.str();
+    EXPECT_THAT(
+        cerr_stream.str(),
+        Not(HasSubstr("Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
+                      "<command> <arguments>\n")));
 }
 
 TEST_F(Client, exec_cmd_no_double_dash_no_unknown_option_fails_does_not_print_suggested_command)
 {
     std::stringstream cerr_stream;
-    EXPECT_THAT(send_command({"exec", "foo", "cmd", "--help"}, trash_stream, cerr_stream),
-                Eq(mp::ReturnCode::CommandLineError));
-    EXPECT_EQ(std::string::npos,
-              cerr_stream.str().find(
-                  "Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
-                  "<command> <arguments>\n"))
-        << "cerr has: " << cerr_stream.str();
+    EXPECT_THAT(send_command({"exec", "foo", "cmd", "--help"}, trash_stream, cerr_stream), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(
+        cerr_stream.str(),
+        Not(HasSubstr("Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
+                      "<command> <arguments>\n")));
 }
 
 // help cli tests

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -713,6 +713,42 @@ TEST_F(Client, exec_cmd_help_ok)
     EXPECT_THAT(send_command({"exec", "-h"}), Eq(mp::ReturnCode::Ok));
 }
 
+TEST_F(Client, exec_cmd_no_double_dash_unknown_option_fails_print_suggested_command)
+{
+    std::stringstream cerr_stream;
+    EXPECT_THAT(send_command({"exec", "foo", "cmd", "--unknownOption"}, trash_stream, cerr_stream),
+                Eq(mp::ReturnCode::CommandLineError));
+    EXPECT_NE(std::string::npos,
+              cerr_stream.str().find(
+                  "Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
+                  "<command> <arguments>\n"))
+        << "cerr has: " << cerr_stream.str();
+}
+
+TEST_F(Client, exec_cmd_double_dash_unknown_option_fails_does_not_print_suggested_command)
+{
+    std::stringstream cerr_stream;
+    EXPECT_THAT(send_command({"exec", "foo", "--", "cmd", "--unknownOption"}, trash_stream, cerr_stream),
+                Eq(mp::ReturnCode::CommandLineError));
+    EXPECT_EQ(std::string::npos,
+              cerr_stream.str().find(
+                  "Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
+                  "<command> <arguments>\n"))
+        << "cerr has: " << cerr_stream.str();
+}
+
+TEST_F(Client, exec_cmd_no_double_dash_no_unknown_option_fails_does_not_print_suggested_command)
+{
+    std::stringstream cerr_stream;
+    EXPECT_THAT(send_command({"exec", "foo", "cmd", "--help"}, trash_stream, cerr_stream),
+                Eq(mp::ReturnCode::CommandLineError));
+    EXPECT_EQ(std::string::npos,
+              cerr_stream.str().find(
+                  "Options to the inner command should come after \"--\", like this:\nmultipass exec <instance> -- "
+                  "<command> <arguments>\n"))
+        << "cerr has: " << cerr_stream.str();
+}
+
 // help cli tests
 TEST_F(Client, help_cmd_ok_with_valid_single_arg)
 {


### PR DESCRIPTION
Addresses #531 . When a user forgets to separate options with `--` when running the `exec` command, provides a suggested command that includes the `--`. Below is a screenshot of the behavior with the change.

![multipass_error_msg](https://user-images.githubusercontent.com/48418745/100534761-6f9e1b00-31e0-11eb-83c6-58aadcb041b3.png)
