### PR TITLE
Singleton consts

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -36,21 +36,21 @@ public:
     FileOps(const Singleton<FileOps>::PrivatePass&) noexcept;
 
     // QDir operations
-    virtual bool isReadable(QDir& dir);
-    virtual bool rmdir(QDir& dir, const QString& dirName);
+    virtual bool isReadable(QDir& dir) const;
+    virtual bool rmdir(QDir& dir, const QString& dirName) const;
 
     // QFile operations
-    virtual bool open(QFile& file, QIODevice::OpenMode mode);
+    virtual bool open(QFile& file, QIODevice::OpenMode mode) const;
     virtual bool is_open(const QFile& file) const;
-    virtual qint64 read(QFile& file, char* data, qint64 maxSize);
+    virtual qint64 read(QFile& file, char* data, qint64 maxSize) const;
     virtual QString read_line(QTextStream& text_stream) const;
-    virtual bool remove(QFile& file);
-    virtual bool rename(QFile& file, const QString& newName);
-    virtual bool resize(QFile& file, qint64 sz);
-    virtual bool seek(QFile& file, qint64 pos);
-    virtual bool setPermissions(QFile& file, QFileDevice::Permissions permissions);
-    virtual qint64 write(QFile& file, const char* data, qint64 maxSize);
-    virtual qint64 write(QFile& file, const QByteArray& data);
+    virtual bool remove(QFile& file) const;
+    virtual bool rename(QFile& file, const QString& newName) const;
+    virtual bool resize(QFile& file, qint64 sz) const;
+    virtual bool seek(QFile& file, qint64 pos) const;
+    virtual bool setPermissions(QFile& file, QFileDevice::Permissions permissions) const;
+    virtual qint64 write(QFile& file, const char* data, qint64 maxSize) const;
+    virtual qint64 write(QFile& file, const QByteArray& data) const;
 };
 } // namespace multipass
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -50,13 +50,13 @@ public:
     Platform(const Singleton::PrivatePass&) noexcept;
     // Get information on the network interfaces that are seen by the platform, indexed by name
     virtual std::map<std::string, NetworkInterfaceInfo> get_network_interfaces_info() const;
-    virtual QString get_workflows_url_override();
-    virtual bool is_alias_supported(const std::string& alias, const std::string& remote);
-    virtual bool is_remote_supported(const std::string& remote);
-    virtual int chown(const char* path, unsigned int uid, unsigned int gid);
-    virtual bool link(const char* target, const char* link);
-    virtual bool symlink(const char* target, const char* link, bool is_dir);
-    virtual int utime(const char* path, int atime, int mtime);
+    virtual QString get_workflows_url_override() const;
+    virtual bool is_alias_supported(const std::string& alias, const std::string& remote) const;
+    virtual bool is_remote_supported(const std::string& remote) const;
+    virtual int chown(const char* path, unsigned int uid, unsigned int gid) const;
+    virtual bool link(const char* target, const char* link) const;
+    virtual bool symlink(const char* target, const char* link, bool is_dir) const;
+    virtual int utime(const char* path, int atime, int mtime) const;
 };
 
 std::map<QString, QString> extra_settings_defaults();

--- a/include/multipass/poco_zip_utils.h
+++ b/include/multipass/poco_zip_utils.h
@@ -33,7 +33,7 @@ class PocoZipUtils : public Singleton<PocoZipUtils>
 public:
     PocoZipUtils(const Singleton<PocoZipUtils>::PrivatePass&) noexcept;
 
-    virtual Poco::Zip::ZipArchive zip_archive_for(std::ifstream& zip_stream);
+    virtual Poco::Zip::ZipArchive zip_archive_for(std::ifstream& zip_stream) const;
 };
 } // namespace multipass
 

--- a/include/multipass/url_downloader.h
+++ b/include/multipass/url_downloader.h
@@ -40,7 +40,7 @@ class NetworkManagerFactory : public Singleton<NetworkManagerFactory>
 public:
     NetworkManagerFactory(const Singleton<NetworkManagerFactory>::PrivatePass&) noexcept;
 
-    virtual std::unique_ptr<QNetworkAccessManager> make_network_manager(const Path& cache_dir_path);
+    virtual std::unique_ptr<QNetworkAccessManager> make_network_manager(const Path& cache_dir_path) const;
 };
 
 class URLDownloader

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -133,12 +133,12 @@ class Utils : public Singleton<Utils>
 public:
     Utils(const Singleton<Utils>::PrivatePass&) noexcept;
 
