### PR TITLE
Platform singleton

### DIFF
--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -48,7 +48,7 @@ namespace platform
 class Platform : public Singleton<Platform>
 {
 public:
-    Platform(const Singleton<Platform>::PrivatePass&);
+    Platform(const Singleton::PrivatePass&);
     // Get information on the network interfaces that are seen by the platform, indexed by name
     virtual std::map<std::string, NetworkInterfaceInfo> get_network_interfaces_info() const;
 };

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -39,6 +39,8 @@
 #include <string>
 #include <vector>
 
+#define MP_PLATFORM multipass::platform::Platform::instance()
+
 namespace multipass
 {
 namespace platform

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -87,4 +87,9 @@ std::string reinterpret_interface_id(const std::string& ux_id); // give platform
 
 } // namespace platform
 } // namespace multipass
+
+inline multipass::platform::Platform::Platform(const PrivatePass& pass) : Singleton(pass)
+{
+}
+
 #endif // MULTIPASS_PLATFORM_H

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@
 #include <multipass/network_interface_info.h>
 #include <multipass/process/process.h>
 #include <multipass/process/process_spec.h>
+#include <multipass/singleton.h>
 #include <multipass/sshfs_server_config.h>
 #include <multipass/update_prompt.h>
 #include <multipass/url_downloader.h>
@@ -42,6 +43,14 @@ namespace multipass
 {
 namespace platform
 {
+class Platform : public Singleton<Platform>
+{
+public:
+    Platform(const Singleton<Platform>::PrivatePass&);
+    // Get information on the network interfaces that are seen by the platform, indexed by name
+    virtual std::map<std::string, NetworkInterfaceInfo> get_network_interfaces_info() const;
+};
+
 std::map<QString, QString> extra_settings_defaults();
 
 QString interpret_setting(const QString& key, const QString& val);
@@ -72,8 +81,6 @@ bool is_image_url_supported();
 
 std::function<int()> make_quit_watchdog(); // call while single-threaded; call result later, in dedicated thread
 
-// Get information on the network interfaces that are seen by the platform, indexed by name
-std::map<std::string, NetworkInterfaceInfo> get_network_interfaces_info();
 std::string reinterpret_interface_id(const std::string& ux_id); // give platforms a chance to reinterpret network IDs
 
 } // namespace platform

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,6 +47,15 @@ namespace
 constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
 } // namespace
+
+multipass::platform::Platform::Platform(const PrivatePass& pass) : Singleton(pass)
+{
+}
+
+std::map<std::string, mp::NetworkInterfaceInfo> mp::platform::Platform::get_network_interfaces_info() const
+{
+    throw mp::NotImplementedOnThisBackendException("get_network_interfaces_info");
+}
 
 std::map<QString, QString> mp::platform::extra_settings_defaults()
 {
@@ -172,11 +181,6 @@ bool mp::platform::is_remote_supported(const std::string& remote)
 bool mp::platform::is_image_url_supported()
 {
     return true;
-}
-
-std::map<std::string, mp::NetworkInterfaceInfo> mp::platform::get_network_interfaces_info()
-{
-    throw mp::NotImplementedOnThisBackendException("get_network_interfaces_info");
 }
 
 std::string mp::platform::reinterpret_interface_id(const std::string& ux_id)

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -48,10 +48,6 @@ constexpr auto autostart_filename = "multipass.gui.autostart.desktop";
 
 } // namespace
 
