### PR TITLE
Networks bash completion

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -125,8 +125,14 @@ _multipass_complete()
         fi
     }
 
-    # Add the comma to the list of word separators, useful to separate options of the form "opt1=val1,opt2=val2".
-    COMP_WORDBREAKS="${COMP_WORDBREAKS},"
+    # Add comma and equals sign to the list of word separators if they are not already there, useful to separate
+    # options of the form "opt1=val1,opt2=val2".
+    if [[ ! "${COMP_WORDBREAKS}" =~ "," ]]; then
+        COMP_WORDBREAKS="${COMP_WORDBREAKS},"
+    fi
+    if [[ ! "${COMP_WORDBREAKS}" =~ "=" ]]; then
+        COMP_WORDBREAKS="${COMP_WORDBREAKS}="
+    fi
 
     local cur cmd opts prev prev2 prev_opts
     COMPREPLY=()

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -76,8 +76,8 @@ _multipass_complete()
         esac
     }
 
-    # Set $last_match to the name of the last argument whose name matches with, or the empty string if there is no
-    # match. Return its position in COMP_WORDS.
+    # Set $last_match to the last argument that matches the provided regex, or the empty string if there is no
+    # match. Return its position in COMP_WORDS, or 0 when there is no match.
     _find_last_match()
     {
         local last_pos

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -76,34 +76,79 @@ _multipass_complete()
         esac
     }
 
-    # Scan the command-line to find the last appearance of "--network". Then, scan from there until the end of the
-    # command-line for the names of the variables which were already specified. And fill-in $opts with the
-    # variables which were not yet specified.
-    _unspecified_network_vars()
+    # Find the position of the last appearance of a given parameter name in the command-line. Return its index, or
+    # 0 if not found.
+    _find_last_par()
     {
-        local network_pos=COMP_CWORD
+        local last_pos
 
-        for ((i=COMP_CWORD; i>0; --i)); do
-            if [[ "${COMP_WORDS[$i]}" == '--network' ]]; then
-                network_pos=$i
+        for ((last_pos=COMP_CWORD; last_pos>0; --last_pos)); do
+            if [[ "${COMP_WORDS[$last_pos]}" == "$1" ]]; then
                 break
             fi
         done
 
-        local id_found=0
-        local mac_found=0
-        local mode_found=0
+        return ${last_pos}
+    }
 
-        for ((i=${network_pos}+1; i<COMP_CWORD; ++i)); do
-            if [[ "${COMP_WORDS[$i]}" == 'id' ]]; then id_found=1; fi
-            if [[ "${COMP_WORDS[$i]}" == 'mac' ]]; then mac_found=1; fi
-            if [[ "${COMP_WORDS[$i]}" == 'mode' ]]; then mode_found=1; fi
+    # Find the position of the last appearance of parameter starting with "--" in the command-line. Return its
+    # index, or 0 if not found.
+    _find_last_dashdash()
+    {
+        local last_pos
+
+        for ((last_pos=COMP_CWORD; last_pos>0; --last_pos)); do
+            if [[ "${COMP_WORDS[$last_pos]}" =~ ^--.* ]]; then
+                break
+            fi
         done
 
+        return ${last_pos}
+    }
+
+    # Sets $1 to the name of the last argument whose name starts with "--", or the empty string if there is none.
+    _last_dashdash_name()
+    {
+        local last_pos
+
+        last_dashdash_arg=""
+        for ((last_pos=COMP_CWORD; last_pos>0; --last_pos)); do
+            if [[ "${COMP_WORDS[$last_pos]}" =~ ^--.* ]]; then
+                last_dashdash_arg=${COMP_WORDS[$last_pos]}
+                break
+            fi
+        done
+    }
+
+    # If the last argument starting with "--" is "--network", scan from there until the end of the command-line for
+    # the names of the variables which were already specified. And fill-in $opts with the variables which were not
+    # yet specified.
+    # TODO: In case of adding more parameters starting with "--", factor out this function and take as parameters
+    # an argument name and the list of possible "var=" keys. Calling this function would then look like
+    # _unspecified_vars "--network" ("id= mac= mode=")
+    _unspecified_network_vars()
+    {
+        local last_network_pos=$(_find_last_par "--network")
+
+        local last_dashdash_pos=$(_find_last_dashdash)
+
         opts=""
-        if [[ ${id_found} == 0 ]]; then opts="${opts} id="; fi
-        if [[ ${mac_found} == 0 ]]; then opts="${opts} mac="; fi
-        if [[ ${mode_found} == 0 ]]; then opts="${opts} mode="; fi
+
+        if [[ ${last_network_pos} == ${last_dashdash_pos} ]]; then
+            local id_found=0
+            local mac_found=0
+            local mode_found=0
+
+            for ((i=${last_network_pos}+1; i<COMP_CWORD; ++i)); do
+                if [[ "${COMP_WORDS[$i]}" == 'id' ]]; then id_found=1; fi
+                if [[ "${COMP_WORDS[$i]}" == 'mac' ]]; then mac_found=1; fi
+                if [[ "${COMP_WORDS[$i]}" == 'mode' ]]; then mode_found=1; fi
+            done
+
+            if [[ ${id_found} == 0 ]]; then opts="${opts} id="; fi
+            if [[ ${mac_found} == 0 ]]; then opts="${opts} mac="; fi
+            if [[ ${mode_found} == 0 ]]; then opts="${opts} mode="; fi
+        fi
     }
 
     # Add the comma to the list of word separators, useful to separate options of the form "opt1=val1,opt2=val2".
