### PR TITLE
Implement `networks` in LXD backend

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,6 +51,8 @@ public:
     VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                           const Path& cache_dir_path, const Path& data_dir_path,
                                           const days& days_to_expire) override;
+
+    std::vector<NetworkInterfaceInfo> networks() const override;
 
 private:
     NetworkAccessManager::UPtr manager;

--- a/tests/lxd/mock_lxd_server_responses.h
+++ b/tests/lxd/mock_lxd_server_responses.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1139,6 +1139,16 @@ const QByteArray image_upload_task_complete_data{
     "\"status_code\": 200,"
     "\"type\": \"sync\""
     "}"};
+
+const QByteArray networks_empty_data{R"({
+                                         "type": "sync",
+                                         "status": "Success",
+                                         "status_code": 200,
+                                         "operation": "",
+                                         "error_code": 0,
+                                         "error": "",
+                                         "metadata": []
+                                     })"};
 } // namespace test
 } // namespace multipass
 

--- a/tests/lxd/mock_lxd_server_responses.h
+++ b/tests/lxd/mock_lxd_server_responses.h
@@ -1280,6 +1280,61 @@ const QByteArray networks_realistic_data{R"(
         }
     ]
 })"};
+
+const QByteArray networks_faulty_data{R"(
+{
+    "status": "Success",
+    "status_code": 200,
+    "nonsense": "field",
+    "metadata": [
+        {
+            "type": "bridge",
+            "but": "noname"
+        },
+        {
+            "name": "virbr0",
+            "type": "bridge"
+        },
+        {
+            "name": "",
+            "type": "bridge",
+            "but": "empty name"
+        },
+        {
+            "name": "bla",
+            "but": "notype"
+        },
+        {
+            "name": "en0",
+            "type": "physical"
+        },
+        {
+            "name": "lxdbr0",
+            "type": "bridge"
+        },
+        {
+            "name": 123,
+            "type": "bridge"
+        },
+        {
+            "name": "eth0",
+            "type": 123
+        },
+        {
+            "name": "mpbr0",
+            "type": "bridge"
+        },
+        {
+            "name": "mpqemubr0",
+            "type": "bridge"
+        },
+        {
+            "name": "blahh",
+            "type": "unknown"
+        }
+    ]
+})"};
+
 } // namespace test
 } // namespace multipass
 

--- a/tests/lxd/mock_lxd_server_responses.h
+++ b/tests/lxd/mock_lxd_server_responses.h
@@ -1140,15 +1140,146 @@ const QByteArray image_upload_task_complete_data{
     "\"type\": \"sync\""
     "}"};
 
-const QByteArray networks_empty_data{R"({
-                                         "type": "sync",
-                                         "status": "Success",
-                                         "status_code": 200,
-                                         "operation": "",
-                                         "error_code": 0,
-                                         "error": "",
-                                         "metadata": []
-                                     })"};
+const QByteArray networks_empty_data{R"(
+{
+     "type": "sync",
+     "status": "Success",
+     "status_code": 200,
+     "operation": "",
+     "error_code": 0,
+     "error": "",
+     "metadata": []
+})"};
+
+const QByteArray networks_realistic_data{R"(
+{
+    "type": "sync",
+    "status": "Success",
+    "status_code": 200,
+    "operation": "",
+    "error_code": 0,
+    "error": "",
+    "metadata": [
+        {
+            "config": {
+                "ipv4.address": "10.48.127.1/24",
+                "ipv4.nat": "true",
+                "ipv6.address": "fd42:f933:79c:618f::1/64",
+                "ipv6.nat": "true"
+            },
+            "description": "",
+            "name": "lxdbr0",
+            "type": "bridge",
+            "used_by": [
+                "/1.0/profiles/default"
+            ],
+            "managed": true,
+            "status": "Created",
+            "locations": [
+                "none"
+            ]
+        },
+        {
+            "config": {
+                "ipv4.address": "10.186.122.1/24",
+                "ipv4.nat": "true",
+                "ipv6.address": "fd42:3d5d:5553:7fc8::1/64",
+                "ipv6.nat": "true"
+            },
+            "description": "Network bridge for Multipass",
+            "name": "mpbr0",
+            "type": "bridge",
+            "used_by": [
+                "/1.0/profiles/default?project=multipass"
+            ],
+            "managed": true,
+            "status": "Created",
+            "locations": [
+                "none"
+            ]
+        },
+        {
+            "config": {},
+            "description": "",
+            "name": "lo",
+            "type": "loopback",
+            "used_by": [],
+            "managed": false,
+            "status": "",
+            "locations": null
+        },
+        {
+            "config": {},
+            "description": "",
+            "name": "wlp2s0",
+            "type": "physical",
+            "used_by": null,
+            "managed": false,
+            "status": "",
+            "locations": null
+        },
+        {
+            "config": {},
+            "description": "",
+            "name": "virbr0",
+            "type": "bridge",
+            "used_by": null,
+            "managed": false,
+            "status": "",
+            "locations": null
+        },
+        {
+            "config": {},
+            "description": "",
+            "name": "virbr0-nic",
+            "type": "unknown",
+            "used_by": null,
+            "managed": false,
+            "status": "",
+            "locations": null
+        },
+        {
+            "config": {},
+            "description": "",
+            "name": "enxe4b97a832426",
+            "type": "physical",
+            "used_by": null,
+            "managed": false,
+            "status": "",
+            "locations": null
+        },
+        {
+            "config": {},
+            "description": "",
+            "name": "mpqemubr0-dummy",
+            "type": "unknown",
+            "used_by": null,
+            "managed": false,
+            "status": "",
+            "locations": null
+        },
+        {
+            "config": {},
+            "description": "",
+            "name": "mpqemubr0",
+            "type": "bridge",
+            "used_by": null,
+            "managed": false,
+            "status": "",
+            "locations": null
+        },
+        {
+            "config": {},
+            "description": "",
+            "name": "tap-a1a0e5e916d",
+            "type": "unknown",
+            "used_by": null,
+            "managed": false,
+            "status": "",
+            "locations": null
+        }
+    ]
+})"};
 } // namespace test
 } // namespace multipass
 

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1656,3 +1656,26 @@ TEST_P(LXDNetworksBadJson, handles_gibberish_networks_reply)
 
 INSTANTIATE_TEST_SUITE_P(LXDBackend, LXDNetworksBadJson,
                          Values("gibberish", "", "unstarted}", "{unfinished", "strange\"", "{noval}", "]["));