-multipass::platform::Platform::Platform(const PrivatePass& pass) : Singleton(pass)
-{
-}
-
 std::map<std::string, mp::NetworkInterfaceInfo> mp::platform::Platform::get_network_interfaces_info() const
 {
     throw mp::NotImplementedOnThisBackendException("get_network_interfaces_info");

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_PLATFORM_H
+#define MULTIPASS_MOCK_PLATFORM_H
+
+#include <multipass/platform.h>
+
+#include <scope_guard.hpp>
+
+#include <gmock/gmock.h>
+
+#include <utility>
+
+namespace multipass::test
+{
+class MockPlatform : public platform::Platform
+{
+public:
+    using platform::Platform::Platform;
+    MOCK_CONST_METHOD0(get_network_interfaces_info, std::map<std::string, NetworkInterfaceInfo>());
+
+    // only one at a time, please
+    static MockPlatform& mock_instance()
+    {
+        return dynamic_cast<MockPlatform&>(instance());
+    }
+
+    [[nodiscard]] static auto inject()
+    {
+        platform::Platform::mock<MockPlatform>();
+        return std::make_pair(&mock_instance(), sg::make_scope_guard([]() { platform::Platform::reset(); }));
+    }
+};
+} // namespace multipass::test
+
+#endif // MULTIPASS_MOCK_PLATFORM_H

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -49,10 +49,10 @@ namespace multipass::test
 class MockPlatform : public platform::Platform
 {
 public:
-    using platform::Platform::Platform;
+    using Platform::Platform;
     MOCK_CONST_METHOD0(get_network_interfaces_info, std::map<std::string, NetworkInterfaceInfo>());
 
-    MP_SINGLETON_MOCK_BOILERPLATE(MockPlatform, platform::Platform);
+    MP_SINGLETON_MOCK_BOILERPLATE(MockPlatform, Platform);
 };
 } // namespace multipass::test
 

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -32,7 +32,7 @@ public:
     using Platform::Platform;
     MOCK_CONST_METHOD0(get_network_interfaces_info, std::map<std::string, NetworkInterfaceInfo>());
 
-    MP_SINGLETON_MOCK_BOILERPLATE(MockPlatform, Platform);
+    MP_MOCK_SINGLETON_BOILERPLATE(MockPlatform, Platform);
 };
 } // namespace multipass::test
 

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -18,7 +18,7 @@
 #ifndef MULTIPASS_MOCK_PLATFORM_H
 #define MULTIPASS_MOCK_PLATFORM_H
 
-#include "mock_singleton_helper.h"
+#include "mock_singleton_helpers.h"
 
 #include <multipass/platform.h>
 

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -18,31 +18,11 @@
 #ifndef MULTIPASS_MOCK_PLATFORM_H
 #define MULTIPASS_MOCK_PLATFORM_H
 
+#include "mock_singleton_helper.h"
+
 #include <multipass/platform.h>
 
-#include <scope_guard.hpp>
-
 #include <gmock/gmock.h>
-
-#include <utility>
-
-#define MP_SINGLETON_MOCK_INSTANCE(mock_class)                                                                         \
-    static mock_class& mock_instance()                                                                                 \
-    {                                                                                                                  \
-        return dynamic_cast<mock_class&>(instance());                                                                  \
-    }
-
-#define MP_SINGLETON_MOCK_INJECT(mock_class, parent_class)                                                             \
-    [[nodiscard]] static auto inject()                                                                                 \
-    {                                                                                                                  \
-        parent_class::reset();                                                                                         \
-        parent_class::mock<mock_class>();                                                                              \
-        return std::make_pair(&mock_instance(), sg::make_scope_guard([]() { parent_class::reset(); }));                \
-    } // one at a time, please!
-
-#define MP_SINGLETON_MOCK_BOILERPLATE(mock_class, parent_class)                                                        \
-    MP_SINGLETON_MOCK_INSTANCE(mock_class)                                                                             \
-    MP_SINGLETON_MOCK_INJECT(mock_class, parent_class)
 
 namespace multipass::test
 {

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -42,6 +42,7 @@ public:
 
     [[nodiscard]] static auto inject()
     {
+        platform::Platform::reset();
         platform::Platform::mock<MockPlatform>();
         return std::make_pair(&mock_instance(), sg::make_scope_guard([]() { platform::Platform::reset(); }));
     }

--- a/tests/mock_settings.h
+++ b/tests/mock_settings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 #ifndef MULTIPASS_MOCK_SETTINGS_H
 #define MULTIPASS_MOCK_SETTINGS_H
 
-#include "mock_singleton_helper.h"
+#include "mock_singleton_helpers.h"
 
 #include <multipass/settings.h>
 

--- a/tests/mock_singleton_helpers.h
+++ b/tests/mock_singleton_helpers.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef MULTIPASS_MOCK_SINGLETON_HELPER_H
-#define MULTIPASS_MOCK_SINGLETON_HELPER_H
+#ifndef MULTIPASS_MOCK_SINGLETON_HELPERS_H
+#define MULTIPASS_MOCK_SINGLETON_HELPERS_H
 
 #include <scope_guard.hpp>
 
@@ -90,11 +90,11 @@ void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::SetUp()
 template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::TearDown()
 {
-    release_accountant();       // release this mock's test observer
-    ConcreteMock::reset();      /* Make sure this runs before gtest unwinds, so that:
-                                   - the mock doesn't leak
-                                   - expectations are checked
-                                   - it doesn't refer to stuff that was already deleted */
+    release_accountant();  // release this mock's test observer
+    ConcreteMock::reset(); /* Make sure this runs before gtest unwinds, so that:
+                              - the mock doesn't leak
+                              - expectations are checked
+                              - it doesn't refer to stuff that was already deleted */
 }
 
 template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
@@ -122,4 +122,4 @@ void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::Accounta
     ::testing::Mock::VerifyAndClearExpectations(&ConcreteMock::mock_instance());
 }
 
