### PR TITLE
Bridge members lxd

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -44,7 +44,7 @@ std::string describe_bridge(const std::string& id, const QString& lxd_descriptio
 
     if (!lxd_description.isEmpty())
         return lxd_description.toStdString();
-    else if (auto it = platform_networks.find(id); it != platform_networks.end())
+    else if (auto it = platform_networks.find(id); it != platform_networks.end() && !it->second.description.empty())
         return it->second.description;
     else
         return default_description;

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -23,6 +23,7 @@
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/network_interface_info.h>
+#include <multipass/platform.h>
 #include <multipass/utils.h>
 
 #include <QJsonDocument>
@@ -35,6 +36,19 @@ namespace
 {
 constexpr auto category = "lxd factory";
 const QString multipass_bridge_name = "mpbr0";
+
+std::string describe_bridge(const std::string& id, const QString& lxd_description,
+                            const std::map<std::string, mp::NetworkInterfaceInfo>& platform_networks)
+{
+    static constexpr auto default_description = "Network bridge";
+
+    if (!lxd_description.isEmpty())
+        return lxd_description.toStdString();
+    else if (auto it = platform_networks.find(id); it != platform_networks.end())
+        return it->second.description;
+    else
+        return default_description;
+}
 } // namespace
 
 mp::LXDVirtualMachineFactory::LXDVirtualMachineFactory(NetworkAccessManager::UPtr manager, const mp::Path& data_dir,
@@ -146,7 +160,6 @@ mp::VMImageVault::UPtr mp::LXDVirtualMachineFactory::create_image_vault(std::vec
 auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterfaceInfo>
 {
     static constexpr auto type = "bridge";
-    static constexpr auto default_description = "Network bridge";
 
     auto url = QUrl{QString{"%1/networks?recursion=1"}.arg(base_url.toString())};
     auto reply = lxd_request(manager.get(), "GET", url);
@@ -154,14 +167,22 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
     auto ret = std::vector<NetworkInterfaceInfo>{};
     auto networks = reply["metadata"].toArray();
 
-    QString description;
-    for (const auto& net_value : networks)
-        if (auto network = net_value.toObject(); network["type"].toString() == type) // no network filter from LXD ATTOW
-            if (auto id = network["name"].toString(); !id.isEmpty())
-                ret.push_back({id.toStdString(), type,
-                               (description = network["description"].toString()).isEmpty()
-                                   ? default_description
-                                   : description.toStdString()});
+    if (!networks.isEmpty())
+    {
+        auto platform_networks = MP_PLATFORM.get_network_interfaces_info();
+        for (const auto& net_value : networks)
+        {
+            if (auto network = net_value.toObject(); network["type"].toString() == type) // no network filter ATTOW
+            {
+                if (auto qid = network["name"].toString(); !qid.isEmpty())
+                {
+                    auto id = qid.toStdString();
+                    auto description = describe_bridge(id, network["description"].toString(), platform_networks);
+                    ret.push_back({std::move(id), type, std::move(description)});
+                }
+            }
+        }
+    }
 
     return ret;
 }

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -46,9 +46,9 @@ namespace
 {
 constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
-mp::NetworkInterfaceInfo get_network(const QString& name)
+mp::NetworkInterfaceInfo get_network(const QDir& net_dir)
 {
-    return {name.toStdString(), "", ""};
+    return {net_dir.dirName().toStdString(), "", ""};
 }
 } // namespace
 
@@ -63,7 +63,7 @@ auto mp::platform::detail::get_network_interfaces_from(const QDir& sys_dir)
     auto ifaces_info = std::map<std::string, mp::NetworkInterfaceInfo>();
     for (const auto& entry : sys_dir.entryList(QDir::NoDotAndDotDot | QDir::Dirs))
     {
-        auto iface = get_network(entry);
+        auto iface = get_network(QDir{sys_dir.filePath(entry)});
         auto name = iface.id; // (can't rely on param evaluation order)
         ifaces_info.emplace(std::move(name), std::move(iface));
     }

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -32,6 +32,7 @@
 #include "backends/lxd/lxd_virtual_machine_factory.h"
 #include "backends/qemu/qemu_virtual_machine_factory.h"
 #include "logger/journald_logger.h"
+#include "platform_linux_detail.h"
 #include "platform_shared.h"
 #include "shared/linux/process_factory.h"
 #include "shared/sshfs_server_process_spec.h"
@@ -53,8 +54,14 @@ mp::NetworkInterfaceInfo get_network(const QString& name)
 
 std::map<std::string, mp::NetworkInterfaceInfo> mp::platform::Platform::get_network_interfaces_info() const
 {
+    return detail::get_network_interfaces_from(QDir{QStringLiteral("/sys/class/net")});
+}
+
+auto mp::platform::detail::get_network_interfaces_from(const QDir& sys_dir)
+    -> std::map<std::string, NetworkInterfaceInfo>
+{
     auto ifaces_info = std::map<std::string, mp::NetworkInterfaceInfo>();
-    for (const auto& entry : QDir{QStringLiteral("/sys/class/net")}.entryList(QDir::NoDotAndDotDot | QDir::Dirs))
+    for (const auto& entry : sys_dir.entryList(QDir::NoDotAndDotDot | QDir::Dirs))
     {
         auto iface = get_network(entry);
         auto name = iface.id; // (can't rely on param evaluation order)

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -48,7 +48,16 @@ constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
 mp::NetworkInterfaceInfo get_network(const QDir& net_dir)
 {
-    return {net_dir.dirName().toStdString(), "", ""};
+    std::string type, description;
+    if (auto bridge = "bridge"; net_dir.exists(bridge))
+    {
+        type = bridge;
+        QStringList bridge_members = QDir{net_dir.filePath("brif")}.entryList(QDir::NoDotAndDotDot | QDir::Dirs);
+        description = bridge_members.isEmpty() ? "Empty network bridge"
+                                               : fmt::format("Network bridge with {}", bridge_members.join(", "));
+    }
+
+    return mp::NetworkInterfaceInfo{net_dir.dirName().toStdString(), std::move(type), std::move(description)};
 }
 } // namespace
 

--- a/src/platform/platform_linux_detail.h
+++ b/src/platform/platform_linux_detail.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_PLATFORM_LINUX_DETAIL_H
+#define MULTIPASS_PLATFORM_LINUX_DETAIL_H
+
+#include <multipass/network_interface_info.h>
+
+#include <map>
+
+namespace multipass::platform::detail
+{
+std::map<std::string, NetworkInterfaceInfo> get_network_interfaces_from(const QDir& sys_dir);
+}
+
+#endif // MULTIPASS_PLATFORM_LINUX_DETAIL_H

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -382,7 +382,7 @@ TEST_F(PlatformLinux, retrieves_networks_from_the_system)
 
     QDir fake_sys_class_net{tmp_dir.path()};
     for (const auto& net : fake_nets)
-        fake_sys_class_net.mkpath(net);
+        ASSERT_TRUE(fake_sys_class_net.mkpath(net));
 
     auto net_map = mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path());
     ASSERT_EQ(net_map.size(), fake_nets.size());
@@ -402,7 +402,7 @@ TEST_F(PlatformLinux, retrieves_empty_bridges)
     const auto fake_bridge = "somebridge";
 
     QDir fake_sys_class_net{tmp_dir.path()};
-    fake_sys_class_net.mkpath(QString{fake_bridge} + "/bridge");
+    ASSERT_TRUE(fake_sys_class_net.mkpath(QString{fake_bridge} + "/bridge"));
 
     auto net_map = mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path());
 

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -395,4 +395,23 @@ TEST_F(PlatformLinux, retrieves_networks_from_the_system)
         EXPECT_EQ(val.id, key);
     }
 }
