### PR TITLE
Rename 'id' to 'name' in launch command

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -85,7 +85,7 @@ auto net_digest(const QString& options)
 
             const auto& key = key_value_split[0].toLower();
             const auto& val = key_value_split[1];
-            if (key == "id")
+            if (key == "name")
                 net.set_id(val.toStdString());
             else if (key == "mode")
                 net.set_mode(checked_mode(val.toLower().toStdString()));
@@ -95,7 +95,7 @@ auto net_digest(const QString& options)
                 throw NetworkDefinitionException{fmt::format("Bad network field: {}", key)};
         }
 
-        // Interpret as "id" the argument when there are no ',' and no '='.
+        // Interpret as "name" the argument when there are no ',' and no '='.
         else if (key_value_split.size() == 1 && split.size() == 1)
             net.set_id(key_value_split[0].toStdString());
 
@@ -104,7 +104,7 @@ auto net_digest(const QString& options)
     }
 
     if (net.id().empty())
-        throw NetworkDefinitionException{fmt::format("Bad network definition, need at least an ID field")};
+        throw NetworkDefinitionException{fmt::format("Bad network definition, need at least a 'name' field")};
 
     return net;
 }
@@ -198,11 +198,11 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
     QCommandLineOption networkOption("network",
                                      "Add a network interface to the instance, where <spec> is in the "
                                      "\"key=value,key=value\" format, with the following keys available:\n"
-                                     "  id: the network to connect to (required), use the networks command for a "
+                                     "  name: the network to connect to (required), use the networks command for a "
                                      "list of possible values\n"
                                      "  mode: auto|manual (default: auto)\n"
                                      "  mac: hardware address (default: random).\n"
-                                     "You can also use a shortcut of \"<id>\" to mean \"id=<id>\".",
+                                     "You can also use a shortcut of \"<name>\" to mean \"name=<name>\".",
                                      "spec");
 
     parser->addOptions({cpusOption, diskOption, memOption, nameOption, cloudInitOption, networkOption});

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -426,7 +426,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
 
         if (result == factory_networks->cend())
         {
-            mpl::log(mpl::Level::warning, category, fmt::format("Invalid network id \"{}\"", net.id()));
+            mpl::log(mpl::Level::warning, category, fmt::format("Invalid network name \"{}\"", net.id()));
             option_errors.add_error_codes(mp::LaunchError::INVALID_NETWORK);
         }
 

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -675,8 +675,8 @@ INSTANTIATE_TEST_SUITE_P(Client, TestInvalidNetworkOptions,
                                 std::vector<std::string>{"--network"},
                                 std::vector<std::string>{"--network", "mode=manual"},
                                 std::vector<std::string>{"--network", "mode=manual=auto"},
-                                std::vector<std::string>{"--network", "id=eth0,mode=man"},
-                                std::vector<std::string>{"--network", "id=eth1,mac=0a"},
+                                std::vector<std::string>{"--network", "name=eth0,mode=man"},
+                                std::vector<std::string>{"--network", "name=eth1,mac=0a"},
                                 std::vector<std::string>{"--network", "eth2", "--network"}));
 
 struct TestValidNetworkOptions : Client, WithParamInterface<std::vector<std::string>>
@@ -695,11 +695,11 @@ TEST_P(TestValidNetworkOptions, launch_cmd_return)
 
 INSTANTIATE_TEST_SUITE_P(Client, TestValidNetworkOptions,
                          Values(std::vector<std::string>{"--network", "eth3"},
-                                std::vector<std::string>{"--network", "id=eth4", "--network", "eth5"},
-                                std::vector<std::string>{"--network", "id=eth6,mac=01:23:45:67:89:ab"},
-                                std::vector<std::string>{"--network", "id=eth7,mode=manual"},
-                                std::vector<std::string>{"--network", "id=eth8,mode=auto"},
-                                std::vector<std::string>{"--network", "id=eth9", "--network", "id=eth9"}));
+                                std::vector<std::string>{"--network", "name=eth4", "--network", "eth5"},
+                                std::vector<std::string>{"--network", "name=eth6,mac=01:23:45:67:89:ab"},
+                                std::vector<std::string>{"--network", "name=eth7,mode=manual"},
+                                std::vector<std::string>{"--network", "name=eth8,mode=auto"},
+                                std::vector<std::string>{"--network", "name=eth9", "--network", "name=eth9"}));
 
 // purge cli tests
 TEST_F(Client, purge_cmd_ok_no_args)


### PR DESCRIPTION
`multipass launch --network` accepts `id=` as the key to the interface name argument. This must be changed to `name=` in order to avoid confusion with the network listing, on which interface names are listed using 'name' as field name.