### PR TITLE
[daemon] Remove network ID reinterpretation

### DIFF
--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -65,9 +65,6 @@ public:
     // List all the network interfaces seen by the backend.
     virtual std::vector<NetworkInterfaceInfo> networks() const = 0;
 
-    // Given the id the user sees in networks(), return the id of an interface which identifies it.
-    virtual std::string reinterpret_interface_id(const std::string& ux_id) const = 0;
-
 protected:
     VirtualMachineFactory() = default;
     VirtualMachineFactory(const VirtualMachineFactory&) = delete;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2200,13 +2200,10 @@ void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriter<Crea
             // This set stores the MAC's which need to be in the allocated_mac_addrs if everything goes well.
             auto new_macs = allocated_mac_addrs;
 
-            // let the backend re-interpret the id and check for repetition of requested macs
+            // check for repetition of requested macs
             for (auto& iface : checked_args.extra_interfaces)
-            {
-                iface.id = config->factory->reinterpret_interface_id(iface.id);
                 if (!iface.mac_address.empty() && !new_macs.insert(iface.mac_address).second)
                     throw std::runtime_error(fmt::format("Repeated MAC address {}", iface.mac_address));
-            }
 
             // generate missing macs in a second pass, to avoid repeating macs that the user requested
             for (auto& iface : checked_args.extra_interfaces)

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -57,10 +57,6 @@ public:
         throw NotImplementedOnThisBackendException("networks");
     };
 
-    std::string reinterpret_interface_id(const std::string& ux_id) const override
-    {
-        return ux_id;
-    }
 };
 } // namespace multipass
 

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -43,7 +43,6 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD5(create_image_vault,
                  VMImageVault::UPtr(std::vector<VMImageHost*>, URLDownloader*, const Path&, const Path&, const days&));
     MOCK_CONST_METHOD0(networks, std::vector<NetworkInterfaceInfo>());
-    MOCK_CONST_METHOD1(reinterpret_interface_id, std::string(const std::string&));
 };
 }
 }


### PR DESCRIPTION
Stop reinterpreting network IDs at the daemon, and remove the corresponding interface from the VM factories. Network ID reinterpretation can be treated as an implementation detail of the VirtualBox backend.