### PR TITLE
[test] Extract property matching for exceptions

### DIFF
--- a/tests/extra_assertions.h
+++ b/tests/extra_assertions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 #ifndef MULTIPASS_EXTRA_ASSERTIONS_H
 #define MULTIPASS_EXTRA_ASSERTIONS_H
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 // Extra macros for testing exceptions.
@@ -53,5 +54,14 @@
             }                                                                                                          \
         },                                                                                                             \
         expected_exception)
+
+namespace multipass::test
+{
+template <typename MsgMatcher>
+auto match_what(MsgMatcher&& matcher)
+{
+    return testing::Property(&std::runtime_error::what, std::forward<MsgMatcher>(matcher));
+}
+} // namespace multipass::test
 
 #endif // MULTIPASS_EXTRA_ASSERTIONS_H

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -431,7 +431,7 @@ TEST_F(LibVirtBackend, shutdown_while_starting_throws_and_sets_correct_state)
         std::this_thread::sleep_for(1ms);
 
     MP_EXPECT_THROW_THAT(machine->ensure_vm_is_running(), mp::StartException,
-                         Property(&mp::StartException::what, StrEq("Instance failed to start")));
+                         mpt::match_what(StrEq("Instance failed to start")));
 
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::off);
 }

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -114,7 +114,7 @@ void test_image_resizing(const char* img, const mp::MemorySize& img_virtual_size
 
     if (throw_msg_matcher)
         MP_EXPECT_THROW_THAT(mp::backend::resize_instance_image(requested_size, img), std::runtime_error,
-                             Property(&std::runtime_error::what, *throw_msg_matcher));
+                             mpt::match_what(*throw_msg_matcher));
     else
         mp::backend::resize_instance_image(requested_size, img);
 
@@ -146,7 +146,7 @@ void test_image_conversion(const char* img_path, const char* expected_img_path, 
 
     if (throw_msg_matcher)
         MP_EXPECT_THROW_THAT(mp::backend::convert_to_qcow_if_necessary(img_path), std::runtime_error,
-                             Property(&std::runtime_error::what, *throw_msg_matcher));
+                             mpt::match_what(*throw_msg_matcher));
     else
         EXPECT_THAT(mp::backend::convert_to_qcow_if_necessary(img_path), Eq(expected_img_path));
 

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -723,7 +723,7 @@ TEST_F(LXDBackend, healthcheck_throws_when_untrusted)
     mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
 
     MP_EXPECT_THROW_THAT(backend.hypervisor_health_check(), std::runtime_error,
-                         Property(&std::runtime_error::what, StrEq("Failed to authenticate to LXD.")));
+                         mpt::match_what(StrEq("Failed to authenticate to LXD.")));
 }
 
 TEST_F(LXDBackend, healthcheck_connection_refused_error_throws_with_expected_message)
@@ -739,10 +739,9 @@ TEST_F(LXDBackend, healthcheck_connection_refused_error_throws_with_expected_mes
 
     MP_EXPECT_THROW_THAT(
         backend.hypervisor_health_check(), std::runtime_error,
-        Property(&std::runtime_error::what,
-                 StrEq(fmt::format("{}\n\nPlease ensure the LXD snap is installed and enabled. Also make sure\n"
-                                   "the LXD interface is connected via `snap connect multipass:lxd lxd`.",
-                                   exception_message))));
+        mpt::match_what(StrEq(fmt::format("{}\n\nPlease ensure the LXD snap is installed and enabled. Also make sure\n"
+                                          "the LXD interface is connected via `snap connect multipass:lxd lxd`.",
+                                          exception_message))));
 }
 
 TEST_F(LXDBackend, healthcheck_unknown_server_error_throws_with_expected_message)