-#endif // MULTIPASS_MOCK_SINGLETON_HELPER_H
+#endif // MULTIPASS_MOCK_SINGLETON_HELPERS_H

--- a/tests/mock_singleton_helpers.h
+++ b/tests/mock_singleton_helpers.h
@@ -25,13 +25,13 @@
 #include <cassert>
 #include <utility>
 
-#define MP_SINGLETON_MOCK_INSTANCE(mock_class)                                                                         \
+#define MP_MOCK_SINGLETON_INSTANCE(mock_class)                                                                         \
     static mock_class& mock_instance()                                                                                 \
     {                                                                                                                  \
         return dynamic_cast<mock_class&>(instance());                                                                  \
     }
 
-#define MP_SINGLETON_MOCK_INJECT(mock_class, parent_class)                                                             \
+#define MP_MOCK_SINGLETON_INJECT(mock_class, parent_class)                                                             \
     [[nodiscard]] static auto inject()                                                                                 \
     {                                                                                                                  \
         parent_class::reset();                                                                                         \
@@ -39,9 +39,9 @@
         return std::make_pair(&mock_instance(), sg::make_scope_guard([]() { parent_class::reset(); }));                \
     } // one at a time, please!
 
-#define MP_SINGLETON_MOCK_BOILERPLATE(mock_class, parent_class)                                                        \
-    MP_SINGLETON_MOCK_INSTANCE(mock_class)                                                                             \
-    MP_SINGLETON_MOCK_INJECT(mock_class, parent_class)
+#define MP_MOCK_SINGLETON_BOILERPLATE(mock_class, parent_class)                                                        \
+    MP_MOCK_SINGLETON_INSTANCE(mock_class)                                                                             \
+    MP_MOCK_SINGLETON_INJECT(mock_class, parent_class)
 
 namespace multipass::test
 {

--- a/tests/mock_standard_paths.h
+++ b/tests/mock_standard_paths.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 #ifndef MULTIPASS_MOCK_STANDARD_PATHS_H
 #define MULTIPASS_MOCK_STANDARD_PATHS_H
 
-#include "mock_singleton_helper.h"
+#include "mock_singleton_helpers.h"
 
 #include <multipass/standard_paths.h>
 


### PR DESCRIPTION
Create a `Platform` singleton to facilitate mocking. Move `get_network_interfaces_info()` into it. Provide a `MockPlatform` for it.

Note: I kept it in the `multipass::platform` namespace for now, for consistency with the free functions. When/if we move all free functions to the class, we should probably get rid of the `platform` namespace altogether, to reduce verbosity in things like `using multipass::platform::Platform::Platform` :)