### PR TITLE
[qemu] ensure `dnsmasq.hosts` exists

### DIFF
--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -52,6 +52,13 @@ mp::DNSMasqServer::DNSMasqServer(const Path& data_dir, const QString& bridge_nam
     conf_file.open();
     conf_file.close();
 
+    QFile fd_Hosts(QDir(data_dir).filePath("dnsmasq.hosts"));
+    if (!fd_Hosts.exists())
+    {
+        fd_Hosts.open(QIODevice::WriteOnly);
+        fd_Hosts.close();
+    }
+
     dnsmasq_cmd = make_dnsmasq_process(data_dir, bridge_name, subnet, conf_file.fileName());
     start_dnsmasq();
 }

--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -52,10 +52,10 @@ mp::DNSMasqServer::DNSMasqServer(const Path& data_dir, const QString& bridge_nam
     conf_file.open();
     conf_file.close();
 
-    QFile fd_Hosts(QDir(data_dir).filePath("dnsmasq.hosts"));
-    if (!fd_Hosts.exists())
+    QFile dnsmasq_hosts(QDir(data_dir).filePath("dnsmasq.hosts"));
+    if (!dnsmasq_hosts.exists())
     {
-        fd_Hosts.open(QIODevice::WriteOnly);
+        dnsmasq_hosts.open(QIODevice::WriteOnly);
     }
 
     dnsmasq_cmd = make_dnsmasq_process(data_dir, bridge_name, subnet, conf_file.fileName());

--- a/src/platform/backends/qemu/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/dnsmasq_server.cpp
@@ -56,7 +56,6 @@ mp::DNSMasqServer::DNSMasqServer(const Path& data_dir, const QString& bridge_nam
     if (!fd_Hosts.exists())
     {
         fd_Hosts.open(QIODevice::WriteOnly);
-        fd_Hosts.close();
     }
 
     dnsmasq_cmd = make_dnsmasq_process(data_dir, bridge_name, subnet, conf_file.fileName());

--- a/tests/qemu/test_dnsmasq_server.cpp
+++ b/tests/qemu/test_dnsmasq_server.cpp
@@ -171,6 +171,14 @@ TEST_F(DNSMasqServer, dnsmasq_creates_conf_file)
     EXPECT_FALSE(QDir(data_dir.path()).entryList({"dnsmasq-??????.conf"}, QDir::Files).isEmpty());
 }
 
+TEST_F(DNSMasqServer, dnsmasq_creates_empty_dnsmasq_hosts_file)
+{
+    const QString dnsmasq_hosts{QDir{data_dir.path()}.filePath("dnsmasq.hosts")};
+    auto dns = make_default_dnsmasq_server();
+
+    EXPECT_TRUE(QFile::exists(dnsmasq_hosts));
+}
+
 struct DNSMasqServerMockedProcess : public DNSMasqServer
 {
     void SetUp() override


### PR DESCRIPTION
**_With respect to issue #1118:_**
Added a check on `DNSMasq` bootstrapping for `dnsmasq.hosts` file in the constructor. If absent, an empty file will be created in the `data_dir`.