### PR TITLE
[daemon] fix invalid Json reference

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -215,7 +215,7 @@ std::vector<mp::NetworkInterface> read_extra_interfaces(const QJsonObject& recor
 
     if (record.contains("extra_interfaces"))
     {
-        for (const auto& entry : record["extra_interfaces"].toArray())
+        for (QJsonValueRef entry : record["extra_interfaces"].toArray())
         {
             auto id = entry.toObject()["id"].toString().toStdString();
             auto mac_address = entry.toObject()["mac_address"].toString().toStdString();


### PR DESCRIPTION
---

```gcc
multipass/src/daemon/daemon.cpp:218:26: error: loop variable 'entry' is always a copy because the range of type 'QJsonArray' does not return a reference [-Werror,-Wrange-loop-analysis]
        for (const auto& entry : record["extra_interfaces"].toArray())
                         ^
multipass/src/daemon/daemon.cpp:218:14: note: use non-reference type 'QJsonValueRef'                                                                                                                     
        for (const auto& entry : record["extra_interfaces"].toArray())
             ^~~~~~~~~~~~~~~~~~~
```