### PR TITLE
[timer] Make current_state enum atomic

### DIFF
--- a/include/multipass/timer.h
+++ b/include/multipass/timer.h
@@ -18,6 +18,7 @@
 #ifndef MULTIPASS_TIMER_H
 #define MULTIPASS_TIMER_H
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -53,7 +54,7 @@ private:
     void main();
     const std::chrono::seconds timeout;
     const std::function<void()> callback;
-    TimerState current_state;
+    std::atomic<TimerState> current_state;
     std::thread t;
     std::condition_variable cv;
     std::mutex cv_m;

--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -95,7 +95,5 @@ void mpu::Timer::stop()
 
 mpu::TimerState mpu::Timer::state()
 {
-    std::lock_guard<std::mutex> lk(cv_m);
-
     return current_state;
 }

--- a/src/utils/timer.cpp
+++ b/src/utils/timer.cpp
@@ -61,32 +61,28 @@ void mpu::Timer::main()
 
 void mpu::Timer::pause()
 {
-    {
-        std::lock_guard<std::mutex> lk(cv_m);
-        if (current_state != TimerState::Running)
-            return;
-        current_state = TimerState::Paused;
-    }
+    if (current_state != TimerState::Running)
+        return;
+
+    current_state = TimerState::Paused;
+
     cv.notify_all();
 }
 
 void mpu::Timer::resume()
 {
-    {
-        std::lock_guard<std::mutex> lk(cv_m);
-        if (current_state != TimerState::Paused)
-            return;
-        current_state = TimerState::Running;
-    }
+    if (current_state != TimerState::Paused)
+        return;
+
+    current_state = TimerState::Running;
+
     cv.notify_all();
 }
 
 void mpu::Timer::stop()
 {
-    {
-        std::lock_guard<std::mutex> lk(cv_m);
-        current_state = TimerState::Stopped;
-    }
+    current_state = TimerState::Stopped;
+
     cv.notify_all();
 
     if (t.joinable())


### PR DESCRIPTION
Make the current_state enum atomic and remove some of the locks.  This also makes the state() getter deterministic.
