### PR TITLE
[Nomerge] shortcircuit bridge creation

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -382,7 +382,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
         auto pred = [net](const mp::NetworkInterfaceInfo& info) { return info.id == net.id(); };
         const auto& result = std::find_if(factory_networks->cbegin(), factory_networks->cend(), pred);
 
-        if (result == factory_networks->cend())
+        if (result == factory_networks->cend() && request->instance_name() != "fixme") // FIXME
         {
             mpl::log(mpl::Level::warning, category, fmt::format("Invalid network name \"{}\"", net.id()));
             option_errors.add_error_codes(mp::LaunchError::INVALID_NETWORK);

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -18,6 +18,7 @@
 #include "lxd_virtual_machine_factory.h"
 #include "lxd_virtual_machine.h"
 #include "lxd_vm_image_vault.h"
+#include <shared/linux/backend_utils.h>
 
 #include <multipass/exceptions/local_socket_connection_exception.h>
 #include <multipass/format.h>
@@ -25,6 +26,7 @@
 #include <multipass/network_interface_info.h>
 #include <multipass/platform.h>
 #include <multipass/utils.h>
+#include <multipass/virtual_machine_description.h> // FIXME
 
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -67,6 +69,12 @@ mp::LXDVirtualMachineFactory::LXDVirtualMachineFactory(const mp::Path& data_dir,
 mp::VirtualMachine::UPtr mp::LXDVirtualMachineFactory::create_virtual_machine(const VirtualMachineDescription& desc,
                                                                               VMStatusMonitor& monitor)
 {
+    if (desc.vm_name == "fixme" && !desc.extra_interfaces.empty()) // FIXME
+    {
+        mp::backend::create_bridge_with(desc.extra_interfaces[0].id); // FIXME
+        throw std::runtime_error("Fail on purpose");
+    }
+
     return std::make_unique<mp::LXDVirtualMachine>(desc, monitor, manager.get(), base_url, multipass_bridge_name);
 }
 

--- a/src/platform/backends/shared/linux/CMakeLists.txt
+++ b/src/platform/backends/shared/linux/CMakeLists.txt
@@ -26,6 +26,7 @@ function(add_target TARGET_NAME)
   target_link_libraries(${TARGET_NAME}
     apparmor
     fmt
+    scope_guard
     shared
     utils
     Qt5::Core

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -53,6 +53,7 @@
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
+namespace mpdbus = multipass::backend::dbus;
 
 namespace
 {
@@ -100,18 +101,17 @@ auto virtual_switch_subnet(const QString& bridge_name)
     return subnet.toStdString();
 }
 
-const mp::backend::dbus::DBusConnection& checked_system_bus()
+const mpdbus::DBusConnection& checked_system_bus() // TODO@ricab rename uniformly
 {
-    const auto& system_bus = mp::backend::dbus::DBusProvider::instance().get_system_bus();
+    const auto& system_bus = mpdbus::DBusProvider::instance().get_system_bus();
     if (!system_bus.is_connected())
         throw mp::backend::CreateBridgeException{"Failed to connect to D-Bus system bus", system_bus.last_error()};
 
     return system_bus;
 }
 
-std::unique_ptr<mp::backend::dbus::DBusInterface> get_checked_interface(const mp::backend::dbus::DBusConnection& bus,
-                                                                        const QString& service, const QString& path,
-                                                                        const QString& interface)
+std::unique_ptr<mpdbus::DBusInterface> get_checked_interface(const mpdbus::DBusConnection& bus, const QString& service,
+                                                             const QString& path, const QString& interface)
 {
     auto ret = bus.get_interface(service, path, interface);
 
@@ -123,7 +123,7 @@ std::unique_ptr<mp::backend::dbus::DBusInterface> get_checked_interface(const mp
 }
 
 template <typename T, typename... Ts>
-T checked_dbus_call(mp::backend::dbus::DBusInterface& interface, const QString& method_name, Ts&&... params)
+T checked_dbus_call(mpdbus::DBusInterface& interface, const QString& method_name, Ts&&... params)
 {
     static constexpr auto error_template = "Failed DBus call. (Service: {}; Object: {}; Interface: {}; Method: {})";
 

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -257,19 +257,22 @@ void mp::backend::create_bridge_with(const std::string& interface)
 
     // TODO@ricab verify if suitable bridge exists
     // TODO@ricab derive new bridge name
+    // TODO@ricab get rid of superflus QVariant{}s
 
     // AddConnection expects the following DBus argument type: a{sa{sv}}
     // The following two DBus calls are roughly equivalent to:
-    //   `nmcli connection add type bridge ifname <br>`
-    //   `nmcli connection add type bridge-slave ifname <if> master <br>`
-    VariantMapMap arg1{{"connection", {{"type", QVariant{"bridge"}}, {"id", QVariant{"qtbr0"}}}},
-                       {"bridge", {{"interface-name", QVariant{"qtbr0"}}}}};
+    VariantMapMap arg1{
+        {"connection", {{"type", QVariant{"bridge"}}, {"id", QVariant{"qtbr0"}}, {"autoconnect-slaves", 1}}},
+        {"bridge", {{"interface-name", QVariant{"qtbr0"}}}}};
+    //   `nmcli connection add type bridge ifname <br> connection.autoconnect-slaves 1`
+    //   `nmcli connection add type bridge-slave ifname <if> master <br> connection.autoconnect-priority 10`
     VariantMapMap arg2{{"connection",
                         {{"id", QVariant{"qtbr0-child"}},
                          {"type", "802-3-ethernet"},
                          {"slave-type", QVariant{"bridge"}},
                          {"master", QVariant{"qtbr0"}},
-                         {"interface-name", QVariant{QString::fromStdString(interface)}}}}};
+                         {"interface-name", QVariant{QString::fromStdString(interface)}},
+                         {"autoconnect-priority", 10}}}};
 
     for (const auto& arg : {arg1, arg2})
     {
@@ -281,8 +284,6 @@ void mp::backend::create_bridge_with(const std::string& interface)
             // TODO@ricab: the bridge could already be there (e.g. disconnect after creation), so revert
         }
     }
-
-    // TODO@ricab activate the bridge: `nmcli connection up bridge-mybr0`
 }
 
 mp::backend::CreateBridgeException::CreateBridgeException(const std::string& detail, const QDBusError& dbus_error)

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -282,16 +282,16 @@ void mp::backend::create_bridge_with(const std::string& interface)
     QDBusObjectPath connection_to_activate;
     for (const auto& arg : {arg1, arg2})
     {
-        QDBusReply<QDBusObjectPath> obj = nm_settings->call(QDBus::Block, "AddConnection", QVariant::fromValue(arg));
+        QDBusReply<QDBusObjectPath> reply = nm_settings->call(QDBus::Block, "AddConnection", QVariant::fromValue(arg));
 
-        if (!obj.isValid())
+        if (!reply.isValid())
         {
             throw CreateBridgeException{fmt::format("Failed to add connection {}", arg["connection"]["id"].toString()),
-                                        obj.error()};
+                                        reply.error()};
             // TODO@ricab: the bridge could already be there (e.g. disconnect after creation), so revert
         }
 
