### PR TITLE
[snap] Add system-observe interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,6 +48,7 @@ apps:
       - network-observe # for network listing (to read `/sys/devices/**/net/*`)
       - lxd
       - removable-media
+      - system-observe  # to read the host's os-release
   multipass:
     environment:
       <<: &client-environment


### PR DESCRIPTION
To be able to read the host's os-release.