### PR TITLE
[gha] add basic integration tests on bors runs

### DIFF
--- a/.github/actions/build-params/action.yml
+++ b/.github/actions/build-params/action.yml
@@ -51,7 +51,7 @@ runs:
 
       # All other pushes annotate with the CI run number.
       # This includes `main`, as `edge` will get published from automatic builds on snapcraft.io.
-      elif [ ${{ github.event_name }} == "push" ]; then
+      elif [[ ${{ github.event_name }} == "push" || ${{ github.event_name }} == "workflow_dispatch" ]]; then
         echo "::set-output name=label::ci${{ github.run_number }}"
 
       # This shouldn't happen.

--- a/.github/actions/build-params/action.yml
+++ b/.github/actions/build-params/action.yml
@@ -33,6 +33,12 @@ runs:
       elif [ ${{ github.event_name }} == "pull_request" ]; then
         echo "::set-output name=label::pr${{ github.event.number }}"
         echo "::set-output name=channel::edge/pr${{ github.event.number }}"
+
+      # If it's the `staging` branch, annotate with `ci#` and publish to `edge/ci#`.
+      elif [[ ${{ github.event_name }} == "push" && ${{ github.ref }} == "refs/heads/staging" ]]; then
+        echo "::set-output name=label::ci${{ github.run_number }}"
+        echo "::set-output name=channel::edge/ci${{ github.run_number}}"
+
       # If it's the `trying` branch, get the PR number from HEAD's Subject
       elif [[ ${{ github.event_name }} == "push" && ${{ github.ref }} == "refs/heads/trying" && "$( git log -1 --pretty=%s )" =~ ^Try\ #([0-9]+): ]]; then
         echo "::set-output name=label::pr${BASH_REMATCH[1]}"
@@ -44,7 +50,7 @@ runs:
         echo "::set-output name=channel::candidate"
 
       # All other pushes annotate with the CI run number.
-      # This includes `main` and `staging`, as `edge` will get published from automatic builds on snapcraft.io.
+      # This includes `main`, as `edge` will get published from automatic builds on snapcraft.io.
       elif [ ${{ github.event_name }} == "push" ]; then
         echo "::set-output name=label::ci${{ github.run_number }}"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,22 +3,47 @@ name: Integration
 on:
   workflow_dispatch:
     inputs:
+      os:
+        description: OS to test on
+        required: true
+      package:
+        description: Package to test
       channel:
         description: Snap channel to test
-        required: true
 
 jobs:
+  GetMatrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+    - name: Determine job matrix
+      id: set-matrix
+      run: |
+        set -euo pipefail
+
+        if [ '${{ github.event.inputs.os }}' == 'Linux' ]; then
+          echo '::set-output name=matrix::{"os": ["Linux"], "driver": ["qemu", "lxd"]}'
+        elif [ '${{ github.event.inputs.os }}' == 'macOS' ]; then
+          echo '::set-output name=matrix::{"os": ["macOS"], "driver": ["hyperkit"]}'
+        elif [ '${{ github.event.inputs.os }}' == 'Windows' ]; then
+          echo '::set-output name=matrix::{"os": ["Windows"], "driver": ["hyperv"]}'
+        fi
+
   Integration:
+    needs: GetMatrix
+
     runs-on: testflinger
 
     timeout-minutes: 30
 
     strategy:
-      matrix:
-        driver: ["qemu", "lxd"]
+      matrix: ${{ fromJSON(needs.GetMatrix.outputs.matrix) }}
 
     env:
-      TESTFLINGER_FILE: testflinger-${{ matrix.driver }}.yaml
+      TESTFLINGER_FILE: testflinger-${{ matrix.os }}-${{ matrix.driver }}.yaml
 
     steps:
     - name: Write the testflinger job
@@ -29,17 +54,24 @@ jobs:
         contents: |
           job_queue: vmware-fusion
           provision_data:
-            vmx: /Users/michal/Virtual Machines.localized/linux.vmwarevm/linux.vmx
+            ${{ matrix.os == 'Linux' && 'vmx: /Users/michal/Virtual Machines.localized/linux.vmwarevm/linux.vmx' || '' }}
+            ${{ matrix.os == 'macOS' && 'vmx: /Users/michal/Virtual Machines.localized/macos-11.vmwarevm/macos-11.vmx' || '' }}
+            ${{ matrix.os == 'Windows' && 'vmx: /Users/michal/Virtual Machines.localized/windows-10.vmwarevm/windows-10.vmx' || '' }}
             snapshot: Testflinger
-            image_url: http://cloud-images.ubuntu.com/releases/groovy/release/ubuntu-20.10-server-cloudimg-amd64.img
+            ${{ matrix.os == 'Linux' && 'image_url: http://cloud-images.ubuntu.com/releases/groovy/release/ubuntu-20.10-server-cloudimg-amd64.img' || '' }}
             vmx_config:
+              ${{ matrix.os == 'Linux' && 'memsize: 2048' || '' }}
               memsize: 2048
               vhv.enable: true
               vpmc.enable: true
 
           test_data:
+            ${{ matrix.os == 'Windows' && 'test_username: user' || '' }}
             test_cmds: |
               set -xeuo pipefail
+
+              MP=multipass
+              [ '${{ matrix.os }}' == 'macOS' ] && MP=/usr/local/bin/multipass
 
               function _run() {{
                 ssh ${{ '${{SSH_OPTS}} "${{DEVICE_USER}}@${{DEVICE_IP}}" -- "${{@}}"' }}
@@ -60,12 +92,34 @@ jobs:
 
               # Log journal entries on bad exit
               function _exit() {{
-                [ $? -eq 0 ] || _run sudo journalctl -u snap.multipass*
+                if [ '${{ matrix.os }}' == 'Linux' ]; then
+                  [ $? -eq 0 ] || _run sudo journalctl -u snap.multipass*
+                elif [ '${{ matrix.os }}' == 'macOS' ]; then
+                  [ $? -eq 0 ] || _run sudo cat /Library/Logs/Multipass/multipassd.log
+                fi
               }}
               trap _exit EXIT
 
-              # Give snapd time to settle
-              _retry 5 30 _run sudo snap install multipass --channel ${{ github.event.inputs.channel }}
+              function _ps() {{
+                _run powershell -noprofile -noninteractive -command ${{ '${{@}}' }}
+              }}
+
+              if [ '${{ matrix.os }}' == 'Linux' ]; then
+                # Give snapd time to settle
+                _retry 5 30 _run sudo snap install multipass --channel ${{ github.event.inputs.channel }}
+
+              elif [ '${{ matrix.os }}' == 'macOS' ]; then
+                _run curl --location --output multipass.pkg ${{ github.event.inputs.package }}
+                _run sudo installer -dumplog -target / -pkg multipass.pkg
+
+              elif [ '${{ matrix.os }}' == 'Windows' ]; then
+                _ps "(New-Object System.Net.WebClient).DownloadFile('${{ github.event.inputs.package }}', 'multipass-installer.exe')"
+                _run .\\multipass-installer.exe /S
+
+                _ps "Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart"
+                _ps "Restart-Computer -Force"
+                sleep 60
+              fi
 
               if [ '${{ matrix.driver }}' == 'lxd' ]; then
                 _run sudo snap connect multipass:lxd lxd
@@ -74,14 +128,15 @@ jobs:
               fi
 
               # Give multipassd time to settle
-              _retry 12 5 _run multipass find
+              _retry 12 5 _run $MP find
 
               # Deal with launch timeouts
-              _retry 3 60 _run multipass start
+              _retry 3 60 _run $MP start
 
-              _run multipass list
+              _run $MP list
 
-              _run multipass exec primary -- uname -a
+              # Deal with incorrect running state
+              _retry 10 60 _run $MP exec primary -- uname -a
 
     - name: Submit and poll the job
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,90 @@
+name: Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Snap channel to test
+        required: true
+
+jobs:
+  Integration:
+    runs-on: testflinger
+
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        driver: ["qemu", "lxd"]
+
+    env:
+      TESTFLINGER_FILE: testflinger-${{ matrix.driver }}.yaml
+
+    steps:
+    - name: Write the testflinger job
+      uses: DamianReeves/write-file-action@v1.0
+      with:
+        path: ${{ env.TESTFLINGER_FILE }}
+        write-mode: overwrite
+        contents: |
+          job_queue: vmware-fusion
+          provision_data:
+            vmx: /Users/michal/Virtual Machines.localized/linux.vmwarevm/linux.vmx
+            snapshot: Testflinger
+            image_url: http://cloud-images.ubuntu.com/releases/groovy/release/ubuntu-20.10-server-cloudimg-amd64.img
+            vmx_config:
+              memsize: 2048
+              vhv.enable: true
+              vpmc.enable: true
+
+          test_data:
+            test_cmds: |
+              set -xeuo pipefail
+
+              function _run() {{
+                ssh ${{ '${{SSH_OPTS}} "${{DEVICE_USER}}@${{DEVICE_IP}}" -- "${{@}}"' }}
+              }}
+
+              # Retry $1 times, with $2 seconds in between tries
+              function _retry() {{
+                  tries=$1
+                  interval=$2
+                  shift 2
+                  for try in $( seq $tries ); do
+                      RC=0
+                      ${{ '"${{@}}"' }} || RC=$?
+                      [ $RC -eq 0 -o $try -eq $tries ] && return $RC
+                      sleep $interval;
+                  done
+              }}
+
+              # Log journal entries on bad exit
+              function _exit() {{
+                [ $? -eq 0 ] || _run sudo journalctl -u snap.multipass*
+              }}
+              trap _exit EXIT
+
+              # Give snapd time to settle
+              _retry 5 30 _run sudo snap install multipass --channel ${{ github.event.inputs.channel }}
+
+              if [ '${{ matrix.driver }}' == 'lxd' ]; then
+                _run sudo snap connect multipass:lxd lxd
+                _run sudo lxd init --auto
+                _run sudo multipass set local.driver=lxd
+              fi
+
+              # Give multipassd time to settle
+              _retry 12 5 _run multipass find
+
+              # Deal with launch timeouts
+              _retry 3 60 _run multipass start
+
+              _run multipass list
+
+              _run multipass exec primary -- uname -a
+
+    - name: Submit and poll the job
+      run: |
+        JOB_ID=$( testflinger-cli submit --quiet ${TESTFLINGER_FILE} )
+        testflinger-cli poll ${JOB_ID}
+        [ "$( testflinger-cli results ${JOB_ID} | jq -r .test_status )" -eq 0 ]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ jobs:
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      bors-matrix: ${{ steps.set-matrix.outputs.bors-matrix }}
 
     steps:
     - name: Determine job matrix
@@ -26,10 +27,13 @@ jobs:
 
         if [ '${{ github.event.inputs.os }}' == 'Linux' ]; then
           echo '::set-output name=matrix::{"os": ["Linux"], "driver": ["qemu", "lxd"]}'
+          echo '::set-output name=bors-matrix::{"os": ["Linux"]}'
         elif [ '${{ github.event.inputs.os }}' == 'macOS' ]; then
           echo '::set-output name=matrix::{"os": ["macOS"], "driver": ["hyperkit"]}'
+          echo '::set-output name=bors-matrix::{"os": ["macOS"]}'
         elif [ '${{ github.event.inputs.os }}' == 'Windows' ]; then
           echo '::set-output name=matrix::{"os": ["Windows"], "driver": ["hyperv"]}'
+          echo '::set-output name=bors-matrix::{"os": ["Windows"]}'
         fi
 
   Integration:
@@ -143,3 +147,19 @@ jobs:
         JOB_ID=$( testflinger-cli submit --quiet ${TESTFLINGER_FILE} )
         testflinger-cli poll ${JOB_ID}
         [ "$( testflinger-cli results ${JOB_ID} | jq -r .test_status )" -eq 0 ]
+
+  # Report result to Bors
+  CI:
+    needs:
+    - GetMatrix
+    - Integration
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJSON(needs.GetMatrix.outputs.bors-matrix) }}
+
+    steps:
+    - name: Report CI failure
+      if: ${{ needs.Integration.result != 'success' }}
+      run: exit 1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -215,7 +215,9 @@ jobs:
 
   # Dispatch to the private side
   Dispatch:
-    needs: BuildAndTest
+    needs:
+    - BuildAndTest
+    - Publish-Snap
 
     # Only dispatch if we have access to secrets.
     # Need to explicitly continue on Lint getting skipped.
@@ -238,7 +240,19 @@ jobs:
             echo "::set-output name=head_sha::${{ github.sha }}"
         fi
 
-    - uses: peter-evans/repository-dispatch@v1
+    - name: Dispatch Linux integration tests
+      if: ${{ env.BORS_RUN == 'true' }}
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        token: ${{ secrets.PRIVATE_GITHUB_TOKEN }}
+        workflow: Integration
+        inputs: |
+          {
+            "channel": "${{ needs.BuildAndTest.outputs.channel }}"
+          }
+
+    - name: Dispatch macOS and Windows builds
+      uses: peter-evans/repository-dispatch@v1
       with:
         token: ${{ secrets.PRIVATE_GITHUB_TOKEN }}
         repository: ${{ secrets.PRIVATE_GITHUB_REPO }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -235,8 +235,10 @@ jobs:
       id: dispatch-params
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "::set-output name=head_ref::${{ github.head_ref }}"
             echo "::set-output name=head_sha::${{ github.event.pull_request.head.sha }}"
         else
+            echo "::set-output name=head_ref::${{ github.ref }}"
             echo "::set-output name=head_sha::${{ github.sha }}"
         fi
 
@@ -262,10 +264,11 @@ jobs:
           {
             "repository": "${{ github.repository }}",
             "repositoryUrl": "${{ github.repositoryUrl }}",
-            "head_ref": "${{ github.head_ref }}",
+            "head_ref": "${{ steps.dispatch-params.outputs.head_ref }}",
             "head_sha": "${{ steps.dispatch-params.outputs.head_sha }}",
             "ref": "${{ github.ref }}",
             "sha": "${{ github.sha }}",
             "draft": "${{ github.event.pull_request.draft }}",
-            "label": "${{ needs.BuildAndTest.outputs.label }}"
+            "label": "${{ needs.BuildAndTest.outputs.label }}",
+            "dispatch_ci": "${{ env.BORS_RUN == 'true' }}"
           }

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -248,6 +248,7 @@ jobs:
         workflow: Integration
         inputs: |
           {
+            "os": "Linux",
             "channel": "${{ needs.BuildAndTest.outputs.channel }}"
           }
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+env:
+  BORS_RUN: ${{ github.event_name == 'push' && contains('refs/heads/staging refs/heads/trying', github.ref) }}
+
 jobs:
   Lint:
     runs-on: ubuntu-latest

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,4 @@
-status = [ "Linux", "Windows", "macOS" ]
+status = [ "Linux", "CI (Linux)", "Windows", "CI (Windows)", "macOS", "CI (macOS)" ]
 block-labels = [ "no-merge" ]
 timeout-sec = 12000
 delete-merged-branches = true


### PR DESCRIPTION
This will run the `Integration` workflow on four platforms:
- Linux / qemu
- Linux / LXD
- Windows / Hyper-v
- macOS / hyperkit

---


The functioning of this can be seen in https://github.com/Saviq/multipass/pull/1#issuecomment-815273255, as things need to be on main branches for dispatches to work.