### PR TITLE
<lsb-release> reader #1781

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ parts
 prime
 stage
 snap/.snapcraft/state
+
+# build artifacts
+build/
+multipass-build-deps*
+

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -125,6 +125,8 @@ QString make_uuid();
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>
 void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds timeout, TryAction&& try_action,
                     Args&&... args);
+std::pair<QString, QString> read_LSB_Release(const QString& path = "/etc/lsb-release");
+std::pair<QString, QString> parse_LSB_Release(const QStringList& lsb_file_data, const char& delimiter = '=');
 
 } // namespace utils
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -125,8 +125,8 @@ QString make_uuid();
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>
 void try_action_for(OnTimeoutCallable&& on_timeout, std::chrono::milliseconds timeout, TryAction&& try_action,
                     Args&&... args);
-std::pair<QString, QString> read_LSB_Release(const QString& path = "/etc/lsb-release");
-std::pair<QString, QString> parse_LSB_Release(const QStringList& lsb_file_data, const char& delimiter = '=');
+std::pair<QString, QString> read_lsb_release(const QString& path = "/etc/lsb-release");
+std::pair<QString, QString> parse_lsb_release(const QStringList& lsb_file_data, const char& delimiter = '=');
 
 } // namespace utils
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -123,8 +123,11 @@ auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider, const
     auto pollinate_user_agent_string =
         fmt::format("multipass/version/{} # written by Multipass\n", multipass::version_string);
     pollinate_user_agent_string += fmt::format("multipass/driver/{} # written by Multipass\n", backend_version_string);
-    pollinate_user_agent_string += fmt::format("multipass/host/{}-{} # written by Multipass\n", QSysInfo::productType(),
-                                               QSysInfo::productVersion());
+
+    auto OS_descriptor = mp::utils::read_LSB_Release();
+    pollinate_user_agent_string += fmt::format("multipass/host/{}-{} # written by Multipass\n",
+                                               OS_descriptor.first,
+                                               OS_descriptor.second);
 
     YAML::Node pollinate_user_agent_node;
     pollinate_user_agent_node["path"] = "/etc/pollinate/add-user-agent";

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -124,7 +124,7 @@ auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider, const
         fmt::format("multipass/version/{} # written by Multipass\n", multipass::version_string);
     pollinate_user_agent_string += fmt::format("multipass/driver/{} # written by Multipass\n", backend_version_string);
 
-    auto OS_descriptor = mp::utils::read_LSB_Release();
+    auto OS_descriptor = mp::utils::read_lsb_release();
     pollinate_user_agent_string += fmt::format("multipass/host/{}-{} # written by Multipass\n",
                                                OS_descriptor.first,
                                                OS_descriptor.second);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -33,6 +33,7 @@
 #include <QStorageInfo>
 #include <QUuid>
 #include <QtGlobal>
+#include <QTextStream>
 
 #include <algorithm>
 #include <array>
@@ -562,4 +563,53 @@ std::string mp::utils::emit_yaml(const YAML::Node& node)
 std::string mp::utils::emit_cloud_config(const YAML::Node& node)
 {
     return fmt::format("#cloud-config\n{}\n", emit_yaml(node));
+}
+
+std::pair<QString, QString> mp::utils::parse_LSB_Release(const QStringList& lsb_file_data, const char& delimiter)
+{
+    const QString id_postfix = "_ID";
+    const QString release_postfix = "_RELEASE";
+
+    QString distro_id = "parse_distro-id_failed";
+    QString distro_rel = "parse_distro-release_failed";
+
+    for (QString line : lsb_file_data)
+    {
+        QStringList split = line.split(delimiter, Qt::KeepEmptyParts);
+        if (split.length() != 2)
+            continue;
+
+        if (split[0].endsWith(id_postfix, Qt::CaseInsensitive))
+            distro_id = split[1];
+
+        else if (split[0].endsWith(release_postfix, Qt::CaseInsensitive))
+            distro_rel = split[1];
+    }
+
+    return std::pair(distro_id, distro_rel);
+}
+
+std::pair<QString, QString> mp::utils::read_LSB_Release(const QString& path)
+{
+    QStringList lsb_file_data;
+    QFile fd(path);
+    if (fd.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        QTextStream input(&fd);
+
+        QString line = input.readLine();
+        while (!line.isNull())
+        {
+            lsb_file_data.append(line);
+            line = input.readLine();
+        }
+
+        fd.close();
+
+        return parse_LSB_Release(lsb_file_data);
+    }
+    else
+    {
+        return std::pair(QSysInfo::productType(), QSysInfo::productVersion());
+    }
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -565,7 +565,7 @@ std::string mp::utils::emit_cloud_config(const YAML::Node& node)
     return fmt::format("#cloud-config\n{}\n", emit_yaml(node));
 }
 
