### PR TITLE
[bors] Do not delete any child branches if parent branch is deleted

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,4 +2,5 @@ status = [ "Linux", "Windows", "macOS" ]
 block-labels = [ "no-merge" ]
 timeout-sec = 12000
 delete-merged-branches = true
+update_base_for_deletes = true
 cut_body_after = "---"


### PR DESCRIPTION
---
According to [this](https://bors.tech/documentation/), setting this supposedly keeps any child branches from being deleted when merging and deleting parent branches:
```
If turned on, and if delete_merged_branches is also turned on, then when a pull request is merged and its
base branch is about to be deleted, any other pull requests made against the base branch will be fixed up.
```

Thought we should give it a try.