@@ -758,10 +757,9 @@ TEST_F(LXDBackend, healthcheck_unknown_server_error_throws_with_expected_message
 
     MP_EXPECT_THROW_THAT(
         backend.hypervisor_health_check(), std::runtime_error,
-        Property(&std::runtime_error::what,
-                 StrEq(fmt::format("{}\n\nPlease ensure the LXD snap is installed and enabled. Also make sure\n"
-                                   "the LXD interface is connected via `snap connect multipass:lxd lxd`.",
-                                   exception_message))));
+        mpt::match_what(StrEq(fmt::format("{}\n\nPlease ensure the LXD snap is installed and enabled. Also make sure\n"
+                                          "the LXD interface is connected via `snap connect multipass:lxd lxd`.",
+                                          exception_message))));
 }
 
 TEST_F(LXDBackend, returns_expected_network_info)
@@ -901,7 +899,7 @@ TEST_F(LXDBackend, lxd_request_timeout_aborts_and_throws)
                     mpt::MockLogger::make_cstring_matcher(HasSubstr(error_string))));
 
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), op, base_url, mp::nullopt, 3),
-                         std::runtime_error, Property(&std::runtime_error::what, HasSubstr(error_string)));
+                         std::runtime_error, mpt::match_what(HasSubstr(error_string)));
 }
 
 TEST_F(LXDBackend, lxd_request_empty_data_returned_throws_and_logs)
@@ -924,7 +922,7 @@ TEST_F(LXDBackend, lxd_request_empty_data_returned_throws_and_logs)
                     mpt::MockLogger::make_cstring_matcher(HasSubstr(error_string))));
 
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), op, base_url), std::runtime_error,
-                         Property(&std::runtime_error::what, HasSubstr(error_string)));
+                         mpt::match_what(HasSubstr(error_string)));
 }
 
 TEST_F(LXDBackend, lxd_request_invalid_json_throws_and_logs)
@@ -944,9 +942,9 @@ TEST_F(LXDBackend, lxd_request_invalid_json_throws_and_logs)
                     mpt::MockLogger::make_cstring_matcher(
                         AllOf(HasSubstr(base_url.toString().toStdString()), HasSubstr("illegal value")))));
 
-    MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url), std::runtime_error,
-                         Property(&std::runtime_error::what,
-                                  AllOf(HasSubstr(base_url.toString().toStdString()), HasSubstr("illegal value"))));
+    MP_EXPECT_THROW_THAT(
+        mp::lxd_request(mock_network_access_manager.get(), "GET", base_url), std::runtime_error,
+        mpt::match_what(AllOf(HasSubstr(base_url.toString().toStdString()), HasSubstr("illegal value"))));
 }
 
 TEST_F(LXDBackend, lxd_request_wrong_json_throws_and_logs)
@@ -969,7 +967,7 @@ TEST_F(LXDBackend, lxd_request_wrong_json_throws_and_logs)
                         AllOf(HasSubstr(base_url.toString().toStdString()), HasSubstr(invalid_json.toStdString())))));
 
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url), std::runtime_error,
-                         Property(&std::runtime_error::what, AllOf(HasSubstr(base_url.toString().toStdString()))));
+                         mpt::match_what(AllOf(HasSubstr(base_url.toString().toStdString()))));
 }
 
 TEST_F(LXDBackend, lxd_request_bad_request_throws_and_logs)
@@ -995,7 +993,7 @@ TEST_F(LXDBackend, lxd_request_bad_request_throws_and_logs)
                     mpt::MockLogger::make_cstring_matcher(error_matcher)));
 
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url), std::runtime_error,
-                         Property(&std::runtime_error::what, error_matcher));
+                         mpt::match_what(error_matcher));
 }
 
 TEST_F(LXDBackend, lxd_request_multipart_bbad_request_throws_and_logs)
@@ -1022,7 +1020,7 @@ TEST_F(LXDBackend, lxd_request_multipart_bbad_request_throws_and_logs)
                     mpt::MockLogger::make_cstring_matcher(error_matcher)));
 
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url, stub_multipart),
-                         std::runtime_error, Property(&std::runtime_error::what, error_matcher));
+                         std::runtime_error, mpt::match_what(error_matcher));
 }
 
 TEST_F(LXDBackend, lxd_wait_error_returned_throws_and_logs)
