### PR TITLE
Rework disk space check. Fixes #1926

### DIFF
--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -96,7 +96,8 @@ int mp::Client::run(const QStringList& arguments)
 
     ParseCode parse_status = parser.parse();
 
-    mp::client::set_logger(mpl::level_from(parser.verbosityLevel())); // we need logging for...
+    if (!mpl::get_logger())
+        mp::client::set_logger(mpl::level_from(parser.verbosityLevel())); // we need logging for...
     mp::client::pre_setup(); // ... something we want to do even if the command was wrong
 
     const auto ret =

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -789,7 +789,8 @@ mp::MemorySize compute_final_image_size(const mp::MemorySize image_size,
     if (available_disk_space < disk_space)
     {
         mpl::log(mpl::Level::warning, category,
-                 fmt::format("Reserving more disk space than available ({} bytes)", available_disk_space.in_bytes()));
+                 fmt::format("Reserving more disk space ({} bytes) than available ({} bytes)", disk_space.in_bytes(),
+                             available_disk_space.in_bytes()));
     }
 
     return disk_space;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -788,8 +788,8 @@ mp::MemorySize compute_final_image_size(const mp::MemorySize image_size,
 
     if (available_disk_space < disk_space)
     {
-        throw std::runtime_error(fmt::format("Available disk ({} bytes) below requested/default size ({} bytes)",
-                                             available_disk_space.in_bytes(), disk_space.in_bytes()));
+        mpl::log(mpl::Level::warning, category,
+                 fmt::format("Reserving more disk space than available ({} bytes)", available_disk_space.in_bytes()));
     }
 
     return disk_space;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -780,6 +780,12 @@ mp::MemorySize compute_final_image_size(const mp::MemorySize image_size,
     std::string available_bytes_str = QString::number(available_bytes).toStdString();
     auto available_disk_space = mp::MemorySize(available_bytes_str + "B");
 
+    if (available_disk_space < image_size)
+    {
+        throw std::runtime_error(fmt::format("Available disk ({} bytes) below minimum for this image ({} bytes)",
+                                             available_disk_space.in_bytes(), image_size.in_bytes()));
+    }
+
     if (available_disk_space < disk_space)
     {
         throw std::runtime_error(fmt::format("Available disk ({} bytes) below requested/default size ({} bytes)",

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -944,7 +944,7 @@ TEST_P(LaunchStorageCheckSuite, launch_warns_when_overcommitting_disk_space)
     mp::Daemon daemon{config_builder.build()};
 
     auto logger_scope = mpt::MockLogger::inject();
-    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
 
     auto available_disk{16'106'127'360}; // 15G
     REPLACE(filesystem_bytes_available, [&available_disk](auto...) { return available_disk; });

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -949,6 +949,7 @@ TEST_P(LaunchStorageCheckSuite, launch_warns_when_overcommitting_disk_space)
     auto available_disk{16'106'127'360}; // 15G
     REPLACE(filesystem_bytes_available, [&available_disk](auto...) { return available_disk; });
 
+    logger_scope.mock_logger->expect_log(mpl::Level::error, "autostart prerequisites", AtMost(1));
     logger_scope.mock_logger->expect_log(
         mpl::Level::warning, fmt::format("Reserving more disk space than available ({} bytes)", available_disk));
     EXPECT_CALL(*mock_factory, create_virtual_machine(_, _));

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -949,10 +949,8 @@ TEST_P(LaunchStorageCheckSuite, launch_warns_when_overcommitting_disk_space)
     auto available_disk{16'106'127'360}; // 15G
     REPLACE(filesystem_bytes_available, [&available_disk](auto...) { return available_disk; });
 
-    EXPECT_CALL(*logger_scope.mock_logger,
-                log(Eq(mpl::Level::warning), mpt::MockLogger::make_cstring_matcher(StrEq("daemon")),
-                    mpt::MockLogger::make_cstring_matcher(StrEq(
-                        fmt::format("Reserving more disk space than available (\"{}\" bytes)", available_disk)))));
+    logger_scope.mock_logger->expect_log(
+        mpl::Level::warning, fmt::format("Reserving more disk space than available (\"{}\" bytes)", available_disk));
     EXPECT_CALL(*mock_factory, create_virtual_machine(_, _));
 
     send_command({GetParam(), "--disk", "20G"}, trash_stream, trash_stream);

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -950,7 +950,7 @@ TEST_P(LaunchStorageCheckSuite, launch_warns_when_overcommitting_disk_space)
     REPLACE(filesystem_bytes_available, [&available_disk](auto...) { return available_disk; });
 
     logger_scope.mock_logger->expect_log(
-        mpl::Level::warning, fmt::format("Reserving more disk space than available (\"{}\" bytes)", available_disk));
+        mpl::Level::warning, fmt::format("Reserving more disk space than available ({} bytes)", available_disk));
     EXPECT_CALL(*mock_factory, create_virtual_machine(_, _));
 
     send_command({GetParam(), "--disk", "20G"}, trash_stream, trash_stream);


### PR DESCRIPTION
Allow over-committing disk space, as that's a feature, not a bug. Still fail on disk space lower than image size, and warn on over-committing.