### PR TITLE
Fix eclipsing vms in ctor

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -901,6 +901,14 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
         }
 
         auto vm_image = fetch_image_for(name, config->factory->fetch_type(), *config->vault);
+        if (!QFile::exists(vm_image.image_path))
+        {
+            mpl::log(mpl::Level::warning, category,
+                     fmt::format("Could not find image for '{}'. Expected location: {}", name, vm_image.image_path));
+            invalid_specs.push_back(name);
+            continue;
+        }
+
         const auto instance_dir = mp::utils::base_dir(vm_image.image_path);
         const auto cloud_init_iso = instance_dir.filePath("cloud-init-config.iso");
         mp::VirtualMachineDescription vm_desc{spec.num_cores,

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -953,6 +953,7 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
 
     for (const auto& bad_spec : invalid_specs)
     {
+        mpl::log(mpl::Level::warning, category, fmt::format("Removing invalid instance: {}", bad_spec));
         vm_instance_specs.erase(bad_spec);
     }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -917,18 +917,8 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
                                               {},
                                               {}};
 
-        try
-        {
-            auto& instance_record = spec.deleted ? deleted_instances : vm_instances;
-            instance_record[name] = config->factory->create_virtual_machine(vm_desc, *this);
-        }
-        catch (const std::exception& e)
-        {
-            mpl::log(mpl::Level::error, category, fmt::format("Removing instance {}: {}", name, e.what()));
-            invalid_specs.push_back(name);
-            config->vault->remove(name);
-            continue;
-        }
+        auto& instance_record = spec.deleted ? deleted_instances : vm_instances;
+        instance_record[name] = config->factory->create_virtual_machine(vm_desc, *this);
 
         allocated_mac_addrs = std::move(new_macs); // Add the new macs to the daemon's list only if we got this far
 

--- a/tests/mock_vm_image_vault.h
+++ b/tests/mock_vm_image_vault.h
@@ -37,7 +37,7 @@ public:
     MockVMImageVault()
     {
         ON_CALL(*this, fetch_image(_, _, _, _)).WillByDefault([this](auto, auto, const PrepareAction& prepare, auto) {
-            return prepare({dummy_image.name(), dummy_image.name(), dummy_image.name(), {}, {}, {}, {}, {}});
+            return VMImage{dummy_image.name(), dummy_image.name(), dummy_image.name(), {}, {}, {}, {}, {}};
         });
         ON_CALL(*this, has_record_for(_)).WillByDefault(Return(true));
         ON_CALL(*this, minimum_image_size_for(_)).WillByDefault(Return(MemorySize{"1048576"}));

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1148,9 +1148,12 @@ TEST_F(Daemon, ctor_drops_removed_instances)
 
     std::stringstream stream;
     send_command({"list"}, stream);
-    EXPECT_THAT(stream.str(), AllOf(HasSubstr(stayed), Not(HasSubstr(gone))));
 
-    // TODO@ricab verify json
+    auto instance_matchers = AllOf(HasSubstr(stayed), Not(HasSubstr(gone)));
+    EXPECT_THAT(stream.str(), instance_matchers);
+
+    auto updated_json = mpt::load(filename);
+    EXPECT_THAT(updated_json.toStdString(), instance_matchers);
 }
 
 TEST_P(ListIP, lists_with_ip)


### PR DESCRIPTION
Let exceptions that arise when creating a VM in the daemon constructor through. This avoids erasing instance data that could be recoverable and important for the user, but aborts the daemon since it can't honor its database, which would otherwise be out of sync. More robust approaches for particular causes can always added. Fixes #1658.