### PR TITLE
[daemon] disallow `--network ...,mode=auto` on Ubuntu Core 16

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -92,7 +92,7 @@ const std::unordered_set<std::string> no_bridging_images = {
     "release:12.10", "release:quantal", "release:13.04", "release:raring",  "release:13.10", "release:saucy",
     "release:14.04", "release:trusty",  "release:14.10", "release:utopic",  "release:15.04", "release:vivid",
     "release:15.10", "release:wily",    "release:16.04", "release:xenial",  "release:16.10", "release:yakkety",
-    "release:17.04", "release:zesty",   "snapcraft:core"};
+    "release:17.04", "release:zesty",   "release:core",  "release:core16",  "snapcraft:core"};
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
 {


### PR DESCRIPTION
`netplan` in the image is too old to handle our config:

```plain
Stderr: Error in network definition //etc/netplan/50-cloud-init.yaml line 12 column 12: unknown key dhcp4-overrides
```

---

For reference: https://bugs.launchpad.net/netplan/+bug/1759014