### PR TITLE
[cli] Fix launch client logging messages

### DIFF
--- a/include/multipass/cli/command.h
+++ b/include/multipass/cli/command.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -80,8 +80,6 @@ protected:
 
         while (reader->Read(&reply))
         {
-            if (!reply.log_line().empty())
-                cerr << reply.log_line() << "\n";
             streaming_callback(reply);
         }
 

--- a/include/multipass/cli/command.h
+++ b/include/multipass/cli/command.h
@@ -126,7 +126,12 @@ protected:
     {
         using Arg0Type = typename multipass::callable_traits<SuccessCallable>::template arg<0>::type;
         using ReplyType = typename std::remove_reference<Arg0Type>::type;
-        return dispatch(rpc_func, request, on_success, on_failure, [](ReplyType&) {});
+        return dispatch(rpc_func, request, on_success, on_failure, [this](ReplyType& reply) {
+            if (!reply.log_line().empty())
+            {
+                cerr << reply.log_line();
+            }
+        });
     }
 
     Command(const Command&) = delete;

--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,9 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #include "animated_spinner.h"
@@ -47,11 +44,18 @@ void mp::AnimatedSpinner::start(const std::string& start_message)
     std::unique_lock<decltype(mutex)> lock{mutex};
     if (!running)
     {
+        current_message = start_message;
         running = true;
         clear_line(cout);
         cout << start_message << "  " << std::flush;
         t = std::thread(&AnimatedSpinner::draw, this);
     }
+}
+
+void mp::AnimatedSpinner::start()
+{
+    if (!current_message.empty())
+        start(current_message);
 }
 
 void mp::AnimatedSpinner::stop()

--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -72,6 +72,15 @@ void mp::AnimatedSpinner::stop()
     clear_line(cout);
 }
 
+void mp::AnimatedSpinner::print(std::ostream& stream, const std::string& message)
+{
+    stop();
+
+    stream << message;
+
+    start();
+}
+
 void mp::AnimatedSpinner::draw()
 {
     std::unique_lock<decltype(mutex)> lock{mutex};

--- a/src/client/cli/cmd/animated_spinner.h
+++ b/src/client/cli/cmd/animated_spinner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,9 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #ifndef MULTIPASS_ANIMATED_SPINNER_H
@@ -33,6 +30,7 @@ public:
     ~AnimatedSpinner();
 
     void start(const std::string& message);
+    void start();
     void stop();
 
 private:
@@ -40,6 +38,7 @@ private:
     const std::vector<char> spinner;
     std::ostream& cout;
     bool running;
+    std::string current_message;
     std::mutex mutex;
     std::condition_variable cv;
     std::thread t;

--- a/src/client/cli/cmd/animated_spinner.h
+++ b/src/client/cli/cmd/animated_spinner.h
@@ -32,6 +32,7 @@ public:
     void start(const std::string& message);
     void start();
     void stop();
+    void print(std::ostream& stream, const std::string& message);
 
 private:
     void draw();

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -442,6 +442,13 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
             {LaunchProgress_ProgressTypes_VERIFY, "Verifying image: "},
             {LaunchProgress_ProgressTypes_WAITING, "Preparing image: "}};
 
+        if (!reply.log_line().empty())
+        {
+            spinner.stop();
+            cerr << reply.log_line() << "\n";
+            spinner.start();
+        }
+
         if (reply.create_oneof_case() == mp::LaunchReply::CreateOneofCase::kLaunchProgress)
         {
             auto& progress_message = progress_messages[reply.launch_progress().type()];

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -444,9 +444,7 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
 
         if (!reply.log_line().empty())
         {
-            spinner.stop();
-            cerr << reply.log_line() << "\n";
-            spinner.start();
+            spinner->print(cerr, reply.log_line());
         }
 
         if (reply.create_oneof_case() == mp::LaunchReply::CreateOneofCase::kLaunchProgress)

--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -70,7 +70,14 @@ mp::ReturnCode cmd::Mount::run(mp::ArgParser* parser)
         return standard_failure_handler_for(name(), cerr, status);
     };
 
