### PR TITLE
[lxd_request] Set JSON parsing error dump to debug

### DIFF
--- a/src/platform/backends/lxd/lxd_request.cpp
+++ b/src/platform/backends/lxd/lxd_request.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -94,11 +94,21 @@ const QJsonObject lxd_request_common(const std::string& method, QUrl& url, int t
     auto json_reply = QJsonDocument::fromJson(bytearray_reply, &json_error);
 
     if (json_error.error != QJsonParseError::NoError)
-        throw mp::LXDRuntimeError(fmt::format("Error parsing JSON response for {}: {}\n{}", url.toString(),
-                                              json_error.errorString(), bytearray_reply));
+    {
+        std::string error_string{
+            fmt::format("Error parsing JSON response for {}: {}", url.toString(), json_error.errorString())};
+
+        mpl::log(mpl::Level::debug, request_category, fmt::format("{}\n{}", error_string, bytearray_reply));
+        throw mp::LXDJsonParseError(error_string);
+    }
 
     if (json_reply.isNull() || !json_reply.isObject())
-        throw mp::LXDRuntimeError(fmt::format("Invalid LXD response for {}: {}", url.toString(), bytearray_reply));
+    {
+        std::string error_string{fmt::format("Invalid LXD response for {}", url.toString())};
+
+        mpl::log(mpl::Level::debug, request_category, fmt::format("{}\n{}", error_string, bytearray_reply));
+        throw mp::LXDJsonParseError(error_string);
+    }
 
     mpl::log(mpl::Level::trace, request_category, fmt::format("Got reply: {}", QJsonDocument(json_reply).toJson()));
 

--- a/src/platform/backends/lxd/lxd_request.h
+++ b/src/platform/backends/lxd/lxd_request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,6 +45,14 @@ class LXDRuntimeError : public std::runtime_error
 {
 public:
     LXDRuntimeError(const std::string& message) : runtime_error{message}
+    {
+    }
+};
+
+class LXDJsonParseError : public std::runtime_error
+{
+public:
+    LXDJsonParseError(const std::string& message) : runtime_error{message}
     {
     }
 };

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -927,7 +927,7 @@ TEST_F(LXDBackend, lxd_request_invalid_json_throws_and_logs)
     base_url.setHost("test");
 
     EXPECT_CALL(*logger_scope.mock_logger,
-                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("lxd request")),
+                log(Eq(mpl::Level::debug), mpt::MockLogger::make_cstring_matcher(StrEq("lxd request")),
                     mpt::MockLogger::make_cstring_matcher(
                         AllOf(HasSubstr(base_url.toString().toStdString()), HasSubstr("illegal value")))));
 
@@ -951,13 +951,12 @@ TEST_F(LXDBackend, lxd_request_wrong_json_throws_and_logs)
     base_url.setHost("test");
 
     EXPECT_CALL(*logger_scope.mock_logger,
-                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("lxd request")),
+                log(Eq(mpl::Level::debug), mpt::MockLogger::make_cstring_matcher(StrEq("lxd request")),
                     mpt::MockLogger::make_cstring_matcher(
                         AllOf(HasSubstr(base_url.toString().toStdString()), HasSubstr(invalid_json.toStdString())))));
 
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url), std::runtime_error,
-                         Property(&std::runtime_error::what, AllOf(HasSubstr(base_url.toString().toStdString()),
-                                                                   HasSubstr(invalid_json.toStdString()))));
+                         Property(&std::runtime_error::what, AllOf(HasSubstr(base_url.toString().toStdString()))));
 }
 
 TEST_F(LXDBackend, lxd_request_bad_request_throws_and_logs)
@@ -1676,7 +1675,7 @@ TEST_P(LXDNetworksBadJson, handles_gibberish_networks_reply)
 {
     auto log_matcher =
         mpt::MockLogger::make_cstring_matcher(AnyOf(HasSubstr("Error parsing JSON"), HasSubstr("Empty reply")));
-    EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::error), _, log_matcher)).Times(1);
+    EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::debug), _, log_matcher)).Times(1);
     EXPECT_CALL(*mock_network_access_manager,
                 createRequest(QNetworkAccessManager::CustomOperation, network_request_matcher, _))
         .WillOnce(Return(new mpt::MockLocalSocketReply{GetParam()}));
@@ -1687,7 +1686,7 @@ TEST_P(LXDNetworksBadJson, handles_gibberish_networks_reply)
 }
 
 INSTANTIATE_TEST_SUITE_P(LXDBackend, LXDNetworksBadJson,
-                         Values("gibberish", "", "unstarted}", "{unfinished", "strange\"", "{noval}", "]["));
+                         Values("gibberish", "unstarted}", "{unfinished", "strange\"", "{noval}", "]["));
 
 struct LXDNetworksBadFields : LXDBackend, WithParamInterface<QByteArray>
 {


### PR DESCRIPTION
This will keep the user from seeing a bunch of JSON from being spewed in their client.

Fixes #1927 