@@ -1078,7 +1076,7 @@ TEST_F(LXDBackend, lxd_wait_error_returned_throws_and_logs)
                     mpt::MockLogger::make_cstring_matcher(error_matcher)));
 
     MP_EXPECT_THROW_THAT(mp::lxd_wait(mock_network_access_manager.get(), base_url, json_reply.object(), 1000),
-                         std::runtime_error, Property(&std::runtime_error::what, error_matcher));
+                         std::runtime_error, mpt::match_what(error_matcher));
 }
 
 TEST_F(LXDBackend, lxd_wait_status_code_failure_returned_throws_and_logs)
@@ -1134,7 +1132,7 @@ TEST_F(LXDBackend, lxd_wait_status_code_failure_returned_throws_and_logs)
                     mpt::MockLogger::make_cstring_matcher(error_matcher)));
 
     MP_EXPECT_THROW_THAT(mp::lxd_wait(mock_network_access_manager.get(), base_url, json_reply.object(), 1000),
-                         std::runtime_error, Property(&std::runtime_error::what, error_matcher));
+                         std::runtime_error, mpt::match_what(error_matcher));
 }
 
 TEST_F(LXDBackend, lxd_wait_metadata_status_code_failure_returned_throws_and_logs)
@@ -1190,7 +1188,7 @@ TEST_F(LXDBackend, lxd_wait_metadata_status_code_failure_returned_throws_and_log
                     mpt::MockLogger::make_cstring_matcher(error_matcher)));
 
     MP_EXPECT_THROW_THAT(mp::lxd_wait(mock_network_access_manager.get(), base_url, json_reply.object(), 1000),
-                         std::runtime_error, Property(&std::runtime_error::what, error_matcher));
+                         std::runtime_error, mpt::match_what(error_matcher));
 }
 
 TEST_F(LXDBackend, unsupported_suspend_throws)
@@ -1221,7 +1219,7 @@ TEST_F(LXDBackend, unsupported_suspend_throws)
                                   bridge_name};
 
     MP_EXPECT_THROW_THAT(machine.suspend(), std::runtime_error,
-                         Property(&std::runtime_error::what, StrEq("suspend is currently not supported")));
+                         mpt::match_what(StrEq("suspend is currently not supported")));
 }
 
 TEST_F(LXDBackend, start_while_suspending_throws)
@@ -1244,7 +1242,7 @@ TEST_F(LXDBackend, start_while_suspending_throws)
                                   bridge_name};
 
     MP_EXPECT_THROW_THAT(machine.start(), std::runtime_error,
-                         Property(&std::runtime_error::what, StrEq("cannot start the instance while suspending")));
+                         mpt::match_what(StrEq("cannot start the instance while suspending")));
 }
 
 TEST_F(LXDBackend, start_while_frozen_unfreezes)
@@ -1494,7 +1492,7 @@ TEST_F(LXDBackend, shutdown_while_starting_throws_and_sets_correct_state)
         std::this_thread::sleep_for(1ms);
 
     MP_EXPECT_THROW_THAT(machine.ensure_vm_is_running(1ms), mp::StartException,
-                         Property(&mp::StartException::what, StrEq("Instance shutdown during start")));
+                         mpt::match_what(StrEq("Instance shutdown during start")));
 
     EXPECT_TRUE(start_called);
     EXPECT_TRUE(stop_called);
@@ -1546,7 +1544,7 @@ TEST_F(LXDBackend, start_failure_while_starting_throws_and_sets_correct_state)
     EXPECT_EQ(machine.current_state(), mp::VirtualMachine::State::starting);
 
     MP_EXPECT_THROW_THAT(machine.ensure_vm_is_running(1ms), mp::StartException,
-                         Property(&mp::StartException::what, StrEq("Instance shutdown during start")));
+                         mpt::match_what(StrEq("Instance shutdown during start")));
 
     EXPECT_EQ(machine.current_state(), mp::VirtualMachine::State::stopped);
 }

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -182,9 +182,9 @@ TEST_F(LXDImageVault, throws_with_invalid_alias)
     mp::LXDVMImageVault image_vault{hosts,    &stub_url_downloader, mock_network_access_manager.get(),
                                     base_url, cache_dir.path(),     mp::days{0}};
 
