### PR TITLE
Remove useless SSH session in the daemon

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1422,8 +1422,6 @@ try // clang-format on
 
         if (request->request_ipv4() && mp::utils::is_running(present_state))
         {
-            auto vm_specs = vm_instance_specs[name];
-
             std::string management_ip = vm->management_ipv4();
             auto all_ipv4 = vm->get_all_ipv4(*config->ssh_key_provider);
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1423,8 +1423,6 @@ try // clang-format on
         if (request->request_ipv4() && mp::utils::is_running(present_state))
         {
             auto vm_specs = vm_instance_specs[name];
-            mp::SSHSession session{vm->ssh_hostname(), vm->ssh_port(), vm_specs.ssh_username,
-                                   *config->ssh_key_provider};
 
             std::string management_ip = vm->management_ipv4();
             auto all_ipv4 = vm->get_all_ipv4(*config->ssh_key_provider);


### PR DESCRIPTION
In our first implementation of IP listing in the `list` command, we used to create a SSH session in the daemon to communicate with the instance. We moved later creating that session to the VirtualMachine class, but we forgot to remove the code in the daemon to create such session. As a result, we created two sessions each time we wanted to ask an instance for its IP's.

This PR just removes the spurious SSH session in the daemon.