-    virtual qint64 filesystem_bytes_available(const QString& data_directory);
+    virtual qint64 filesystem_bytes_available(const QString& data_directory) const;
     virtual void exit(int code);
 
     // virtual machine helpers
     virtual void wait_for_cloud_init(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
-                                     const SSHKeyProvider& key_provider);
+                                     const SSHKeyProvider& key_provider) const;
 
     // system info helpers
     virtual std::string get_kernel_version() const;

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -156,7 +156,8 @@ mp::NetworkManagerFactory::NetworkManagerFactory(const Singleton<NetworkManagerF
 {
 }
 
-std::unique_ptr<QNetworkAccessManager> mp::NetworkManagerFactory::make_network_manager(const mp::Path& cache_dir_path)
+std::unique_ptr<QNetworkAccessManager>
+mp::NetworkManagerFactory::make_network_manager(const mp::Path& cache_dir_path) const
 {
     return ::make_network_manager(cache_dir_path);
 }

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -224,23 +224,23 @@ std::map<std::string, mp::NetworkInterfaceInfo> mp::platform::Platform::get_netw
     return detail::get_network_interfaces_from(sysfs);
 }
 
-QString mp::platform::Platform::get_workflows_url_override()
+QString mp::platform::Platform::get_workflows_url_override() const
 {
     return QString::fromUtf8(qgetenv("MULTIPASS_WORKFLOWS_URL"));
 }
 
-bool mp::platform::Platform::is_alias_supported(const std::string& alias, const std::string& remote)
+bool mp::platform::Platform::is_alias_supported(const std::string& alias, const std::string& remote) const
 {
     return true;
 }
 
-bool mp::platform::Platform::is_remote_supported(const std::string& remote)
+bool mp::platform::Platform::is_remote_supported(const std::string& remote) const
 {
     // snapcraft:core{18,20} images don't work on LXD yet, so whack it altogether.
     return remote != "snapcraft" || utils::get_driver_str() != "lxd";
 }
 
-bool mp::platform::Platform::link(const char* target, const char* link)
+bool mp::platform::Platform::link(const char* target, const char* link) const
 {
     return ::link(target, link) == 0;
 }

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -46,17 +46,17 @@ sftp_attributes_struct stat_to_attr(const struct stat* st)
 }
 } // namespace
 
-int mp::platform::Platform::chown(const char* path, unsigned int uid, unsigned int gid)
+int mp::platform::Platform::chown(const char* path, unsigned int uid, unsigned int gid) const
 {
     return ::lchown(path, uid, gid);
 }
 
-bool mp::platform::Platform::symlink(const char* target, const char* link, bool is_dir)
+bool mp::platform::Platform::symlink(const char* target, const char* link, bool is_dir) const
 {
     return ::symlink(target, link) == 0;
 }
 
-int mp::platform::Platform::utime(const char* path, int atime, int mtime)
+int mp::platform::Platform::utime(const char* path, int atime, int mtime) const
 {
     struct timeval tv[2];
     tv[0].tv_sec = atime;

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -23,17 +23,17 @@ mp::FileOps::FileOps(const Singleton<FileOps>::PrivatePass& pass) noexcept : Sin
 {
 }
 
-bool mp::FileOps::isReadable(QDir& dir)
+bool mp::FileOps::isReadable(QDir& dir) const
 {
     return dir.isReadable();
 }
 
-bool mp::FileOps::rmdir(QDir& dir, const QString& dirName)
+bool mp::FileOps::rmdir(QDir& dir, const QString& dirName) const
 {
     return dir.rmdir(dirName);
 }
 
-bool mp::FileOps::open(QFile& file, QIODevice::OpenMode mode)
+bool mp::FileOps::open(QFile& file, QIODevice::OpenMode mode) const
 {
     return file.open(mode);
 }
@@ -43,7 +43,7 @@ bool mp::FileOps::is_open(const QFile& file) const
     return file.isOpen();
 }
 
-qint64 mp::FileOps::read(QFile& file, char* data, qint64 maxSize)
+qint64 mp::FileOps::read(QFile& file, char* data, qint64 maxSize) const
 {
     return file.read(data, maxSize);
 }
@@ -53,37 +53,37 @@ QString mp::FileOps::read_line(QTextStream& text_stream) const
     return text_stream.readLine();
 }
 
-bool mp::FileOps::remove(QFile& file)
+bool mp::FileOps::remove(QFile& file) const
 {
     return file.remove();
 }
 