@@ -168,24 +213,30 @@ _multipass_complete()
                 # TODO: Do use spaces after the completion of an interface name.
                 compopt -o nospace
         esac
+    else
+        local last_dashdash_arg
+        _last_dashdash_name
 
-    # We need to complete the option pairs in two steps. One, when the last input char was an equals sign. Two,
-    # when the user starts to input something, because prev changes when she starts to type a value.
-    elif [[ "${cur}" == '=' ]] && [[ "${prev2}" == ',' || "${prev2}" == '--network' ]] ; then
-        compopt -o nospace
-        _remove_trailing_char
-        _complete_network_var "${prev}"
+        if [[ ${last_dashdash_arg} == "--network" ]]; then
+            # We need to complete the option pairs in two steps. One, when the last input char was an equals sign. Two,
+            # when the user starts to input something, because prev changes when she starts to type a value.
+            if [[ "${cur}" == '=' ]] && [[ "${prev2}" == ',' || "${prev2}" == '--network' ]] ; then
+                compopt -o nospace
+                _remove_trailing_char
+                _complete_network_var "${prev}"
 
-    elif [[ "${prev}" == '=' ]]; then
-        compopt -o nospace
-        _complete_network_var "${prev2}"
+            elif [[ "${prev}" == '=' ]]; then
+                compopt -o nospace
+                _complete_network_var "${prev2}"
 
-    # Complete now in the case on which there is a comma separating var=val pairs.
-    elif [[ "${cur}" == ',' && "${prev2}" == '=' ]] || [[ "${prev}" == ',' && "${COMP_WORDS[COMP_CWORD-3]}" == '=' ]];
-    then
-        _remove_trailing_char
-        compopt -o nospace
-        _unspecified_network_vars
+            # Complete now in the case on which there is a comma separating var=val pairs.
+            elif [[ "${cur}" == ',' && "${prev2}" == '=' ]] ||
+                 [[ "${prev}" == ',' && "${COMP_WORDS[COMP_CWORD-3]}" == '=' ]]; then
+                _remove_trailing_char
+                compopt -o nospace
+                _unspecified_network_vars
+            fi
+        fi
     fi
 
     if [[ "$prev_opts" = false ]]; then

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -49,10 +49,11 @@ _multipass_complete()
         opts="${opts} ${networks}"
     }
 
