### PR TITLE
Improve Timer test reliability part deux

### DIFF
--- a/include/multipass/timer.h
+++ b/include/multipass/timer.h
@@ -53,7 +53,7 @@ private:
     void main();
     const std::chrono::seconds timeout;
     const std::function<void()> callback;
-    TimerState state;
+    TimerState current_state;
     std::thread t;
     std::condition_variable cv;
     std::mutex cv_m;

--- a/include/multipass/timer.h
+++ b/include/multipass/timer.h
@@ -52,7 +52,7 @@ private:
     void main();
     const std::chrono::seconds timeout;
     const std::function<void()> callback;
-    multipass::utils::TimerState state;
+    TimerState state;
     std::thread t;
     std::condition_variable cv;
     std::mutex cv_m;

--- a/include/multipass/timer.h
+++ b/include/multipass/timer.h
@@ -47,6 +47,7 @@ public:
     void pause();
     void resume();
     void stop();
+    TimerState current_state();
 
 private:
     void main();

--- a/include/multipass/timer.h
+++ b/include/multipass/timer.h
@@ -47,7 +47,7 @@ public:
     void pause();
     void resume();
     void stop();
-    TimerState current_state();
+    TimerState state();
 
 private:
     void main();

--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -92,3 +92,10 @@ void mpu::Timer::stop()
     if (t.joinable())
         t.join();
 }
+
+mpu::TimerState mpu::Timer::current_state()
+{
+    std::lock_guard<std::mutex> lk(cv_m);
+
+    return state;
+}

--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -93,7 +93,7 @@ void mpu::Timer::stop()
         t.join();
 }
 
-mpu::TimerState mpu::Timer::current_state()
+mpu::TimerState mpu::Timer::state()
 {
     std::lock_guard<std::mutex> lk(cv_m);
 

--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -18,20 +18,19 @@
 #include <multipass/timer.h>
 #include <multipass/top_catch_all.h>
 
-namespace multipass::utils
-{
+namespace mpu = multipass::utils;
 
-Timer::Timer(std::chrono::seconds timeout, std::function<void()> callback)
+mpu::Timer::Timer(std::chrono::seconds timeout, std::function<void()> callback)
     : timeout(timeout), callback(callback), state(TimerState::Stopped)
 {
 }
 
-Timer::~Timer()
+mpu::Timer::~Timer()
 {
     multipass::top_catch_all("timer", [this]() { stop(); });
 }
 
-void Timer::start()
+void mpu::Timer::start()
 {
     stop();
 
@@ -39,7 +38,7 @@ void Timer::start()
     t = std::thread(&Timer::main, this);
 }
 
-void Timer::main()
+void mpu::Timer::main()
 {
     auto remaining_time = timeout;
     std::unique_lock<std::mutex> lk(cv_m);
@@ -60,7 +59,7 @@ void Timer::main()
     }
 }
 
-void Timer::pause()
+void mpu::Timer::pause()
 {
     {
         std::lock_guard<std::mutex> lk(cv_m);
@@ -71,7 +70,7 @@ void Timer::pause()
     cv.notify_all();
 }
 
-void Timer::resume()
+void mpu::Timer::resume()
 {
     {
         std::lock_guard<std::mutex> lk(cv_m);
@@ -82,7 +81,7 @@ void Timer::resume()
     cv.notify_all();
 }
 
-void Timer::stop()
+void mpu::Timer::stop()
 {
     {
         std::lock_guard<std::mutex> lk(cv_m);
@@ -93,5 +92,3 @@ void Timer::stop()
     if (t.joinable())
         t.join();
 }
-
-} // namespace multipass::utils

--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -53,12 +53,12 @@ TEST_F(Timer, times_out)
 
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
+    EXPECT_EQ(t.state(), mpu::TimerState::Running);
 
     cv.wait_for(lk, 10ms); // Windows CI needs longer...
 
     ASSERT_TRUE(timedout.load()) << "Should have timed out";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
+    EXPECT_EQ(t.state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, stops)
@@ -67,13 +67,13 @@ TEST_F(Timer, stops)
 
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
+    EXPECT_EQ(t.state(), mpu::TimerState::Running);
 
     t.stop();
     std::this_thread::sleep_for(5ms);
 
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
+    EXPECT_EQ(t.state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, pauses)
@@ -82,13 +82,13 @@ TEST_F(Timer, pauses)
 
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
+    EXPECT_EQ(t.state(), mpu::TimerState::Running);
 
     t.pause();
     std::this_thread::sleep_for(5ms);
 
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Paused);
+    EXPECT_EQ(t.state(), mpu::TimerState::Paused);
 }
 
 TEST_F(Timer, resumes)
@@ -104,23 +104,23 @@ TEST_F(Timer, resumes)
 
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
+    EXPECT_EQ(t.state(), mpu::TimerState::Running);
 
     lk.unlock();
 
     t.pause();
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Paused);
+    EXPECT_EQ(t.state(), mpu::TimerState::Paused);
 
     std::this_thread::sleep_for(5ms);
     lk.lock();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
 
     t.resume();
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
+    EXPECT_EQ(t.state(), mpu::TimerState::Running);
 
     cv.wait_for(lk, 10ms); // Windows CI needs longer...
     ASSERT_TRUE(timedout.load()) << "Should have timed out now";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
