### PR TITLE
[sftp_server] Add better logging and handle failure conditions

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_FILE_OPS_H
+#define MULTIPASS_FILE_OPS_H
+
+#include "singleton.h"
+
+#include <QDir>
+#include <QFile>
+#include <QString>
+
+#define MP_FILEOPS multipass::FileOps::instance()
+
+namespace multipass
+{
+class FileOps : public Singleton<FileOps>
+{
+public:
+    FileOps(const Singleton<FileOps>::PrivatePass&);
+
+    // QDir operations
+    virtual bool isReadable(QDir& dir);
+    virtual bool rmdir(QDir& dir, const QString& dirName);
+
+    // QFile operations
+    virtual bool open(QFile& file, QIODevice::OpenMode mode);
+    virtual qint64 read(QFile& file, char* data, qint64 maxSize);
+    virtual bool remove(QFile& file);
+    virtual bool rename(QFile& file, const QString& newName);
+    virtual bool resize(QFile& file, qint64 sz);
+    virtual bool seek(QFile& file, qint64 pos);
+    virtual bool setPermissions(QFile& file, QFileDevice::Permissions permissions);
+    virtual qint64 write(QFile& file, const char* data, qint64 maxSize);
+};
+} // namespace multipass
+
+#endif // MULTIPASS_FILE_OPS_H

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -53,6 +53,10 @@ public:
     virtual std::map<std::string, NetworkInterfaceInfo> get_network_interfaces_info() const;
     virtual bool is_alias_supported(const std::string& alias, const std::string& remote);
     virtual bool is_remote_supported(const std::string& remote);
+    virtual int chown(const char* path, unsigned int uid, unsigned int gid);
+    virtual bool link(const char* target, const char* link);
+    virtual bool symlink(const char* target, const char* link, bool is_dir);
+    virtual int utime(const char* path, int atime, int mtime);
 };
 
 std::map<QString, QString> extra_settings_defaults();
@@ -74,10 +78,6 @@ logging::Logger::UPtr make_logger(logging::Level level);
 UpdatePrompt::UPtr make_update_prompt();
 std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& config);
 std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spec);
-int chown(const char* path, unsigned int uid, unsigned int gid);
-bool symlink(const char* target, const char* link, bool is_dir);
-bool link(const char* target, const char* link);
-int utime(const char* path, int atime, int mtime);
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 bool is_image_url_supported();
 

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -77,6 +77,11 @@ bool mp::platform::Platform::is_remote_supported(const std::string& remote)
     return remote != "snapcraft" || utils::get_driver_str() != "lxd";
 }
 
+bool mp::platform::Platform::link(const char* target, const char* link)
+{
+    return ::link(target, link) == 0;
+}
+
 auto mp::platform::detail::get_network_interfaces_from(const QDir& sys_dir)
     -> std::map<std::string, NetworkInterfaceInfo>
 {
@@ -189,11 +194,6 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
 mp::logging::Logger::UPtr mp::platform::make_logger(mp::logging::Level level)
 {
     return std::make_unique<logging::JournaldLogger>(level);
-}
-
-bool mp::platform::link(const char* target, const char* link)
-{
-    return ::link(target, link) == 0;
 }
 
 bool mp::platform::is_image_url_supported()

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,17 +46,17 @@ sftp_attributes_struct stat_to_attr(const struct stat* st)
 }
 } // namespace
 
-int mp::platform::chown(const char* path, unsigned int uid, unsigned int gid)
+int mp::platform::Platform::chown(const char* path, unsigned int uid, unsigned int gid)
 {
     return ::lchown(path, uid, gid);
 }
 
-bool mp::platform::symlink(const char* target, const char* link, bool is_dir)
+bool mp::platform::Platform::symlink(const char* target, const char* link, bool is_dir)
 {
     return ::symlink(target, link) == 0;
 }
 