-    MP_EXPECT_THROW_THAT(
-        image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor), std::runtime_error,
-        Property(&std::runtime_error::what, StrEq(fmt::format("Unable to find an image matching \"{}\"", alias))));
+    MP_EXPECT_THROW_THAT(image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor),
+                         std::runtime_error,
+                         mpt::match_what(StrEq(fmt::format("Unable to find an image matching \"{}\"", alias))));
 }
 
 TEST_F(LXDImageVault, throws_with_invalid_remote)
@@ -199,9 +199,9 @@ TEST_F(LXDImageVault, throws_with_invalid_remote)
     mp::LXDVMImageVault image_vault{hosts,    &stub_url_downloader, mock_network_access_manager.get(),
                                     base_url, cache_dir.path(),     mp::days{0}};
 
-    MP_EXPECT_THROW_THAT(
-        image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor), std::runtime_error,
-        Property(&std::runtime_error::what, HasSubstr(fmt::format("Remote \'{}\' is not found.", remote))));
+    MP_EXPECT_THROW_THAT(image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr(fmt::format("Remote \'{}\' is not found.", remote))));
 }
 
 TEST_F(LXDImageVault, does_not_download_if_image_exists)
@@ -910,9 +910,9 @@ TEST_F(LXDImageVault, minimum_image_size_throws_when_not_found)
                                     base_url, cache_dir.path(),     mp::days{0}};
 
     const std::string id{"12345"};
-    MP_EXPECT_THROW_THAT(image_vault.minimum_image_size_for(id), std::runtime_error,
-                         Property(&std::runtime_error::what,
-                                  AllOf(HasSubstr(fmt::format("Cannot retrieve info for image with id \'{}\'", id)))));
+    MP_EXPECT_THROW_THAT(
+        image_vault.minimum_image_size_for(id), std::runtime_error,
+        mpt::match_what(AllOf(HasSubstr(fmt::format("Cannot retrieve info for image with id \'{}\'", id)))));
 }
 
 TEST_F(LXDImageVault, http_based_image_downloads_and_creates_correct_upload)
@@ -1054,7 +1054,7 @@ TEST_F(LXDImageVault, invalid_local_file_image_throws)
     const std::string missing_file{"/foo"};
     const mp::Query query{"", fmt::format("file://{}", missing_file), false, "", mp::Query::Type::LocalFile};
 
-    MP_EXPECT_THROW_THAT(
-        image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor), std::runtime_error,
-        Property(&std::runtime_error::what, StrEq(fmt::format("Custom image `{}` does not exist.", missing_file))));
+    MP_EXPECT_THROW_THAT(image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor),
+                         std::runtime_error,
+                         mpt::match_what(StrEq(fmt::format("Custom image `{}` does not exist.", missing_file))));
 }

--- a/tests/qemu/test_dnsmasq_server.cpp
+++ b/tests/qemu/test_dnsmasq_server.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -261,7 +261,7 @@ TEST_F(DNSMasqServerMockedProcess, dnsmasq_throws_on_failure_to_start)
     });
 
     MP_EXPECT_THROW_THAT(make_default_dnsmasq_server(), std::runtime_error,
-                         Property(&std::runtime_error::what, HasSubstr("failed to start")));
+                         mpt::match_what(HasSubstr("failed to start")));
 }
 
 TEST_F(DNSMasqServerMockedProcess, dnsmasq_throws_when_it_dies_immediately)
@@ -278,9 +278,8 @@ TEST_F(DNSMasqServerMockedProcess, dnsmasq_throws_when_it_dies_immediately)
         EXPECT_CALL(*process, process_state()).WillOnce(Return(state));
     });
 
