### PR TITLE
Add helper types to singleton mocks

### DIFF
--- a/tests/mock_singleton_helpers.h
+++ b/tests/mock_singleton_helpers.h
@@ -58,7 +58,7 @@ public:                                                                         
 namespace multipass::test
 {
 
-template <typename ConcreteMock, template <typename MockClass> typename MockCharacter = ::testing::NaggyMock>
+template <typename ConcreteMock, template <typename /*MockClass*/> typename MockCharacter = ::testing::NaggyMock>
 class MockSingletonHelper : public ::testing::Environment
 {
 public:
@@ -81,14 +81,14 @@ private:
 };
 } // namespace multipass::test
 
-template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+template <typename ConcreteMock, template <typename /*MockClass*/> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::mockit()
 {
     ::testing::AddGlobalTestEnvironment(
         new MockSingletonHelper<ConcreteMock, MockCharacter>{}); // takes pointer ownership o_O
 }
 
-template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+template <typename ConcreteMock, template <typename /*MockClass*/> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::SetUp()
 {
     ConcreteMock::template mock<MockCharacter<ConcreteMock>>(); // Register mock as the singleton instance
@@ -99,7 +99,7 @@ void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::SetUp()
     register_accountant(); // register a test observer to verify and clear mock expectations
 }
 
-template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+template <typename ConcreteMock, template <typename /*MockClass*/> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::TearDown()
 {
     release_accountant();  // release this mock's test observer
@@ -109,14 +109,14 @@ void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::TearDown
                               - it doesn't refer to stuff that was already deleted */
 }
 
-template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+template <typename ConcreteMock, template <typename /*MockClass*/> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::register_accountant()
 {
     accountant = new Accountant{};
     ::testing::UnitTest::GetInstance()->listeners().Append(accountant); // takes ownership
 }
 
-template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+template <typename ConcreteMock, template <typename /*MockClass*/> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::release_accountant()
 {
     [[maybe_unused]] auto* listener =
@@ -127,7 +127,7 @@ void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::release_
     accountant = nullptr;
 }
 
-template <typename ConcreteMock, template <typename MockClass> typename MockCharacter>
+template <typename ConcreteMock, template <typename /*MockClass*/> typename MockCharacter>
 void multipass::test::MockSingletonHelper<ConcreteMock, MockCharacter>::Accountant::OnTestEnd(
     const ::testing::TestInfo& /*unused*/)
 {

--- a/tests/mock_singleton_helpers.h
+++ b/tests/mock_singleton_helpers.h
@@ -35,7 +35,7 @@ public:                                                                         
 #define MP_MOCK_SINGLETON_HELPER_TYPES(mock_class, parent_class)                                                       \
 private:                                                                                                               \
     static constexpr auto academy = [] { return sg::make_scope_guard([] { parent_class::reset(); }); }; /*             \
-                                    use a lambda so that the type gets deduced before decltype below */                \
+                   Produces "guards" :) Use a lambda so that the type gets deduced before decltype below */            \
                                                                                                                        \
 public:                                                                                                                \
     using Guard = decltype(academy());                                                                                 \

--- a/tests/mock_singleton_helpers.h
+++ b/tests/mock_singleton_helpers.h
@@ -51,6 +51,7 @@ public:                                                                         
     } // one at a time, please!
 
 #define MP_MOCK_SINGLETON_BOILERPLATE(mock_class, parent_class)                                                        \
+public:                                                                                                                \
     MP_MOCK_SINGLETON_HELPER_TYPES(mock_class, parent_class)                                                           \
     MP_MOCK_SINGLETON_INSTANCE(mock_class)                                                                             \
     MP_MOCK_SINGLETON_INJECT(mock_class, parent_class)

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -62,7 +62,7 @@ struct CustomImageHost : public Test
     std::chrono::seconds default_ttl{1};
     const QString test_path{mpt::test_data_path() + "custom/"};
 
-    decltype(mpt::MockPlatform::inject()) attr{mpt::MockPlatform::inject()};
+    mpt::MockPlatform::GuardedMock attr{mpt::MockPlatform::inject()};
     mpt::MockPlatform* mock_platform = attr.first;
 };
 } // namespace

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -330,7 +330,7 @@ struct Daemon : public Test
     mp::DaemonConfigBuilder config_builder;
     inline static std::stringstream trash_stream{}; // this may have contents (that we don't care about)
 
-    decltype(mpt::MockUtils::inject()) attr{mpt::MockUtils::inject()};
+    mpt::MockUtils::GuardedMock attr{mpt::MockUtils::inject()};
     NiceMock<mpt::MockUtils>* mock_utils = attr.first;
 };
 

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -68,7 +68,7 @@ struct UbuntuImageHost : public testing::Test
     QString expected_location{host_url + "newest_image.img"};
     QString expected_id{"8842e7a8adb01c7a30cc702b01a5330a1951b12042816e87efd24b61c5e2239f"};
 
-    decltype(mpt::MockPlatform::inject()) attr{mpt::MockPlatform::inject()};
+    mpt::MockPlatform::GuardedMock attr{mpt::MockPlatform::inject()};
     mpt::MockPlatform* mock_platform = attr.first;
 };
 }


### PR DESCRIPTION
Add and use singleton-mock public types, to facilitate injecting into test fixture classes (whose attributes need a fixed type).

