### PR TITLE
Generalize catch all

### DIFF
--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -35,17 +35,17 @@ namespace multipass
  * @param args The arguments to pass to the function f
  * @return The result of f when no exception is thrown, EXIT_FAILURE (from cstdlib) otherwise
  */
-template <typename F, typename... Args>                                      // F needs to return int
-int top_catch_all(const logging::CString log_category, F f, Args&&... args); // not noexcept because logging isn't
+template <typename F, typename... Args>                                        // F needs to return int
+int top_catch_all(const logging::CString log_category, F&& f, Args&&... args); // not noexcept because logging isn't
 }
 
 template <typename F, typename... Args>
-inline int multipass::top_catch_all(const logging::CString log_category, F f, Args&&... args)
+inline int multipass::top_catch_all(const logging::CString log_category, F&& f, Args&&... args)
 {
     namespace mpl = multipass::logging;
     try
     {
-        return std::invoke(f, std::forward<Args>(args)...);
+        return std::invoke(std::forward<F>(f), std::forward<Args>(args)...);
     }
     catch (const std::exception& e)
     {

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -34,13 +34,15 @@ namespace multipass
  * @param f The int-returning function to protect with a catch-all
  * @param args The arguments to pass to the function f
  * @return The result of f when no exception is thrown, EXIT_FAILURE (from cstdlib) otherwise
+ * TODO@ricab fix doc
  */
-template <typename F, typename... Args>                                         // F needs to return int
-int top_catch_all(const logging::CString& log_category, F&& f, Args&&... args); // not noexcept because logging isn't
+template <typename T, typename F, typename... Args> // F needs to return int
+T top_catch_all(const logging::CString& log_category, T&& fallback_return, F&& f,
+                Args&&... args); // not noexcept because logging isn't
 }
 
-template <typename F, typename... Args>
-inline int multipass::top_catch_all(const logging::CString& log_category, F&& f, Args&&... args)
+template <typename T, typename F, typename... Args>
+inline T multipass::top_catch_all(const logging::CString& log_category, T&& fallback_return, F&& f, Args&&... args)
 {
     namespace mpl = multipass::logging;
     try
@@ -50,12 +52,12 @@ inline int multipass::top_catch_all(const logging::CString& log_category, F&& f,
     catch (const std::exception& e)
     {
         mpl::log(mpl::Level::error, log_category, fmt::format("Caught an unhandled exception: {}", e.what()));
-        return EXIT_FAILURE;
+        return std::forward<decltype(fallback_return)>(fallback_return);
     }
     catch (...)
     {
         mpl::log(mpl::Level::error, log_category, "Caught an unknown exception");
-        return EXIT_FAILURE;
+        return std::forward<decltype(fallback_return)>(fallback_return);
     }
 }
 

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -46,7 +46,7 @@ void error(const multipass::logging::CString& log_category); // not noexcept bec
  */
 template <typename T, typename Fun, typename... Args> // Fun needs to return non-void
 auto top_catch_all(const logging::CString& log_category, T&& fallback_return, Fun&& f,
-                   Args&&... args); // not noexcept because logging isn't
+                   Args&&... args) noexcept; // logging can throw, but we want to std::terminate in that case
 
 /**
  * Call a void function within a try-catch, catching and logging anything that it throws.
@@ -59,7 +59,7 @@ auto top_catch_all(const logging::CString& log_category, T&& fallback_return, Fu
  */
 template <typename Fun, typename... Args> // Fun needs to return void
 void top_catch_all(const logging::CString& log_category, Fun&& f,
-                   Args&&... args); // not noexcept because logging isn't
+                   Args&&... args) noexcept; // logging can throw, but we want to std::terminate in that case
 } // namespace multipass
 
 inline void multipass::detail::error(const multipass::logging::CString& log_category, const std::exception& e)
@@ -75,7 +75,8 @@ inline void multipass::detail::error(const multipass::logging::CString& log_cate
 }
 
 template <typename T, typename Fun, typename... Args>