-        connection_to_activate = obj; // we want to activate the last one (the child)
+        connection_to_activate = reply; // we want to activate the last one (the child)
     }
 
     QDBusReply<QDBusObjectPath> reply =

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -286,7 +286,9 @@ void mp::backend::create_bridge_with(const std::string& interface)
 
         if (!obj.isValid())
         {
-            throw std::runtime_error{fmt::format("Could not create bridge: {}", obj.error().message())}; // TODO@ricab
+            throw CreateBridgeException{
+                fmt::format("Failed to add connection with id {}", arg["connection"]["id"].toString().toStdString()),
+                obj.error()};
             // TODO@ricab: the bridge could already be there (e.g. disconnect after creation), so revert
         }
 

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -286,9 +286,8 @@ void mp::backend::create_bridge_with(const std::string& interface)
 
         if (!obj.isValid())
         {
-            throw CreateBridgeException{
-                fmt::format("Failed to add connection with id {}", arg["connection"]["id"].toString().toStdString()),
-                obj.error()};
+            throw CreateBridgeException{fmt::format("Failed to add connection {}", arg["connection"]["id"].toString()),
+                                        obj.error()};
             // TODO@ricab: the bridge could already be there (e.g. disconnect after creation), so revert
         }
 

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -101,7 +101,7 @@ auto virtual_switch_subnet(const QString& bridge_name)
     return subnet.toStdString();
 }
 
