### PR TITLE
[default_image_vault] Use new common copy util

### DIFF
--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -169,21 +169,6 @@ std::unordered_map<std::string, mp::VaultRecord> load_db(const QString& db_name)
     return reconstructed_records;
 }
 
-QString copy(const QString& file_name, const QDir& output_dir)
-{
-    if (file_name.isEmpty())
-        return {};
-
-    if (!QFileInfo::exists(file_name))
-        throw std::runtime_error(fmt::format("{} missing", file_name));
-
-    QFileInfo info{file_name};
-    const auto source_name = info.fileName();
-    auto new_path = output_dir.filePath(source_name);
-    QFile::copy(file_name, new_path);
-    return new_path;
-}
-
 void remove_source_images(const mp::VMImage& source_image, const mp::VMImage& prepared_image)
 {
     // The prepare phase may have been a no-op, check and only remove source images
@@ -667,9 +652,9 @@ mp::VMImage mp::DefaultVMImageVault::image_instance_from(const std::string& inst
     auto name = QString::fromStdString(instance_name);
     auto output_dir = mp::utils::make_dir(instances_dir, name);
 
-    return {copy(prepared_image.image_path, output_dir),
-            copy(prepared_image.kernel_path, output_dir),
-            copy(prepared_image.initrd_path, output_dir),
+    return {mp::vault::copy(prepared_image.image_path, output_dir),
+            mp::vault::copy(prepared_image.kernel_path, output_dir),
+            mp::vault::copy(prepared_image.initrd_path, output_dir),
             prepared_image.id,
             prepared_image.original_release,
             prepared_image.current_release,


### PR DESCRIPTION
---

There was a question in https://github.com/canonical/multipass/pull/1931#discussion_r595008464 about whether returning an empty path in `vault::copy()` is the right thing to do.  This is done because of https://github.com/canonical/multipass/blob/afbea256e07cde725f32807adb11fb08782e1b97/src/daemon/default_vm_image_vault.cpp#L656-L657 where there may not be a kernel and initrd to copy.  It basically makes it a no-op on platforms that don't need that and is the easiest way to handle all cases.
