### PR TITLE
Don't use cloud-init to configure network in old images

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -394,7 +394,8 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
                 return net.mode() == multipass::LaunchRequest_NetworkOptions_Mode_AUTO;
             }) != request->network_options().end())
         {
-            throw std::runtime_error(fmt::format("Automatic bridge configuration not implemented for {}", full_name));
+            throw std::runtime_error(fmt::format(
+                "Automatic network configuration not available for {}. Consider using manual mode.", full_name));
         }
 
         try

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -85,7 +85,12 @@ constexpr auto cloud_init_timeout = 5min;
 constexpr auto stop_ssh_cmd = "sudo systemctl stop ssh";
 const std::string sshfs_error_template = "Error enabling mount support in '{}'"
                                          "\n\nPlease install the 'multipass-sshfs' snap manually inside the instance.";
-const std::unordered_set<std::string> no_bridging_images = {"release:16.04", "release:xenial", "snapcraft:core"};
+const std::unordered_set<std::string> no_bridging_images = {
+    "release:10.04", "release:lucid",   "release:11.10", "release:oneiric", "release:12.04", "release:precise",
+    "release:12.10", "release:quantal", "release:13.04", "release:raring",  "release:13.10", "release:saucy",
+    "release:14.04", "release:trusty",  "release:14.10", "release:utopic",  "release:15.04", "release:vivid",
+    "release:15.10", "release:wily",    "release:16.04", "release:xenial",  "release:16.10", "release:yakkety",
+    "release:17.04", "release:zesty",   "snapcraft:core"};
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
 {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -393,7 +393,9 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
             std::find_if(request->network_options().begin(), request->network_options().end(), [](const auto& net) {
                 return net.mode() == multipass::LaunchRequest_NetworkOptions_Mode_AUTO;
             }) != request->network_options().end())
-            throw std::runtime_error(fmt::format("--network not implemented for {}", full_name));
+        {
+            throw std::runtime_error(fmt::format("Automatic bridge configuration not implemented for {}", full_name));
+        }
 
         try
         {
@@ -401,8 +403,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
         }
         catch (const mp::NotImplementedOnThisBackendException&)
         {
-            // If networks is not implemented, we should report that --network is not implemented on this backend.
-            throw mp::NotImplementedOnThisBackendException("--network");
+            throw mp::NotImplementedOnThisBackendException("bridging");
         }
     }
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -746,6 +746,19 @@ TEST_P(DaemonCreateLaunchTestSuite, adds_pollinate_user_agent_to_cloud_init_conf
     send_command({GetParam()});
 }
 
+TEST_F(Daemon, no_network_cloud_init)
+{
+    mpt::MockVirtualMachineFactory* mock_factory = use_a_mock_vm_factory();
+    mp::Daemon daemon{config_builder.build()};
+
+    EXPECT_CALL(*mock_factory, prepare_instance_image(_, _))
+        .WillOnce(Invoke([](const multipass::VMImage&, const mp::VirtualMachineDescription& desc) {
+            EXPECT_TRUE(desc.network_data_config.IsNull());
+        }));
+
+    send_command({"launch"});
+}
+
 TEST_P(LaunchWithBridges, creates_network_cloud_init_iso)
 {
     mpt::MockVirtualMachineFactory* mock_factory = use_a_mock_vm_factory();
@@ -810,7 +823,7 @@ typedef typename std::pair<std::vector<std::tuple<std::string, std::string, std:
 
 INSTANTIATE_TEST_SUITE_P(
     Daemon, LaunchWithBridges,
-    Values(BridgeTestArgType({}, {"extra0"}), BridgeTestArgType({{"eth0", "extra0", "52:54:00:"}}, {"extra1"}),
+    Values(BridgeTestArgType({{"eth0", "extra0", "52:54:00:"}}, {"extra1"}),
            BridgeTestArgType({{"id=eth0,mac=01:23:45:ab:cd:ef,mode=auto", "extra0", "01:23:45:ab:cd:ef"},
                               {"wlan0", "extra1", "52:54:00:"}},
                              {"extra2"}),

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1086,7 +1086,7 @@ TEST_F(Daemon, refuses_launch_because_bridging_is_not_implemented)
 
     std::stringstream err_stream;
     send_command({"launch", "--network", "eth0"}, std::cout, err_stream);
-    EXPECT_THAT(err_stream.str(), HasSubstr("The --network feature is not implemented on this backend"));
+    EXPECT_THAT(err_stream.str(), HasSubstr("The bridging feature is not implemented on this backend"));
 }
 
 TEST_F(Daemon, refuses_bridging_in_old_image)
@@ -1095,7 +1095,7 @@ TEST_F(Daemon, refuses_bridging_in_old_image)
 
     std::stringstream err_stream;
     send_command({"launch", "xenial", "--network", "eth0"}, std::cout, err_stream);
-    EXPECT_THAT(err_stream.str(), HasSubstr("--network not implemented for release:xenial"));
+    EXPECT_THAT(err_stream.str(), HasSubstr("Automatic bridge configuration not implemented for release:xenial"));
 }
 
 std::unique_ptr<mpt::TempDir> plant_instance_json(const std::string& contents) // unique_ptr bypasses missing move ctor

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1077,6 +1077,15 @@ TEST_F(Daemon, refuses_launch_because_bridging_is_not_implemented)
     EXPECT_THAT(err_stream.str(), HasSubstr("The --network feature is not implemented on this backend"));
 }
 
+TEST_F(Daemon, refuses_bridging_in_old_image)
+{
+    mp::Daemon daemon{config_builder.build()};
+
+    std::stringstream err_stream;
+    send_command({"launch", "xenial", "--network", "eth0"}, std::cout, err_stream);
+    EXPECT_THAT(err_stream.str(), HasSubstr("--network not implemented for release:xenial"));
+}
+
 std::unique_ptr<mpt::TempDir> plant_instance_json(const std::string& contents) // unique_ptr bypasses missing move ctor
 {
     auto temp_dir = std::make_unique<mpt::TempDir>();

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1111,7 +1111,11 @@ TEST_P(RefuseBridging, old_image)
     const auto [remote, image] = GetParam();
     std::string full_image_name = remote.empty() ? image : remote + ":" + image;
 
+    auto mock_factory = use_a_mock_vm_factory();
+
     mp::Daemon daemon{config_builder.build()};
+
+    EXPECT_CALL(*mock_factory, networks());
 
     std::stringstream err_stream;
     send_command({"launch", full_image_name, "--network", "eth0"}, std::cout, err_stream);


### PR DESCRIPTION
We use to configure the network interfaces using cloud-init. Specifically, we use version 2 of the network configuration. However, old images, like xenial, don't support this version of the network configuration file.

In this PR, we do the following to overcome the situation:
1. don't allow old images to use bridging (which needed configuration via cloud-init);
2. don't use cloud-init at all to configure network interfaces in the case on which bridging is not used.

This addresses issue https://github.com/canonical/multipass/issues/1904