-int mp::platform::utime(const char* path, int atime, int mtime)
+int mp::platform::Platform::utime(const char* path, int atime, int mtime)
 {
     struct timeval tv[2];
     tv[0].tv_sec = atime;

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -524,7 +524,7 @@ int mp::SftpServer::handle_mkdir(sftp_client_message msg)
     if (ret < 0)
     {
         mpl::log(mpl::Level::error, category,
-                 fmt::format("failed to chown '{}' to owner:{} and group:{}\n", filename, parent_dir.ownerId(),
+                 fmt::format("failed to chown '{}' to owner:{} and group:{}", filename, parent_dir.ownerId(),
                              parent_dir.groupId()));
         return reply_failure(msg);
     }
@@ -613,7 +613,7 @@ int mp::SftpServer::handle_open(sftp_client_message msg)
         if (ret < 0)
         {
             mpl::log(mpl::Level::error, category,
-                     fmt::format("failed to chown '{}' to owner:{} and group:{}\n", filename, current_dir.ownerId(),
+                     fmt::format("failed to chown '{}' to owner:{} and group:{}", filename, current_dir.ownerId(),
                                  current_dir.groupId()));
             return reply_failure(msg);
         }
@@ -992,7 +992,7 @@ int mp::SftpServer::handle_symlink(sftp_client_message msg)
     if (ret < 0)
     {
         mpl::log(mpl::Level::error, category,
-                 fmt::format("failed to chown '{}' to owner:{} and group:{}\n", new_name, current_dir.ownerId(),
+                 fmt::format("failed to chown '{}' to owner:{} and group:{}", new_name, current_dir.ownerId(),
                              current_dir.groupId()));
         return reply_failure(msg);
     }

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -580,6 +580,11 @@ int mp::SftpServer::handle_open(sftp_client_message msg)
     }
 
     SftpHandleUPtr sftp_handle{sftp_handle_alloc(sftp_server_session.get(), file.get()), ssh_string_free};
+    if (!sftp_handle)
+    {
+        return reply_failure(msg);
+    }
+
     open_file_handles.emplace(file.get(), std::move(file));
 
     return sftp_reply_handle(msg, sftp_handle.get());
@@ -602,6 +607,11 @@ int mp::SftpServer::handle_opendir(sftp_client_message msg)
         std::make_unique<QFileInfoList>(dir.entryInfoList(QDir::AllEntries | QDir::System | QDir::Hidden));
 
     SftpHandleUPtr sftp_handle{sftp_handle_alloc(sftp_server_session.get(), entry_list.get()), ssh_string_free};
+    if (!sftp_handle)
+    {
+        return reply_failure(msg);
+    }
+
     open_dir_handles.emplace(entry_list.get(), std::move(entry_list));
 
     return sftp_reply_handle(msg, sftp_handle.get());

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -520,7 +520,7 @@ int mp::SftpServer::handle_mkdir(sftp_client_message msg)
 
     QFileInfo current_dir(filename);
     QFileInfo parent_dir(current_dir.path());
-    auto ret = mp::platform::chown(filename, parent_dir.ownerId(), parent_dir.groupId());
+    auto ret = MP_PLATFORM.chown(filename, parent_dir.ownerId(), parent_dir.groupId());
     if (ret < 0)
     {
         mpl::log(mpl::Level::error, category,
@@ -609,7 +609,7 @@ int mp::SftpServer::handle_open(sftp_client_message msg)
 
         QFileInfo current_file(filename);
         QFileInfo current_dir(current_file.path());
-        auto ret = mp::platform::chown(filename, current_dir.ownerId(), current_dir.groupId());
+        auto ret = MP_PLATFORM.chown(filename, current_dir.ownerId(), current_dir.groupId());
         if (ret < 0)
         {
             mpl::log(mpl::Level::error, category,
@@ -907,7 +907,7 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
 
     if (msg->attr->flags & SSH_FILEXFER_ATTR_ACMODTIME)
     {
-        if (mp::platform::utime(filename.toStdString().c_str(), msg->attr->atime, msg->attr->mtime) < 0)
+        if (MP_PLATFORM.utime(filename.toStdString().c_str(), msg->attr->atime, msg->attr->mtime) < 0)
         {
             mpl::log(mpl::Level::error, category,
                      fmt::format("{}: cannot set modification date for \'{}\'", __FUNCTION__, filename));
@@ -917,7 +917,7 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
 
     if (msg->attr->flags & SSH_FILEXFER_ATTR_UIDGID)
     {
-        if (mp::platform::chown(filename.toStdString().c_str(), msg->attr->uid, msg->attr->gid) < 0)
+        if (MP_PLATFORM.chown(filename.toStdString().c_str(), msg->attr->uid, msg->attr->gid) < 0)
         {
             mpl::log(mpl::Level::error, category,
                      fmt::format("{}: cannot set ownership for \'{}\'", __FUNCTION__, filename));
@@ -979,7 +979,7 @@ int mp::SftpServer::handle_symlink(sftp_client_message msg)
         return reply_perm_denied(msg);
     }
 
-    if (!mp::platform::symlink(old_name, new_name, QFileInfo(old_name).isDir()))
+    if (!MP_PLATFORM.symlink(old_name, new_name, QFileInfo(old_name).isDir()))
     {
         mpl::log(mpl::Level::error, category,
                  fmt::format("{}: failure creating symlink from \'{}\' to \'{}\'", __FUNCTION__, old_name, new_name));
@@ -988,7 +988,7 @@ int mp::SftpServer::handle_symlink(sftp_client_message msg)
 
     QFileInfo current_file(new_name);
     QFileInfo current_dir(current_file.path());
-    auto ret = mp::platform::chown(new_name, current_dir.ownerId(), current_dir.groupId());
+    auto ret = MP_PLATFORM.chown(new_name, current_dir.ownerId(), current_dir.groupId());
     if (ret < 0)
     {
         mpl::log(mpl::Level::error, category,
@@ -1061,7 +1061,7 @@ int mp::SftpServer::handle_extended(sftp_client_message msg)
             return reply_perm_denied(msg);
         }
 
-        if (!mp::platform::link(old_name, new_name))
+        if (!MP_PLATFORM.link(old_name, new_name))
         {
             mpl::log(mpl::Level::error, category,
                      fmt::format("{}: failed creating link from \'{}\' to \'{}\'", __FUNCTION__, old_name, new_name));

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2020 Canonical Ltd.
+# Copyright © 2017-2021 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -13,6 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 add_library(utils STATIC
+  file_ops.cpp
   memory_size.cpp
   settings.cpp
   snap_utils.cpp

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/file_ops.h>
+
+namespace mp = multipass;
+
+mp::FileOps::FileOps(const Singleton<FileOps>::PrivatePass& pass) : Singleton<FileOps>::Singleton{pass}
+{
+}
+
+bool mp::FileOps::isReadable(QDir& dir)
+{
+    return dir.isReadable();
+}
+
+bool mp::FileOps::rmdir(QDir& dir, const QString& dirName)
+{
+    return dir.rmdir(dirName);
+}
+
+bool mp::FileOps::open(QFile& file, QIODevice::OpenMode mode)
+{
+    return file.open(mode);
+}
+
+qint64 mp::FileOps::read(QFile& file, char* data, qint64 maxSize)
+{
+    return file.read(data, maxSize);
+}
+
+bool mp::FileOps::remove(QFile& file)
+{
+    return file.remove();
+}
+
+bool mp::FileOps::rename(QFile& file, const QString& newName)
+{
+    return file.rename(newName);
+}
+
+bool mp::FileOps::resize(QFile& file, qint64 sz)
+{
+    return file.resize(sz);
+}
+
+bool mp::FileOps::seek(QFile& file, qint64 pos)
+{
+    return file.seek(pos);
+}
+
+bool mp::FileOps::setPermissions(QFile& file, QFileDevice::Permissions permissions)
+{
+    return file.setPermissions(permissions);
+}
+
+qint64 mp::FileOps::write(QFile& file, const char* data, qint64 maxSize)
+{
+    return file.write(data, maxSize);
+}

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_FILE_OPS_H
+#define MULTIPASS_MOCK_FILE_OPS_H
+
+#include "mock_singleton_helpers.h"
+
+#include <multipass/file_ops.h>
+
+#include <gmock/gmock.h>
+
+namespace multipass::test
+{
+class MockFileOps : public FileOps
+{
+public:
+    using FileOps::FileOps;
+
+    MOCK_METHOD1(isReadable, bool(QDir&));
+    MOCK_METHOD2(rmdir, bool(QDir&, const QString& dirName));
+    MOCK_METHOD2(open, bool(QFile&, QIODevice::OpenMode));
+    MOCK_METHOD3(read, qint64(QFile&, char*, qint64));
+    MOCK_METHOD1(remove, bool(QFile&));
+    MOCK_METHOD2(rename, bool(QFile&, const QString& newName));
+    MOCK_METHOD2(resize, bool(QFile&, qint64 sz));
+    MOCK_METHOD2(seek, bool(QFile&, qint64 pos));
+    MOCK_METHOD2(setPermissions, bool(QFile&, QFileDevice::Permissions));
+    MOCK_METHOD3(write, qint64(QFile&, const char*, qint64));
+
+    MP_MOCK_SINGLETON_BOILERPLATE(MockFileOps, FileOps);
+};
+} // namespace multipass::test
+
+#endif // MULTIPASS_MOCK_FILE_OPS_H

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -33,6 +33,10 @@ public:
     MOCK_CONST_METHOD0(get_network_interfaces_info, std::map<std::string, NetworkInterfaceInfo>());
     MOCK_METHOD1(is_remote_supported, bool(const std::string&));
     MOCK_METHOD2(is_alias_supported, bool(const std::string&, const std::string&));
+    MOCK_METHOD3(chown, int(const char*, unsigned int, unsigned int));
+    MOCK_METHOD2(link, bool(const char*, const char*));
+    MOCK_METHOD3(symlink, bool(const char*, const char*, bool));
+    MOCK_METHOD3(utime, int(const char*, int, int));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockPlatform, Platform);
 };

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -826,7 +826,7 @@ TEST_F(SftpServer, handles_readdir)
     void* id{nullptr};
     auto handle_alloc = [&id](sftp_session, void* info) {
         id = info;
-        return nullptr;
+        return ssh_string_new(4);
     };
 
     int eof_num_calls{0};
@@ -879,7 +879,7 @@ TEST_F(SftpServer, handles_readdir_attributes_preserved)
     void* id{nullptr};
     auto handle_alloc = [&id](sftp_session, void* info) {
         id = info;
-        return nullptr;
+        return ssh_string_new(4);
     };
 
     int eof_num_calls{0};
@@ -935,7 +935,7 @@ TEST_F(SftpServer, handles_close)
     void* id{nullptr};
     auto handle_alloc = [&id](sftp_session, void* info) {
         id = info;
-        return nullptr;
+        return ssh_string_new(4);
     };
 
     int ok_num_calls{0};
@@ -971,7 +971,7 @@ TEST_F(SftpServer, handles_fstat)
     void* id{nullptr};
     auto handle_alloc = [&id](sftp_session, void* info) {
         id = info;
-        return nullptr;
+        return ssh_string_new(4);
     };
 
     int num_calls{0};
@@ -1017,7 +1017,7 @@ TEST_F(SftpServer, handles_fsetstat)
     void* id{nullptr};
     auto handle_alloc = [&id](sftp_session, void* info) {
         id = info;
-        return nullptr;
+        return ssh_string_new(4);
     };
 
     int num_calls{0};
@@ -1117,7 +1117,7 @@ TEST_F(SftpServer, handles_writes)
     void* id{nullptr};
     auto handle_alloc = [&id](sftp_session, void* info) {
         id = info;
-        return nullptr;
+        return ssh_string_new(4);
     };
 
     int num_calls{0};
@@ -1159,7 +1159,7 @@ TEST_F(SftpServer, handles_reads)
     void* id{nullptr};
     auto handle_alloc = [&id](sftp_session, void* info) {
         id = info;
-        return nullptr;
+        return ssh_string_new(4);
     };
 
     int num_calls{0};

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -35,7 +35,9 @@
 #include <queue>
 
 namespace mp = multipass;
+namespace mpl = multipass::logging;
 namespace mpt = multipass::test;
+
 using namespace testing;
 
 using StringUPtr = std::unique_ptr<ssh_string_struct, void (*)(ssh_string)>;
@@ -399,6 +401,13 @@ TEST_F(SftpServer, opendir_not_readable_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("Cannot read directory"),
+                                                                HasSubstr(mpt::test_data_path().toStdString()),
+                                                                HasSubstr("permission denied")))));
+
     sftp.run();
 
     EXPECT_EQ(perm_denied_num_calls, 1);
@@ -418,6 +427,11 @@ TEST_F(SftpServer, opendir_no_handle_allocated_fails)
     REPLACE(sftp_handle_alloc, [](auto...) { return nullptr; });
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(StrEq("Cannot allocate handle for opendir()"))));
 
     sftp.run();
 
@@ -472,6 +486,11 @@ TEST_F(SftpServer, mkdir_on_existing_dir_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("mkdir failed for"), HasSubstr(new_dir)))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -500,6 +519,12 @@ TEST_F(SftpServer, mkdir_set_permissions_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(
+        *logger_scope.mock_logger,
+        log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+            mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("set permissions failed for"), HasSubstr(new_dir)))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -527,6 +552,11 @@ TEST_F(SftpServer, mkdir_chown_failure_fails)
 
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("failed to chown"), HasSubstr(new_dir)))));
 
     sftp.run();
 
@@ -574,6 +604,11 @@ TEST_F(SftpServer, rmdir_non_existing_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("rmdir failed for"), HasSubstr(new_dir)))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -598,6 +633,11 @@ TEST_F(SftpServer, rmdir_unable_to_remove_fails)
 
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("rmdir failed for"), HasSubstr(new_dir)))));
 
     sftp.run();
 
