### PR TITLE
[snap] Drop the network-utils part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,6 @@ apps:
       XDG_CACHE_HOME: $SNAP_COMMON/cache
       XDG_CONFIG_HOME: &daemon-config $SNAP_DATA/config
       DAEMON_CONFIG_HOME: *daemon-config # temporary
-      XTABLES_LIBDIR: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/xtables
     daemon: simple
     plugs:
       - all-home
@@ -151,16 +150,6 @@ parts:
     override-pull: ""
     stage-packages:
     - try: [msr-tools]
-
-  network-utils:
-    plugin: nil
-    override-pull: ""
-    stage-packages:
-    - iproute2
-    - iptables
-    - iputils-ping
-    - libatm1
-    - libxtables12
 
   xterm:
     plugin: nil


### PR DESCRIPTION
The core18 snap already includes everything we need, so this part is no longer necessary.