-const mpdbus::DBusConnection& checked_system_bus() // TODO@ricab rename uniformly
+const mpdbus::DBusConnection& get_checked_system_bus()
 {
     const auto& system_bus = mpdbus::DBusProvider::instance().get_system_bus();
     if (!system_bus.is_connected())
@@ -287,7 +287,7 @@ void mp::backend::create_bridge_with(const std::string& interface)
     static std::once_flag once;
     std::call_once(once, [] { qDBusRegisterMetaType<VariantMapMap>(); });
 
-    const auto& system_bus = checked_system_bus();
+    const auto& system_bus = get_checked_system_bus();
     auto nm_root = get_checked_interface(system_bus, nm_bus_name, nm_root_obj, nm_root_ifc);
     auto nm_settings = get_checked_interface(system_bus, nm_bus_name, nm_settings_obj, nm_settings_ifc);
     auto parent_name = base_name + interface.c_str();

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -58,6 +58,11 @@ namespace
 {
 std::default_random_engine gen;
 std::uniform_int_distribution<int> dist{0, 255};
+const auto nm_bus_name = QStringLiteral("org.freedesktop.NetworkManager");
+const auto nm_root_obj = QStringLiteral("/org/freedesktop/NetworkManager");
+const auto nm_root_ifc = QStringLiteral("org.freedesktop.NetworkManager");
+const auto nm_settings_obj = QStringLiteral("/org/freedesktop/NetworkManager/Settings");
+const auto nm_settings_ifc = QStringLiteral("org.freedesktop.NetworkManager.Settings");
 
 bool subnet_used_locally(const std::string& subnet)
 {
@@ -97,12 +102,6 @@ auto virtual_switch_subnet(const QString& bridge_name)
 
 auto get_nm_interfaces()
 {
-    static const auto nm_bus_name = QStringLiteral("org.freedesktop.NetworkManager");
-    static const auto nm_root_obj = QStringLiteral("/org/freedesktop/NetworkManager");
-    static const auto nm_root_ifc = QStringLiteral("org.freedesktop.NetworkManager");
-    static const auto nm_settings_obj = QStringLiteral("/org/freedesktop/NetworkManager/Settings");
-    static const auto nm_settings_ifc = QStringLiteral("org.freedesktop.NetworkManager.Settings");
-
     const auto& system_bus = mp::backend::dbus::DBusProvider::instance().get_system_bus();
     if (!system_bus.is_connected())
         throw mp::backend::CreateBridgeException{"Failed to connect to D-Bus system bus", system_bus.last_error()};

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -257,21 +257,19 @@ void mp::backend::create_bridge_with(const std::string& interface)
 
     // TODO@ricab verify if suitable bridge exists
     // TODO@ricab derive new bridge name
-    // TODO@ricab get rid of superflus QVariant{}s
 
     // AddConnection expects the following DBus argument type: a{sa{sv}}
     // The following two DBus calls are roughly equivalent to:
-    VariantMapMap arg1{
-        {"connection", {{"type", QVariant{"bridge"}}, {"id", QVariant{"qtbr0"}}, {"autoconnect-slaves", 1}}},
-        {"bridge", {{"interface-name", QVariant{"qtbr0"}}}}};
     //   `nmcli connection add type bridge ifname <br> connection.autoconnect-slaves 1`
     //   `nmcli connection add type bridge-slave ifname <if> master <br> connection.autoconnect-priority 10`
+    VariantMapMap arg1{{"connection", {{"type", "bridge"}, {"id", "qtbr0"}, {"autoconnect-slaves", 1}}},
+                       {"bridge", {{"interface-name", "qtbr0"}}}};
     VariantMapMap arg2{{"connection",
-                        {{"id", QVariant{"qtbr0-child"}},
+                        {{"id", "qtbr0-child"},
                          {"type", "802-3-ethernet"},
-                         {"slave-type", QVariant{"bridge"}},
-                         {"master", QVariant{"qtbr0"}},
-                         {"interface-name", QVariant{QString::fromStdString(interface)}},
+                         {"slave-type", "bridge"},
+                         {"master", "qtbr0"},
+                         {"interface-name", QString::fromStdString(interface)},
                          {"autoconnect-priority", 10}}}};
 
     for (const auto& arg : {arg1, arg2})

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -352,8 +352,9 @@ void mp::backend::create_bridge_with(const std::string& interface)
     mpl::log(mpl::Level::info, log_category, fmt::format("Created bridge: {}", parent_name));
 }
 
-mp::backend::CreateBridgeException::CreateBridgeException(const std::string& detail, const QDBusError& dbus_error)
-    : std::runtime_error(fmt::format("Could not create bridge. {}: {}", detail,
-                                     dbus_error.isValid() ? dbus_error.message() : "unknown cause"))
+mp::backend::CreateBridgeException::CreateBridgeException(const std::string& detail, const QDBusError& dbus_error,
+                                                          bool rollback)
+    : std::runtime_error(fmt::format("{}. {}: {}", rollback ? "Could not rollback bridge" : "Could not create bridge",
+                                     detail, dbus_error.isValid() ? dbus_error.message() : "unknown cause"))
 {
 }

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -123,14 +123,15 @@ auto get_nm_interfaces()
 template <typename T, typename... Ts>
 T checked_dbus_call(mp::backend::dbus::DBusInterface& interface, const QString& method_name, Ts&&... params)
 {
-    static constexpr auto error_template = "DBus call to NetworkManager failed. Interface: {}; Method: {}";
+    static constexpr auto error_template = "Failed DBus call. (Service: {}; Object: {}; Interface: {}; Method: {})";
 
     auto reply_msg = interface.call(QDBus::Block, method_name, QVariant::fromValue(std::forward<Ts>(params))...);
     QDBusReply<T> reply = reply_msg;
 
     if (!reply.isValid())
-        throw mp::backend::CreateBridgeException{fmt::format(error_template, reply_msg.interface(), method_name),
-                                                 reply.error()};
+        throw mp::backend::CreateBridgeException{
+            fmt::format(error_template, interface.service(), interface.path(), interface.interface(), method_name),
+            reply.error()};
 
     return reply.value();
 }

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -64,6 +64,7 @@ const auto nm_root_obj = QStringLiteral("/org/freedesktop/NetworkManager");
 const auto nm_root_ifc = QStringLiteral("org.freedesktop.NetworkManager");
 const auto nm_settings_obj = QStringLiteral("/org/freedesktop/NetworkManager/Settings");
 const auto nm_settings_ifc = QStringLiteral("org.freedesktop.NetworkManager.Settings");
+constexpr auto max_bridge_name_len = 15; // maximum number of characters in a bridge name
 
 bool subnet_used_locally(const std::string& subnet)
 {
@@ -282,7 +283,7 @@ Q_DECLARE_METATYPE(VariantMapMap)
 void mp::backend::create_bridge_with(const std::string& interface)
 {
     static const auto root_path = QDBusObjectPath{"/"};
-    static const auto base_name = QStringLiteral("mpbr-");
+    static const auto base_name = QStringLiteral("br-");
 
     static std::once_flag once;
     std::call_once(once, [] { qDBusRegisterMetaType<VariantMapMap>(); });
@@ -290,7 +291,8 @@ void mp::backend::create_bridge_with(const std::string& interface)
     const auto& system_bus = get_checked_system_bus();
     auto nm_root = get_checked_interface(system_bus, nm_bus_name, nm_root_obj, nm_root_ifc);
     auto nm_settings = get_checked_interface(system_bus, nm_bus_name, nm_settings_obj, nm_settings_ifc);
-    auto parent_name = base_name + interface.c_str();
+
+    auto parent_name = (base_name + interface.c_str()).left(max_bridge_name_len);
     auto child_name = parent_name + "-child";
 
     // TODO@ricab verify if suitable bridge exists

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -110,11 +110,12 @@ auto get_nm_interfaces()
     auto nm_root = system_bus.get_interface(nm_bus_name, nm_root_obj, nm_root_ifc);
     auto nm_settings = system_bus.get_interface(nm_bus_name, nm_settings_obj, nm_settings_ifc);
 
-    assert(nm_root && nm_settings);
-    if (!nm_root->is_valid())
-        throw mp::backend::CreateBridgeException{"Could not reach remote D-Bus object", nm_root->last_error()};
-    if (!nm_settings->is_valid()) // TODO@ricab merge all this
-        throw mp::backend::CreateBridgeException{"Could not reach remote D-Bus object", nm_settings->last_error()};
+    for (const auto* nm_interface : {nm_root.get(), nm_settings.get()})
+    {
+        assert(nm_interface);
+        if (!nm_interface->is_valid())
+            throw mp::backend::CreateBridgeException{"Could not reach remote D-Bus object", nm_interface->last_error()};
+    }
 
     return std::pair{std::move(nm_root), std::move(nm_settings)};
 }

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -301,6 +301,8 @@ void mp::backend::create_bridge_with(const std::string& interface)
 
     // TODO@ricab verify if suitable bridge exists
 
+    mpl::log(mpl::Level::debug, log_category, fmt::format("Creating bridge: {}", parent_name));
+
     // AddConnection expects the following DBus argument type: a{sa{sv}}
     // The following two DBus calls are roughly equivalent to:
     //   `nmcli connection add type bridge ifname <br> connection.autoconnect-slaves 1`
@@ -332,7 +334,6 @@ void mp::backend::create_bridge_with(const std::string& interface)
             }
             catch (const std::exception& e)
             {
-                // TODO@ricab add a couple logs outside
                 mpl::log(mpl::Level::warning, log_category,
                          fmt::format("Exception caught when trying to rollback bridge. {}", e.what()));
             }
@@ -348,6 +349,7 @@ void mp::backend::create_bridge_with(const std::string& interface)
     for '/' to signal null `device` and `specific-object` derived from nmcli and libnm. See https://bit.ly/3dMA3QB */
 
     rollback_guard.dismiss(); // we succeeded!
+    mpl::log(mpl::Level::info, log_category, fmt::format("Created bridge: {}", parent_name));
 }
 
 mp::backend::CreateBridgeException::CreateBridgeException(const std::string& detail, const QDBusError& dbus_error)

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -320,6 +320,8 @@ void mp::backend::check_if_kvm_is_in_use()
     close(ret);
 }
 
+// @precondition no bridge exists for this interface
+// @precondition interface identifies an ethernet device
 void mp::backend::create_bridge_with(const std::string& interface)
 {
     static constexpr auto log_category_create = "create bridge";
@@ -336,9 +338,6 @@ void mp::backend::create_bridge_with(const std::string& interface)
 
     auto parent_name = (base_name + interface.c_str()).left(max_bridge_name_len);
     auto child_name = parent_name + "-child";
-
-    // TODO@ricab verify if suitable bridge exists
-
     mpl::log(mpl::Level::debug, log_category_create, fmt::format("Creating bridge: {}", parent_name));
 
     // AddConnection expects the following DBus argument type: a{sa{sv}}

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -100,7 +100,7 @@ auto virtual_switch_subnet(const QString& bridge_name)
     return subnet.toStdString();
 }
 
-mp::backend::dbus::DBusConnection checked_system_bus()
+const mp::backend::dbus::DBusConnection& checked_system_bus()
 {
     const auto& system_bus = mp::backend::dbus::DBusProvider::instance().get_system_bus();
     if (!system_bus.is_connected())
@@ -289,7 +289,7 @@ void mp::backend::create_bridge_with(const std::string& interface)
     static std::once_flag once;
     std::call_once(once, [] { qDBusRegisterMetaType<VariantMapMap>(); });
 
-    auto system_bus = checked_system_bus();
+    const auto& system_bus = checked_system_bus();
     auto [nm_root, nm_settings] = get_nm_interfaces(system_bus);
     auto parent_name = base_name + interface.c_str();
     auto child_name = parent_name + "-child";

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -252,14 +252,14 @@ void mp::backend::create_bridge_with(const std::string& interface)
     if (!system_bus.is_connected())
         throw CreateBridgeException{"Failed to connect to D-Bus system bus", system_bus.last_error()};
 
-    auto nm_settings = system_bus.get_interface(nm_bus_name, nm_settings_obj, nm_settings_ifc);
     auto nm_root = system_bus.get_interface(nm_bus_name, nm_root_obj, nm_root_ifc);
+    auto nm_settings = system_bus.get_interface(nm_bus_name, nm_settings_obj, nm_settings_ifc);
 
-    assert(nm_settings && nm_root);
-    if (!nm_settings->is_valid()) // TODO@ricab merge all this
-        throw CreateBridgeException{"Could not reach remote D-Bus object", nm_settings->last_error()};
+    assert(nm_root && nm_settings);
     if (!nm_root->is_valid())
         throw CreateBridgeException{"Could not reach remote D-Bus object", nm_root->last_error()};
+    if (!nm_settings->is_valid()) // TODO@ricab merge all this
+        throw CreateBridgeException{"Could not reach remote D-Bus object", nm_settings->last_error()};
 
     // TODO@ricab verify if suitable bridge exists
     // TODO@ricab derive new bridge name

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -327,6 +327,7 @@ void mp::backend::create_bridge_with(const std::string& interface)
                 {
                     if (auto path = obj_path.path(); !path.isNull())
                     {
+                        // TODO@ricab use checked version
                         auto connection = system_bus.get_interface(nm_bus_name, path, nm_connection_ifc);
                         connection->call(QDBus::Block, "Delete");
                     }

--- a/src/platform/backends/shared/linux/backend_utils.h
+++ b/src/platform/backends/shared/linux/backend_utils.h
@@ -45,7 +45,7 @@ void create_bridge_with(const std::string& interface);
 class CreateBridgeException : public std::runtime_error
 {
 public:
-    CreateBridgeException(const std::string& detail, const QDBusError& dbus_error);
+    CreateBridgeException(const std::string& detail, const QDBusError& dbus_error, bool rollback = false);
 };
 } // namespace backend
 } // namespace multipass

--- a/src/platform/backends/shared/linux/dbus_wrappers.h
+++ b/src/platform/backends/shared/linux/dbus_wrappers.h
@@ -51,6 +51,24 @@ public:
         return iface->lastError();
     }
 
+    virtual QString interface() const
+    {
+        assert(iface);
+        return iface->interface();
+    }
+
+    virtual QString path() const
+    {
+        assert(iface);
+        return iface->path();
+    }
+
+    virtual QString service() const
+    {
+        assert(iface);
+        return iface->service();
+    }
+
     QDBusMessage call(QDBus::CallMode mode, const QString& method, const QVariant& arg1 = {}, const QVariant& arg2 = {},
                       const QVariant& arg3 = {}) // three args should be enough for the DBus methods we need
     {

--- a/src/platform/backends/shared/linux/dbus_wrappers.h
+++ b/src/platform/backends/shared/linux/dbus_wrappers.h
@@ -100,6 +100,8 @@ class DBusConnection
 {
 public:
     virtual ~DBusConnection() = default;
+    DBusConnection(const DBusConnection&) = delete;
+    DBusConnection& operator=(const DBusConnection&) = delete;
 
     virtual bool is_connected() const
     {

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -257,6 +257,9 @@ public:
 
     MOCK_CONST_METHOD0(is_valid, bool());
     MOCK_CONST_METHOD0(last_error, QDBusError());
+    MOCK_CONST_METHOD0(interface, QString());
+    MOCK_CONST_METHOD0(path, QString());
+    MOCK_CONST_METHOD0(service, QString());
     MOCK_METHOD5(call_impl,
                  QDBusMessage(QDBus::CallMode, const QString&, const QVariant&, const QVariant&, const QVariant&));
 };

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -340,9 +340,10 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_if_bus_disconnected)
                        HasSubstr(msg.toStdString()))));
 }
 
