### PR TITLE
[virtual_machine_factory] Handle creating cloud-init ISO image

### DIFF
--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -61,6 +61,7 @@ public:
     virtual VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                                   const Path& cache_dir_path, const Path& data_dir_path,
                                                   const days& days_to_expire) = 0;
+    virtual void configure(VirtualMachineDescription& vm_desc) = 0;
 
     // List all the network interfaces seen by the backend.
     virtual std::vector<NetworkInterfaceInfo> networks() const = 0;

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -34,7 +34,6 @@ function(add_daemon_target TARGET_NAME)
     cert
     delayed_shutdown
     fmt
-    iso
     logger
     metrics
     petname

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -51,6 +51,7 @@ public:
     VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                           const Path& cache_dir_path, const Path& data_dir_path,
                                           const days& days_to_expire) override;
+    void configure(VirtualMachineDescription& vm_desc) override{};
 
     std::vector<NetworkInterfaceInfo> networks() const override;
 

--- a/src/platform/backends/shared/CMakeLists.txt
+++ b/src/platform/backends/shared/CMakeLists.txt
@@ -16,10 +16,12 @@ set (CMAKE_AUTOMOC ON)
 
 add_library(shared STATIC
   base_virtual_machine.cpp
+  base_virtual_machine_factory.cpp
   sshfs_server_process_spec.cpp
   ${CMAKE_SOURCE_DIR}/include/multipass/process/basic_process.h)
 
 target_link_libraries(shared
+  iso
   process
   utils
   Qt5::Core)

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "base_virtual_machine_factory.h"
+
+#include <multipass/cloud_init_iso.h>
+#include <multipass/utils.h>
+#include <multipass/virtual_machine_description.h>
+
+namespace mp = multipass;
+namespace mpu = multipass::utils;
+
+void mp::BaseVirtualMachineFactory::configure(VirtualMachineDescription& vm_desc)
+{
+    auto instance_dir{mpu::base_dir(vm_desc.image.image_path)};
+    const auto cloud_init_iso = instance_dir.filePath("cloud-init-config.iso");
+
+    if (!QFile::exists(cloud_init_iso))
+    {
+        mp::CloudInitIso iso;
+        iso.add_file("meta-data", mpu::emit_cloud_config(vm_desc.meta_data_config));
+        iso.add_file("vendor-data", mpu::emit_cloud_config(vm_desc.vendor_data_config));
+        iso.add_file("user-data", mpu::emit_cloud_config(vm_desc.user_data_config));
+        if (!vm_desc.network_data_config.IsNull())
+            iso.add_file("network-config", mpu::emit_cloud_config(vm_desc.network_data_config));
+
+        iso.write_to(cloud_init_iso);
+    }
+
+    vm_desc.cloud_init_iso = cloud_init_iso;
+}

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,6 +51,8 @@ public:
         return std::make_unique<DefaultVMImageVault>(image_hosts, downloader, cache_dir_path, data_dir_path,
                                                      days_to_expire);
     };
+
+    void configure(VirtualMachineDescription& vm_desc) override;
 
     std::vector<NetworkInterfaceInfo> networks() const override
     {

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -215,6 +215,18 @@ TEST_F(LXDBackend, factory_creates_expected_image_vault)
     EXPECT_TRUE(dynamic_cast<mp::LXDVMImageVault*>(vault.get()));
 }
 
+TEST_F(LXDBackend, factory_does_nothing_on_configure)
+{
+    mpt::TempDir data_dir;
+    mp::VirtualMachineDescription vm_desc{default_description};
+
+    mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
+
+    backend.configure(vm_desc);
+
+    EXPECT_TRUE(vm_desc.cloud_init_iso.isEmpty());
+}
+
 TEST_F(LXDBackend, creates_in_stopped_state)
 {
     mpt::StubVMStatusMonitor stub_monitor;

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,6 +42,7 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD0(get_backend_version_string, QString());
     MOCK_METHOD5(create_image_vault,
                  VMImageVault::UPtr(std::vector<VMImageHost*>, URLDownloader*, const Path&, const Path&, const days&));
+    MOCK_METHOD1(configure, void(VirtualMachineDescription&));
     MOCK_CONST_METHOD0(networks, std::vector<NetworkInterfaceInfo>());
 };
 }


### PR DESCRIPTION
Move cloud-init ISO image creation to the VirtualMachineFactory.
Have a base implementation in BaseVirtualMachineFactory.
Override in LXDVirtualMachineFactory as the ISO is not used with the LXD backend.

Fixes #1977 