-inline auto multipass::top_catch_all(const logging::CString& log_category, T&& fallback_return, Fun&& f, Args&&... args)
+inline auto multipass::top_catch_all(const logging::CString& log_category, T&& fallback_return, Fun&& f,
+                                     Args&&... args) noexcept
 {
     try
     {
@@ -95,7 +96,7 @@ inline auto multipass::top_catch_all(const logging::CString& log_category, T&& f
 
 template <typename Fun, typename... Args>
 inline void multipass::top_catch_all(const logging::CString& log_category, Fun&& f,
-                                     Args&&... args) // not noexcept because logging isn't
+                                     Args&&... args) noexcept // not noexcept because logging isn't
 {
     try
     {

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -53,13 +53,13 @@ inline Ret multipass::top_catch_all(const logging::CString& log_category, Ret&& 
     catch (const std::exception& e)
     {
         mpl::log(mpl::Level::error, log_category, fmt::format("Caught an unhandled exception: {}", e.what()));
-        return std::forward<decltype(fallback_return)>(fallback_return);
     }
     catch (...)
     {
         mpl::log(mpl::Level::error, log_category, "Caught an unknown exception");
-        return std::forward<decltype(fallback_return)>(fallback_return);
     }
+
+    return std::forward<decltype(fallback_return)>(fallback_return);
 }
 
 #endif // MULTIPASS_TOP_CATCH_ALL_H

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -36,14 +36,13 @@ namespace multipass
  * @return The result of f when no exception is thrown, EXIT_FAILURE (from cstdlib) otherwise
  * TODO@ricab fix doc
  */
-template <typename Ret, typename Fun, typename... Args> // Fun needs to return int
-Ret top_catch_all(const logging::CString& log_category, Ret&& fallback_return, Fun&& f,
-                  Args&&... args); // not noexcept because logging isn't
+template <typename T, typename Fun, typename... Args> // Fun needs to return int
+auto top_catch_all(const logging::CString& log_category, T&& fallback_return, Fun&& f,
+                   Args&&... args); // not noexcept because logging isn't
 }
 
-template <typename Ret, typename Fun, typename... Args>
-inline Ret multipass::top_catch_all(const logging::CString& log_category, Ret&& fallback_return, Fun&& f,
-                                    Args&&... args)
+template <typename T, typename Fun, typename... Args>
+inline auto multipass::top_catch_all(const logging::CString& log_category, T&& fallback_return, Fun&& f, Args&&... args)
 {
     namespace mpl = multipass::logging;
     try
@@ -59,7 +58,7 @@ inline Ret multipass::top_catch_all(const logging::CString& log_category, Ret&& 
         mpl::log(mpl::Level::error, log_category, "Caught an unknown exception");
     }
 
-    return std::forward<decltype(fallback_return)>(fallback_return);
+    return std::invoke_result_t<Fun, Args...>{std::forward<decltype(fallback_return)>(fallback_return)};
 }
 
 #endif // MULTIPASS_TOP_CATCH_ALL_H

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -25,6 +25,13 @@
 
 namespace multipass
 {
+namespace detail
+{
+void error(const multipass::logging::CString& log_category,
+           const std::exception& e);                         // not noexcept because logging isn't
+void error(const multipass::logging::CString& log_category); // not noexcept because logging isn't
+} // namespace detail
+
 /**
  * Call f within a try-catch, catching and logging anything that it throws.
  *
@@ -39,26 +46,59 @@ namespace multipass
 template <typename T, typename Fun, typename... Args> // Fun needs to return int
 auto top_catch_all(const logging::CString& log_category, T&& fallback_return, Fun&& f,
                    Args&&... args); // not noexcept because logging isn't
+
+template <typename Fun, typename... Args>
+void top_catch_all(const logging::CString& log_category, Fun&& f,
+                   Args&&... args); // not noexcept because logging isn't
+} // namespace multipass
+
+inline void multipass::detail::error(const multipass::logging::CString& log_category, const std::exception& e)
+{
+    namespace mpl = multipass::logging;
+    mpl::log(mpl::Level::error, log_category, fmt::format("Caught an unhandled exception: {}", e.what()));
+}
+
+inline void multipass::detail::error(const multipass::logging::CString& log_category)
+{
+    namespace mpl = multipass::logging;
+    mpl::log(mpl::Level::error, log_category, "Caught an unknown exception");
 }
 
 template <typename T, typename Fun, typename... Args>
 inline auto multipass::top_catch_all(const logging::CString& log_category, T&& fallback_return, Fun&& f, Args&&... args)
 {
-    namespace mpl = multipass::logging;
     try
     {
         return std::invoke(std::forward<Fun>(f), std::forward<Args>(args)...);
     }
     catch (const std::exception& e)
     {
-        mpl::log(mpl::Level::error, log_category, fmt::format("Caught an unhandled exception: {}", e.what()));
+        detail::error(log_category, e);
     }
     catch (...)
     {
-        mpl::log(mpl::Level::error, log_category, "Caught an unknown exception");
+        detail::error(log_category);
     }
 
     return std::invoke_result_t<Fun, Args...>{std::forward<decltype(fallback_return)>(fallback_return)};
+}
+
+template <typename Fun, typename... Args>
+inline void multipass::top_catch_all(const logging::CString& log_category, Fun&& f,
+                                     Args&&... args) // not noexcept because logging isn't
+{
+    try
+    {
+        std::invoke(std::forward<Fun>(f), std::forward<Args>(args)...);
+    }
+    catch (const std::exception& e)
+    {
+        detail::error(log_category, e);
+    }
+    catch (...)
+    {
+        detail::error(log_category);
+    }
 }
 
 #endif // MULTIPASS_TOP_CATCH_ALL_H

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -33,21 +33,31 @@ void error(const multipass::logging::CString& log_category); // not noexcept bec
 } // namespace detail
 
 /**
- * Call f within a try-catch, catching and logging anything that it throws.
+ * Call a non-void function within a try-catch, catching and logging anything that it throws.
  *
- * @tparam Fun The type of the callable f. It must be callable and return int.
+ * @tparam T The type of the value that is used to initialize the return value when an exception is caught
+ * @tparam Fun The type of the callable f. It must be callable and return non-void.
  * @tparam Args The types of f's arguments
  * @param log_category The category to use when logging exceptions
- * @param f The int-returning function to protect with a catch-all
+ * @param fallback_return The value that is used to initialize the return value when an exception is caught
+ * @param f The non-void function to protect with a catch-all
  * @param args The arguments to pass to the function f
- * @return The result of f when no exception is thrown, EXIT_FAILURE (from cstdlib) otherwise
- * TODO@ricab fix doc
+ * @return The result of f when no exception is thrown, fallback_return otherwise
  */
-template <typename T, typename Fun, typename... Args> // Fun needs to return int
+template <typename T, typename Fun, typename... Args> // Fun needs to return non-void
 auto top_catch_all(const logging::CString& log_category, T&& fallback_return, Fun&& f,
                    Args&&... args); // not noexcept because logging isn't
 
-template <typename Fun, typename... Args>
+/**
+ * Call a void function within a try-catch, catching and logging anything that it throws.
+ *
+ * @tparam Fun The type of the callable f. It must be callable and return void.
+ * @tparam Args The types of f's arguments
+ * @param log_category The category to use when logging exceptions
+ * @param f The non-void function to protect with a catch-all
+ * @param args The arguments to pass to the function f
+ */
+template <typename Fun, typename... Args> // Fun needs to return void
 void top_catch_all(const logging::CString& log_category, Fun&& f,
                    Args&&... args); // not noexcept because logging isn't
 } // namespace multipass

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +20,8 @@
 
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
+
+#include <functional>
 
 namespace multipass
 {
@@ -43,7 +45,7 @@ inline int multipass::top_catch_all(const logging::CString log_category, F f, Ar
     namespace mpl = multipass::logging;
     try
     {
-        return f(std::forward<Args>(args)...);
+        return std::invoke(f, std::forward<Args>(args)...);
     }
     catch (const std::exception& e)
     {

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -28,7 +28,7 @@ namespace multipass
 /**
  * Call f within a try-catch, catching and logging anything that it throws.
  *
- * @tparam F The type of the callable f. It must be callable and return int.
+ * @tparam Fun The type of the callable f. It must be callable and return int.
  * @tparam Args The types of f's arguments
  * @param log_category The category to use when logging exceptions
  * @param f The int-returning function to protect with a catch-all
@@ -36,18 +36,19 @@ namespace multipass
  * @return The result of f when no exception is thrown, EXIT_FAILURE (from cstdlib) otherwise
  * TODO@ricab fix doc
  */
-template <typename T, typename F, typename... Args> // F needs to return int
-T top_catch_all(const logging::CString& log_category, T&& fallback_return, F&& f,
-                Args&&... args); // not noexcept because logging isn't
+template <typename Ret, typename Fun, typename... Args> // Fun needs to return int
+Ret top_catch_all(const logging::CString& log_category, Ret&& fallback_return, Fun&& f,
+                  Args&&... args); // not noexcept because logging isn't
 }
 
-template <typename T, typename F, typename... Args>
-inline T multipass::top_catch_all(const logging::CString& log_category, T&& fallback_return, F&& f, Args&&... args)
+template <typename Ret, typename Fun, typename... Args>
+inline Ret multipass::top_catch_all(const logging::CString& log_category, Ret&& fallback_return, Fun&& f,
+                                    Args&&... args)
 {
     namespace mpl = multipass::logging;
     try
     {
-        return std::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+        return std::invoke(std::forward<Fun>(f), std::forward<Args>(args)...);
     }
     catch (const std::exception& e)
     {

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -35,12 +35,12 @@ namespace multipass
  * @param args The arguments to pass to the function f
  * @return The result of f when no exception is thrown, EXIT_FAILURE (from cstdlib) otherwise
  */
-template <typename F, typename... Args>                                        // F needs to return int
-int top_catch_all(const logging::CString log_category, F&& f, Args&&... args); // not noexcept because logging isn't
+template <typename F, typename... Args>                                         // F needs to return int
+int top_catch_all(const logging::CString& log_category, F&& f, Args&&... args); // not noexcept because logging isn't
 }
 
 template <typename F, typename... Args>
-inline int multipass::top_catch_all(const logging::CString log_category, F&& f, Args&&... args)
+inline int multipass::top_catch_all(const logging::CString& log_category, F&& f, Args&&... args)
 {
     namespace mpl = multipass::logging;
     try

--- a/src/client/cli/main.cpp
+++ b/src/client/cli/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,5 +46,5 @@ int main_impl(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-    return mp::top_catch_all("client", main_impl, argc, argv);
+    return mp::top_catch_all("client", /* fallback_return = */ EXIT_FAILURE, main_impl, argc, argv);
 }

--- a/src/client/gui/main.cpp
+++ b/src/client/gui/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,5 +44,5 @@ int main_impl(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-    return mp::top_catch_all("client", main_impl, argc, argv);
+    return mp::top_catch_all("client", /* fallback_return = */ EXIT_FAILURE, main_impl, argc, argv);
 }

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -133,5 +133,5 @@ int main_impl(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-    return mp::top_catch_all("daemon", main_impl, argc, argv);
+    return mp::top_catch_all("daemon", /* fallback_return = */ EXIT_FAILURE, main_impl, argc, argv);
 }

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -133,3 +133,17 @@ TEST_F(TopCatchAll, uses_fallback_object_of_other_types_on_exception)
     EXPECT_NO_THROW(got = mp::top_catch_all(category, fallback, []() -> std::string { throw 31; }));
     EXPECT_EQ(got, fallback);
 }
+
+TEST_F(TopCatchAll, calls_void_callable)
+{
+    auto ran = false;
+    EXPECT_NO_THROW(mp::top_catch_all("", [&ran] { ran = true; }));
+    EXPECT_TRUE(ran);
+}
+
+TEST_F(TopCatchAll, handles_exception_in_void_callable)
+{
+    EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
+                                               mpt::MockLogger::make_cstring_matcher(HasSubstr("unknown"))));
+    EXPECT_NO_THROW(mp::top_catch_all(category, [] { throw 123; }));
+}

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -141,9 +141,16 @@ TEST_F(TopCatchAll, calls_void_callable)
     EXPECT_TRUE(ran);
 }
 
-TEST_F(TopCatchAll, handles_exception_in_void_callable)
+TEST_F(TopCatchAll, handles_unknown_error_in_void_callable)
 {
     EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
                                                mpt::MockLogger::make_cstring_matcher(HasSubstr("unknown"))));
     EXPECT_NO_THROW(mp::top_catch_all(category, [] { throw 123; }));
+}
+
+TEST_F(TopCatchAll, handles_exception_in_void_callable)
+{
+    EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
+                                               mpt::MockLogger::make_cstring_matcher(HasSubstr("exception"))));
+    EXPECT_NO_THROW(mp::top_catch_all(category, [] { throw std::exception{}; }));
 }

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 
 #include <stdexcept>