@@ -745,6 +785,13 @@ TEST_F(SftpServer, symlink_failure_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("failure creating symlink from"),
+                                                                HasSubstr(file_name.toStdString()),
+                                                                HasSubstr(link_name.toStdString())))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -775,6 +822,12 @@ TEST_F(SftpServer, symlink_chown_failure_fails)
 
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("failed to chown"), HasSubstr(link_name.toStdString())))));
 
     sftp.run();
 
@@ -834,6 +887,12 @@ TEST_F(SftpServer, rename_cannot_remove_target_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(AllOf(
+                        HasSubstr("cannot remove"), HasSubstr(new_name.toStdString()), HasSubstr("for renaming")))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -863,6 +922,13 @@ TEST_F(SftpServer, rename_failure_fails)
 
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(
+        *logger_scope.mock_logger,
+        log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+            mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("failed renaming"), HasSubstr(old_name.toStdString()),
+                                                        HasSubstr(new_name.toStdString())))));
 
     sftp.run();
 
@@ -935,6 +1001,12 @@ TEST_F(SftpServer, remove_non_existing_fails)
 
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("cannot remove"), HasSubstr(file_name.toStdString())))));
 
     sftp.run();
 
@@ -1030,6 +1102,12 @@ TEST_F(SftpServer, open_unable_to_open_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("Cannot open"), HasSubstr(file_name.toStdString())))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -1060,6 +1138,12 @@ TEST_F(SftpServer, open_unable_to_set_permissions_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("Cannot set permissions for"), HasSubstr(file_name.toStdString())))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -1089,6 +1173,12 @@ TEST_F(SftpServer, open_chown_failure_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("failed to chown"), HasSubstr(file_name.toStdString())))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -1116,6 +1206,11 @@ TEST_F(SftpServer, open_no_handle_allocated_fails)
     REPLACE(sftp_handle_alloc, [](auto...) { return nullptr; });
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(StrEq("Cannot allocate handle for open()"))));
 
     sftp.run();
 
