### PR TITLE
Don't ask for IP when querying the daemon from the GUI

### DIFF
--- a/src/client/cli/cmd/list.cpp
+++ b/src/client/cli/cmd/list.cpp
@@ -46,6 +46,7 @@ mp::ReturnCode cmd::List::run(mp::ArgParser* parser)
 
     ListRequest request;
     request.set_verbosity_level(parser->verbosityLevel());
+    request.set_request_ipv4(true);
     return dispatch(&RpcMethod::list, request, on_success, on_failure);
 }
 

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -349,6 +349,7 @@ mp::ListReply cmd::GuiCmd::retrieve_all_instances()
     };
 
     ListRequest request;
+    request.set_request_ipv4(false);
     dispatch(&RpcMethod::list, request, on_success, on_failure);
 
     return list_reply;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1420,7 +1420,7 @@ try // clang-format on
 
         entry->set_current_release(current_release);
 
-        if (mp::utils::is_running(present_state))
+        if (request->request_ipv4() && mp::utils::is_running(present_state))
         {
             auto vm_specs = vm_instance_specs[name];
             mp::SSHSession session{vm->ssh_hostname(), vm->ssh_port(), vm_specs.ssh_username,

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -223,6 +223,7 @@ message InfoReply {
 
 message ListRequest {
     int32 verbosity_level = 1;
+    bool request_ipv4 = 2;
 }
 
 message ListVMInstance {


### PR DESCRIPTION
The GUI issues one `list` request to the daemon per second. Since now `list` asks the instances for the IP's it's using, this consumes lots of resources.

This PR fixes that, by adding a hidden parameter to the `list` command, telling the daemon whether it should ask the instance for the IP's.