+#include <string>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -66,6 +67,13 @@ TEST_F(TopCatchAll, calls_function_with_no_args)
 {
     int ret = 123, got = 0;
     EXPECT_NO_THROW(got = mp::top_catch_all("", EXIT_FAILURE, [ret] { return ret; }););
+    EXPECT_EQ(got, ret);
+}
+
+TEST_F(TopCatchAll, calls_function_with_other_return)
+{
+    std::string ret{"abc"}, got;
+    EXPECT_NO_THROW(got = mp::top_catch_all("", "unused", [&ret] { return ret; }););
     EXPECT_EQ(got, ret);
 }
 

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -125,3 +125,11 @@ TEST_F(TopCatchAll, handles_custom_exception)
                     }));
     EXPECT_EQ(got, EXIT_FAILURE);
 }
+
+TEST_F(TopCatchAll, uses_fallback_object_of_other_types_on_exception)
+{
+    std::string fallback{"default"}, got;
+    EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::error), _, _)).Times(1);
+    EXPECT_NO_THROW(got = mp::top_catch_all(category, fallback, []() -> std::string { throw 31; }));
+    EXPECT_EQ(got, fallback);
+}

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,14 +65,14 @@ public:
 TEST_F(TopCatchAll, calls_function_with_no_args)
 {
     int ret = 123, got = 0;
-    EXPECT_NO_THROW(got = mp::top_catch_all("", [ret] { return ret; }););
+    EXPECT_NO_THROW(got = mp::top_catch_all("", EXIT_FAILURE, [ret] { return ret; }););
     EXPECT_EQ(got, ret);
 }
 
 TEST_F(TopCatchAll, calls_function_with_args)
 {
     int a = 5, b = 7, got = 0;
-    EXPECT_NO_THROW(got = mp::top_catch_all("", std::plus<int>{}, a, b););
+    EXPECT_NO_THROW(got = mp::top_catch_all("", EXIT_FAILURE, std::plus<int>{}, a, b););
     EXPECT_EQ(got, a + b);
 }
 