@@ -1450,6 +1545,12 @@ TEST_F(SftpServer, setstat_resize_failure_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("cannot resize"), HasSubstr(file_name.toStdString())))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -1485,6 +1586,12 @@ TEST_F(SftpServer, setstat_set_permissions_failure_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("set permissions failed for"), HasSubstr(file_name.toStdString())))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -1519,6 +1626,12 @@ TEST_F(SftpServer, setstat_chown_failure_fails)
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
 
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("cannot set ownership for"), HasSubstr(file_name.toStdString())))));
+
     sftp.run();
 
     EXPECT_EQ(failure_num_calls, 1);
@@ -1552,6 +1665,12 @@ TEST_F(SftpServer, setstat_utime_failure_fails)
 
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("cannot set modification date for"), HasSubstr(file_name.toStdString())))));
 
     sftp.run();
 
@@ -1610,6 +1729,7 @@ TEST_F(SftpServer, handles_writes)
 
 TEST_F(SftpServer, write_cannot_seek_fails)
 {
+    const int seek_pos{10};
     mpt::TempDir temp_dir;
     auto file_name = temp_dir.path() + "/test-file";
 
@@ -1626,7 +1746,7 @@ TEST_F(SftpServer, write_cannot_seek_fails)
     auto write_msg = make_msg(SFTP_WRITE);
     auto data1 = make_data("The answer is ");
     write_msg->data = data1.get();
-    write_msg->offset = 10;
+    write_msg->offset = seek_pos;
 
     void* id{nullptr};
     auto handle_alloc = [&id](sftp_session, void* info) {
@@ -1649,6 +1769,13 @@ TEST_F(SftpServer, write_cannot_seek_fails)
     REPLACE(sftp_handle, [&id](auto...) { return id; });
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr(fmt::format("cannot seek to position {} in", seek_pos)),
+                              HasSubstr(file_name.toStdString())))));
 
     sftp.run();
 