+    EXPECT_EQ(t.state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, stops_paused)
@@ -129,16 +129,16 @@ TEST_F(Timer, stops_paused)
 
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
+    EXPECT_EQ(t.state(), mpu::TimerState::Running);
 
     t.pause();
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Paused);
+    EXPECT_EQ(t.state(), mpu::TimerState::Paused);
 
     t.stop();
     std::this_thread::sleep_for(5ms);
 
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
+    EXPECT_EQ(t.state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, cancels)
@@ -185,7 +185,7 @@ TEST_F(Timer, stopped_ignores_pause)
     t.pause();
 
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
+    EXPECT_EQ(t.state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, stopped_ignores_resume)
@@ -195,7 +195,7 @@ TEST_F(Timer, stopped_ignores_resume)
     t.resume();
 
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
-    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
+    EXPECT_EQ(t.state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, running_ignores_resume)

--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -50,40 +50,50 @@ TEST_F(Timer, times_out)
                      cv.notify_all();
                  }};
     std::unique_lock<std::mutex> lk(cv_m);
+
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
 
     cv.wait_for(lk, 10ms); // Windows CI needs longer...
+
     ASSERT_TRUE(timedout.load()) << "Should have timed out";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, stops)
 {
-    mpu::Timer t{duration_cast<seconds>(1ms), [this]() { timedout.store(true); }};
+    mpu::Timer t{duration_cast<seconds>(10s), [this]() { timedout.store(true); }};
+
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
 
     t.stop();
-
     std::this_thread::sleep_for(5ms);
+
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, pauses)
 {
-    mpu::Timer t{duration_cast<seconds>(1ms), [this]() { timedout.store(true); }};
+    mpu::Timer t{duration_cast<seconds>(10s), [this]() { timedout.store(true); }};
+
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
 
     t.pause();
-
     std::this_thread::sleep_for(5ms);
+
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Paused);
 }
 
 TEST_F(Timer, resumes)
 {
-    mpu::Timer t{duration_cast<seconds>(1ms), [this]() {
+    mpu::Timer t{duration_cast<seconds>(5ms), [this]() {
                      {
                          std::lock_guard<std::mutex> lk{cv_m};
                          timedout.store(true);
@@ -91,39 +101,50 @@ TEST_F(Timer, resumes)
                      cv.notify_all();
                  }};
     std::unique_lock<std::mutex> lk(cv_m);
+
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
+
     lk.unlock();
 
     t.pause();
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Paused);
 
     std::this_thread::sleep_for(5ms);
     lk.lock();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
 
     t.resume();
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
 
     cv.wait_for(lk, 10ms); // Windows CI needs longer...
     ASSERT_TRUE(timedout.load()) << "Should have timed out now";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, stops_paused)
 {
-    mpu::Timer t{duration_cast<seconds>(1ms), [this]() { timedout.store(true); }};
+    mpu::Timer t{duration_cast<seconds>(10s), [this]() { timedout.store(true); }};
+
     t.start();
     ASSERT_FALSE(timedout.load()) << "Should not have timed out yet";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Running);
 
     t.pause();
-    t.stop();
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Paused);
 
+    t.stop();
     std::this_thread::sleep_for(5ms);
+
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, cancels)
 {
     {
-        mpu::Timer t{duration_cast<seconds>(1ms), [this]() { timedout.store(true); }};
+        mpu::Timer t{duration_cast<seconds>(10s), [this]() { timedout.store(true); }};
         t.start();
     }
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
@@ -164,6 +185,7 @@ TEST_F(Timer, stopped_ignores_pause)
     t.pause();
 
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, stopped_ignores_resume)
@@ -173,6 +195,7 @@ TEST_F(Timer, stopped_ignores_resume)
     t.resume();
 
     ASSERT_FALSE(timedout.load()) << "Should not have timed out";
+    EXPECT_EQ(t.current_state(), mpu::TimerState::Stopped);
 }
 
 TEST_F(Timer, running_ignores_resume)


### PR DESCRIPTION
Adds a getter function for current Timer state for better testing Timer state expectations.
Relax timeouts in some tests to improve reliability.