-    _remove_trailing_sign()
+    # Removes the comma or equals sign at the end of $cur.
+    _remove_trailing_char()
     {
-        if [[ $cur == *= ]]; then
-            cur="${cur#*=}"
+        if [[ $cur =~ [,=]$ ]]; then
+            cur="${cur#*[,=]}"
             return 0
         fi
 
@@ -66,6 +67,9 @@ _multipass_complete()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
+    prev2="${COMP_WORDS[COMP_CWORD-2]}"
+    prev3="${COMP_WORDS[COMP_CWORD-3]}"
+    prev4="${COMP_WORDS[COMP_CWORD-4]}"
     cmd="${COMP_WORDS[1]}"
     prev_opts=false
     multipass_cmds="transfer delete exec find help info launch list mount networks \
@@ -124,13 +128,16 @@ _multipass_complete()
 
     # We need to complete the option pairs in two steps. One, when the last input char was an equals sign. Two,
     # when the user starts to input something, because prev changes when she starts to type a value.
-    elif [[ "${COMP_WORDS[COMP_CWORD-2]}" == '--network' && "${cur}" == '=' ]]; then
+    elif [[ "${cur}" == '=' ]] && [[ "${prev2}" == ',' || "${prev2}" == '--network' ]] ; then
         compopt -o nospace
-        _remove_trailing_sign
+        _remove_trailing_char
         case "${prev}" in
             "id")
                 opts=""
                 _multipass_networks
+            ;;
+            "mac")
+                opts=""
             ;;
             "mode")
                 opts="auto manual"
@@ -138,15 +145,28 @@ _multipass_complete()
         esac
     elif [[ "${prev}" == '=' ]]; then
         compopt -o nospace
-        case "${COMP_WORDS[COMP_CWORD-2]}" in
+        case "${prev2}" in
             "id")
                 opts=""
                 _multipass_networks
+            ;;
+            "mac")
+                opts=""
             ;;
             "mode")
                 opts="auto manual"
             ;;
         esac
+    elif [[ "${cur}" == ',' && "${prev2}" == '=' ]] || [[ "${prev}" == ',' && "${prev3}" == '=' ]] ; then
+        _remove_trailing_char
+        compopt -o nospace
+        if [[ "${prev3}" == 'id' || "${prev4}" == 'id' ]]; then
+            opts="mode= mac="
+        elif [[ "${prev3}" == 'mode' || "${prev4}" == 'mode' ]]; then
+            opts="mac= id="
+        elif [[ "${prev3}" == 'mac' || "${prev4}" == 'mac' ]]; then
+                opts="id= mode="
+        fi
     fi
 
     if [[ "$prev_opts" = false ]]; then

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -43,7 +43,7 @@ _multipass_complete()
     # Set $opts to the list of available networks.
     _multipass_networks()
     {
-        local cmd="multipass networks --format=csv"
+        local cmd="multipass networks --format=csv 2>/dev/null"
 
         opts=$( \eval $cmd | \grep -Ev '(\+--|Name)' | \cut -d',' -f 1 )
     }

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -40,6 +40,28 @@ _multipass_complete()
         done
     }
 
+    _multipass_networks()
+    {
+        local cmd="multipass networks --format=csv"
+
+        networks=$( \eval $cmd | \grep -Ev '(\+--|Name)' | \cut -d',' -f 1 )
+
+        opts="${opts} ${networks}"
+    }
+
+    _remove_trailing_sign()
+    {
+        if [[ $cur == *= ]]; then
+            cur="${cur#*=}"
+            return 0
+        fi
+
+        return 1
+    }
+
+    # Add the comma to the list of word separators, useful to separate options of the form "opt1=val1,opt2=val2".
+    COMP_WORDBREAKS="${COMP_WORDBREAKS},"
+
     local cur cmd opts prev prev_opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -90,7 +112,40 @@ _multipass_complete()
                 _filedir
                 return
             ;;
-            # TODO: add "--network" here
+            "--network")
+                compopt -o nospace
+                # TODO: Do use spaces after the completion of an interface name.
+                opts=""
+                _multipass_networks
+                for net in ${opts}; do
+                    opts="${opts} id= mode= mac="
+                done
+        esac
+
+    # We need to complete the option pairs in two steps. One, when the last input char was an equals sign. Two,
+    # when the user starts to input something, because prev changes when she starts to type a value.
+    elif [[ "${COMP_WORDS[COMP_CWORD-2]}" == '--network' && "${cur}" == '=' ]]; then
+        compopt -o nospace
+        _remove_trailing_sign
+        case "${prev}" in
+            "id")
+                opts=""
+                _multipass_networks
+            ;;
+            "mode")
+                opts="auto manual"
+            ;;
+        esac
+    elif [[ "${prev}" == '=' ]]; then
+        compopt -o nospace
+        case "${COMP_WORDS[COMP_CWORD-2]}" in
+            "id")
+                opts=""
+                _multipass_networks
+            ;;
+            "mode")
+                opts="auto manual"
+            ;;
         esac
     fi
 

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -76,62 +76,35 @@ _multipass_complete()
         esac
     }
 