-std::pair<QString, QString> mp::utils::parse_LSB_Release(const QStringList& lsb_file_data, const char& delimiter)
+std::pair<QString, QString> mp::utils::parse_lsb_release(const QStringList& lsb_file_data, const char& delimiter)
 {
     const QString id_postfix = "_ID";
     const QString release_postfix = "_RELEASE";
@@ -589,7 +589,7 @@ std::pair<QString, QString> mp::utils::parse_LSB_Release(const QStringList& lsb_
     return std::pair(distro_id, distro_rel);
 }
 
-std::pair<QString, QString> mp::utils::read_LSB_Release(const QString& path)
+std::pair<QString, QString> mp::utils::read_lsb_release(const QString& path)
 {
     QStringList lsb_file_data;
     QFile fd(path);
@@ -606,7 +606,7 @@ std::pair<QString, QString> mp::utils::read_LSB_Release(const QString& path)
 
         fd.close();
 
-        return parse_LSB_Release(lsb_file_data);
+        return parse_lsb_release(lsb_file_data);
     }
     else
     {

--- a/tests/test_data/lsb-release_dummy
+++ b/tests/test_data/lsb-release_dummy
@@ -1,0 +1,4 @@
+DISTRIB_ID=distribution_name
+DISTRIB_RELEASE=distribution_release
+DISTRIB_CODENAME=distribution_codename
+DISTRIB_DESCRIPTION=distribution_description

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -25,6 +25,7 @@
 #include "mock_ssh.h"
 #include "mock_ssh_process_exit_status.h"
 #include "mock_virtual_machine.h"
+#include "path.h"
 #include "stub_ssh_key_provider.h"
 #include "temp_dir.h"
 #include "temp_file.h"
@@ -585,19 +586,19 @@ TEST(VaultUtils, copy_throws_when_file_does_not_exist)
                          mpt::match_what(StrEq(fmt::format("{} missing", file_name))));
 }
 
-TEST(Utils, parse_LSB_Release_empty)
+TEST(Utils, parse_lsb_release_empty)
 {
     QStringList input = {};
 
     auto expected = std::pair<std::string, std::string>("parse_distro-id_failed", "parse_distro-release_failed");
 
-    auto output = mp::utils::parse_LSB_Release(input);
+    auto output = mp::utils::parse_lsb_release(input);
 
     EXPECT_EQ(expected.first, output.first.toStdString());
     EXPECT_EQ(expected.second, output.second.toStdString());
 }
 