-TEST_F(CreateBridgeTest, bridge_creation_throws_if_interface_invalid)
+TEST_F(CreateBridgeTest, bridge_creation_throws_if_nm_settings_interface_invalid)
 {
     auto msg = QStringLiteral("DBus error msg");
+    EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(true));
     EXPECT_CALL(*mock_nm_settings, is_valid).WillOnce(Return(false));
     EXPECT_CALL(*mock_nm_settings, last_error).WillOnce(Return(QDBusError{QDBusError::InvalidInterface, msg}));
     inject_dbus_interfaces();

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -360,21 +360,24 @@ TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections)
     EXPECT_CALL(*mock_nm_settings, is_valid).WillOnce(Return(true));
     EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(true));
 
-    // TODO@ricab in seq
-    auto empty = QVariant{};
-    EXPECT_CALL(*mock_nm_settings,
-                call_impl(QDBus::Block, Eq("AddConnection"), make_parent_connection_matcher(), empty, empty))
-        .WillOnce(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/an/obj/path/for/parent"}))));
+    {
+        InSequence seq{};
+        auto empty = QVariant{};
+        EXPECT_CALL(*mock_nm_settings,
+                    call_impl(QDBus::Block, Eq("AddConnection"), make_parent_connection_matcher(), empty, empty))
+            .WillOnce(
+                Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/an/obj/path/for/parent"}))));
 
-    EXPECT_CALL(*mock_nm_settings,
-                call_impl(QDBus::Block, Eq("AddConnection"), make_child_connection_matcher(network), empty, empty))
-        .WillOnce(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{child_obj_path}))));
+        EXPECT_CALL(*mock_nm_settings,
+                    call_impl(QDBus::Block, Eq("AddConnection"), make_child_connection_matcher(network), empty, empty))
+            .WillOnce(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{child_obj_path}))));
 