-bool mp::FileOps::rename(QFile& file, const QString& newName)
+bool mp::FileOps::rename(QFile& file, const QString& newName) const
 {
     return file.rename(newName);
 }
 
-bool mp::FileOps::resize(QFile& file, qint64 sz)
+bool mp::FileOps::resize(QFile& file, qint64 sz) const
 {
     return file.resize(sz);
 }
 
-bool mp::FileOps::seek(QFile& file, qint64 pos)
+bool mp::FileOps::seek(QFile& file, qint64 pos) const
 {
     return file.seek(pos);
 }
 
-bool mp::FileOps::setPermissions(QFile& file, QFileDevice::Permissions permissions)
+bool mp::FileOps::setPermissions(QFile& file, QFileDevice::Permissions permissions) const
 {
     return file.setPermissions(permissions);
 }
 
-qint64 mp::FileOps::write(QFile& file, const char* data, qint64 maxSize)
+qint64 mp::FileOps::write(QFile& file, const char* data, qint64 maxSize) const
 {
     return file.write(data, maxSize);
 }
 
-qint64 mp::FileOps::write(QFile& file, const QByteArray& data)
+qint64 mp::FileOps::write(QFile& file, const QByteArray& data) const
 {
     return file.write(data);
 }

--- a/src/utils/poco_zip_utils.cpp
+++ b/src/utils/poco_zip_utils.cpp
@@ -24,7 +24,7 @@ mp::PocoZipUtils::PocoZipUtils(const Singleton<PocoZipUtils>::PrivatePass& pass)
 {
 }
 
-Poco::Zip::ZipArchive mp::PocoZipUtils::zip_archive_for(std::ifstream& zip_stream)
+Poco::Zip::ZipArchive mp::PocoZipUtils::zip_archive_for(std::ifstream& zip_stream) const
 {
     return Poco::Zip::ZipArchive{zip_stream};
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -83,7 +83,7 @@ mp::Utils::Utils(const Singleton<Utils>::PrivatePass& pass) noexcept : Singleton
 {
 }
 
-qint64 mp::Utils::filesystem_bytes_available(const QString& data_directory)
+qint64 mp::Utils::filesystem_bytes_available(const QString& data_directory) const
 {
     return QStorageInfo(QDir(data_directory)).bytesAvailable();
 }
@@ -94,7 +94,7 @@ void mp::Utils::exit(int code)
 }
 
 void mp::Utils::wait_for_cloud_init(mp::VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
-                                    const mp::SSHKeyProvider& key_provider)
+                                    const mp::SSHKeyProvider& key_provider) const
 {
     auto action = [virtual_machine, &key_provider] {
         virtual_machine->ensure_vm_is_running();

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef MULTIPASS_MOCK_FILE_OPS_H
-#define MULTIPASS_MOCK_FILE_OPS_H
+#ifndef MULTIPASS_MOCK_CONST_FILE_OPS_H
+#define MULTIPASS_MOCK_CONST_FILE_OPS_H
 
 #include "mock_singleton_helpers.h"
 
@@ -31,19 +31,19 @@ class MockFileOps : public FileOps
 public:
     using FileOps::FileOps;
 
-    MOCK_METHOD1(isReadable, bool(QDir&));
-    MOCK_METHOD2(rmdir, bool(QDir&, const QString& dirName));
-    MOCK_METHOD2(open, bool(QFile&, QIODevice::OpenMode));
+    MOCK_CONST_METHOD1(isReadable, bool(QDir&));
+    MOCK_CONST_METHOD2(rmdir, bool(QDir&, const QString& dirName));
+    MOCK_CONST_METHOD2(open, bool(QFile&, QIODevice::OpenMode));
     MOCK_CONST_METHOD1(is_open, bool(const QFile&));
-    MOCK_METHOD3(read, qint64(QFile&, char*, qint64));
+    MOCK_CONST_METHOD3(read, qint64(QFile&, char*, qint64));
     MOCK_CONST_METHOD1(read_line, QString(QTextStream&));
-    MOCK_METHOD1(remove, bool(QFile&));
-    MOCK_METHOD2(rename, bool(QFile&, const QString& newName));
-    MOCK_METHOD2(resize, bool(QFile&, qint64 sz));
-    MOCK_METHOD2(seek, bool(QFile&, qint64 pos));
-    MOCK_METHOD2(setPermissions, bool(QFile&, QFileDevice::Permissions));
-    MOCK_METHOD3(write, qint64(QFile&, const char*, qint64));
-    MOCK_METHOD2(write, qint64(QFile&, const QByteArray&));
+    MOCK_CONST_METHOD1(remove, bool(QFile&));
+    MOCK_CONST_METHOD2(rename, bool(QFile&, const QString& newName));
+    MOCK_CONST_METHOD2(resize, bool(QFile&, qint64 sz));
+    MOCK_CONST_METHOD2(seek, bool(QFile&, qint64 pos));
+    MOCK_CONST_METHOD2(setPermissions, bool(QFile&, QFileDevice::Permissions));
+    MOCK_CONST_METHOD3(write, qint64(QFile&, const char*, qint64));
+    MOCK_CONST_METHOD2(write, qint64(QFile&, const QByteArray&));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockFileOps, FileOps);
 };

