### PR TITLE
[3rd-party] Bump scope_guard to v1.0.0

### DIFF
--- a/3rd-party/submodule_info.md
+++ b/3rd-party/submodule_info.md
@@ -27,7 +27,7 @@ Version: 1.4.2 |
 <https://github.com/Skycoder42/QHotkey/releases>
 
 ### scope_guard
-Version: 0.2.3 (+[upstream patches](https://github.com/ricab/scope_guard/compare/v0.2.3..760de0a)) |
+Version: 1.0.0 |
 <https://github.com/ricab/scope_guard.git> |
 <https://github.com/ricab/scope_guard/releases>
 


### PR DESCRIPTION
Needed to avoid warning in newer clangs:

```
`ISO C++ requires the name after '::~' to be found in the same scope as the name before '::~' [-Werror,-Wdtor-name]
sg::detail::scope_guard<Callback>::~scope_guard() noexcept´
```