-    MP_EXPECT_THROW_THAT(
-        make_default_dnsmasq_server(), std::runtime_error,
-        Property(&std::runtime_error::what, AllOf(HasSubstr(msg), HasSubstr("died"), HasSubstr("port 53"))));
+    MP_EXPECT_THROW_THAT(make_default_dnsmasq_server(), std::runtime_error,
+                         mpt::match_what(AllOf(HasSubstr(msg), HasSubstr("died"), HasSubstr("port 53"))));
 }
 
 TEST_F(DNSMasqServerMockedProcess, dnsmasq_logs_error_when_it_dies)

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -231,10 +231,10 @@ TEST_F(QemuBackend, includes_error_when_shutdown_while_starting)
     while (machine->state != mp::VirtualMachine::State::off)
         std::this_thread::sleep_for(1ms);
 
-    MP_EXPECT_THROW_THAT(machine->ensure_vm_is_running(), mp::StartException,
-                         AllOf(Property(&mp::StartException::name, Eq(machine->vm_name)),
-                               Property(&mp::StartException::what,
-                                        AllOf(HasSubstr(error_msg), HasSubstr("shutdown"), HasSubstr("starting")))));
+    MP_EXPECT_THROW_THAT(
+        machine->ensure_vm_is_running(), mp::StartException,
+        AllOf(Property(&mp::StartException::name, Eq(machine->vm_name)),
+              mpt::match_what(AllOf(HasSubstr(error_msg), HasSubstr("shutdown"), HasSubstr("starting")))));
 }
 
 TEST_F(QemuBackend, machine_unknown_state_properly_shuts_down)

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -257,9 +257,9 @@ TEST_F(CustomImageHost, all_info_for_unsupported_alias_throws)
     const std::string unsupported_alias{"core"};
     EXPECT_CALL(*mock_platform, is_alias_supported(unsupported_alias, _)).WillOnce(Return(false));
 
-    MP_EXPECT_THROW_THAT(host.all_info_for(make_query(unsupported_alias, "snapcraft")), mp::UnsupportedAliasException,
-                         Property(&std::runtime_error::what,
-                                  HasSubstr(fmt::format("\'{}\' is not a supported alias.", unsupported_alias))));
+    MP_EXPECT_THROW_THAT(
+        host.all_info_for(make_query(unsupported_alias, "snapcraft")), mp::UnsupportedAliasException,
+        mpt::match_what(HasSubstr(fmt::format("\'{}\' is not a supported alias.", unsupported_alias))));
 }
 
 TEST_F(CustomImageHost, supported_remotes_returns_expected_values)
@@ -340,7 +340,6 @@ TEST_F(CustomImageHost, info_for_unsupported_remote_throws)
     EXPECT_CALL(*mock_platform, is_remote_supported(unsupported_remote)).WillRepeatedly(Return(false));
 
     MP_EXPECT_THROW_THAT(host.info_for(make_query("xenial", unsupported_remote)), mp::UnsupportedRemoteException,
-                         Property(&std::runtime_error::what,
-                                  HasSubstr(fmt::format("Remote \'{}\' is not a supported remote for this platform.",
-                                                        unsupported_remote))));
+                         mpt::match_what(HasSubstr(fmt::format(
+                             "Remote \'{}\' is not a supported remote for this platform.", unsupported_remote))));
 }

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -562,8 +562,7 @@ TEST_F(ImageVault, minimum_image_size_throws_when_not_cached)
 
     const std::string id{"12345"};
     MP_EXPECT_THROW_THAT(vault.minimum_image_size_for(id), std::runtime_error,
-                         Property(&std::runtime_error::what,
-                                  StrEq(fmt::format("Cannot determine minimum image size for id \'{}\'", id))));
+                         mpt::match_what(StrEq(fmt::format("Cannot determine minimum image size for id \'{}\'", id))));
 }
 
 TEST_F(ImageVault, minimum_image_size_throws_when_qemuimg_info_crashes)
