### PR TITLE
[networking] Drop unused traits in VM description

### DIFF
--- a/include/multipass/virtual_machine_description.h
+++ b/include/multipass/virtual_machine_description.h
@@ -41,7 +41,7 @@ public:
     MemorySize mem_size;
     MemorySize disk_space;
     std::string vm_name;
-    NetworkInterface default_interface;
+    std::string default_mac_address;
     std::vector<NetworkInterface> extra_interfaces;
     std::string ssh_username;
     VMImage image;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -52,7 +52,7 @@ struct VMSpecs
     int num_cores;
     MemorySize mem_size;
     MemorySize disk_space;
-    NetworkInterface default_interface;
+    std::string default_mac_address;
     std::vector<NetworkInterface> extra_interfaces; // We want interfaces to be ordered.
     std::string ssh_username;
     VirtualMachine::State state;

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
@@ -177,8 +177,7 @@ auto generate_xml_config_for(const mp::VirtualMachineDescription& desc, const st
         "  </devices>\n"
         "</domain>",
         desc.vm_name, mem_unit, memory, mem_unit, memory, desc.num_cores, arch, qemu_path,
-        desc.image.image_path.toStdString(), desc.cloud_init_iso.toStdString(), desc.default_interface.mac_address,
-        bridge_name);
+        desc.image.image_path.toStdString(), desc.cloud_init_iso.toStdString(), desc.default_mac_address, bridge_name);
 }
 
 auto domain_by_name_for(const std::string& vm_name, virConnectPtr connection,

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -105,7 +105,7 @@ mp::LXDVirtualMachine::LXDVirtualMachine(const VirtualMachineDescription& desc, 
       manager{manager},
       base_url{base_url},
       bridge_name{bridge_name},
-      mac_addr{QString::fromStdString(desc.default_interface.mac_address)}
+      mac_addr{QString::fromStdString(desc.default_mac_address)}
 {
     try
     {

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -199,7 +199,7 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
     : VirtualMachine{instance_image_has_snapshot(desc.image.image_path) ? State::suspended : State::off, desc.vm_name},
       tap_device_name{tap_device_name},
       desc{desc},
-      mac_addr{desc.default_interface.mac_address},
+      mac_addr{desc.default_mac_address},
       username{desc.ssh_username},
       dnsmasq_server{&dnsmasq_server},
       monitor{&monitor}

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -140,7 +140,7 @@ mp::VirtualMachine::UPtr mp::QemuVirtualMachineFactory::create_virtual_machine(c
 
     auto vm = std::make_unique<mp::QemuVirtualMachine>(desc, tap_device_name, dnsmasq_server, monitor);
 
-    name_to_mac_map.emplace(desc.vm_name, desc.default_interface.mac_address);
+    name_to_mac_map.emplace(desc.vm_name, desc.default_mac_address);
     return vm;
 }
 

--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -38,27 +38,27 @@ QStringList initial_qemu_arguments(const mp::VirtualMachineDescription& desc, co
     auto mem_size = QString::number(desc.mem_size.in_megabytes()) + 'M'; /* flooring here; format documented in
     `man qemu-system`, under `-m` option; including suffix to avoid relying on default unit */
 
-    QStringList args{"--enable-kvm",
-                     "-hda",
-                     desc.image.image_path,
-                     "-smp",
-                     QString::number(desc.num_cores),
-                     "-m",
-                     mem_size,
-                     "-device",
-                     QString("virtio-net-pci,netdev=hostnet0,id=net0,mac=%1")
-                         .arg(QString::fromStdString(desc.default_interface.mac_address)),
-                     "-netdev",
-                     QString("tap,id=hostnet0,ifname=%1,script=no,downscript=no").arg(tap_device_name),
-                     "-qmp",
-                     "stdio",
-                     "-cpu",
-                     "host",
-                     "-chardev",
-                     "null,id=char0",
-                     "-serial",
-                     "chardev:char0",
-                     "-nographic"};
+    QStringList args{
+        "--enable-kvm",
+        "-hda",
+        desc.image.image_path,
+        "-smp",
+        QString::number(desc.num_cores),
+        "-m",
+        mem_size,
+        "-device",
+        QString("virtio-net-pci,netdev=hostnet0,id=net0,mac=%1").arg(QString::fromStdString(desc.default_mac_address)),
+        "-netdev",
+        QString("tap,id=hostnet0,ifname=%1,script=no,downscript=no").arg(tap_device_name),
+        "-qmp",
+        "stdio",
+        "-cpu",
+        "host",
+        "-chardev",
+        "null,id=char0",
+        "-serial",
+        "chardev:char0",
+        "-nographic"};
 
     if (use_cdrom)
     {
@@ -128,7 +128,7 @@ QStringList mp::QemuVMProcessSpec::arguments() const
         // Create a virtual NIC in the VM
         args << "-device"
              << QString("virtio-net-pci,netdev=hostnet0,id=net0,mac=%1")
-                    .arg(QString::fromStdString(desc.default_interface.mac_address));
+                    .arg(QString::fromStdString(desc.default_mac_address));
         // Create tap device to connect to virtual bridge
         args << "-netdev";
         args << QString("tap,id=hostnet0,ifname=%1,script=no,downscript=no").arg(tap_device_name);

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -50,7 +50,7 @@ struct LibVirtBackend : public Test
                                                       mp::MemorySize{"3M"},
                                                       mp::MemorySize{}, // not used
                                                       "pied-piper-valley",
-                                                      {"default", "", true},
+                                                      "",
                                                       {},
                                                       "",
                                                       {dummy_image.name(), "", "", "", "", "", "", {}},

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -66,7 +66,7 @@ struct LXDBackend : public Test
                                                       mp::MemorySize{"3M"},
                                                       mp::MemorySize{}, // not used
                                                       "pied-piper-valley",
-                                                      {"default", "00:16:3e:fe:f2:b9", true},
+                                                      "00:16:3e:fe:f2:b9",
                                                       {},
                                                       "yoda",
                                                       {},

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -57,7 +57,7 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
                                                       mp::MemorySize{"3M"},
                                                       mp::MemorySize{}, // not used
                                                       "pied-piper-valley",
-                                                      {"default", "", true},
+                                                      "",
                                                       {},
                                                       "",
                                                       {dummy_image.name(), "", "", "", "", "", {}, {}},

--- a/tests/qemu/test_qemu_vm_process_spec.cpp
+++ b/tests/qemu/test_qemu_vm_process_spec.cpp
@@ -32,7 +32,7 @@ struct TestQemuVMProcessSpec : public Test
                                              mp::MemorySize{"3G"} /*mem_size*/,
                                              mp::MemorySize{"4G"} /*disk_space*/,
                                              "vm_name",
-                                             {"default", "00:11:22:33:44:55", true},
+                                             "00:11:22:33:44:55",
                                              {},
                                              "ssh_username",
                                              {"/path/to/image", "", "", "", "", "", "", {}}, // VMImage


### PR DESCRIPTION
We had left this for after the main PRs were merged. 

Revert to mac address only instead of a full network interface struct in VM description. This keeps the code aligned with persistent records and avoids failure to honor the extra properties (id and mode).