-    # Find the position of the last appearance of a given parameter name in the command-line. Return its index, or
-    # 0 if not found.
-    _find_last_par()
+    # Set $last_match to the name of the last argument whose name matches with, or the empty string if there is no
+    # match. Return its position in COMP_WORDS.
+    _find_last_match()
     {
         local last_pos
 
+        last_match=""
         for ((last_pos=COMP_CWORD; last_pos>0; --last_pos)); do
-            if [[ "${COMP_WORDS[$last_pos]}" == "$1" ]]; then
+            if [[ "${COMP_WORDS[$last_pos]}" =~ $1 ]]; then
+                last_match=${COMP_WORDS[$last_pos]}
                 break
             fi
         done
 
         return ${last_pos}
-    }
-
-    # Find the position of the last appearance of parameter starting with "--" in the command-line. Return its
-    # index, or 0 if not found.
-    _find_last_dashdash()
-    {
-        local last_pos
-
-        for ((last_pos=COMP_CWORD; last_pos>0; --last_pos)); do
-            if [[ "${COMP_WORDS[$last_pos]}" =~ ^--.* ]]; then
-                break
-            fi
-        done
-
-        return ${last_pos}
-    }
-
-    # Set $last_dashdash to the name of the last argument whose name starts with "--", or the empty string if there
-    # is none.
-    _last_dashdash_name()
-    {
-        local last_pos
-
-        last_dashdash_arg=""
-        for ((last_pos=COMP_CWORD; last_pos>0; --last_pos)); do
-            if [[ "${COMP_WORDS[$last_pos]}" =~ ^--.* ]]; then
-                last_dashdash_arg=${COMP_WORDS[$last_pos]}
-                break
-            fi
-        done
     }
 
     # If the last argument starting with "--" is "--network", scan from there until the end of the command-line for
     # the names of the variables which were already specified. And fill-in $opts with the variables which were not
     # yet specified.
-    # TODO: In case of adding more parameters starting with "--", factor out this function and take as parameters
-    # an argument name and the list of possible "var=" keys. Calling this function would then look like
+    # In case of adding more parameters starting with "--" to the completion script, this function can be factored
+    # out, taking as parameters an argument name and the list of possible "var=" keys. Calling this function
+    # would then look like:
     # _unspecified_vars "--network" ("id=" "mac=" "mode=")
     _unspecified_network_vars()
     {
-        local last_network_pos=$(_find_last_par "--network")
+        local last_network_pos=$(_find_last_match "^--network$")
 
-        local last_dashdash_pos=$(_find_last_dashdash)
+        local last_dashdash_pos=$(_find_last_match "^-.*")
 
         opts=""
 
@@ -215,10 +188,10 @@ _multipass_complete()
                 compopt -o nospace
         esac
     else
-        local last_dashdash_arg
-        _last_dashdash_name
+        local last_match
+        _find_last_match "--"
 
-        if [[ ${last_dashdash_arg} == "--network" ]]; then
+        if [[ ${last_match} == "--network" ]]; then
             # We need to complete the option pairs in two steps. One, when the last input char was an equals sign. Two,
             # when the user starts to input something, because prev changes when she starts to type a value.
             if [[ "${cur}" == '=' ]] && [[ "${prev2}" == ',' || "${prev2}" == '--network' ]] ; then

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -93,36 +93,28 @@ _multipass_complete()
         return ${last_pos}
     }
 
