### PR TITLE
[cmake] Catch base classes with non-virtual dtors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2020 Canonical Ltd.
+# Copyright © 2017-2021 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -166,7 +166,7 @@ else()
   if(APPLE)
     add_definitions(-DMULTIPASS_PLATFORM_APPLE)
   else()
-    add_compile_options(-Wextra -Wempty-body -Wformat-security -Winit-self -Warray-bounds)
+    add_compile_options(-Wextra -Wempty-body -Wformat-security -Winit-self -Warray-bounds -Wnon-virtual-dtor)
 
     if(NOT ${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "^arm")
       add_compile_options(-Wcast-align)


### PR DESCRIPTION
The whole `-Weffc++` doesn't work for us because:

> When selecting this option, be aware that the standard library headers do not obey all of these guidelines; use grep -v to filter out those warnings.

Puzzling why `-Wnon-virtual-dtor` is not part of `-Wall` or even `-Wextra`. It built fine here and we could remove it if it started failing on external headers.