### PR TITLE
[cli] Info For No Active Mounts

### DIFF
--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -93,10 +93,13 @@ std::string mp::TableFormatter::format(const InfoReply& reply) const
         fmt::format_to(buf, "{:<16}{}\n", "Memory usage:", to_usage(info.memory_usage(), info.memory_total()));
 
         auto mount_paths = info.mount_info().mount_paths();
+        fmt::format_to(buf, "{:<16}{}", "Mounts:", (mount_paths.empty()) ? "--\n" : "");
         for (auto mount = mount_paths.cbegin(); mount != mount_paths.cend(); ++mount)
         {
-            fmt::format_to(buf, "{:<16}{:{}} => {}\n", (mount == mount_paths.cbegin()) ? "Mounts:" : " ",
-                           mount->source_path(), info.mount_info().longest_path_len(), mount->target_path());
+            if (mount != mount_paths.cbegin())
+                fmt::format_to(buf, "{:<16}", " ");
+            fmt::format_to(buf, "{:{}} => {}\n", mount->source_path(), info.mount_info().longest_path_len(),
+                           mount->target_path());
 
             for (auto uid_map = mount->mount_maps().uid_map().cbegin(); uid_map != mount->mount_maps().uid_map().cend();
                  ++uid_map)

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -97,7 +97,7 @@ std::string mp::TableFormatter::format(const InfoReply& reply) const
         for (auto mount = mount_paths.cbegin(); mount != mount_paths.cend(); ++mount)
         {
             if (mount != mount_paths.cbegin())
-                fmt::format_to(buf, "{:<16}", " ");
+                fmt::format_to(buf, "{:<16}", "");
             fmt::format_to(buf, "{:{}} => {}\n", mount->source_path(), info.mount_info().longest_path_len(),
                            mount->target_path());
 

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -93,7 +93,7 @@ std::string mp::TableFormatter::format(const InfoReply& reply) const
         fmt::format_to(buf, "{:<16}{}\n", "Memory usage:", to_usage(info.memory_usage(), info.memory_total()));
 
         auto mount_paths = info.mount_info().mount_paths();
-        fmt::format_to(buf, "{:<16}{}", "Mounts:", (mount_paths.empty()) ? "--\n" : "");
+        fmt::format_to(buf, "{:<16}{}", "Mounts:", mount_paths.empty() ? "--\n" : "");
         for (auto mount = mount_paths.cbegin(); mount != mount_paths.cend(); ++mount)
         {
             if (mount != mount_paths.cbegin())

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -447,7 +447,8 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "Image hash:     ab5191cc1725 (Ubuntu 18.04 LTS)\n"
      "Load:           --\n"
      "Disk usage:     --\n"
-     "Memory usage:   --\n",
+     "Memory usage:   --\n"
+     "Mounts:         --\n",
      "table_info_multiple"},
 
     {&csv_formatter, &empty_list_reply, "Name,State,IPv4,IPv6,Release,AllIPv4\n", "csv_list_empty"},


### PR DESCRIPTION
**_Issue #2108:_**
Should output `--` when no active mounts are available in conformity with `table` output for other unavailable information:
https://github.com/surahman/multipass/blob/5f9ba4bd6db5fa31f59cbae0fbbf8fb3556e2d29/tests/test_output_formatter.cpp#L431-L452

The other formatters seem to already handle this situation. `YAML` outputs its `null` indicator as a tilde `~` character, `JSON` will create a `null` sub-record, and  `CSV` will output an empty field.