-    # If the last argument starting with "--" is "--network", scan from there until the end of the command-line for
-    # the names of the variables which were already specified. And fill-in $opts with the variables which were not
-    # yet specified.
-    # In case of adding more parameters starting with "--" to the completion script, this function can be factored
-    # out, taking as parameters an argument name and the list of possible "var=" keys. Calling this function
-    # would then look like:
-    # _unspecified_vars "--network" ("id=" "mac=" "mode=")
+    # Given the last argument starting with "--" is "--network", scan from there until the end of the command-line
+    # for the names of the variables which were already specified. And fill-in $opts with the variables which were
+    # not yet specified.
+    # Precondition: the last dash-something argument must be "--network".
+    # Parameters: $1 the position of the last "--network".
     _unspecified_network_vars()
     {
-        local last_network_pos=$(_find_last_match "^--network$")
-
-        local last_dashdash_pos=$(_find_last_match "^-.*")
-
         opts=""
 
-        if [[ ${last_network_pos} == ${last_dashdash_pos} ]]; then
-            local id_found=0
-            local mac_found=0
-            local mode_found=0
+        local id_found=0
+        local mac_found=0
+        local mode_found=0
 
-            for ((i=${last_network_pos}+1; i<COMP_CWORD; ++i)); do
-                if [[ "${COMP_WORDS[$i]}" == 'id' ]]; then id_found=1; fi
-                if [[ "${COMP_WORDS[$i]}" == 'mac' ]]; then mac_found=1; fi
-                if [[ "${COMP_WORDS[$i]}" == 'mode' ]]; then mode_found=1; fi
-            done
+        for ((i=$1+1; i<COMP_CWORD; ++i)); do
+            if [[ "${COMP_WORDS[$i]}" == 'id' ]]; then id_found=1; fi
+            if [[ "${COMP_WORDS[$i]}" == 'mac' ]]; then mac_found=1; fi
+            if [[ "${COMP_WORDS[$i]}" == 'mode' ]]; then mode_found=1; fi
+        done
 
-            if [[ ${id_found} == 0 ]]; then opts="${opts} id="; fi
-            if [[ ${mac_found} == 0 ]]; then opts="${opts} mac="; fi
-            if [[ ${mode_found} == 0 ]]; then opts="${opts} mode="; fi
-        fi
+        if [[ ${id_found} == 0 ]]; then opts="${opts} id="; fi
+        if [[ ${mac_found} == 0 ]]; then opts="${opts} mac="; fi
+        if [[ ${mode_found} == 0 ]]; then opts="${opts} mode="; fi
     }
 
     # Add comma and equals sign to the list of word separators if they are not already there, useful to separate
@@ -195,7 +187,8 @@ _multipass_complete()
         esac
     else
         local last_match
-        _find_last_match "--"
+        _find_last_match ^-.*
+        local last_match_pos=$?
 
         if [[ ${last_match} == "--network" ]]; then
             # We need to complete the option pairs in two steps. One, when the last input char was an equals sign. Two,
@@ -214,7 +207,7 @@ _multipass_complete()
                  [[ "${prev}" == ',' && "${COMP_WORDS[COMP_CWORD-3]}" == '=' ]]; then
                 _remove_trailing_char
                 compopt -o nospace
-                _unspecified_network_vars
+                _unspecified_network_vars ${last_match_pos}
             fi
         fi
     fi

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -60,6 +60,24 @@ _multipass_complete()
         return 1
     }
 
+    # When options for --network are specified in the form var=val, this function sets $opts to the values needed
+    # depending on the value of var (which is specified as the parameter $1).
+    _complete_network_vars()
+    {
+        case "$1" in
+            "id")
+                opts=""
+                _multipass_networks
+            ;;
+            "mac")
+                opts=""
+            ;;
+            "mode")
+                opts="auto manual"
+            ;;
+        esac
+    }
+
     # Add the comma to the list of word separators, useful to separate options of the form "opt1=val1,opt2=val2".
     COMP_WORDBREAKS="${COMP_WORDBREAKS},"
 
@@ -121,9 +139,7 @@ _multipass_complete()
                 # TODO: Do use spaces after the completion of an interface name.
                 opts=""
                 _multipass_networks