@@ -82,7 +82,7 @@ TEST_F(TopCatchAll, handles_unknown_error)
 
     EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
                                                mpt::MockLogger::make_cstring_matcher(HasSubstr("unknown"))));
-    EXPECT_NO_THROW(got = mp::top_catch_all(category, [] {
+    EXPECT_NO_THROW(got = mp::top_catch_all(category, EXIT_FAILURE, [] {
                         throw 123;
                         return 0;
                     }););
@@ -97,7 +97,7 @@ TEST_F(TopCatchAll, handles_standard_exception)
 
     EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
                                                mpt::MockLogger::make_cstring_matcher(msg_matcher)));
-    EXPECT_NO_THROW(got = mp::top_catch_all(category, [&emsg] {
+    EXPECT_NO_THROW(got = mp::top_catch_all(category, EXIT_FAILURE, [&emsg] {
                         throw std::runtime_error{emsg};
                         return 0;
                     }););
@@ -111,7 +111,7 @@ TEST_F(TopCatchAll, handles_custom_exception)
 
     EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::error), make_category_matcher(),
                                                mpt::MockLogger::make_cstring_matcher(msg_matcher)));
-    EXPECT_NO_THROW(got = mp::top_catch_all(category, [] {
+    EXPECT_NO_THROW(got = mp::top_catch_all(category, EXIT_FAILURE, [] {
                         throw CustomExceptionForTesting{};
                         return 42;
                     }));


### PR DESCRIPTION
Generalize catch-all wrapper, to handle other sorts of callables, with different return types.