### PR TITLE
Inject templated mock singleton characters

### DIFF
--- a/tests/mock_singleton_helpers.h
+++ b/tests/mock_singleton_helpers.h
@@ -44,10 +44,11 @@ public:                                                                         
 
 #define MP_MOCK_SINGLETON_INJECT(mock_class, parent_class)                                                             \
 public:                                                                                                                \
+    template <template <typename /*MockClass*/> typename MockCharacter = ::testing::NaggyMock>                         \
     [[nodiscard]] static GuardedMock inject()                                                                          \
     {                                                                                                                  \
         parent_class::reset();                                                                                         \
-        parent_class::mock<mock_class>();                                                                              \
+        parent_class::mock<MockCharacter<mock_class>>();                                                               \
         return std::make_pair(&mock_instance(), academy());                                                            \
     } // one at a time, please!
 
@@ -55,7 +56,8 @@ public:                                                                         
 public:                                                                                                                \
     MP_MOCK_SINGLETON_HELPER_TYPES(mock_class, parent_class)                                                           \
     MP_MOCK_SINGLETON_INSTANCE(mock_class)                                                                             \
-    MP_MOCK_SINGLETON_INJECT(mock_class, parent_class)
+    MP_MOCK_SINGLETON_INJECT(mock_class, parent_class)                                                                 \
+    void please_dont_call_this_undefined_method_that_gobbles_semicolons() // see https://godbolt.org/z/7ac1zaGxr
 
 namespace multipass::test
 {

--- a/tests/mock_utils.h
+++ b/tests/mock_utils.h
@@ -34,7 +34,7 @@ public:
     MOCK_METHOD1(exit, void(int));
     MOCK_METHOD3(wait_for_cloud_init, void(VirtualMachine*, std::chrono::milliseconds, const SSHKeyProvider&));
 
-    MP_MOCK_SINGLETON_BOILERPLATE(::testing::NiceMock<MockUtils>, Utils);
+    MP_MOCK_SINGLETON_BOILERPLATE(MockUtils, Utils);
 };
 } // namespace multipass::test
 #endif // MULTIPASS_MOCK_UTILS_FUNCTIONS_H

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -114,8 +114,8 @@ struct Daemon : public mpt::DaemonTestFixture
             .Times(AnyNumber()); /* Admit get calls beyond explicitly expected in tests. */
     }
 
-    mpt::MockUtils::GuardedMock attr{mpt::MockUtils::inject()};
-    NiceMock<mpt::MockUtils>* mock_utils = attr.first;
+    mpt::MockUtils::GuardedMock attr{mpt::MockUtils::inject<NiceMock>()};
+    mpt::MockUtils* mock_utils = attr.first;
 
     mpt::MockPlatform::GuardedMock platform_attr{mpt::MockPlatform::inject()};
     mpt::MockPlatform* mock_platform = platform_attr.first;


### PR DESCRIPTION
This allows callers of `inject` to decide the "mock character" (naggy, nice, strict) they want, instead of fixing it in the declaration of the singleton mock class.