--- a/tests/mock_network.h
+++ b/tests/mock_network.h
@@ -78,7 +78,7 @@ class MockNetworkManagerFactory : public NetworkManagerFactory
 public:
     using NetworkManagerFactory::NetworkManagerFactory;
 
-    MOCK_METHOD1(make_network_manager, std::unique_ptr<QNetworkAccessManager>(const Path&));
+    MOCK_CONST_METHOD1(make_network_manager, std::unique_ptr<QNetworkAccessManager>(const Path&));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockNetworkManagerFactory, NetworkManagerFactory);
 };

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -31,13 +31,13 @@ class MockPlatform : public platform::Platform
 public:
     using Platform::Platform;
     MOCK_CONST_METHOD0(get_network_interfaces_info, std::map<std::string, NetworkInterfaceInfo>());
-    MOCK_METHOD0(get_workflows_url_override, QString());
-    MOCK_METHOD1(is_remote_supported, bool(const std::string&));
-    MOCK_METHOD2(is_alias_supported, bool(const std::string&, const std::string&));
-    MOCK_METHOD3(chown, int(const char*, unsigned int, unsigned int));
-    MOCK_METHOD2(link, bool(const char*, const char*));
-    MOCK_METHOD3(symlink, bool(const char*, const char*, bool));
-    MOCK_METHOD3(utime, int(const char*, int, int));
+    MOCK_CONST_METHOD0(get_workflows_url_override, QString());
+    MOCK_CONST_METHOD1(is_remote_supported, bool(const std::string&));
+    MOCK_CONST_METHOD2(is_alias_supported, bool(const std::string&, const std::string&));
+    MOCK_CONST_METHOD3(chown, int(const char*, unsigned int, unsigned int));
+    MOCK_CONST_METHOD2(link, bool(const char*, const char*));
+    MOCK_CONST_METHOD3(symlink, bool(const char*, const char*, bool));
+    MOCK_CONST_METHOD3(utime, int(const char*, int, int));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockPlatform, Platform);
 };

--- a/tests/mock_poco_zip_utils.h
+++ b/tests/mock_poco_zip_utils.h
@@ -31,7 +31,7 @@ class MockPocoZipUtils : public PocoZipUtils
 public:
     using PocoZipUtils::PocoZipUtils;
 
-    MOCK_METHOD1(zip_archive_for, Poco::Zip::ZipArchive(std::ifstream&));
+    MOCK_CONST_METHOD1(zip_archive_for, Poco::Zip::ZipArchive(std::ifstream&));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockPocoZipUtils, PocoZipUtils);
 };

--- a/tests/mock_utils.h
+++ b/tests/mock_utils.h
@@ -32,9 +32,9 @@ class MockUtils : public Utils
 {
 public:
     using Utils::Utils;
-    MOCK_METHOD1(filesystem_bytes_available, qint64(const QString&));
+    MOCK_CONST_METHOD1(filesystem_bytes_available, qint64(const QString&));
     MOCK_METHOD1(exit, void(int));
-    MOCK_METHOD3(wait_for_cloud_init, void(VirtualMachine*, std::chrono::milliseconds, const SSHKeyProvider&));
+    MOCK_CONST_METHOD3(wait_for_cloud_init, void(VirtualMachine*, std::chrono::milliseconds, const SSHKeyProvider&));
     MOCK_CONST_METHOD0(get_kernel_version, std::string());
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockUtils, Utils);


### PR DESCRIPTION
Add missing `const`s to singleton methods. I left a couple of conceptual exceptions untouched, like `Utils::exit` or `Settings::set`. The latter would allow caching without changing the interface.