### PR TITLE
Add --no-ipv4 hidden parameter to list command

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -1,4 +1,4 @@
-# Copyright © 2017-2020 Canonical Ltd.
+# Copyright © 2017-2021 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,7 +18,7 @@ _multipass_complete()
     {
         local state=$1
 
-        local cmd="multipass list --format=csv"
+        local cmd="multipass list --format=csv --no-ipv4"
         [ -n "$state" ] && cmd="$cmd | \grep -E '$state'"
 
         local instances=$( \eval $cmd | \grep -Ev '(\+--|Name)' | \cut -d',' -f 1 )

--- a/src/client/cli/cmd/list.cpp
+++ b/src/client/cli/cmd/list.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,9 +44,7 @@ mp::ReturnCode cmd::List::run(mp::ArgParser* parser)
 
     auto on_failure = [this](grpc::Status& status) { return standard_failure_handler_for(name(), cerr, status); };
 
-    ListRequest request;
     request.set_verbosity_level(parser->verbosityLevel());
-    request.set_request_ipv4(true);
     return dispatch(&RpcMethod::list, request, on_success, on_failure);
 }
 
@@ -76,7 +74,10 @@ mp::ParseCode cmd::List::parse_args(mp::ArgParser* parser)
         "format", "Output list in the requested format.\nValid formats are: table (default), json, csv and yaml",
         "format", "table");
 
-    parser->addOption(formatOption);
+    QCommandLineOption noIpv4Option("no-ipv4", "Do not query the instances for the IPv4's they are using");
+    noIpv4Option.setFlags(QCommandLineOption::HiddenFromHelp);
+
+    parser->addOptions({formatOption, noIpv4Option});
 
     auto status = parser->commandParse(this);
 
@@ -90,6 +91,8 @@ mp::ParseCode cmd::List::parse_args(mp::ArgParser* parser)
         cerr << "This command takes no arguments\n";
         return ParseCode::CommandLineError;
     }
+
+    request.set_request_ipv4(!parser->isSet(noIpv4Option));
 
     status = handle_format_option(parser, &chosen_formatter, cerr);
 

--- a/src/client/cli/cmd/list.h
+++ b/src/client/cli/cmd/list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
  *
  */
 
@@ -42,6 +40,7 @@ public:
 private:
     ParseCode parse_args(ArgParser *parser) override;
 
+    ListRequest request;
     Formatter* chosen_formatter;
 };
 }

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -848,7 +848,7 @@ TEST_F(Client, info_cmd_fails_with_names_and_all)
 // list cli tests
 TEST_F(Client, list_cmd_ok_no_args)
 {
-    EXPECT_CALL(mock_daemon, list(_, _, _));
+    EXPECT_CALL(mock_daemon, list(_, Property(&mp::ListRequest::request_ipv4, IsTrue()), _));
     EXPECT_THAT(send_command({"list"}), Eq(mp::ReturnCode::Ok));
 }
 
@@ -860,6 +860,12 @@ TEST_F(Client, list_cmd_fails_with_args)
 TEST_F(Client, list_cmd_help_ok)
 {
     EXPECT_THAT(send_command({"list", "-h"}), Eq(mp::ReturnCode::Ok));
+}
+
+TEST_F(Client, list_cmd_no_ipv4_ok)
+{
+    EXPECT_CALL(mock_daemon, list(_, Property(&mp::ListRequest::request_ipv4, IsFalse()), _));
+    EXPECT_THAT(send_command({"list", "--no-ipv4"}), Eq(mp::ReturnCode::Ok));
 }
 
 // mount cli tests

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -39,6 +39,7 @@
 #include "mock_logger.h"
 #include "mock_process_factory.h"
 #include "mock_standard_paths.h"
+#include "mock_virtual_machine.h"
 #include "mock_virtual_machine_factory.h"
 #include "mock_vm_image_vault.h"
 #include "stub_cert_store.h"
@@ -498,6 +499,12 @@ struct LaunchWithNoNetworkCloudInit : public Daemon, public WithParamInterface<s
 };
 
 struct RefuseBridging : public Daemon, public WithParamInterface<std::tuple<std::string, std::string>>
+{
+};
+
+struct ListIP : public Daemon,
+                public WithParamInterface<
+                    std::tuple<mp::VirtualMachine::State, std::vector<std::string>, std::vector<std::string>>>
 {
 };
 
@@ -1216,6 +1223,45 @@ TEST_F(Daemon, skips_over_instance_ghosts_in_db) // which will have been sometim
 
     mp::Daemon daemon{config_builder.build()};
 }
+
+TEST_P(ListIP, lists_with_ip)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+
+    mp::Daemon daemon{config_builder.build()};
+
+    auto instance_ptr = std::make_unique<NiceMock<mpt::MockVirtualMachine>>("mock");
+    EXPECT_CALL(*mock_factory, create_virtual_machine).WillRepeatedly([&instance_ptr](const auto&, auto&) {
+        return std::move(instance_ptr);
+    });
+
+    auto [state, cmd, strs] = GetParam();
+
+    EXPECT_CALL(*instance_ptr, current_state()).WillRepeatedly(Return(state));
+    EXPECT_CALL(*instance_ptr, ensure_vm_is_running()).WillRepeatedly(Invoke([]() {
+        throw std::runtime_error("Not running");
+    }));
+
+    send_command({"launch"});
+
+    std::stringstream stream;
+    send_command(cmd, stream);
+
+    for (const auto& s : strs)
+        EXPECT_THAT(stream.str(), HasSubstr(s));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Daemon, ListIP,
+    Values(std::make_tuple(mp::VirtualMachine::State::running, std::vector<std::string>{"list"},
+                           std::vector<std::string>{"Running", "192.168.2.123"}),
+           std::make_tuple(mp::VirtualMachine::State::running, std::vector<std::string>{"list", "--no-ipv4"},
+                           std::vector<std::string>{"Running", "--"}),
+           std::make_tuple(mp::VirtualMachine::State::off, std::vector<std::string>{"list"},
+                           std::vector<std::string>{"Stopped", "--"}),
+           std::make_tuple(mp::VirtualMachine::State::off, std::vector<std::string>{"list", "--no-ipv4"},
+                           std::vector<std::string>{"Stopped", "--"})));
 
 TEST_F(Daemon, prevents_repetition_of_loaded_mac_addresses)
 {

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1239,9 +1239,7 @@ TEST_P(ListIP, lists_with_ip)
     auto [state, cmd, strs] = GetParam();
 
     EXPECT_CALL(*instance_ptr, current_state()).WillRepeatedly(Return(state));
-    EXPECT_CALL(*instance_ptr, ensure_vm_is_running()).WillRepeatedly(Invoke([]() {
-        throw std::runtime_error("Not running");
-    }));
+    EXPECT_CALL(*instance_ptr, ensure_vm_is_running()).WillRepeatedly(Throw(std::runtime_error("Not running")));
 
     send_command({"launch"});
 


### PR DESCRIPTION
So far we added in the RPC the ability to list instances without asking them for the IP. This saves precious time in situations on which the IP is not needed. In this PR, we add an option to the CLI to do this.