### PR TITLE
[ubuntu_image_host] Only reject multiple hash matches if not a full hash

### DIFF
--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -89,7 +89,7 @@ mp::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& query
     auto key = key_from(query.release);
     auto image_id = images.front().second.id;
 
-    // If more than one match and query is a hash but not a full hash, throw an exception
+    // If a partial hash query matches more than once, throw an exception
     if (images.size() > 1 && key != image_id && image_id.startsWith(key))
         throw std::runtime_error(fmt::format("Too many images matching \"{}\"", query.release));
 

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -83,14 +83,18 @@ mp::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& query
 {
     auto images = all_info_for(query);
 
-    // If more than one match and query is a hash, throw an exception
-    if (images.size() > 1 && images.front().second.id.startsWith(key_from(query.release)))
-        throw std::runtime_error(fmt::format("Too many images matching \"{}\"", query.release));
-    // If query is an alias, choose the first one returned if more than one
-    else if (images.size() != 0)
-        return images.front().second;
-    else
+    if (images.size() == 0)
         return nullopt;
+
+    auto key = key_from(query.release);
+    auto image_id = images.front().second.id;
+
+    // If more than one match and query is a hash but not a full hash, throw an exception
+    if (images.size() > 1 && key != image_id && image_id.startsWith(key))
+        throw std::runtime_error(fmt::format("Too many images matching \"{}\"", query.release));
+
+    // It's not a hash match, so choose the first one no matter what
+    return images.front().second;
 }
 
 std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for(const Query& query)

--- a/tests/test_data/daily/daily_manifest.json
+++ b/tests/test_data/daily/daily_manifest.json
@@ -42,6 +42,40 @@
           "pubname": "ubuntu-artful-daily-amd64-server-20170702"
         }
       }
+    },
+    "com.ubuntu.cloud:server:17.04:amd64": {
+      "aliases": "17.04,z,zesty",
+      "arch": "amd64",
+      "os": "ubuntu",
+      "release": "zesty",
+      "release_codename": "Zesty Zapus",
+      "release_title": "17.04",
+      "support_eol": "2018-01-25",
+      "supported": true,
+      "version": "17.04",
+      "versions": {
+        "20170619.1": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "cc2bc360fec3086edcd4e69d7d8113fc",
+              "path": "zesty_newest.img",
+              "sha256": "ab115b83e7a8bebf3d3a02bf55ad0cb75a0ed515fcbc65fb0c9abe76c752921c",
+              "size": 346882048
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "f50337be60f7fce4ddd71397285490115e208aeb37565b8d77529cb352cdad05",
+              "ftype": "lxd.tar.xz",
+              "md5": "21a945923eff127e1553d581c8872bb6",
+              "path": "server/releases/zesty/release-20170619.1/ubuntu-17.04-server-cloudimg-amd64-lxd.tar.xz",
+              "sha256": "c258ec70a733b5ea22c7b8a608d2b2e95fb1cf6ec01e0ffba367bd46baf1f8e1",
+              "size": 848
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-zesty-17.04-amd64-server-20170619.1"
+        }
+      }
     }
   },
   "updated": "Wed, 18 Oct 2017 12:14:50 +0000"

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -242,13 +242,13 @@ TEST_F(UbuntuImageHost, all_images_for_release_unsupported_returns_five_matches)
     EXPECT_THAT(images.size(), Eq(expected_matches));
 }
 
-TEST_F(UbuntuImageHost, all_images_for_daily_returns_two_matches)
+TEST_F(UbuntuImageHost, all_images_for_daily_returns_all_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
 
     auto images = host.all_images_for(daily_remote_spec.first, false);
 
-    const size_t expected_matches{2};
+    const size_t expected_matches{3};
     EXPECT_THAT(images.size(), Eq(expected_matches));
 }
 
@@ -361,6 +361,25 @@ TEST_F(UbuntuImageHost, info_for_too_many_hash_matches_throws)
 
     MP_EXPECT_THROW_THAT(host.info_for(make_query(release, release_remote_spec.first)), std::runtime_error,
                          mpt::match_what(StrEq(fmt::format("Too many images matching \"{}\"", release))));
+}
+
+TEST_F(UbuntuImageHost, info_for_same_full_hash_in_both_remotes_does_not_throw)
+{
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+
+    const auto hash_query{"ab115b83e7a8bebf3d3a02bf55ad0cb75a0ed515fcbc65fb0c9abe76c752921c"};
+
+    EXPECT_NO_THROW(host.info_for(make_query(hash_query, "")));
+}
+
+TEST_F(UbuntuImageHost, info_for_partial_hash_in_both_remotes_throws)
+{
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+
+    const auto hash_query{"ab115"};
+
+    MP_EXPECT_THROW_THAT(host.info_for(make_query(hash_query, "")), std::runtime_error,
+                         mpt::match_what(StrEq(fmt::format("Too many images matching \"{}\"", hash_query))));
 }
 
 TEST_F(UbuntuImageHost, all_info_for_no_remote_query_defaults_to_release)


### PR DESCRIPTION
It's possible that the same full hash will exist in both the release and daily remotes, so don't reject it.

Fixes #2072