-    auto null_obj_matcher = make_object_path_matcher(null_obj_path);
-    auto child_obj_matcher = make_object_path_matcher(child_obj_path);
-    EXPECT_CALL(*mock_nm_root, call_impl(QDBus::Block, Eq("ActivateConnection"), child_obj_matcher, null_obj_matcher,
-                                         null_obj_matcher))
-        .WillOnce(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/active/obj/path"}))));
+        auto null_obj_matcher = make_object_path_matcher(null_obj_path);
+        auto child_obj_matcher = make_object_path_matcher(child_obj_path);
+        EXPECT_CALL(*mock_nm_root, call_impl(QDBus::Block, Eq("ActivateConnection"), child_obj_matcher,
+                                             null_obj_matcher, null_obj_matcher))
+            .WillOnce(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/active/obj/path"}))));
+    }
 
     inject_dbus_interfaces();
 

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -391,7 +391,7 @@ INSTANTIATE_TEST_SUITE_P(CreateBridgeInvalidInterfaceTest, CreateBridgeInvalidIn
 TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_first_connection)
 {
     auto msg = QStringLiteral("Nope");
-    EXPECT_CALL(*mock_nm_settings, call_impl(QDBus::Block, Eq("AddConnection"), _, _, _))
+    EXPECT_CALL(*mock_nm_settings, call_impl(_, Eq("AddConnection"), _, _, _))
         .WillOnce(Return(QDBusMessage::createError(QDBusError::AccessDenied, msg)));
 
     inject_dbus_interfaces();
@@ -402,7 +402,7 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_first_conne
 TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_second_connection)
 {
     auto msg = QStringLiteral("Still not");
-    EXPECT_CALL(*mock_nm_settings, call_impl(QDBus::Block, Eq("AddConnection"), _, _, _))
+    EXPECT_CALL(*mock_nm_settings, call_impl(_, Eq("AddConnection"), _, _, _))
         .WillOnce(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/a/b/c"}))))
         .WillOnce(Return(QDBusMessage::createError(QDBusError::UnknownMethod, msg)));
 

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -345,8 +345,8 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_if_nm_root_interface_invalid)
     auto msg = QStringLiteral("DBus error msg");
     EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(false));
     EXPECT_CALL(*mock_nm_root, last_error).WillOnce(Return(QDBusError{QDBusError::InvalidInterface, msg}));
-    inject_dbus_interfaces();
 
+    inject_dbus_interfaces();
     MP_ASSERT_THROW_THAT(
         mp::backend::create_bridge_with("whatever"), mp::backend::CreateBridgeException,
         mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Could not reach remote D-Bus object"))));
@@ -358,8 +358,8 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_if_nm_settings_interface_invalid
     EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(true));
     EXPECT_CALL(*mock_nm_settings, is_valid).WillOnce(Return(false));
     EXPECT_CALL(*mock_nm_settings, last_error).WillOnce(Return(QDBusError{QDBusError::InvalidInterface, msg}));
-    inject_dbus_interfaces();
 
+    inject_dbus_interfaces();
     MP_ASSERT_THROW_THAT(
         mp::backend::create_bridge_with("whatever"), mp::backend::CreateBridgeException,
         mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Could not reach remote D-Bus object"))));
@@ -393,7 +393,6 @@ TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections)
     }
 
     inject_dbus_interfaces();
-
     EXPECT_NO_THROW(mp::backend::create_bridge_with(network));
 }
 

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -438,10 +438,10 @@ TEST_F(CreateBridgeTest, throws_on_failure_to_create_first_connection)
 
 TEST_F(CreateBridgeTest, throws_on_failure_to_create_second_connection)
 {
-    auto msg = QStringLiteral("Still not");
-    auto ifc = QStringLiteral("the interface");
-    auto obj = QStringLiteral("the object");
-    auto svc = QStringLiteral("the service");
+    const auto msg = QStringLiteral("Still not");
+    const auto ifc = QStringLiteral("the interface");
+    const auto obj = QStringLiteral("the object");
+    const auto svc = QStringLiteral("the service");
     const auto new_connection_path = QStringLiteral("/a/b/c");
 
     EXPECT_CALL(*mock_nm_settings, call_impl(_, Eq("AddConnection"), _, _, _))
@@ -466,10 +466,10 @@ TEST_F(CreateBridgeTest, throws_on_failure_to_create_second_connection)
 
 TEST_F(CreateBridgeTest, throws_on_failure_to_activate_second_connection)
 {
-    auto msg = QStringLiteral("Refusing");
-    auto ifc = QStringLiteral("interface");
-    auto obj = QStringLiteral("object");
-    auto svc = QStringLiteral("service");
+    const auto msg = QStringLiteral("Refusing");
+    const auto ifc = QStringLiteral("interface");
+    const auto obj = QStringLiteral("object");
+    const auto svc = QStringLiteral("service");
     const auto new_connection_path1 = QStringLiteral("/foo");
     const auto new_connection_path2 = QStringLiteral("/bar");
 
@@ -500,6 +500,8 @@ TEST_F(CreateBridgeTest, throws_on_failure_to_activate_second_connection)
                          mpt::match_what(AllOf(HasSubstr(msg.toStdString()), HasSubstr(ifc.toStdString()),
                                                HasSubstr(obj.toStdString()), HasSubstr(svc.toStdString()))));
 }