-    auto streaming_callback = [&spinner](mp::MountReply& reply) {
+    auto streaming_callback = [this, &spinner](mp::MountReply& reply) {
+        if (!reply.log_line().empty())
+        {
+            spinner.stop();
+            cerr << reply.log_line() << "\n";
+            spinner.start();
+        }
+
         spinner.stop();
         spinner.start(reply.mount_message());
     };

--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -73,9 +73,7 @@ mp::ReturnCode cmd::Mount::run(mp::ArgParser* parser)
     auto streaming_callback = [this, &spinner](mp::MountReply& reply) {
         if (!reply.log_line().empty())
         {
-            spinner.stop();
-            cerr << reply.log_line() << "\n";
-            spinner.start();
+            spinner.print(cerr, reply.log_line());
         }
 
         spinner.stop();

--- a/src/client/cli/cmd/start.cpp
+++ b/src/client/cli/cmd/start.cpp
@@ -105,7 +105,14 @@ mp::ReturnCode cmd::Start::run(mp::ArgParser* parser)
         return standard_failure_handler_for(name(), cerr, status, details);
     };
 
-    auto streaming_callback = [&spinner](mp::StartReply& reply) {
+    auto streaming_callback = [this, &spinner](mp::StartReply& reply) {
+        if (!reply.log_line().empty())
+        {
+            spinner.stop();
+            cerr << reply.log_line() << "\n";
+            spinner.start();
+        }
+
         spinner.stop();
         spinner.start(reply.reply_message());
     };

--- a/src/client/cli/cmd/start.cpp
+++ b/src/client/cli/cmd/start.cpp
@@ -108,9 +108,7 @@ mp::ReturnCode cmd::Start::run(mp::ArgParser* parser)
     auto streaming_callback = [this, &spinner](mp::StartReply& reply) {
         if (!reply.log_line().empty())
         {
-            spinner.stop();
-            cerr << reply.log_line() << "\n";
-            spinner.start();
+            spinner.print(cerr, reply.log_line());
         }
 
         spinner.stop();

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -679,26 +679,6 @@ TEST_F(Client, launch_cmd_does_not_automount_in_normal_instances)
     EXPECT_THAT(send_command({"launch"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, launch_cmd_prints_out_log_message_when_received)
-{
-    const std::string log_message{"This is a fake log message"};
-
-    EXPECT_CALL(mock_daemon, launch(_, _, _))
-        .WillOnce(Invoke([&log_message](Unused, Unused, grpc::ServerWriter<mp::LaunchReply>* response) {
-            mp::LaunchReply reply;
-            reply.set_log_line(log_message);
-
-            response->Write(reply);
-            return grpc::Status{};
-        }));
-
-    std::stringstream cerr_stream;
-
-    send_command({"launch"}, trash_stream, cerr_stream);
-
-    EXPECT_EQ(cerr_stream.str(), log_message + "\n");
-}
-
 struct TestInvalidNetworkOptions : Client, WithParamInterface<std::vector<std::string>>
 {
 };
@@ -983,26 +963,6 @@ TEST_F(Client, mount_cmd_fails_invalid_host_int_gid_map)
                 Eq(mp::ReturnCode::CommandLineError));
 }
 
-TEST_F(Client, mount_cmd_prints_out_log_message_when_received)
-{
-    const std::string log_message{"This is a fake log message"};
-
-    EXPECT_CALL(mock_daemon, mount(_, _, _))
-        .WillOnce(Invoke([&log_message](Unused, Unused, grpc::ServerWriter<mp::MountReply>* response) {
-            mp::MountReply reply;
-            reply.set_log_line(log_message);
-
-            response->Write(reply);
-            return grpc::Status{};
-        }));
-
-    std::stringstream cerr_stream;
-
-    send_command({"mount", "..", "test-vm:test"}, trash_stream, cerr_stream);
-
-    EXPECT_EQ(cerr_stream.str(), log_message + "\n");
-}
-
 // recover cli tests
 TEST_F(Client, recover_cmd_fails_no_args)
 {
@@ -1101,26 +1061,6 @@ TEST_F(Client, start_cmd_can_target_petenv_among_others)
     EXPECT_THAT(send_command({"start", "foo", petenv_name()}), Eq(mp::ReturnCode::Ok));
     EXPECT_THAT(send_command({"start", petenv_name(), "bar"}), Eq(mp::ReturnCode::Ok));
     EXPECT_THAT(send_command({"start", "foo", petenv_name(), "bar", "baz"}), Eq(mp::ReturnCode::Ok));
-}
-
-TEST_F(Client, start_cmd_prints_out_log_message_when_received)
-{
-    const std::string log_message{"This is a fake log message"};
-
-    EXPECT_CALL(mock_daemon, start(_, _, _))
-        .WillOnce(Invoke([&log_message](Unused, Unused, grpc::ServerWriter<mp::StartReply>* response) {
-            mp::StartReply reply;
-            reply.set_log_line(log_message);
-
-            response->Write(reply);
-            return grpc::Status{};
-        }));
-
-    std::stringstream cerr_stream;
-
-    send_command({"start"}, trash_stream, cerr_stream);
-
-    EXPECT_EQ(cerr_stream.str(), log_message + "\n");
 }
 
 namespace
@@ -2097,24 +2037,47 @@ TEST_P(TimeoutSuite, command_completes_without_timeout)
 
 INSTANTIATE_TEST_SUITE_P(Client, TimeoutSuite, ValuesIn(timeout_commands));
 
-// general version tests
-TEST_F(Client, version_cmd_prints_out_log_message_when_received)
+struct ClientLogMessageSuite : Client, WithParamInterface<std::vector<std::string>>
 {
-    const std::string log_message{"This is a fake log message"};
+    void SetUp() override
+    {
+        Client::SetUp();
 
-    EXPECT_CALL(mock_daemon, version(_, _, _))
-        .WillOnce(Invoke([&log_message](Unused, Unused, grpc::ServerWriter<mp::VersionReply>* response) {
-            mp::VersionReply reply;
-            reply.set_log_line(log_message);
+        ON_CALL(mock_daemon, launch).WillByDefault(reply_log_message<mp::LaunchReply>);
+        ON_CALL(mock_daemon, mount).WillByDefault(reply_log_message<mp::MountReply>);
+        ON_CALL(mock_daemon, start).WillByDefault(reply_log_message<mp::StartReply>);
+        ON_CALL(mock_daemon, version).WillByDefault(reply_log_message<mp::VersionReply>);
+    }
 
-            response->Write(reply);
-            return grpc::Status{};
-        }));
+    template <typename ReplyType>
+    static grpc::Status reply_log_message(Unused, Unused, grpc::ServerWriter<ReplyType>* response)
+    {
+        ReplyType reply;
+        reply.set_log_line(log_message);
+
+        response->Write(reply);
+        return grpc::Status{};
+    }
+
+    static constexpr auto log_message = "This is a fake log message";
+};
+
+TEST_P(ClientLogMessageSuite, clientPrintsOutExpectedLogMessage)
+{
+    EXPECT_CALL(mock_daemon, launch).Times(AtMost(1));
+    EXPECT_CALL(mock_daemon, mount).Times(AtMost(1));
+    EXPECT_CALL(mock_daemon, start).Times(AtMost(1));
+    EXPECT_CALL(mock_daemon, version).Times(AtMost(1));
 
     std::stringstream cerr_stream;
 
-    send_command({"version"}, trash_stream, cerr_stream);
+    send_command(GetParam(), trash_stream, cerr_stream);
 
-    EXPECT_EQ(cerr_stream.str(), log_message + "\n");
+    EXPECT_EQ(cerr_stream.str(), log_message);
 }
+
+INSTANTIATE_TEST_SUITE_P(Client, ClientLogMessageSuite,
+                         Values(std::vector<std::string>{"launch"},
+                                std::vector<std::string>{"mount", "..", "test-vm:test"},
+                                std::vector<std::string>{"start"}, std::vector<std::string>{"version"}));
 } // namespace


### PR DESCRIPTION
Create logger for thread and slot during the VM creation.
Let the client's streaming callback handle log message printing since different operations such as launch may handle this differently.
Modify AnimatedSpinner to save the current message and start again using the saved current message.

Fixes #962, Fixes #459