-                for net in ${opts}; do
-                    opts="${opts} id= mode= mac="
-                done
+                opts="${opts} id= mode= mac="
         esac
 
     # We need to complete the option pairs in two steps. One, when the last input char was an equals sign. Two,
@@ -131,35 +147,17 @@ _multipass_complete()
     elif [[ "${cur}" == '=' ]] && [[ "${prev2}" == ',' || "${prev2}" == '--network' ]] ; then
         compopt -o nospace
         _remove_trailing_char
-        case "${prev}" in
-            "id")
-                opts=""
-                _multipass_networks
-            ;;
-            "mac")
-                opts=""
-            ;;
-            "mode")
-                opts="auto manual"
-            ;;
-        esac
+        _complete_network_vars "${prev}"
+
     elif [[ "${prev}" == '=' ]]; then
         compopt -o nospace
-        case "${prev2}" in
-            "id")
-                opts=""
-                _multipass_networks
-            ;;
-            "mac")
-                opts=""
-            ;;
-            "mode")
-                opts="auto manual"
-            ;;
-        esac
+        _complete_network_vars "${prev2}"
+
+    # Complete now in the case on which there is a comma separating var=val pairs.
     elif [[ "${cur}" == ',' && "${prev2}" == '=' ]] || [[ "${prev}" == ',' && "${prev3}" == '=' ]] ; then
         _remove_trailing_char
         compopt -o nospace
+        # TODO: Keep track of the previously used options and show only options which were not specified before.
         if [[ "${prev3}" == 'id' || "${prev4}" == 'id' ]]; then
             opts="mode= mac="
         elif [[ "${prev3}" == 'mode' || "${prev4}" == 'mode' ]]; then

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -40,13 +40,12 @@ _multipass_complete()
         done
     }
 
+    # Set $opts to the list of available networks.
     _multipass_networks()
     {
         local cmd="multipass networks --format=csv"
 
-        networks=$( \eval $cmd | \grep -Ev '(\+--|Name)' | \cut -d',' -f 1 )
-
-        opts="${opts} ${networks}"
+        opts=$( \eval $cmd | \grep -Ev '(\+--|Name)' | \cut -d',' -f 1 )
     }
 
     # Removes the comma or equals sign at the end of $cur.
@@ -62,11 +61,10 @@ _multipass_complete()
 
     # When options for --network are specified in the form var=val, this function sets $opts to the values needed
     # depending on the value of var (which is specified as the parameter $1).
-    _complete_network_vars()
+    _complete_network_var()
     {
         case "$1" in
             "id")
-                opts=""
                 _multipass_networks
             ;;
             "mac")
@@ -78,6 +76,36 @@ _multipass_complete()
         esac
     }
 
+    # Scan the command-line to find the last appearance of "--network". Then, scan from there until the end of the
+    # command-line for the names of the variables which were already specified. And fill-in $opts with the
+    # variables which were not yet specified.
+    _unspecified_network_vars()
+    {
+        local network_pos=COMP_CWORD
+
+        for ((i=COMP_CWORD; i>0; --i)); do
+            if [[ "${COMP_WORDS[$i]}" == '--network' ]]; then
+                network_pos=$i
+                break
+            fi
+        done
+
+        local id_found=0
+        local mac_found=0
+        local mode_found=0
+
+        for ((i=${network_pos}+1; i<COMP_CWORD; ++i)); do
+            if [[ "${COMP_WORDS[$i]}" == 'id' ]]; then id_found=1; fi
+            if [[ "${COMP_WORDS[$i]}" == 'mac' ]]; then mac_found=1; fi
+            if [[ "${COMP_WORDS[$i]}" == 'mode' ]]; then mode_found=1; fi
+        done
+
+        opts=""
+        if [[ ${id_found} == 0 ]]; then opts="${opts} id="; fi
+        if [[ ${mac_found} == 0 ]]; then opts="${opts} mac="; fi
+        if [[ ${mode_found} == 0 ]]; then opts="${opts} mode="; fi
+    }
+
     # Add the comma to the list of word separators, useful to separate options of the form "opt1=val1,opt2=val2".
     COMP_WORDBREAKS="${COMP_WORDBREAKS},"
 