+
+TEST_F(PlatformLinux, retrieves_empty_bridges)
+{
+    const mpt::TempDir tmp_dir;
+    const auto fake_bridge = "somebridge";
+
+    QDir fake_sys_class_net{tmp_dir.path()};
+    fake_sys_class_net.mkpath(QString{fake_bridge} + "/bridge");
+
+    auto net_map = mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path());
+
+    using value_type = decltype(net_map)::value_type;
+    using Net = mp::NetworkInterfaceInfo;
+    EXPECT_THAT(net_map, ElementsAre(AllOf(Field(&value_type::first, fake_bridge),
+                                           Field(&value_type::second,
+                                                 AllOf(Field(&Net::id, fake_bridge), Field(&Net::type, "bridge"),
+                                                       Field(&Net::description, HasSubstr("Empty network bridge")))))));
+}
+
 } // namespace

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,12 +18,14 @@
 #include "tests/fake_handle.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_settings.h"
+#include "tests/temp_dir.h"
 #include "tests/test_with_mocked_bin_path.h"
 
 #include <src/platform/backends/libvirt/libvirt_virtual_machine_factory.h>
 #include <src/platform/backends/libvirt/libvirt_wrapper.h>
 #include <src/platform/backends/lxd/lxd_virtual_machine_factory.h>
 #include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
