### PR TITLE
Bash completions for the aliases features

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -48,6 +48,28 @@ _multipass_complete()
         opts=$( \eval $cmd | \grep -Ev '(\+--|Name)' | \cut -d',' -f 1 )
     }
 
+    _multipass_instances_with_colon()
+    {
+        local opts_bak="${opts}"
+        opts=""
+
+        _multipass_instances
+        local instances="${opts}"
+        opts="$opts_bak"
+
+        for instance in ${instances}; do
+            opts="${opts} ${instance}:"
+        done
+    }
+
+    # Set $multipass_aliases to the list of available aliases.
+    _multipass_aliases()
+    {
+        local cmd="bin/multipass aliases --format=csv 2>/dev/null"
+
+        multipass_aliases=$( \eval $cmd | \grep -Ev '(\+--|Alias)' | \cut -d',' -f 1 )
+    }
+
     # Removes the comma or equals sign at the end of $cur.
     _remove_trailing_char()
     {
@@ -126,7 +148,7 @@ _multipass_complete()
         COMP_WORDBREAKS="${COMP_WORDBREAKS}="
     fi
 
-    local cur cmd opts prev prev2 prev_opts
+    local cur cmd opts prev prev2 prev_opts multipass_aliases
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -134,9 +156,14 @@ _multipass_complete()
     cmd="${COMP_WORDS[1]}"
     prev_opts=false
     multipass_cmds="transfer delete exec find help info launch list mount networks \
-                    purge recover shell start stop suspend restart umount version get set"
+                    purge recover shell start stop suspend restart umount version get set \
+                    alias aliases unalias"
 
-    opts="--help --verbose"
+    if [[ "${multipass_cmds}" =~ " ${cmd} " || "${multipass_cmds}" =~ ^${cmd} || "${multipass_cmds}" =~ \ ${cmd}$ ]];
+    then
+        opts="--help --verbose"
+    fi
+
     case "${cmd}" in
         "info")
             opts="${opts} --all --format"
@@ -164,6 +191,9 @@ _multipass_complete()
         ;;
         "find")
             opts="${opts} --show-unsupported --format"
+        ;;
+        "aliases")
+            opts="${opts} --format"
         ;;
     esac
 
@@ -266,6 +296,10 @@ _multipass_complete()
                     return
                 fi
             ;;
+            "alias")
+                _multipass_instances_with_colon
+                compopt -o nospace
+            ;;
             "help")
                 opts=$multipass_cmds
             ;;
@@ -273,7 +307,8 @@ _multipass_complete()
     fi
 
     if [[ ${COMP_CWORD} -eq 1 ]]; then
-        opts="${opts} ${multipass_cmds}"
+        _multipass_aliases
+        opts="${opts} ${multipass_cmds} ${multipass_aliases}"
     fi
 
     if [[ -n "${opts}" ]]; then

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -62,6 +62,31 @@ _multipass_complete()
         done
     }
 
+    # When we are completing the `alias` command, this function makes sure that each argument was specified at most
+    # once. It fills $opts with the variables which were not yet specified.
+    # Precondition: the command must be "alias".
+    _unspecified_alias_vars()
+    {
+        opts=""
+
+        local help_found=0
+        local definition_found=0
+        local verbose_found=0
+
+        for ((i=$1+1; i<COMP_CWORD; ++i)); do
+            if [[ "${COMP_WORDS[$i]}" == '--help' ]]; then help_found=1; fi
+            if [[ "${COMP_WORDS[$i]}" == '--verbose' ]]; then verbose_found=1; fi
+            if [[ "${COMP_WORDS[$i]}" =~ ':' ]]; then definition_found=1; fi
+        done
+
+        if [[ ${help_found} == 0 ]]; then opts="${opts} --help"; fi
+        if [[ ${verbose_found} == 0 ]]; then opts="${opts} --verbose"; fi
+
+        if [[ ${definition_found} == 0 ]] && [[ "${cur}" != ':' ]]; then
+            _multipass_instances_with_colon
+        fi
+    }
+
     # Set $multipass_aliases to the list of available aliases.
     _multipass_aliases()
     {
@@ -297,9 +322,7 @@ _multipass_complete()
                 fi
             ;;
             "alias")
-                if [[ "${cur}" != ':' ]]; then
-                    _multipass_instances_with_colon
-                fi
+                _unspecified_alias_vars
                 compopt -o nospace
             ;;
             "help")

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -297,7 +297,9 @@ _multipass_complete()
                 fi
             ;;
             "alias")
-                _multipass_instances_with_colon
+                if [[ "${cur}" != ':' ]]; then
+                    _multipass_instances_with_colon
+                fi
                 compopt -o nospace
             ;;
             "help")

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -221,6 +221,10 @@ _multipass_complete()
         "aliases")
             opts="${opts} --format"
         ;;
+        "unalias")
+            _multipass_aliases
+            opts="${opts} ${multipass_aliases}"
+        ;;
     esac
 
     if [[ ${prev} == -* ]]; then

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -65,6 +65,7 @@ _multipass_complete()
     # When we are completing the `alias` command, this function makes sure that each argument was specified at most
     # once. It fills $opts with the variables which were not yet specified.
     # Precondition: the command must be "alias".
+    # Parameters: none.
     _unspecified_alias_vars()
     {
         opts=""
@@ -73,7 +74,7 @@ _multipass_complete()
         local definition_found=0
         local verbose_found=0
 
-        for ((i=$1+1; i<COMP_CWORD; ++i)); do
+        for ((i=2; i<COMP_CWORD; ++i)); do
             if [[ "${COMP_WORDS[$i]}" == '--help' ]]; then help_found=1; fi
             if [[ "${COMP_WORDS[$i]}" == '--verbose' ]]; then verbose_found=1; fi
             if [[ "${COMP_WORDS[$i]}" =~ ':' ]]; then definition_found=1; fi

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -324,6 +324,7 @@ _multipass_complete()
             ;;
             "alias")
                 _unspecified_alias_vars
+                # TODO: Do use spaces after the completion of an option starting with "--".
                 compopt -o nospace
             ;;
             "help")

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -65,7 +65,7 @@ _multipass_complete()
     # Set $multipass_aliases to the list of available aliases.
     _multipass_aliases()
     {
-        local cmd="bin/multipass aliases --format=csv 2>/dev/null"
+        local cmd="multipass aliases --format=csv 2>/dev/null"
 
         multipass_aliases=$( \eval $cmd | \grep -Ev '(\+--|Alias)' | \cut -d',' -f 1 )
     }


### PR DESCRIPTION
This PR adds completion for the Multipass commands `alias`, `unalias` and `aliases`.