### PR TITLE
Fix lambda captures

### DIFF
--- a/tests/qemu/test_dnsmasq_server.cpp
+++ b/tests/qemu/test_dnsmasq_server.cpp
@@ -267,7 +267,7 @@ TEST_F(DNSMasqServerMockedProcess, dnsmasq_throws_on_failure_to_start)
 TEST_F(DNSMasqServerMockedProcess, dnsmasq_throws_when_it_dies_immediately)
 {
     constexpr auto msg = "an error msg";
-    setup([msg](auto* process) {
+    setup([](auto* process) {
         InSequence seq;
 
         EXPECT_CALL(*process, start()).Times(1);


### PR DESCRIPTION
Clang complains about capturing not needed variables. In particular, we are capturing a non-mutable constexpr, which does not need to be captured. See [here](https://en.cppreference.com/w/cpp/language/lambda).