+
+// TODO@ricab check different exceptions within rollback
 
 struct CreateBridgeExceptionTest : public CreateBridgeTest, WithParamInterface<bool>
 {

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -337,9 +337,8 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_if_bus_disconnected)
 
     MP_EXPECT_THROW_THAT(
         mp::backend::create_bridge_with("asdf"), mp::backend::CreateBridgeException,
-        Property(&mp::backend::CreateBridgeException::what,
-                 AllOf(HasSubstr("Could not create bridge"), HasSubstr("Failed to connect to D-Bus system bus"),
-                       HasSubstr(msg.toStdString()))));
+        mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Failed to connect to D-Bus system bus"),
+                              HasSubstr(msg.toStdString()))));
 }
 
 struct CreateBridgeInvalidInterfaceTest : public CreateBridgeTest, WithParamInterface<bool>

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -356,7 +356,8 @@ TEST_P(CreateBridgeInvalidInterfaceTest, bridge_creation_throws_if_interface_inv
     inject_dbus_interfaces();
     MP_ASSERT_THROW_THAT(
         mp::backend::create_bridge_with("whatever"), mp::backend::CreateBridgeException,
-        mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Could not reach remote D-Bus object"))));
+        mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Could not reach remote D-Bus object"),
+                              HasSubstr(msg.toStdString()))));
 }
 
 INSTANTIATE_TEST_SUITE_P(CreateBridgeInvalidInterfaceTest, CreateBridgeInvalidInterfaceTest, Values(true, false));

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -276,9 +276,10 @@ struct CreateBridgeTest : public Test
             QVariantMap::const_iterator inner_it;
 
             return (outer_map = arg.value<QMap<QString, QVariantMap>>()).size() == 2 &&
-                   (outer_it = outer_map.find("connection")) != outer_map.end() && outer_it->size() == 2 &&
+                   (outer_it = outer_map.find("connection")) != outer_map.end() && outer_it->size() == 3 &&
                    (inner_it = outer_it->find("id")) != outer_it->end() && inner_it->toString() == "qtbr0" &&
                    (inner_it = outer_it->find("type")) != outer_it->end() && inner_it->toString() == "bridge" &&
+                   (inner_it = outer_it->find("autoconnect-slaves")) != outer_it->end() && inner_it->toInt() == 1 &&
                    (outer_it = outer_map.find("bridge")) != outer_map.end() && outer_it->size() == 1 &&
                    (inner_it = outer_it->find("interface-name")) != outer_it->end() && inner_it->toString() == "qtbr0";
         });
@@ -291,12 +292,13 @@ struct CreateBridgeTest : public Test
             QVariantMap::const_iterator inner_it;
 
             return (outer_map = arg.value<QMap<QString, QVariantMap>>()).size() == 1 &&
-                   (outer_it = outer_map.find("connection")) != outer_map.end() && outer_it->size() == 5 &&
+                   (outer_it = outer_map.find("connection")) != outer_map.end() && outer_it->size() == 6 &&
                    (inner_it = outer_it->find("id")) != outer_it->end() && inner_it->toString() == "qtbr0-child" &&
                    (inner_it = outer_it->find("type")) != outer_it->end() && inner_it->toString() == "802-3-ethernet" &&
                    (inner_it = outer_it->find("slave-type")) != outer_it->end() && inner_it->toString() == "bridge" &&
                    (inner_it = outer_it->find("master")) != outer_it->end() && inner_it->toString() == "qtbr0" &&
-                   (inner_it = outer_it->find("interface-name")) != outer_it->end() && inner_it->toString() == child;
+                   (inner_it = outer_it->find("interface-name")) != outer_it->end() && inner_it->toString() == child &&
+                   (inner_it = outer_it->find("autoconnect-priority")) != outer_it->end() && inner_it->toInt() > 0;
         });
     }
 

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -268,6 +268,7 @@ struct CreateBridgeTest : public Test
 {
     void SetUp() override
     {
+        // These will accept any number of calls (0..N) but they can still be shadowed
         EXPECT_CALL(*mock_dbus_provider, get_system_bus).WillRepeatedly(ReturnRef(mock_bus));
         EXPECT_CALL(*mock_nm_root, is_valid).WillRepeatedly(Return(true));
         EXPECT_CALL(*mock_nm_settings, is_valid).WillRepeatedly(Return(true));
@@ -399,7 +400,7 @@ TEST_P(CreateBridgeInvalidInterfaceTest, throws_if_interface_invalid)
         mpt::match_what(AllOf(HasSubstr("Could not reach remote D-Bus object"), HasSubstr(msg.toStdString()))));
 }
 
-INSTANTIATE_TEST_SUITE_P(CreateBridgeInvalidInterfaceTest, CreateBridgeInvalidInterfaceTest, Values(true, false));
+INSTANTIATE_TEST_SUITE_P(CreateBridgeTest, CreateBridgeInvalidInterfaceTest, Values(true, false));
 
 // TODO@ricab below this point, need to check that connections are reverted
 TEST_F(CreateBridgeTest, throws_on_failure_to_create_first_connection)

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -302,7 +302,7 @@ struct CreateBridgeTest : public Test
             QMap<QString, QVariantMap> outer_map;
             QMap<QString, QVariantMap>::const_iterator outer_it;
             QVariantMap::const_iterator inner_it;
-            QString parent_name = get_bridge_name(child);
+            QString parent_name = get_bridge_name(child).left(15);
 
             return (outer_map = arg.value<QMap<QString, QVariantMap>>()).size() == 2 &&
                    (outer_it = outer_map.find("connection")) != outer_map.end() && outer_it->size() == 3 &&
@@ -320,7 +320,7 @@ struct CreateBridgeTest : public Test
             QMap<QString, QVariantMap> outer_map;
             QMap<QString, QVariantMap>::const_iterator outer_it;
             QVariantMap::const_iterator inner_it;
-            QString parent_name = get_bridge_name(child);
+            QString parent_name = get_bridge_name(child).left(15);
             QString child_name = parent_name + "-child";
 
             return (outer_map = arg.value<QMap<QString, QVariantMap>>()).size() == 1 &&