@@ -86,8 +114,6 @@ _multipass_complete()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     prev2="${COMP_WORDS[COMP_CWORD-2]}"
-    prev3="${COMP_WORDS[COMP_CWORD-3]}"
-    prev4="${COMP_WORDS[COMP_CWORD-4]}"
     cmd="${COMP_WORDS[1]}"
     prev_opts=false
     multipass_cmds="transfer delete exec find help info launch list mount networks \
@@ -137,7 +163,6 @@ _multipass_complete()
             "--network")
                 compopt -o nospace
                 # TODO: Do use spaces after the completion of an interface name.
-                opts=""
                 _multipass_networks
                 opts="${opts} id= mode= mac="
         esac
@@ -147,24 +172,18 @@ _multipass_complete()
     elif [[ "${cur}" == '=' ]] && [[ "${prev2}" == ',' || "${prev2}" == '--network' ]] ; then
         compopt -o nospace
         _remove_trailing_char
-        _complete_network_vars "${prev}"
+        _complete_network_var "${prev}"
 
     elif [[ "${prev}" == '=' ]]; then
         compopt -o nospace
-        _complete_network_vars "${prev2}"
+        _complete_network_var "${prev2}"
 
     # Complete now in the case on which there is a comma separating var=val pairs.
-    elif [[ "${cur}" == ',' && "${prev2}" == '=' ]] || [[ "${prev}" == ',' && "${prev3}" == '=' ]] ; then
+    elif [[ "${cur}" == ',' && "${prev2}" == '=' ]] || [[ "${prev}" == ',' && "${COMP_WORDS[COMP_CWORD-3]}" == '=' ]];
+    then
         _remove_trailing_char
         compopt -o nospace
-        # TODO: Keep track of the previously used options and show only options which were not specified before.
-        if [[ "${prev3}" == 'id' || "${prev4}" == 'id' ]]; then
-            opts="mode= mac="
-        elif [[ "${prev3}" == 'mode' || "${prev4}" == 'mode' ]]; then
-            opts="mac= id="
-        elif [[ "${prev3}" == 'mac' || "${prev4}" == 'mac' ]]; then
-                opts="id= mode="
-        fi
+        _unspecified_network_vars
     fi
 
     if [[ "$prev_opts" = false ]]; then

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -161,10 +161,12 @@ _multipass_complete()
                 return
             ;;
             "--network")
-                compopt -o nospace
-                # TODO: Do use spaces after the completion of an interface name.
                 _multipass_networks
-                opts="${opts} id= mode= mac="
+                if [[ "${opts}" != "" ]]; then
+                    opts="${opts} id= mode= mac="
+                fi
+                # TODO: Do use spaces after the completion of an interface name.
+                compopt -o nospace
         esac
 
     # We need to complete the option pairs in two steps. One, when the last input char was an equals sign. Two,

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -106,7 +106,8 @@ _multipass_complete()
         return ${last_pos}
     }
 
-    # Sets $1 to the name of the last argument whose name starts with "--", or the empty string if there is none.
+    # Set $last_dashdash to the name of the last argument whose name starts with "--", or the empty string if there
+    # is none.
     _last_dashdash_name()
     {
         local last_pos
@@ -125,7 +126,7 @@ _multipass_complete()
     # yet specified.
     # TODO: In case of adding more parameters starting with "--", factor out this function and take as parameters
     # an argument name and the list of possible "var=" keys. Calling this function would then look like
-    # _unspecified_vars "--network" ("id= mac= mode=")
+    # _unspecified_vars "--network" ("id=" "mac=" "mode=")
     _unspecified_network_vars()
     {
         local last_network_pos=$(_find_last_par "--network")
@@ -154,7 +155,7 @@ _multipass_complete()
     # Add the comma to the list of word separators, useful to separate options of the form "opt1=val1,opt2=val2".
     COMP_WORDBREAKS="${COMP_WORDBREAKS},"
 
-    local cur cmd opts prev prev_opts
+    local cur cmd opts prev prev2 prev_opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"


### PR DESCRIPTION
This PR implements bash autocompletion of the networks available in the host (listed with `multipass networks`). It pops in when the parameter `--network` is specified in the command line.