@@ -1697,6 +1824,12 @@ TEST_F(SftpServer, write_failure_fails)
     REPLACE(sftp_handle, [&id](auto...) { return id; });
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("write failed for"), HasSubstr(file_name.toStdString())))));
 
     sftp.run();
 
@@ -1750,6 +1883,7 @@ TEST_F(SftpServer, handles_reads)
 
 TEST_F(SftpServer, read_cannot_seek_fails)
 {
+    const int seek_pos{10};
     mpt::TempDir temp_dir;
     auto file_name = temp_dir.path() + "/test-file";
     auto size = mpt::make_file_with_content(file_name);
@@ -1761,7 +1895,7 @@ TEST_F(SftpServer, read_cannot_seek_fails)
     open_msg->flags |= SSH_FXF_READ;
 
     auto read_msg = make_msg(SFTP_READ);
-    read_msg->offset = 10;
+    read_msg->offset = seek_pos;
     const int expected_size = size - read_msg->offset;
     read_msg->len = expected_size;
 
@@ -1783,6 +1917,13 @@ TEST_F(SftpServer, read_cannot_seek_fails)
     REPLACE(sftp_handle, [&id](auto...) { return id; });
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr(fmt::format("cannot seek to position {} in", seek_pos)),
+                              HasSubstr(file_name.toStdString())))));
 
     sftp.run();
 
@@ -1825,6 +1966,12 @@ TEST_F(SftpServer, read_returns_failure_fails)
     REPLACE(sftp_handle, [&id](auto...) { return id; });
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        AllOf(HasSubstr("read failed for"), HasSubstr(file_name.toStdString())))));
 
     sftp.run();
 
@@ -1955,6 +2102,13 @@ TEST_F(SftpServer, extended_link_failure_fails)
 
     REPLACE(sftp_get_client_message, make_msg_handler());
     REPLACE(sftp_reply_status, reply_status);
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("sftp server")),
+                    mpt::MockLogger::make_cstring_matcher(AllOf(HasSubstr("failed creating link from"),
+                                                                HasSubstr(file_name.toStdString()),
+                                                                HasSubstr(link_name.toStdString())))));
 
     sftp.run();
 


### PR DESCRIPTION
- Handle when NULL is returned when trying to allocate a handle in libssh
- Add much more logging for error conditions to account for the SFTP protocol's weak error reporting.

Fixes #1933, Fixes #1950 