+
+struct LXDNetworksBadFields : LXDBackend, WithParamInterface<QByteArray>
+{
+};
+
+TEST_P(LXDNetworksBadFields, ignores_network_without_expected_fields)
+{
+    EXPECT_CALL(*mock_network_access_manager,
+                createRequest(QNetworkAccessManager::CustomOperation, network_request_matcher, _))
+        .WillOnce(Return(new mpt::MockLocalSocketReply{GetParam()}));
+
+    mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
+    EXPECT_THAT(backend.networks(), IsEmpty());
+}
+
+INSTANTIATE_TEST_SUITE_P(LXDBackend, LXDNetworksBadFields,
+                         Values("{}", "{\"other\": \"stuff\"}", "{\"metadata\": \"notarray\"}",
+                                "{\"metadata\": [\"notdict\"]}",
+                                "{\"metadata\": [{\"type\": \"bridge\", \"but\": \"noname\"}]}",
+                                "{\"metadata\": [{\"name\": \"\", \"type\": \"bridge\", \"but\": \"empty name\"}]}",
+                                "{\"metadata\": [{\"name\": \"bla\", \"but\": \"notype\"}]}",
+                                "{\"metadata\": [{\"name\": 123, \"type\": \"bridge\"}]}",
+                                "{\"metadata\": [{\"name\": \"eth0\", \"type\": 123}]}"));

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1636,11 +1636,15 @@ TEST_F(LXDBackend, requests_networks)
     EXPECT_THAT(backend.networks(), IsEmpty());
 }
 
-TEST_F(LXDBackend, reports_only_bridge_networks)
+struct LXDNetworksOnlyBridges : LXDBackend, WithParamInterface<QByteArray>
+{
+};
+
+TEST_P(LXDNetworksOnlyBridges, reports_only_bridge_networks)
 {
     EXPECT_CALL(*mock_network_access_manager,
                 createRequest(QNetworkAccessManager::CustomOperation, network_request_matcher, _))
-        .WillOnce(Return(new mpt::MockLocalSocketReply{mpt::networks_realistic_data}));
+        .WillOnce(Return(new mpt::MockLocalSocketReply{GetParam()}));
 
     mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
 
@@ -1649,6 +1653,9 @@ TEST_F(LXDBackend, reports_only_bridge_networks)
                                           UnorderedElementsAre(id_matcher("lxdbr0"), id_matcher("mpbr0"),
                                                                id_matcher("virbr0"), id_matcher("mpqemubr0"))));
 }
+
+INSTANTIATE_TEST_SUITE_P(LXDBackend, LXDNetworksOnlyBridges,
+                         Values(mpt::networks_realistic_data, mpt::networks_faulty_data));
 
 struct LXDNetworksBadJson : LXDBackend, WithParamInterface<QByteArray>
 {

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1613,9 +1613,20 @@ TEST_P(LXDInstanceStatusTestSuite, lxd_state_returns_expected_VirtualMachine_sta
 
 INSTANTIATE_TEST_SUITE_P(LXDBackend, LXDInstanceStatusTestSuite, ValuesIn(lxd_instance_status_suite_inputs));
 
-TEST_F(LXDBackend, lists_no_networks)
+TEST_F(LXDBackend, requests_networks)
 {
-    mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
 
-    EXPECT_THROW(backend.networks(), mp::NotImplementedOnThisBackendException);
+    EXPECT_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+        .WillOnce([](auto, const auto& request, auto) {
+            auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
+            auto url = request.url().toString();
+
+            EXPECT_EQ(op, "GET");
+            EXPECT_TRUE(url.contains("1.0/networks"));
+
+            return new mpt::MockLocalSocketReply(mpt::networks_empty_data);
+        });
+
+    mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
+    EXPECT_THAT(backend.networks(), IsEmpty());
 }


### PR DESCRIPTION
This implements network listing from the LXD backend. As discussed, only bridges are returned. 

If available, descriptions from LXD are used. Otherwise, we fall back to "Network bridge". 

Example:
```
$ multipass networks
Name    Type    Description
lxdbr0  bridge  Network bridge
mpbr0   bridge  Network bridge for Multipass
virbr0  bridge  Network bridge
```

Bridge members are left for another PR, as well as `launch --network`.