### PR TITLE
[cmake] Fix a missing dependency for tests

### DIFF
--- a/tests/libvirt/CMakeLists.txt
+++ b/tests/libvirt/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(multipass_tests
 add_library(broken_libvirt SHARED
     ${CMAKE_CURRENT_LIST_DIR}/broken_libvirt_library.cpp)
 
+add_dependencies(multipass_tests broken_libvirt)
 target_link_options(multipass_tests PRIVATE -rdynamic)
 
 target_compile_definitions(libvirt_backend_test PRIVATE


### PR DESCRIPTION
Another tiny fix that I found when trying to better integrate with CLion. Without this, tests fail if built on their own (e.g. `make covreport`).