@@ -349,13 +349,13 @@ struct CreateBridgeTest : public Test
 private:
     static QString get_bridge_name(const char* child)
     {
-        return QString{"mpbr-"} + child;
+        return QString{"br-"} + child;
     }
 };
 
 TEST_F(CreateBridgeTest, creates_and_activates_connections) // success case
 {
-    static constexpr auto network = "wlan9";
+    static constexpr auto network = "wlan1234567890a";
     static constexpr auto child_obj_path = "/an/obj/path/for/child";
     static constexpr auto null_obj_path = "/";
 

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -403,8 +403,7 @@ TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections)
         auto empty = QVariant{};
         EXPECT_CALL(*mock_nm_settings,
                     call_impl(QDBus::Block, Eq("AddConnection"), make_parent_connection_matcher(), empty, empty))
-            .WillOnce(
-                Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/an/obj/path/for/parent"}))));
+            .WillOnce(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/a/b/c"}))));
 
         EXPECT_CALL(*mock_nm_settings,
                     call_impl(QDBus::Block, Eq("AddConnection"), make_child_connection_matcher(network), empty, empty))

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -363,9 +363,6 @@ INSTANTIATE_TEST_SUITE_P(CreateBridgeInvalidInterfaceTest, CreateBridgeInvalidIn
 
 TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_first_connection)
 {
-    EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(true));
-    EXPECT_CALL(*mock_nm_settings, is_valid).WillOnce(Return(true));
-
     auto msg = QStringLiteral("Nope");
     EXPECT_CALL(*mock_nm_settings, call_impl(QDBus::Block, Eq("AddConnection"), _, _, _))
         .WillOnce(Return(QDBusMessage::createError(QDBusError::AccessDenied, msg)));
@@ -377,9 +374,6 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_first_conne
 
 TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_second_connection)
 {
-    EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(true));
-    EXPECT_CALL(*mock_nm_settings, is_valid).WillOnce(Return(true));
-
     auto msg = QStringLiteral("Still not");
     EXPECT_CALL(*mock_nm_settings, call_impl(QDBus::Block, Eq("AddConnection"), _, _, _))
         .WillOnce(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/a/b/c"}))))
@@ -395,8 +389,6 @@ TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections)
     static constexpr auto network = "wlan9";
     static constexpr auto child_obj_path = "/an/obj/path/for/child";
     static constexpr auto null_obj_path = "/";
-    EXPECT_CALL(*mock_nm_settings, is_valid).WillOnce(Return(true));
-    EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(true));
 
     {
         InSequence seq{};

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -355,8 +355,7 @@ TEST_P(CreateBridgeInvalidInterfaceTest, bridge_creation_throws_if_interface_inv
     inject_dbus_interfaces();
     MP_ASSERT_THROW_THAT(
         mp::backend::create_bridge_with("whatever"), mp::backend::CreateBridgeException,
-        mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Could not reach remote D-Bus object"),
-                              HasSubstr(msg.toStdString()))));
+        mpt::match_what(AllOf(HasSubstr("Could not reach remote D-Bus object"), HasSubstr(msg.toStdString()))));
 }
 
 INSTANTIATE_TEST_SUITE_P(CreateBridgeInvalidInterfaceTest, CreateBridgeInvalidInterfaceTest, Values(true, false));
@@ -369,7 +368,7 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_first_conne
 
     inject_dbus_interfaces();
     MP_ASSERT_THROW_THAT(mp::backend::create_bridge_with("umdolita"), mp::backend::CreateBridgeException,
-                         mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr(msg.toStdString()))));
+                         mpt::match_what(HasSubstr(msg.toStdString())));
 }
 
 TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_second_connection)
@@ -381,7 +380,7 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_second_conn
 
     inject_dbus_interfaces();
     MP_ASSERT_THROW_THAT(mp::backend::create_bridge_with("abc"), mp::backend::CreateBridgeException,
-                         mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr(msg.toStdString()))));
+                         mpt::match_what(HasSubstr(msg.toStdString())));
 }
 
 TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections)

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -340,6 +340,18 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_if_bus_disconnected)
                        HasSubstr(msg.toStdString()))));
 }
 
+TEST_F(CreateBridgeTest, bridge_creation_throws_if_nm_root_interface_invalid)
+{
+    auto msg = QStringLiteral("DBus error msg");
+    EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(false));
+    EXPECT_CALL(*mock_nm_root, last_error).WillOnce(Return(QDBusError{QDBusError::InvalidInterface, msg}));
+    inject_dbus_interfaces();
+
+    MP_ASSERT_THROW_THAT(
+        mp::backend::create_bridge_with("whatever"), mp::backend::CreateBridgeException,
+        mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Could not reach remote D-Bus object"))));
+}
+
 TEST_F(CreateBridgeTest, bridge_creation_throws_if_nm_settings_interface_invalid)
 {
     auto msg = QStringLiteral("DBus error msg");

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -383,6 +383,19 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_second_conn
                          mpt::match_what(HasSubstr(msg.toStdString())));
 }
 
+TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_activate_second_connection)
+{
+    auto msg = QStringLiteral("Refusing");
+    EXPECT_CALL(*mock_nm_settings, call_impl(_, Eq("AddConnection"), _, _, _))
+        .WillRepeatedly(Return(QDBusMessage{}.createReply(QVariant::fromValue(QDBusObjectPath{"/a/b/c"}))));
+    EXPECT_CALL(*mock_nm_root, call_impl(_, Eq("ActivateConnection"), _, _, _))
+        .WillOnce(Return(QDBusMessage::createError(QDBusError::InvalidArgs, msg)));
+
+    inject_dbus_interfaces();
+    MP_ASSERT_THROW_THAT(mp::backend::create_bridge_with("kaka"), mp::backend::CreateBridgeException,
+                         mpt::match_what(HasSubstr(msg.toStdString())));
+}
+
 TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections)
 {
     static constexpr auto network = "wlan9";

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -265,7 +265,7 @@ struct CreateBridgeTest : public Test
 {
     void SetUp() override
     {
-        EXPECT_CALL(*mock_dbus_provider, get_system_bus).WillOnce(ReturnRef(mock_bus));
+        EXPECT_CALL(*mock_dbus_provider, get_system_bus).WillRepeatedly(ReturnRef(mock_bus));
         EXPECT_CALL(*mock_nm_root, is_valid).WillRepeatedly(Return(true));
         EXPECT_CALL(*mock_nm_settings, is_valid).WillRepeatedly(Return(true));
     }
@@ -413,14 +413,14 @@ TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections)
     EXPECT_NO_THROW(mp::backend::create_bridge_with(network));
 }
 