-TEST(Utils, parse_LSB_Release_Ubuntu2104LTS)
+TEST(Utils, parse_lsb_release_ubuntu2104lts)
 {
     QStringList input = {{"DISTRIB_ID=Ubuntu"},
                          {"DISTRIB_RELEASE=21.04"},
@@ -606,13 +607,13 @@ TEST(Utils, parse_LSB_Release_Ubuntu2104LTS)
 
     auto expected = std::pair<std::string, std::string>("Ubuntu", "21.04");
 
-    auto output = mp::utils::parse_LSB_Release(input);
+    auto output = mp::utils::parse_lsb_release(input);
 
     EXPECT_EQ(expected.first, output.first.toStdString());
     EXPECT_EQ(expected.second, output.second.toStdString());
 }
 
-TEST(Utils, parse_LSB_Release_Ubuntu2104LTS_rotation)
+TEST(Utils, parse_lsb_release_ubuntu2104lts_rotation)
 {
     QStringList input = {{"DISTRIB_CODENAME=hirsute"},
                          {"DISTRIB_RELEASE=21.04"},
@@ -621,13 +622,13 @@ TEST(Utils, parse_LSB_Release_Ubuntu2104LTS_rotation)
 
     auto expected = std::pair<std::string, std::string>("Ubuntu", "21.04");
 
-    auto output = mp::utils::parse_LSB_Release(input);
+    auto output = mp::utils::parse_lsb_release(input);
 
     EXPECT_EQ(expected.first, output.first.toStdString());
     EXPECT_EQ(expected.second, output.second.toStdString());
 }
 
-TEST(Utils, parse_LSB_Release_Ubuntu2104LTS_delimiter)
+TEST(Utils, parse_lsb_release_ubuntu2104lts_delimiter)
 {
     QStringList input = {{"DISTRIB_CODENAME#hirsute"},
                          {"DISTRIB_RELEASE#21.04"},
@@ -636,13 +637,13 @@ TEST(Utils, parse_LSB_Release_Ubuntu2104LTS_delimiter)
 
     auto expected = std::pair<std::string, std::string>("Ubuntu", "21.04");
 
-    auto output = mp::utils::parse_LSB_Release(input, '#');
+    auto output = mp::utils::parse_lsb_release(input, '#');
 
     EXPECT_EQ(expected.first, output.first.toStdString());
     EXPECT_EQ(expected.second, output.second.toStdString());
 }
 
-TEST(Utils, parse_LSB_Release_Ubuntu2104LTS_delimiter_fail)
+TEST(Utils, parse_lsb_release_ubuntu2104lts_delimiter_fail)
 {
     QStringList input = {{"DISTRIB_CODENAME=hirsute"},
                          {"DISTRIB_RELEASE=21.04"},
@@ -651,13 +652,13 @@ TEST(Utils, parse_LSB_Release_Ubuntu2104LTS_delimiter_fail)
 
     auto expected = std::pair<std::string, std::string>("parse_distro-id_failed", "parse_distro-release_failed");
 
-    auto output = mp::utils::parse_LSB_Release(input, '#');
+    auto output = mp::utils::parse_lsb_release(input, '#');
 
     EXPECT_EQ(expected.first, output.first.toStdString());
     EXPECT_EQ(expected.second, output.second.toStdString());
 }
 
-TEST(Utils, parse_LSB_Release_Ubuntu2104LTS_case_insenstive)
+TEST(Utils, parse_lsb_release_ubuntu2104lts_case_insenstive)
 {
     QStringList input = {{"DISTRIB_id=Ubuntu"},
                          {"DISTRIB_release=21.04"},
@@ -666,27 +667,27 @@ TEST(Utils, parse_LSB_Release_Ubuntu2104LTS_case_insenstive)
 
     auto expected = std::pair<std::string, std::string>("Ubuntu", "21.04");
 
-    auto output = mp::utils::parse_LSB_Release(input);
+    auto output = mp::utils::parse_lsb_release(input);
 
     EXPECT_EQ(expected.first, output.first.toStdString());
     EXPECT_EQ(expected.second, output.second.toStdString());
 }
 
-TEST(Utils, read_LSB_Release_from_file)
+TEST(Utils, read_lsb_release_from_file)
 {
     auto expected = std::pair<std::string, std::string>("distribution_name", "distribution_release");
 
-    auto output = mp::utils::read_LSB_Release("../../tests/test_data/lsb-release_dummy");
+    auto output = mp::utils::read_lsb_release(mpt::test_data_path() + "lsb-release_dummy");
 
     EXPECT_EQ(expected.first, output.first.toStdString());
     EXPECT_EQ(expected.second, output.second.toStdString());
 }
 
-TEST(Utils, read_LSB_Release_from_OS)
+TEST(Utils, read_lsb_release_from_os)
 {
     auto expected = std::pair(QSysInfo::productType(), QSysInfo::productVersion());
 
-    auto output = mp::utils::read_LSB_Release("/non-existent/dummy/file/no-where-to-be-found");
+    auto output = mp::utils::read_lsb_release("/non-existent/dummy/file/no-where-to-be-found");
 
     EXPECT_EQ(expected.first.toStdString(), output.first.toStdString());
     EXPECT_EQ(expected.second.toStdString(), output.second.toStdString());


### PR DESCRIPTION
**_With respect to issue #1781:_**
I have developed tests and utility routines to read the `lsb-release` file on Ubuntu-based systems when applicable. When it is unavailable, or parsing fails, there will be a failover to the previous method of using `SysInfo::productType()` and `QSysInfo::productVersion()`.