+#include <src/platform/platform_linux_detail.h>
 
 #include <multipass/constants.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
@@ -372,4 +374,25 @@ TEST_P(TestUnsupportedDrivers, test_unsupported_driver)
 
 INSTANTIATE_TEST_SUITE_P(PlatformLinux, TestUnsupportedDrivers,
                          Values(QStringLiteral("hyperkit"), QStringLiteral("hyper-v"), QStringLiteral("other")));
+
+TEST_F(PlatformLinux, retrieves_networks_from_the_system)
+{
+    const mpt::TempDir tmp_dir;
+    const auto fake_nets = {"eth0", "foo", "kkkkk"};
+
+    QDir fake_sys_class_net{tmp_dir.path()};
+    for (const auto& net : fake_nets)
+        fake_sys_class_net.mkpath(net);
+
+    auto net_map = mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path());
+    ASSERT_EQ(net_map.size(), fake_nets.size());
+
+    auto expect_it = std::cbegin(fake_nets);
+    for (const auto& [key, val] : net_map)
+    {
+        ASSERT_NE(expect_it, std::cend(fake_nets));
+        EXPECT_EQ(key, *expect_it++);
+        EXPECT_EQ(val.id, key);
+    }
+}
 } // namespace

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1784,6 +1784,22 @@ TEST_F(LXDBackend, defaults_to_sensible_bridge_description)
                 AllOf(SizeIs(2), Each(Field(&mp::NetworkInterfaceInfo::description, Eq("Network bridge")))));
 }
 
+TEST_F(LXDBackend, skips_platform_network_inspection_when_lxd_reports_no_networks)
+{
+    auto data = QByteArrayLiteral(R"({"metadata": []})");
+
+    auto [mock_platform, guard] = mpt::MockPlatform::inject();
+    EXPECT_CALL(*mock_platform, get_network_interfaces_info).Times(0);
+
+    EXPECT_CALL(*mock_network_access_manager,
+                createRequest(QNetworkAccessManager::CustomOperation, network_request_matcher, _))
+        .WillOnce(Return(new mpt::MockLocalSocketReply{{data}}));
+
+    mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
+
+    EXPECT_THAT(backend.networks(), IsEmpty());
+}
+
 namespace
 {
 Matcher<QIODevice*> request_data_matcher(Matcher<QJsonObject> json_matcher)

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -43,6 +43,7 @@
 #include <QUrl>
 
 #include <gmock/gmock.h>
+#include <tests/mock_platform.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -1748,14 +1749,21 @@ TEST_F(LXDBackend, honors_bridge_description_from_lxd_when_available)
 
 TEST_F(LXDBackend, defaults_to_sensible_bridge_description)
 {
-    auto data = QByteArrayLiteral(R"({"metadata": [{"type": "bridge", "name": "br0", "description": ""}]})");
+    auto data = QByteArrayLiteral(R"({"metadata": [{"type": "bridge", "name": "br0", "description": ""},
+                                                   {"type": "bridge", "name": "br1", "description": ""}]})");
+
+    auto [mock_platform, guard] = mpt::MockPlatform::inject();
+    EXPECT_CALL(*mock_platform, get_network_interfaces_info)
+        .WillOnce(Return(std::map<std::string, mp::NetworkInterfaceInfo>{{"br0", {"br0", "mac", ""}}}));
+
     EXPECT_CALL(*mock_network_access_manager,
                 createRequest(QNetworkAccessManager::CustomOperation, network_request_matcher, _))
         .WillOnce(Return(new mpt::MockLocalSocketReply{{data}}));
 
     mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
 
-    EXPECT_THAT(backend.networks(), ElementsAre(Field(&mp::NetworkInterfaceInfo::description, Eq("Network bridge"))));
+    EXPECT_THAT(backend.networks(),
+                AllOf(SizeIs(2), Each(Field(&mp::NetworkInterfaceInfo::description, Eq("Network bridge")))));
 }
 
 namespace


### PR DESCRIPTION
Include members in bridge descriptions, by implementing bridge inspection on the Linux platform. Example output:

```
$ multipass networks
Name    Type    Description
lxdbr0  bridge  Empty network bridge
mpbr0   bridge  Network bridge for Multipass
mybr0   bridge  Network bridge with enxe4bf7a032432
virbr0  bridge  Network bridge with virbr0-nic
```