-TEST(BackendUtils, create_bridge_exception_info)
+TEST_F(CreateBridgeTest, create_bridge_exception_info)
 {
     static constexpr auto specific_info = "spefic error details";
     EXPECT_THAT((mp::backend::CreateBridgeException{specific_info, QDBusError{}}),
                 mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr(specific_info))));
 }
 
-TEST(BackendUtils, create_bridge_exception_includes_dbus_cause_when_available)
+TEST_F(CreateBridgeTest, create_bridge_exception_includes_dbus_cause_when_available)
 {
     auto msg = QStringLiteral("DBus error msg");
     QDBusError dbus_error = {QDBusError::Other, msg};
@@ -429,7 +429,7 @@ TEST(BackendUtils, create_bridge_exception_includes_dbus_cause_when_available)
                 mpt::match_what(HasSubstr(msg.toStdString())));
 }
 
-TEST(BackendUtils, create_bridge_exception_mentions_unknown_cause_when_unavailable)
+TEST_F(CreateBridgeTest, create_bridge_exception_mentions_unknown_cause_when_unavailable)
 {
     QDBusError dbus_error{};
     ASSERT_FALSE(dbus_error.isValid());

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -329,7 +329,7 @@ struct CreateBridgeTest : public Test
     std::unique_ptr<MockDBusInterface> mock_nm_root = std::make_unique<MockDBusInterface>();
 };
 
-TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections) // success case
+TEST_F(CreateBridgeTest, creates_and_activates_connections) // success case
 {
     static constexpr auto network = "wlan9";
     static constexpr auto child_obj_path = "/an/obj/path/for/child";
@@ -357,7 +357,7 @@ TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections) // s
     EXPECT_NO_THROW(mp::backend::create_bridge_with(network));
 }
 
-TEST_F(CreateBridgeTest, bridge_creation_throws_if_bus_disconnected)
+TEST_F(CreateBridgeTest, throws_if_bus_disconnected)
 {
     auto msg = QStringLiteral("DBus error msg");
     EXPECT_CALL(mock_bus, is_connected).WillOnce(Return(false));
@@ -373,7 +373,7 @@ struct CreateBridgeInvalidInterfaceTest : public CreateBridgeTest, WithParamInte
 {
 };
 
-TEST_P(CreateBridgeInvalidInterfaceTest, bridge_creation_throws_if_interface_invalid)
+TEST_P(CreateBridgeInvalidInterfaceTest, throws_if_interface_invalid)
 {
     auto& mock_nm_interface = GetParam() ? mock_nm_root : mock_nm_settings;
     auto msg = QStringLiteral("DBus error msg");
@@ -388,7 +388,7 @@ TEST_P(CreateBridgeInvalidInterfaceTest, bridge_creation_throws_if_interface_inv
 
 INSTANTIATE_TEST_SUITE_P(CreateBridgeInvalidInterfaceTest, CreateBridgeInvalidInterfaceTest, Values(true, false));
 
-TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_first_connection)
+TEST_F(CreateBridgeTest, throws_on_failure_to_create_first_connection)
 {
     auto msg = QStringLiteral("Nope");
     EXPECT_CALL(*mock_nm_settings, call_impl(_, Eq("AddConnection"), _, _, _))
@@ -399,7 +399,7 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_first_conne
                          mpt::match_what(HasSubstr(msg.toStdString())));
 }
 
-TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_second_connection)
+TEST_F(CreateBridgeTest, throws_on_failure_to_create_second_connection)
 {
     auto msg = QStringLiteral("Still not");
     EXPECT_CALL(*mock_nm_settings, call_impl(_, Eq("AddConnection"), _, _, _))
@@ -411,7 +411,7 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_second_conn
                          mpt::match_what(HasSubstr(msg.toStdString())));
 }
 
-TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_activate_second_connection)
+TEST_F(CreateBridgeTest, throws_on_failure_to_activate_second_connection)
 {
     auto msg = QStringLiteral("Refusing");
     EXPECT_CALL(*mock_nm_settings, call_impl(_, Eq("AddConnection"), _, _, _))

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -365,6 +365,21 @@ TEST_F(CreateBridgeTest, bridge_creation_throws_if_nm_settings_interface_invalid
         mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Could not reach remote D-Bus object"))));
 }
 
+TEST_F(CreateBridgeTest, bridge_creation_throws_on_failure_to_create_first_connection)
+{
+    EXPECT_CALL(*mock_nm_root, is_valid).WillOnce(Return(true));
+    EXPECT_CALL(*mock_nm_settings, is_valid).WillOnce(Return(true));
+
+    auto msg = QStringLiteral("Nope");
+    auto empty = QVariant{};
+    EXPECT_CALL(*mock_nm_settings,
+                call_impl(QDBus::Block, Eq("AddConnection"), make_parent_connection_matcher(), empty, empty))
+        .WillOnce(Return(QDBusMessage::createError(QDBusError::AccessDenied, msg)));
+
+    inject_dbus_interfaces();
+    MP_ASSERT_THROW_THAT(mp::backend::create_bridge_with("umdolita"), mp::backend::CreateBridgeException,
+                         mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr(msg.toStdString()))));
+}
 TEST_F(CreateBridgeTest, bridge_creation_creates_and_activates_connections)
 {
     static constexpr auto network = "wlan9";


### PR DESCRIPTION
Facilitate testing of #2022 under confiment. Includes #2067 as well.

Instructions (adapted for snap from [this earlier comment](https://github.com/canonical/multipass/pull/2022#issuecomment-820648151)): 
1. `snap connect multipass:network-observe multipass:network-manager` # for [this read permission](https://github.com/snapcore/snapd/blob/master/interfaces/builtin/network_observe.go#L122) — should probably request auto connection
1. `sudo multipass set local.driver=lxd`
1. `multipass launch` # to prefetch an image
1. `multipass launch --name fixme --network <device-to-bridge-with>`