### PR TITLE
[doc] Fix brew instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For macOS, you can download the installers [from GitHub](https://github.com/cano
 
 ```
 # Note, this may require you to enter your password for some sudo operations during install
-brew cask install multipass
+brew install --cask multipass
 ```
 
 On Windows, download the installer [from GitHub](https://github.com/canonical/multipass/releases).


### PR DESCRIPTION
Homebrew deprecated the `brew cask` command a while ago (starting from [version 2.6.0](https://brew.sh/2020/12/01/homebrew-2.6.0/) in Dec 2020) and it was deleted recently in [version 3.0.6](https://github.com/Homebrew/brew/releases/tag/3.0.6).