@@ -575,9 +574,8 @@ TEST_F(ImageVault, minimum_image_size_throws_when_qemuimg_info_crashes)
     mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor);
 
-    MP_EXPECT_THROW_THAT(
-        vault.minimum_image_size_for(vm_image.id), std::runtime_error,
-        Property(&std::runtime_error::what, AllOf(HasSubstr("qemu-img failed"), HasSubstr("with output"))));
+    MP_EXPECT_THROW_THAT(vault.minimum_image_size_for(vm_image.id), std::runtime_error,
+                         mpt::match_what(AllOf(HasSubstr("qemu-img failed"), HasSubstr("with output"))));
 }
 
 TEST_F(ImageVault, minimum_image_size_throws_when_qemuimg_info_cannot_find_the_image)
@@ -589,9 +587,8 @@ TEST_F(ImageVault, minimum_image_size_throws_when_qemuimg_info_cannot_find_the_i
     mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor);
 
-    MP_EXPECT_THROW_THAT(
-        vault.minimum_image_size_for(vm_image.id), std::runtime_error,
-        Property(&std::runtime_error::what, AllOf(HasSubstr("qemu-img failed"), HasSubstr("Could not find"))));
+    MP_EXPECT_THROW_THAT(vault.minimum_image_size_for(vm_image.id), std::runtime_error,
+                         mpt::match_what(AllOf(HasSubstr("qemu-img failed"), HasSubstr("Could not find"))));
 }
 
 TEST_F(ImageVault, minimum_image_size_throws_when_qemuimg_info_does_not_understand_the_image_size)
@@ -604,7 +601,7 @@ TEST_F(ImageVault, minimum_image_size_throws_when_qemuimg_info_does_not_understa
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor);
 
     MP_EXPECT_THROW_THAT(vault.minimum_image_size_for(vm_image.id), std::runtime_error,
-                         Property(&std::runtime_error::what, HasSubstr("Could not obtain image's virtual size")));
+                         mpt::match_what(HasSubstr("Could not obtain image's virtual size")));
 }
 
 TEST_F(ImageVault, all_info_for_no_remote_given_returns_expected_data)
@@ -665,7 +662,6 @@ TEST_F(ImageVault, all_info_for_no_images_returned_throws)
     const std::string name{"foo"};
     EXPECT_CALL(host, all_info_for(_)).WillOnce(Return(std::vector<std::pair<std::string, mp::VMImageInfo>>{}));
 
-    MP_EXPECT_THROW_THAT(
-        vault.all_info_for({"", name, false, "", mp::Query::Type::Alias, true}), std::runtime_error,
-        Property(&std::runtime_error::what, StrEq(fmt::format("Unable to find an image matching \"{}\"", name))));
+    MP_EXPECT_THROW_THAT(vault.all_info_for({"", name, false, "", mp::Query::Type::Alias, true}), std::runtime_error,
+                         mpt::match_what(StrEq(fmt::format("Unable to find an image matching \"{}\"", name))));
 }

--- a/tests/test_platform_shared.cpp
+++ b/tests/test_platform_shared.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +29,7 @@
 #include <multipass/exceptions/settings_exceptions.h>
 
 namespace mp = multipass;
+namespace mpt = mp::test;
 using namespace testing;
 
 namespace
@@ -42,8 +43,7 @@ TEST(PlatformShared, hotkey_interpretation_throws_on_invalid_hotkey)
     for (const auto& bad_sequence : bad_sequences)
     {
         MP_EXPECT_THROW_THAT(mp::platform::interpret_hotkey(bad_sequence), mp::InvalidSettingsException,
-                             Property(&mp::InvalidSettingsException::what,
-                                      AllOf(HasSubstr(mp::hotkey_key), HasSubstr(bad_sequence.toStdString()))));
+                             mpt::match_what(AllOf(HasSubstr(mp::hotkey_key), HasSubstr(bad_sequence.toStdString()))));
     }
 }
 

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -359,9 +359,8 @@ TEST_F(UbuntuImageHost, info_for_too_many_hash_matches_throws)
 
     const std::string release{"1"};
 
