### PR TITLE
LXD test improvements

### DIFF
--- a/tests/lxd/mock_network_access_manager.h
+++ b/tests/lxd/mock_network_access_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +20,8 @@
 
 #include <multipass/network_access_manager.h>
 
+#include "mock_local_socket_reply.h"
+
 #include <gmock/gmock.h>
 
 using namespace testing;
@@ -30,6 +32,11 @@ namespace test
 {
 struct MockNetworkAccessManager : public NetworkAccessManager
 {
+    MockNetworkAccessManager()
+    {
+        ON_CALL(*this, createRequest).WillByDefault(Return(new MockLocalSocketReply{""}));
+    }
+
     MOCK_METHOD3(createRequest, QNetworkReply*(Operation, const QNetworkRequest&, QIODevice*));
 };
 } // namespace test

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -103,7 +103,7 @@ TEST_F(LXDBackend, creates_project_and_network_on_healthcheck)
     bool profile_updated{false};
     bool network_created{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&project_created, &profile_updated, &network_created](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -172,7 +172,7 @@ TEST_F(LXDBackend, factory_creates_valid_virtual_machine_ptr)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -220,7 +220,7 @@ TEST_F(LXDBackend, creates_in_stopped_state)
 
     bool vm_created{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&vm_created](auto, auto request, auto) {
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
             auto url = request.url().toString();
@@ -260,7 +260,7 @@ TEST_F(LXDBackend, machine_persists_and_sets_state_on_start)
 
     bool start_called{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&start_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -310,7 +310,7 @@ TEST_F(LXDBackend, machine_persists_and_sets_state_on_shutdown)
 
     bool vm_shutdown{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&vm_shutdown](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -361,7 +361,7 @@ TEST_F(LXDBackend, machine_does_not_update_state_in_dtor)
 
     bool vm_shutdown{false}, stop_requested{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&vm_shutdown, &stop_requested](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -415,7 +415,7 @@ TEST_F(LXDBackend, does_not_call_stop_when_snap_refresh_is_detected)
 
     bool stop_requested{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&stop_requested](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -462,7 +462,7 @@ TEST_F(LXDBackend, calls_stop_when_snap_refresh_does_not_exist)
 
     bool stop_requested{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&stop_requested](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -547,7 +547,7 @@ TEST_F(LXDBackend, posts_expected_data_when_creating_instance)
 
     bool vm_created{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&vm_created, &expected_data](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -624,7 +624,7 @@ TEST_F(LXDBackend, returns_expected_backend_string)
                                  "  }"
                                  "}\n"};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&server_data](auto, auto request, auto) {
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
             auto url = request.url().toString();
@@ -694,7 +694,7 @@ TEST_F(LXDBackend, healthcheck_throws_when_untrusted)
                                     "  }"
                                     "}\n"};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&untrusted_data](auto, auto request, auto) {
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
             auto url = request.url().toString();
@@ -717,7 +717,7 @@ TEST_F(LXDBackend, healthcheck_connection_refused_error_throws_with_expected_mes
 {
     const std::string exception_message{"Connection refused"};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&exception_message](auto...) -> QNetworkReply* {
             throw mp::LocalSocketConnectionException(exception_message);
         });
@@ -736,7 +736,7 @@ TEST_F(LXDBackend, healthcheck_unknown_server_error_throws_with_expected_message
 {
     const std::string exception_message{"Unknown server"};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&exception_message](auto...) -> QNetworkReply* {
             throw mp::LocalSocketConnectionException(exception_message);
         });
@@ -755,7 +755,7 @@ TEST_F(LXDBackend, returns_expected_network_info)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -796,7 +796,7 @@ TEST_F(LXDBackend, ssh_hostname_timeout_throws_and_sets_unknown_state)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -834,7 +834,7 @@ TEST_F(LXDBackend, no_ip_address_returns_unknown)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -869,7 +869,7 @@ TEST_F(LXDBackend, no_ip_address_returns_unknown)
 
 TEST_F(LXDBackend, lxd_request_timeout_aborts_and_throws)
 {
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto...) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto...) {
         QByteArray data;
         auto reply = new mpt::MockLocalSocketReply(data);
         reply->setFinished(false);
@@ -893,7 +893,7 @@ TEST_F(LXDBackend, lxd_request_timeout_aborts_and_throws)
 
 TEST_F(LXDBackend, lxd_request_empty_data_returned_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto...) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto...) {
         QByteArray data;
         auto reply = new mpt::MockLocalSocketReply(data);
 
@@ -916,7 +916,7 @@ TEST_F(LXDBackend, lxd_request_empty_data_returned_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_request_invalid_json_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
         QByteArray invalid_json{"not json\r\n"};
@@ -940,7 +940,7 @@ TEST_F(LXDBackend, lxd_request_wrong_json_throws_and_logs)
 {
     QByteArray invalid_json{"[]\r\n"};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&invalid_json](auto, auto request, auto) {
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
             auto url = request.url().toString();
@@ -962,7 +962,7 @@ TEST_F(LXDBackend, lxd_request_wrong_json_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_request_bad_request_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto...) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto...) {
         const QByteArray error_data{"{"
                                     "\"type\": \"error\","
                                     "\"error\": \"Failure\","
@@ -988,7 +988,7 @@ TEST_F(LXDBackend, lxd_request_bad_request_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_request_multipart_bbad_request_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto...) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto...) {
         const QByteArray error_data{"{"
                                     "\"type\": \"error\","
                                     "\"error\": \"Failure\","
@@ -1015,7 +1015,7 @@ TEST_F(LXDBackend, lxd_request_multipart_bbad_request_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_wait_error_returned_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1071,7 +1071,7 @@ TEST_F(LXDBackend, lxd_wait_error_returned_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_wait_status_code_failure_returned_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1127,7 +1127,7 @@ TEST_F(LXDBackend, lxd_wait_status_code_failure_returned_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_wait_metadata_status_code_failure_returned_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1185,7 +1185,7 @@ TEST_F(LXDBackend, unsupported_suspend_throws)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -1216,7 +1216,7 @@ TEST_F(LXDBackend, start_while_suspending_throws)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1240,7 +1240,7 @@ TEST_F(LXDBackend, start_while_frozen_unfreezes)
     mpt::StubVMStatusMonitor stub_monitor;
     bool unfreeze_called{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&unfreeze_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -1279,7 +1279,7 @@ TEST_F(LXDBackend, start_while_running_does_nothing)
 
     bool put_called{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&put_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -1321,7 +1321,7 @@ TEST_F(LXDBackend, shutdown_while_frozen_does_nothing_and_logs_info)
 {
     mpt::MockVMStatusMonitor mock_monitor;
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1354,7 +1354,7 @@ TEST_F(LXDBackend, ensure_vm_running_does_not_throw_starting)
 
     bool start_called{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&start_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -1402,7 +1402,7 @@ TEST_F(LXDBackend, shutdown_while_starting_throws_and_sets_correct_state)
 
     bool stop_called{false}, start_called{false};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&stop_called, &start_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -1463,7 +1463,7 @@ TEST_F(LXDBackend, start_failure_while_starting_throws_and_sets_correct_state)
     bool start_called{false};
     int running_returned{0};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&start_called, &running_returned](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -1513,7 +1513,7 @@ TEST_F(LXDBackend, reboots_while_starting_does_not_throw_and_sets_correct_state)
     bool start_called{false}, reboot_simulated{false};
     int running_returned{0};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&start_called, &running_returned, &reboot_simulated](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
@@ -1562,7 +1562,7 @@ TEST_F(LXDBackend, current_state_connection_error_logs_warning_and_sets_unknown_
     mpt::StubVMStatusMonitor stub_monitor;
     const std::string exception_message{"Cannot connect to socket"};
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&exception_message](auto...) -> QNetworkReply* {
             throw mp::LocalSocketConnectionException(exception_message);
         });
@@ -1584,7 +1584,7 @@ TEST_P(LXDInstanceStatusTestSuite, lxd_state_returns_expected_VirtualMachine_sta
     const auto status_data = GetParam().first;
     const auto expected_state = GetParam().second;
 
-    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _))
+    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
         .WillByDefault([&status_data](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -58,7 +58,7 @@ const QString bridge_name{"mpbr0"};
 
 struct LXDBackend : public Test
 {
-    LXDBackend() : mock_network_access_manager{std::make_unique<NiceMock<mpt::MockNetworkAccessManager>>()}
+    LXDBackend() : mock_network_access_manager{std::make_unique<StrictMock<mpt::MockNetworkAccessManager>>()}
     {
         logger_scope.mock_logger->screen_logs(mpl::Level::error);
     }
@@ -79,7 +79,7 @@ struct LXDBackend : public Test
 
     mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject();
     mpt::TempDir data_dir;
-    std::unique_ptr<NiceMock<mpt::MockNetworkAccessManager>> mock_network_access_manager;
+    std::unique_ptr<StrictMock<mpt::MockNetworkAccessManager>> mock_network_access_manager;
     QUrl base_url{"unix:///foo@1.0"};
 };
 
@@ -103,8 +103,8 @@ TEST_F(LXDBackend, creates_project_and_network_on_healthcheck)
     bool profile_updated{false};
     bool network_created{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&project_created, &profile_updated, &network_created](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&project_created, &profile_updated, &network_created](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -172,8 +172,8 @@ TEST_F(LXDBackend, factory_creates_valid_virtual_machine_ptr)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -220,8 +220,8 @@ TEST_F(LXDBackend, creates_in_stopped_state)
 
     bool vm_created{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&vm_created](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&vm_created](auto, auto request, auto) {
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
             auto url = request.url().toString();
 
@@ -260,8 +260,8 @@ TEST_F(LXDBackend, machine_persists_and_sets_state_on_start)
 
     bool start_called{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&start_called](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&start_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -310,8 +310,8 @@ TEST_F(LXDBackend, machine_persists_and_sets_state_on_shutdown)
 
     bool vm_shutdown{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&vm_shutdown](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&vm_shutdown](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -361,8 +361,8 @@ TEST_F(LXDBackend, machine_does_not_update_state_in_dtor)
 
     bool vm_shutdown{false}, stop_requested{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&vm_shutdown, &stop_requested](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&vm_shutdown, &stop_requested](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -415,8 +415,8 @@ TEST_F(LXDBackend, does_not_call_stop_when_snap_refresh_is_detected)
 
     bool stop_requested{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&stop_requested](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&stop_requested](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -462,8 +462,8 @@ TEST_F(LXDBackend, calls_stop_when_snap_refresh_does_not_exist)
 
     bool stop_requested{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&stop_requested](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&stop_requested](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -547,8 +547,8 @@ TEST_F(LXDBackend, posts_expected_data_when_creating_instance)
 
     bool vm_created{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&vm_created, &expected_data](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&vm_created, &expected_data](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -624,8 +624,8 @@ TEST_F(LXDBackend, returns_expected_backend_string)
                                  "  }"
                                  "}\n"};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&server_data](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&server_data](auto, auto request, auto) {
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
             auto url = request.url().toString();
 
@@ -694,8 +694,8 @@ TEST_F(LXDBackend, healthcheck_throws_when_untrusted)
                                     "  }"
                                     "}\n"};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&untrusted_data](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&untrusted_data](auto, auto request, auto) {
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
             auto url = request.url().toString();
 
@@ -717,8 +717,8 @@ TEST_F(LXDBackend, healthcheck_connection_refused_error_throws_with_expected_mes
 {
     const std::string exception_message{"Connection refused"};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&exception_message](auto...) -> QNetworkReply* {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillOnce([&exception_message](auto...) -> QNetworkReply* {
             throw mp::LocalSocketConnectionException(exception_message);
         });
 
@@ -736,8 +736,8 @@ TEST_F(LXDBackend, healthcheck_unknown_server_error_throws_with_expected_message
 {
     const std::string exception_message{"Unknown server"};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&exception_message](auto...) -> QNetworkReply* {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillOnce([&exception_message](auto...) -> QNetworkReply* {
             throw mp::LocalSocketConnectionException(exception_message);
         });
 
@@ -755,8 +755,8 @@ TEST_F(LXDBackend, returns_expected_network_info)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -796,8 +796,8 @@ TEST_F(LXDBackend, ssh_hostname_timeout_throws_and_sets_unknown_state)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -834,8 +834,8 @@ TEST_F(LXDBackend, no_ip_address_returns_unknown)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -869,7 +869,7 @@ TEST_F(LXDBackend, no_ip_address_returns_unknown)
 
 TEST_F(LXDBackend, lxd_request_timeout_aborts_and_throws)
 {
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto...) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillOnce([](auto...) {
         QByteArray data;
         auto reply = new mpt::MockLocalSocketReply(data);
         reply->setFinished(false);
@@ -893,7 +893,7 @@ TEST_F(LXDBackend, lxd_request_timeout_aborts_and_throws)
 
 TEST_F(LXDBackend, lxd_request_empty_data_returned_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto...) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillOnce([](auto...) {
         QByteArray data;
         auto reply = new mpt::MockLocalSocketReply(data);
 
@@ -916,7 +916,7 @@ TEST_F(LXDBackend, lxd_request_empty_data_returned_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_request_invalid_json_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillOnce([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
         QByteArray invalid_json{"not json\r\n"};
@@ -940,8 +940,8 @@ TEST_F(LXDBackend, lxd_request_wrong_json_throws_and_logs)
 {
     QByteArray invalid_json{"[]\r\n"};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&invalid_json](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillOnce([&invalid_json](auto, auto request, auto) {
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
             auto url = request.url().toString();
 
@@ -962,7 +962,7 @@ TEST_F(LXDBackend, lxd_request_wrong_json_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_request_bad_request_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto...) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillOnce([](auto...) {
         const QByteArray error_data{"{"
                                     "\"type\": \"error\","
                                     "\"error\": \"Failure\","
@@ -988,7 +988,7 @@ TEST_F(LXDBackend, lxd_request_bad_request_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_request_multipart_bbad_request_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto...) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillOnce([](auto...) {
         const QByteArray error_data{"{"
                                     "\"type\": \"error\","
                                     "\"error\": \"Failure\","
@@ -1015,7 +1015,7 @@ TEST_F(LXDBackend, lxd_request_multipart_bbad_request_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_wait_error_returned_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillOnce([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1071,7 +1071,7 @@ TEST_F(LXDBackend, lxd_wait_error_returned_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_wait_status_code_failure_returned_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillOnce([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1127,7 +1127,7 @@ TEST_F(LXDBackend, lxd_wait_status_code_failure_returned_throws_and_logs)
 
 TEST_F(LXDBackend, lxd_wait_metadata_status_code_failure_returned_throws_and_logs)
 {
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillOnce([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1185,8 +1185,8 @@ TEST_F(LXDBackend, unsupported_suspend_throws)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -1216,7 +1216,7 @@ TEST_F(LXDBackend, start_while_suspending_throws)
 {
     mpt::StubVMStatusMonitor stub_monitor;
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillRepeatedly([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1240,8 +1240,8 @@ TEST_F(LXDBackend, start_while_frozen_unfreezes)
     mpt::StubVMStatusMonitor stub_monitor;
     bool unfreeze_called{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&unfreeze_called](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&unfreeze_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -1279,8 +1279,8 @@ TEST_F(LXDBackend, start_while_running_does_nothing)
 
     bool put_called{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&put_called](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&put_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -1321,7 +1321,7 @@ TEST_F(LXDBackend, shutdown_while_frozen_does_nothing_and_logs_info)
 {
     mpt::MockVMStatusMonitor mock_monitor;
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillRepeatedly([](auto, auto request, auto) {
         auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
         auto url = request.url().toString();
 
@@ -1354,8 +1354,8 @@ TEST_F(LXDBackend, ensure_vm_running_does_not_throw_starting)
 
     bool start_called{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&start_called](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&start_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -1402,8 +1402,8 @@ TEST_F(LXDBackend, shutdown_while_starting_throws_and_sets_correct_state)
 
     bool stop_called{false}, start_called{false};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&stop_called, &start_called](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&stop_called, &start_called](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -1463,8 +1463,8 @@ TEST_F(LXDBackend, start_failure_while_starting_throws_and_sets_correct_state)
     bool start_called{false};
     int running_returned{0};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&start_called, &running_returned](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&start_called, &running_returned](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -1513,8 +1513,8 @@ TEST_F(LXDBackend, reboots_while_starting_does_not_throw_and_sets_correct_state)
     bool start_called{false}, reboot_simulated{false};
     int running_returned{0};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&start_called, &running_returned, &reboot_simulated](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&start_called, &running_returned, &reboot_simulated](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
@@ -1562,8 +1562,8 @@ TEST_F(LXDBackend, current_state_connection_error_logs_warning_and_sets_unknown_
     mpt::StubVMStatusMonitor stub_monitor;
     const std::string exception_message{"Cannot connect to socket"};
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&exception_message](auto...) -> QNetworkReply* {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&exception_message](auto...) -> QNetworkReply* {
             throw mp::LocalSocketConnectionException(exception_message);
         });
 
@@ -1584,8 +1584,8 @@ TEST_P(LXDInstanceStatusTestSuite, lxd_state_returns_expected_VirtualMachine_sta
     const auto status_data = GetParam().first;
     const auto expected_state = GetParam().second;
 
-    ON_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .WillByDefault([&status_data](auto, auto request, auto outgoingData) {
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&status_data](auto, auto request, auto outgoingData) {
             outgoingData->open(QIODevice::ReadOnly);
             auto data = outgoingData->readAll();
             auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();


### PR DESCRIPTION
LXD test improvements extracted from #1912: provide an empty but non-null reply from the mock network mgr by default, to avoid crashing on unexpected mock calls. Expect calls explicitly. Remove superfluous calls to `unique_ptr::get`