-    MP_EXPECT_THROW_THAT(
-        host.info_for(make_query(release, release_remote_spec.first)), std::runtime_error,
-        Property(&std::runtime_error::what, StrEq(fmt::format("Too many images matching \"{}\"", release))));
+    MP_EXPECT_THROW_THAT(host.info_for(make_query(release, release_remote_spec.first)), std::runtime_error,
+                         mpt::match_what(StrEq(fmt::format("Too many images matching \"{}\"", release))));
 }
 
 TEST_F(UbuntuImageHost, all_info_for_no_remote_query_defaults_to_release)
@@ -380,9 +379,9 @@ TEST_F(UbuntuImageHost, all_info_for_unsupported_image_throw)
 
     const std::string release{"artful"};
 
-    MP_EXPECT_THROW_THAT(
-        host.all_info_for(make_query(release, release_remote_spec.first)), mp::UnsupportedImageException,
-        Property(&std::runtime_error::what, StrEq(fmt::format("The {} release is no longer supported.", release))));
+    MP_EXPECT_THROW_THAT(host.all_info_for(make_query(release, release_remote_spec.first)),
+                         mp::UnsupportedImageException,
+                         mpt::match_what(StrEq(fmt::format("The {} release is no longer supported.", release))));
 }
 
 TEST_F(UbuntuImageHost, all_info_for_unsupported_alias_throws)
@@ -392,10 +391,9 @@ TEST_F(UbuntuImageHost, all_info_for_unsupported_alias_throws)
     const std::string unsupported_alias{"daily"};
     EXPECT_CALL(*mock_platform, is_alias_supported(unsupported_alias, _)).WillOnce(Return(false));
 
-    MP_EXPECT_THROW_THAT(host.all_info_for(make_query(unsupported_alias, release_remote_spec.first)),
-                         mp::UnsupportedAliasException,
-                         Property(&std::runtime_error::what,
-                                  HasSubstr(fmt::format("\'{}\' is not a supported alias.", unsupported_alias))));
+    MP_EXPECT_THROW_THAT(
+        host.all_info_for(make_query(unsupported_alias, release_remote_spec.first)), mp::UnsupportedAliasException,
+        mpt::match_what(HasSubstr(fmt::format("\'{}\' is not a supported alias.", unsupported_alias))));
 }
 
 TEST_F(UbuntuImageHost, info_for_unsupported_remote_throws)
@@ -406,9 +404,8 @@ TEST_F(UbuntuImageHost, info_for_unsupported_remote_throws)
     EXPECT_CALL(*mock_platform, is_remote_supported(unsupported_remote)).WillRepeatedly(Return(false));
 
     MP_EXPECT_THROW_THAT(host.info_for(make_query("xenial", unsupported_remote)), mp::UnsupportedRemoteException,
-                         Property(&std::runtime_error::what,
-                                  HasSubstr(fmt::format("Remote \'{}\' is not a supported remote for this platform.",
-                                                        unsupported_remote))));
+                         mpt::match_what(HasSubstr(fmt::format(
+                             "Remote \'{}\' is not a supported remote for this platform.", unsupported_remote))));
 }
 
 TEST_F(UbuntuImageHost, info_for_no_remote_first_unsupported_returns_expected_info)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -515,5 +515,5 @@ TEST(VaultUtils, copy_throws_when_file_does_not_exist)
     const QString file_name{"/foo/bar"};
 
     MP_EXPECT_THROW_THAT(mp::vault::copy(file_name, temp_dir.path()), std::runtime_error,
-                         Property(&std::runtime_error::what, StrEq(fmt::format("{} missing", file_name))));
+                         mpt::match_what(StrEq(fmt::format("{} missing", file_name))));
 }


### PR DESCRIPTION
Another ancillary PR that I am using for bridging tests, providing a helper function to match against runtime_error messages, often needed with the extra assertions.