### PR TITLE
Teach GTest to print QStrings while avoiding breaking ODR

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MULTIPASS_GMOCK_DIR ${CMAKE_SOURCE_DIR}/3rd-party/grpc/third_party/googletes
 set(MULTIPASS_GTEST_DIR ${CMAKE_SOURCE_DIR}/3rd-party/grpc/third_party/googletest/googletest)
 
 add_executable(multipass_tests
+  common.cpp
   file_operations.cpp
   image_host_remote_count.cpp
   main.cpp

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common.h"
+
+#include <multipass/network_interface.h>
+#include <multipass/network_interface_info.h>
+
+#include <QString>
+
+#include <ostream>
+
+QT_BEGIN_NAMESPACE
+void PrintTo(const QString& qstr, std::ostream* os)
+{
+    *os << "QString(\"" << qUtf8Printable(qstr) << "\")";
+}
+QT_END_NAMESPACE
+
+void multipass::PrintTo(const NetworkInterface& net, std::ostream* os)
+{
+    *os << "NetworkInterface(id=\"" << net.id << "\")";
+}
+
+void multipass::PrintTo(const NetworkInterfaceInfo& net, std::ostream* os)
+{
+    *os << "NetworkInterfaceInfo(id=\"" << net.id << "\")";
+}

--- a/tests/common.h
+++ b/tests/common.h
@@ -64,6 +64,13 @@
         },                                                                                                             \
         expected_exception)
 
+QT_BEGIN_NAMESPACE
+inline void PrintTo(const QString& qstr, std::ostream* os)
+{
+    *os << "QString(\"" << qUtf8Printable(qstr) << "\")";
+}
+QT_END_NAMESPACE
+
 namespace multipass
 {
 inline void PrintTo(const NetworkInterface& net, std::ostream* os) // teaching gtest to print NetworkInterface

--- a/tests/common.h
+++ b/tests/common.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef MULTIPASS_EXTRA_ASSERTIONS_H
-#define MULTIPASS_EXTRA_ASSERTIONS_H
+#ifndef MULTIPASS_COMMON_H
+#define MULTIPASS_COMMON_H
 
 #include <multipass/format.h>
 #include <multipass/network_interface.h>
@@ -105,4 +105,4 @@ auto match_qstring(StrMatcher&& matcher)
 }
 } // namespace multipass::test
 
-#endif // MULTIPASS_EXTRA_ASSERTIONS_H
+#endif // MULTIPASS_COMMON_H

--- a/tests/common.h
+++ b/tests/common.h
@@ -19,16 +19,11 @@
 #define MULTIPASS_COMMON_H
 
 #include <multipass/format.h>
-#include <multipass/network_interface.h>
-#include <multipass/network_interface_info.h>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <QString>
-
 #include <algorithm>
-#include <ostream>
 
 // Extra macros for testing exceptions.
 //
@@ -64,26 +59,23 @@
         },                                                                                                             \
         expected_exception)
 
+// Teach GTest to print Qt stuff
 QT_BEGIN_NAMESPACE
-inline void PrintTo(const QString& qstr, std::ostream* os)
-{
-    *os << "QString(\"" << qUtf8Printable(qstr) << "\")";
-}
+class QString;
+void PrintTo(const QString& qstr, std::ostream* os);
 QT_END_NAMESPACE
 
+// Teach GTest to print multipass stuff
 namespace multipass
 {
-inline void PrintTo(const NetworkInterface& net, std::ostream* os) // teaching gtest to print NetworkInterface
-{
-    *os << "NetworkInterface(id=\"" << net.id << "\")";
-}
+struct NetworkInterface;
+struct NetworkInterfaceInfo;
 
-inline void PrintTo(const NetworkInterfaceInfo& net, std::ostream* os) // teaching gtest to print NetworkInterfaceInfo
-{
-    *os << "NetworkInterfaceInfo(id=\"" << net.id << "\")";
-}
+void PrintTo(const NetworkInterface& net, std::ostream* os);
+void PrintTo(const NetworkInterfaceInfo& net, std::ostream* os);
 } // namespace multipass
 
+// Matchers
 namespace multipass::test
 {
 MATCHER_P(ContainedIn, container, "")

--- a/tests/daemon_test_fixture.h
+++ b/tests/daemon_test_fixture.h
@@ -29,7 +29,7 @@
 #include <multipass/cli/command.h>
 #include <multipass/rpc/multipass.grpc.pb.h>
 
-#include "extra_assertions.h"
+#include "common.h"
 #include "mock_standard_paths.h"
 #include "mock_virtual_machine_factory.h"
 #include "stub_cert_store.h"
@@ -42,8 +42,6 @@
 #include "stub_vm_image_vault.h"
 #include "stub_vm_workflow_provider.h"
 #include "temp_dir.h"
-
-#include <gmock/gmock.h>
 
 #include <memory>
 

--- a/tests/daemon_test_fixture.h
+++ b/tests/daemon_test_fixture.h
@@ -18,17 +18,6 @@
 #ifndef MULTIPASS_DAEMON_TEST_FIXTURE_H
 #define MULTIPASS_DAEMON_TEST_FIXTURE_H
 
-#include <src/client/cli/client.h>
-#include <src/daemon/daemon_config.h>
-#include <src/daemon/daemon_rpc.h>
-#include <src/platform/update/disabled_update_prompt.h>
-
-#include <multipass/auto_join_thread.h>
-#include <multipass/cli/argparser.h>
-#include <multipass/cli/client_common.h>
-#include <multipass/cli/command.h>
-#include <multipass/rpc/multipass.grpc.pb.h>
-
 #include "common.h"
 #include "mock_standard_paths.h"
 #include "mock_virtual_machine_factory.h"
@@ -42,6 +31,17 @@
 #include "stub_vm_image_vault.h"
 #include "stub_vm_workflow_provider.h"
 #include "temp_dir.h"
+
+#include <src/client/cli/client.h>
+#include <src/daemon/daemon_config.h>
+#include <src/daemon/daemon_rpc.h>
+#include <src/platform/update/disabled_update_prompt.h>
+
+#include <multipass/auto_join_thread.h>
+#include <multipass/cli/argparser.h>
+#include <multipass/cli/client_common.h>
+#include <multipass/cli/command.h>
+#include <multipass/rpc/multipass.grpc.pb.h>
 
 #include <memory>
 

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -15,9 +15,7 @@
  *
  */
 
-#include <src/platform/backends/libvirt/libvirt_virtual_machine_factory.h>
-
-#include "tests/extra_assertions.h"
+#include "tests/common.h"
 #include "tests/fake_handle.h"
 #include "tests/mock_ssh.h"
 #include "tests/mock_status_monitor.h"
@@ -33,9 +31,9 @@
 #include <multipass/virtual_machine.h>
 #include <multipass/virtual_machine_description.h>
 
-#include <cstdlib>
+#include <src/platform/backends/libvirt/libvirt_virtual_machine_factory.h>
 
-#include <gmock/gmock.h>
+#include <cstdlib>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -24,14 +24,13 @@
 #include "tests/temp_dir.h"
 #include "tests/temp_file.h"
 
+#include <src/platform/backends/libvirt/libvirt_virtual_machine_factory.h>
+
 #include <multipass/auto_join_thread.h>
 #include <multipass/exceptions/start_exception.h>
 #include <multipass/memory_size.h>
-#include <multipass/platform.h>
 #include <multipass/virtual_machine.h>
 #include <multipass/virtual_machine_description.h>
-
-#include <src/platform/backends/libvirt/libvirt_virtual_machine_factory.h>
 
 #include <cstdlib>
 

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -29,6 +29,7 @@
 #include <multipass/auto_join_thread.h>
 #include <multipass/exceptions/start_exception.h>
 #include <multipass/memory_size.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine.h>
 #include <multipass/virtual_machine_description.h>
 

--- a/tests/linux/test_apparmored_process.cpp
+++ b/tests/linux/test_apparmored_process.cpp
@@ -15,18 +15,18 @@
  *
  */
 
-#include <multipass/format.h>
-#include <multipass/process/process.h>
-#include <src/platform/backends/shared/linux/process_factory.h>
-
 #include "mock_aa_syscalls.h"
+#include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_logger.h"
 #include "tests/reset_process_factory.h"
 #include "tests/temp_dir.h"
 #include "tests/test_with_mocked_bin_path.h"
 
-#include <gmock/gmock.h>
+#include <multipass/format.h>
+#include <multipass/process/process.h>
+
+#include <src/platform/backends/shared/linux/process_factory.h>
 
 #include <QFile>
 

--- a/tests/linux/test_apparmored_process.cpp
+++ b/tests/linux/test_apparmored_process.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "mock_aa_syscalls.h"
+
 #include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_logger.h"
@@ -23,10 +24,10 @@
 #include "tests/temp_dir.h"
 #include "tests/test_with_mocked_bin_path.h"
 
+#include <src/platform/backends/shared/linux/process_factory.h>
+
 #include <multipass/format.h>
 #include <multipass/process/process.h>
-
-#include <src/platform/backends/shared/linux/process_factory.h>
 
 #include <QFile>
 

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -15,25 +15,21 @@
  *
  */
 
-#include <src/platform/backends/shared/linux/backend_utils.h>
-#include <src/platform/backends/shared/linux/dbus_wrappers.h>
-
-#include <multipass/format.h>
-#include <multipass/logging/log.h>
-#include <multipass/memory_size.h>
-
-#include <shared/shared_backend_utils.h>
-
-#include "tests/extra_assertions.h"
+#include "tests/common.h"
 #include "tests/mock_logger.h"
 #include "tests/mock_process_factory.h"
 #include "tests/mock_singleton_helpers.h"
 
+#include <multipass/format.h>
+#include <multipass/logging/log.h>
+#include <multipass/memory_size.h>
+#include <src/platform/backends/shared/linux/backend_utils.h>
+#include <src/platform/backends/shared/linux/dbus_wrappers.h>
+
+#include <shared/shared_backend_utils.h>
+
 #include <QMap>
 #include <QVariant>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -20,13 +20,13 @@
 #include "tests/mock_process_factory.h"
 #include "tests/mock_singleton_helpers.h"
 
-#include <multipass/format.h>
-#include <multipass/logging/log.h>
-#include <multipass/memory_size.h>
+#include <shared/shared_backend_utils.h>
 #include <src/platform/backends/shared/linux/backend_utils.h>
 #include <src/platform/backends/shared/linux/dbus_wrappers.h>
 
-#include <shared/shared_backend_utils.h>
+#include <multipass/format.h>
+#include <multipass/logging/log.h>
+#include <multipass/memory_size.h>
 
 #include <QMap>
 #include <QVariant>

--- a/tests/linux/test_local_network_access_manager.cpp
+++ b/tests/linux/test_local_network_access_manager.cpp
@@ -18,6 +18,7 @@
 #include "local_socket_server_test_fixture.h"
 #include "mock_q_buffer.h"
 #include "mock_q_local_socket.h"
+#include "tests/common.h"
 #include "tests/temp_dir.h"
 
 #include <src/network/local_socket_reply.h>
@@ -33,8 +34,6 @@
 #include <QEventLoop>
 #include <QNetworkReply>
 #include <QTimer>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/linux/test_local_network_access_manager.cpp
+++ b/tests/linux/test_local_network_access_manager.cpp
@@ -18,6 +18,7 @@
 #include "local_socket_server_test_fixture.h"
 #include "mock_q_buffer.h"
 #include "mock_q_local_socket.h"
+
 #include "tests/common.h"
 #include "tests/temp_dir.h"
 
@@ -26,14 +27,13 @@
 #include <multipass/exceptions/http_local_socket_exception.h>
 #include <multipass/exceptions/local_socket_connection_exception.h>
 #include <multipass/network_access_manager.h>
-#include <multipass/version.h>
-
-#include <random>
 
 #include <QBuffer>
 #include <QEventLoop>
 #include <QNetworkReply>
 #include <QTimer>
+
+#include <random>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -15,11 +15,14 @@
  *
  */
 
+#include "tests/common.h"
 #include "tests/fake_handle.h"
 #include "tests/file_operations.h"
 #include "tests/mock_environment_helpers.h"
+#include "tests/mock_file_ops.h"
 #include "tests/mock_process_factory.h"
 #include "tests/mock_settings.h"
+#include "tests/path.h"
 #include "tests/temp_dir.h"
 #include "tests/test_with_mocked_bin_path.h"
 
@@ -32,21 +35,16 @@
 #include <multipass/constants.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
 #include <multipass/exceptions/settings_exceptions.h>
+#include <multipass/file_ops.h>
 #include <multipass/platform.h>
+
+#include <scope_guard.hpp>
 
 #include <QDir>
 #include <QFile>
 #include <QString>
 
-#include <scope_guard.hpp>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
-#include <multipass/file_ops.h>
 #include <stdexcept>
-#include <tests/mock_file_ops.h>
-#include <tests/path.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -22,7 +22,6 @@
 #include "tests/mock_file_ops.h"
 #include "tests/mock_process_factory.h"
 #include "tests/mock_settings.h"
-#include "tests/path.h"
 #include "tests/temp_dir.h"
 #include "tests/test_with_mocked_bin_path.h"
 
@@ -35,7 +34,6 @@
 #include <multipass/constants.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
 #include <multipass/exceptions/settings_exceptions.h>
-#include <multipass/file_ops.h>
 #include <multipass/platform.h>
 
 #include <scope_guard.hpp>

--- a/tests/linux/test_snap_utils.cpp
+++ b/tests/linux/test_snap_utils.cpp
@@ -15,17 +15,16 @@
  *
  */
 
+#include "tests/common.h"
+#include "tests/mock_environment_helpers.h"
+
 #include <multipass/exceptions/snap_environment_exception.h>
 #include <multipass/snap_utils.h>
 
 #include <QFile>
 #include <QTemporaryDir>
 
-#include <gtest/gtest.h>
-
 #include <utility>
-
-#include "tests/mock_environment_helpers.h"
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/lxd/mock_network_access_manager.h
+++ b/tests/lxd/mock_network_access_manager.h
@@ -18,11 +18,10 @@
 #ifndef MULTIPASS_MOCK_NETWORK_ACCESS_MANAGER_H
 #define MULTIPASS_MOCK_NETWORK_ACCESS_MANAGER_H
 
-#include <multipass/network_access_manager.h>
-
 #include "mock_local_socket_reply.h"
+#include "tests/common.h"
 
-#include <gmock/gmock.h>
+#include <multipass/network_access_manager.h>
 
 using namespace testing;
 

--- a/tests/lxd/mock_network_access_manager.h
+++ b/tests/lxd/mock_network_access_manager.h
@@ -19,6 +19,7 @@
 #define MULTIPASS_MOCK_NETWORK_ACCESS_MANAGER_H
 
 #include "mock_local_socket_reply.h"
+
 #include "tests/common.h"
 
 #include <multipass/network_access_manager.h>

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -22,10 +22,11 @@
 #include "mock_local_socket_reply.h"
 #include "mock_lxd_server_responses.h"
 #include "mock_network_access_manager.h"
-#include "tests/extra_assertions.h"
+#include "tests/common.h"
 #include "tests/mock_backend_utils.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_logger.h"
+#include "tests/mock_platform.h"
 #include "tests/mock_status_monitor.h"
 #include "tests/stub_status_monitor.h"
 #include "tests/stub_url_downloader.h"
@@ -42,9 +43,6 @@
 #include <QJsonDocument>
 #include <QString>
 #include <QUrl>
-
-#include <gmock/gmock.h>
-#include <tests/mock_platform.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -15,13 +15,10 @@
  *
  */
 
-#include <src/platform/backends/lxd/lxd_virtual_machine.h>
-#include <src/platform/backends/lxd/lxd_virtual_machine_factory.h>
-#include <src/platform/backends/lxd/lxd_vm_image_vault.h>
-
 #include "mock_local_socket_reply.h"
 #include "mock_lxd_server_responses.h"
 #include "mock_network_access_manager.h"
+
 #include "tests/common.h"
 #include "tests/mock_backend_utils.h"
 #include "tests/mock_environment_helpers.h"
@@ -31,6 +28,10 @@
 #include "tests/stub_status_monitor.h"
 #include "tests/stub_url_downloader.h"
 #include "tests/temp_dir.h"
+
+#include <src/platform/backends/lxd/lxd_virtual_machine.h>
+#include <src/platform/backends/lxd/lxd_virtual_machine_factory.h>
+#include <src/platform/backends/lxd/lxd_vm_image_vault.h>
 
 #include <multipass/auto_join_thread.h>
 #include <multipass/exceptions/local_socket_connection_exception.h>

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -20,7 +20,7 @@
 #include "mock_local_socket_reply.h"
 #include "mock_lxd_server_responses.h"
 #include "mock_network_access_manager.h"
-#include "tests/extra_assertions.h"
+#include "tests/common.h"
 #include "tests/mock_image_host.h"
 #include "tests/mock_logger.h"
 #include "tests/mock_process_factory.h"
@@ -36,8 +36,6 @@
 #include <QUrl>
 
 #include <vector>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -15,11 +15,10 @@
  *
  */
 
-#include <src/platform/backends/lxd/lxd_vm_image_vault.h>
-
 #include "mock_local_socket_reply.h"
 #include "mock_lxd_server_responses.h"
 #include "mock_network_access_manager.h"
+
 #include "tests/common.h"
 #include "tests/mock_image_host.h"
 #include "tests/mock_logger.h"
@@ -27,6 +26,8 @@
 #include "tests/stub_url_downloader.h"
 #include "tests/temp_dir.h"
 #include "tests/tracking_url_downloader.h"
+
+#include <src/platform/backends/lxd/lxd_vm_image_vault.h>
 
 #include <multipass/exceptions/aborted_download_exception.h>
 #include <multipass/exceptions/local_socket_connection_exception.h>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,10 +15,9 @@
  *
  */
 
+#include "common.h"
 #include "mock_settings.h"
 #include "mock_standard_paths.h"
-
-#include <gtest/gtest.h>
 
 #include <QCoreApplication>
 

--- a/tests/mock_backend_utils.h
+++ b/tests/mock_backend_utils.h
@@ -18,11 +18,10 @@
 #ifndef MULTIPASS_MOCK_BACKEND_UTILS_H
 #define MULTIPASS_MOCK_BACKEND_UTILS_H
 
+#include "common.h"
 #include "mock_singleton_helpers.h"
 
 #include <src/platform/backends/shared/linux/backend_utils.h>
-
-#include <gmock/gmock.h>
 
 namespace multipass::test
 {

--- a/tests/mock_daemon.h
+++ b/tests/mock_daemon.h
@@ -21,7 +21,7 @@
 #include <src/daemon/daemon.h>
 #include <src/daemon/daemon_rpc.h>
 
-#include <gmock/gmock.h>
+#include "common.h"
 
 namespace multipass
 {

--- a/tests/mock_daemon.h
+++ b/tests/mock_daemon.h
@@ -18,10 +18,10 @@
 #ifndef MULTIPASS_MOCK_DAEMON_H
 #define MULTIPASS_MOCK_DAEMON_H
 
+#include "common.h"
+
 #include <src/daemon/daemon.h>
 #include <src/daemon/daemon_rpc.h>
-
-#include "common.h"
 
 namespace multipass
 {

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -18,11 +18,10 @@
 #ifndef MULTIPASS_MOCK_CONST_FILE_OPS_H
 #define MULTIPASS_MOCK_CONST_FILE_OPS_H
 
+#include "common.h"
 #include "mock_singleton_helpers.h"
 
 #include <multipass/file_ops.h>
-
-#include <gmock/gmock.h>
 
 namespace multipass::test
 {

--- a/tests/mock_image_host.h
+++ b/tests/mock_image_host.h
@@ -18,11 +18,11 @@
 #ifndef MULTIPASS_MOCK_IMAGE_HOST_H
 #define MULTIPASS_MOCK_IMAGE_HOST_H
 
-#include <multipass/vm_image_host.h>
-
+#include "common.h"
 #include "temp_file.h"
 
-#include <gmock/gmock.h>
+#include <multipass/query.h>
+#include <multipass/vm_image_host.h>
 
 using namespace testing;
 

--- a/tests/mock_logger.h
+++ b/tests/mock_logger.h
@@ -18,12 +18,11 @@
 #ifndef MULTIPASS_MOCK_LOGGER_H
 #define MULTIPASS_MOCK_LOGGER_H
 
+#include "common.h"
+
 #include <multipass/logging/log.h>
 #include <multipass/logging/logger.h>
 #include <multipass/private_pass_provider.h>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 namespace multipass
 {

--- a/tests/mock_network.h
+++ b/tests/mock_network.h
@@ -18,14 +18,13 @@
 #ifndef MULTIPASS_MOCK_NETWORK_H
 #define MULTIPASS_MOCK_NETWORK_H
 
+#include "common.h"
 #include "mock_singleton_helpers.h"
 
 #include <multipass/url_downloader.h>
 
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
-
-#include <gmock/gmock.h>
 
 namespace multipass::test
 {

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -18,11 +18,10 @@
 #ifndef MULTIPASS_MOCK_PLATFORM_H
 #define MULTIPASS_MOCK_PLATFORM_H
 
+#include "common.h"
 #include "mock_singleton_helpers.h"
 
 #include <multipass/platform.h>
-
-#include <gmock/gmock.h>
 
 namespace multipass::test
 {

--- a/tests/mock_poco_zip_utils.h
+++ b/tests/mock_poco_zip_utils.h
@@ -18,11 +18,10 @@
 #ifndef MULTIPASS_MOCK_POCO_ZIP_UTILS_H
 #define MULTIPASS_MOCK_POCO_ZIP_UTILS_H
 
+#include "common.h"
 #include "mock_singleton_helpers.h"
 
 #include <multipass/poco_zip_utils.h>
-
-#include <gmock/gmock.h>
 
 namespace multipass::test
 {

--- a/tests/mock_process_factory.h
+++ b/tests/mock_process_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,8 +18,9 @@
 #ifndef MULTIPASS_MOCK_PROCESS_FACTORY_H
 #define MULTIPASS_MOCK_PROCESS_FACTORY_H
 
+#include "common.h"
 #include "process_factory.h" // rely on build system to include the right implementation
-#include <gmock/gmock.h>
+
 #include <multipass/optional.h>
 #include <multipass/process/process.h>
 

--- a/tests/mock_settings.h
+++ b/tests/mock_settings.h
@@ -18,11 +18,10 @@
 #ifndef MULTIPASS_MOCK_SETTINGS_H
 #define MULTIPASS_MOCK_SETTINGS_H
 
+#include "common.h"
 #include "mock_singleton_helpers.h"
 
 #include <multipass/settings.h>
-
-#include <gmock/gmock.h>
 
 namespace multipass
 {

--- a/tests/mock_singleton_helpers.h
+++ b/tests/mock_singleton_helpers.h
@@ -18,9 +18,9 @@
 #ifndef MULTIPASS_MOCK_SINGLETON_HELPERS_H
 #define MULTIPASS_MOCK_SINGLETON_HELPERS_H
 
-#include <scope_guard.hpp>
+#include "common.h"
 
-#include <gmock/gmock.h>
+#include <scope_guard.hpp>
 
 #include <cassert>
 #include <utility>

--- a/tests/mock_standard_paths.h
+++ b/tests/mock_standard_paths.h
@@ -18,11 +18,10 @@
 #ifndef MULTIPASS_MOCK_STANDARD_PATHS_H
 #define MULTIPASS_MOCK_STANDARD_PATHS_H
 
+#include "common.h"
 #include "mock_singleton_helpers.h"
 
 #include <multipass/standard_paths.h>
-
-#include <gmock/gmock.h>
 
 namespace multipass::test
 {

--- a/tests/mock_status_monitor.h
+++ b/tests/mock_status_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,7 +18,8 @@
 #ifndef MULTIPASS_MOCK_STATUS_MONITOR_H
 #define MULTIPASS_MOCK_STATUS_MONITOR_H
 
-#include <gmock/gmock.h>
+#include "common.h"
+
 #include <multipass/vm_status_monitor.h>
 
 namespace multipass

--- a/tests/mock_utils.h
+++ b/tests/mock_utils.h
@@ -18,13 +18,12 @@
 #ifndef MULTIPASS_MOCK_UTILS_H
 #define MULTIPASS_MOCK_UTILS_H
 
+#include "common.h"
 #include "mock_singleton_helpers.h"
 
 #include <multipass/ssh/ssh_key_provider.h>
 #include <multipass/utils.h>
 #include <multipass/virtual_machine.h>
-
-#include <gmock/gmock.h>
 
 namespace multipass::test
 {

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -18,7 +18,8 @@
 #ifndef MULTIPASS_MOCK_VIRTUAL_MACHINE_H
 #define MULTIPASS_MOCK_VIRTUAL_MACHINE_H
 
-#include <gmock/gmock.h>
+#include "common.h"
+
 #include <multipass/virtual_machine.h>
 
 using namespace testing;

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -18,12 +18,12 @@
 #ifndef MULTIPASS_MOCK_VIRTUAL_MACHINE_FACTORY_H
 #define MULTIPASS_MOCK_VIRTUAL_MACHINE_FACTORY_H
 
+#include "common.h"
+
 #include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_description.h>
 #include <multipass/virtual_machine_factory.h>
 #include <multipass/vm_status_monitor.h>
-
-#include <gmock/gmock.h>
 
 namespace multipass
 {

--- a/tests/mock_vm_image_vault.h
+++ b/tests/mock_vm_image_vault.h
@@ -18,12 +18,11 @@
 #ifndef MULTIPASS_MOCK_IMAGE_VAULT_H
 #define MULTIPASS_MOCK_IMAGE_VAULT_H
 
-#include <multipass/query.h>
-#include <multipass/vm_image_vault.h>
-
+#include "common.h"
 #include "temp_file.h"
 
-#include <gmock/gmock.h>
+#include <multipass/query.h>
+#include <multipass/vm_image_vault.h>
 
 using namespace testing;
 

--- a/tests/mock_vm_workflow_provider.h
+++ b/tests/mock_vm_workflow_provider.h
@@ -18,9 +18,9 @@
 #ifndef MULTIPASS_MOCK_VM_WORKFLOW_PROVIDER_H
 #define MULTIPASS_MOCK_VM_WORKFLOW_PROVIDER_H
 
-#include <multipass/vm_workflow_provider.h>
+#include "common.h"
 
-#include <gmock/gmock.h>
+#include <multipass/vm_workflow_provider.h>
 
 namespace multipass
 {

--- a/tests/qemu/mock_dnsmasq_server.h
+++ b/tests/qemu/mock_dnsmasq_server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,9 +18,9 @@
 #ifndef MULTIPASS_MOCK_DNSMASQ_SERVER_H
 #define MULTIPASS_MOCK_DNSMASQ_SERVER_H
 
-#include <src/platform/backends/qemu/dnsmasq_server.h>
+#include "tests/mock_platform.h"
 
-#include <gmock/gmock.h>
+#include <src/platform/backends/qemu/dnsmasq_server.h>
 
 namespace multipass
 {

--- a/tests/qemu/test_dnsmasq_process_spec.cpp
+++ b/tests/qemu/test_dnsmasq_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,11 +15,11 @@
  *
  */
 
-#include <src/platform/backends/qemu/dnsmasq_process_spec.h>
-
+#include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
-#include <gmock/gmock.h>
+
 #include <multipass/ip_address.h>
+#include <src/platform/backends/qemu/dnsmasq_process_spec.h>
 
 #include <QFile>
 #include <QTemporaryDir>

--- a/tests/qemu/test_dnsmasq_process_spec.cpp
+++ b/tests/qemu/test_dnsmasq_process_spec.cpp
@@ -18,8 +18,9 @@
 #include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
 
-#include <multipass/ip_address.h>
 #include <src/platform/backends/qemu/dnsmasq_process_spec.h>
+
+#include <multipass/ip_address.h>
 
 #include <QFile>
 #include <QTemporaryDir>

--- a/tests/qemu/test_dnsmasq_server.cpp
+++ b/tests/qemu/test_dnsmasq_server.cpp
@@ -21,7 +21,7 @@
 #include <multipass/logging/log.h>
 #include <multipass/logging/logger.h>
 
-#include "tests/extra_assertions.h"
+#include "tests/common.h"
 #include "tests/file_operations.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_logger.h"

--- a/tests/qemu/test_dnsmasq_server.cpp
+++ b/tests/qemu/test_dnsmasq_server.cpp
@@ -15,12 +15,6 @@
  *
  */
 
-#include <src/platform/backends/qemu/dnsmasq_process_spec.h>
-#include <src/platform/backends/qemu/dnsmasq_server.h>
-
-#include <multipass/logging/log.h>
-#include <multipass/logging/logger.h>
-
 #include "tests/common.h"
 #include "tests/file_operations.h"
 #include "tests/mock_environment_helpers.h"
@@ -30,10 +24,15 @@
 #include "tests/temp_dir.h"
 #include "tests/test_with_mocked_bin_path.h"
 
+#include <src/platform/backends/qemu/dnsmasq_process_spec.h>
+#include <src/platform/backends/qemu/dnsmasq_server.h>
+
+#include <multipass/logging/log.h>
+#include <multipass/logging/logger.h>
+
 #include <QDir>
 
 #include <memory>
-#include <src/platform/backends/qemu/dnsmasq_process_spec.h>
 #include <stdexcept>
 #include <string>
 

--- a/tests/qemu/test_firewall_config.cpp
+++ b/tests/qemu/test_firewall_config.cpp
@@ -15,15 +15,15 @@
  *
  */
 
-#include <multipass/format.h>
-#include <src/platform/backends/qemu/firewall_config.h>
-
-#include "tests/extra_assertions.h"
+#include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_logger.h"
 #include "tests/mock_process_factory.h"
 #include "tests/mock_utils.h"
 #include "tests/reset_process_factory.h"
+
+#include <multipass/format.h>
+#include <src/platform/backends/qemu/firewall_config.h>
 
 #include <tuple>
 

--- a/tests/qemu/test_firewall_config.cpp
+++ b/tests/qemu/test_firewall_config.cpp
@@ -22,12 +22,13 @@
 #include "tests/mock_utils.h"
 #include "tests/reset_process_factory.h"
 
-#include <multipass/format.h>
 #include <src/platform/backends/qemu/firewall_config.h>
 
-#include <tuple>
+#include <multipass/format.h>
 
 #include <QString>
+
+#include <tuple>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -15,11 +15,8 @@
  *
  */
 
-#include <src/platform/backends/qemu/qemu_virtual_machine.h>
-#include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
-
 #include "mock_dnsmasq_server.h"
-#include "tests/extra_assertions.h"
+#include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_process_factory.h"
 #include "tests/mock_status_monitor.h"
@@ -36,6 +33,8 @@
 #include <multipass/platform.h>
 #include <multipass/virtual_machine.h>
 #include <multipass/virtual_machine_description.h>
+#include <src/platform/backends/qemu/qemu_virtual_machine.h>
+#include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
 
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "mock_dnsmasq_server.h"
+
 #include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_process_factory.h"
@@ -27,14 +28,15 @@
 #include "tests/temp_file.h"
 #include "tests/test_with_mocked_bin_path.h"
 
+#include <src/platform/backends/qemu/qemu_virtual_machine.h>
+#include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
+
 #include <multipass/auto_join_thread.h>
 #include <multipass/exceptions/start_exception.h>
 #include <multipass/memory_size.h>
 #include <multipass/platform.h>
 #include <multipass/virtual_machine.h>
 #include <multipass/virtual_machine_description.h>
-#include <src/platform/backends/qemu/qemu_virtual_machine.h>
-#include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
 
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/tests/qemu/test_qemu_vm_process_spec.cpp
+++ b/tests/qemu/test_qemu_vm_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,10 +15,10 @@
  *
  */
 
-#include <src/platform/backends/qemu/qemu_vm_process_spec.h>
-
+#include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
-#include <gmock/gmock.h>
+
+#include <src/platform/backends/qemu/qemu_vm_process_spec.h>
 
 #include <QTemporaryDir>
 

--- a/tests/qemu/test_qemu_vmstate_process_spec.cpp
+++ b/tests/qemu/test_qemu_vmstate_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,10 +15,10 @@
  *
  */
 
-#include <src/platform/backends/qemu/qemu_vmstate_process_spec.h>
-
+#include "tests/common.h"
 #include "tests/mock_environment_helpers.h"
-#include <gmock/gmock.h>
+
+#include <src/platform/backends/qemu/qemu_vmstate_process_spec.h>
 
 #include <QStringList>
 

--- a/tests/sftp_server_test_fixture.h
+++ b/tests/sftp_server_test_fixture.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,11 +18,10 @@
 #ifndef MULTIPASS_SFTP_SERVER_TEST_FIXTURE_H
 #define MULTIPASS_SFTP_SERVER_TEST_FIXTURE_H
 
+#include "common.h"
 #include "mock_sftp.h"
 #include "mock_sftpserver.h"
 #include "mock_ssh.h"
-
-#include <gtest/gtest.h>
 
 namespace multipass
 {

--- a/tests/stub_logger.h
+++ b/tests/stub_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
 #define MULTIPASS_STUB_LOGGER_H
 
 #include <multipass/logging/logger.h>
+
 namespace multipass
 {
 namespace test

--- a/tests/stub_process_factory.cpp
+++ b/tests/stub_process_factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
  */
 
 #include "stub_process_factory.h"
+
 #include <multipass/optional.h>
 
 namespace mp = multipass;

--- a/tests/stub_process_factory.h
+++ b/tests/stub_process_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,10 +18,10 @@
 #ifndef MULTIPASS_STUB_PROCESS_FACTORY_H
 #define MULTIPASS_STUB_PROCESS_FACTORY_H
 
+#include "common.h"
 #include "process_factory.h" // rely on build system to include the right implementation
-#include <multipass/process/process.h>
 
-#include <gtest/gtest.h>
+#include <multipass/process/process.h>
 
 namespace multipass
 {

--- a/tests/stub_vm_image_vault.h
+++ b/tests/stub_vm_image_vault.h
@@ -18,8 +18,9 @@
 #ifndef MULTIPASS_STUB_VM_IMAGE_VAULT_H
 #define MULTIPASS_STUB_VM_IMAGE_VAULT_H
 
-#include <multipass/vm_image_vault.h>
 #include "temp_file.h"
+
+#include <multipass/vm_image_vault.h>
 
 namespace multipass
 {

--- a/tests/test_argparser.cpp
+++ b/tests/test_argparser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,13 +15,13 @@
  *
  */
 
+#include "common.h"
+
 #include <multipass/cli/argparser.h>
 #include <multipass/cli/command.h>
 
 #include <QString>
 #include <QStringList>
-
-#include <gtest/gtest.h>
 
 #include <sstream>
 #include <vector>

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -15,14 +15,13 @@
  *
  */
 
+#include "common.h"
+#include "dummy_ssh_key_provider.h"
+#include "mock_ssh.h"
+
 #include <multipass/exceptions/ssh_exception.h>
 #include <multipass/ssh/ssh_session.h>
 #include <shared/base_virtual_machine.h>
-
-#include <gmock/gmock.h>
-
-#include "dummy_ssh_key_provider.h"
-#include "mock_ssh.h"
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -19,9 +19,10 @@
 #include "dummy_ssh_key_provider.h"
 #include "mock_ssh.h"
 
+#include <shared/base_virtual_machine.h>
+
 #include <multipass/exceptions/ssh_exception.h>
 #include <multipass/ssh/ssh_session.h>
-#include <shared/base_virtual_machine.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -15,18 +15,15 @@
  *
  */
 
-#include <multipass/network_interface_info.h>
-#include <multipass/virtual_machine_description.h>
-#include <multipass/vm_status_monitor.h>
-#include <shared/base_virtual_machine_factory.h>
-
-#include "extra_assertions.h"
+#include "common.h"
 #include "mock_logger.h"
 #include "stub_url_downloader.h"
 #include "temp_dir.h"
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <multipass/network_interface_info.h>
+#include <multipass/virtual_machine_description.h>
+#include <multipass/vm_status_monitor.h>
+#include <shared/base_virtual_machine_factory.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -20,10 +20,11 @@
 #include "stub_url_downloader.h"
 #include "temp_dir.h"
 
+#include <shared/base_virtual_machine_factory.h>
+
 #include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_description.h>
 #include <multipass/vm_status_monitor.h>
-#include <shared/base_virtual_machine_factory.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/test_basic_process.cpp
+++ b/tests/test_basic_process.cpp
@@ -15,12 +15,11 @@
  *
  */
 
-#include <multipass/process/basic_process.h>
-#include <multipass/process/simple_process_spec.h>
-
+#include "common.h"
 #include "test_with_mocked_bin_path.h"
 
-#include <gmock/gmock.h>
+#include <multipass/process/basic_process.h>
+#include <multipass/process/simple_process_spec.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -27,13 +27,12 @@
 #include "stub_certprovider.h"
 #include "stub_terminal.h"
 
-#include <multipass/constants.h>
-#include <multipass/exceptions/settings_exceptions.h>
-#include <multipass/logging/log.h>
 #include <src/client/cli/client.h>
 #include <src/daemon/daemon_rpc.h>
 
-#include <QEventLoop>
+#include <multipass/constants.h>
+#include <multipass/exceptions/settings_exceptions.h>
+
 #include <QKeySequence>
 #include <QStringList>
 #include <QTemporaryFile>
@@ -41,7 +40,6 @@
 
 #include <chrono>
 #include <initializer_list>
-#include <sstream>
 #include <thread>
 #include <utility>
 

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -15,8 +15,8 @@
  *
  */
 
+#include "common.h"
 #include "disabling_macros.h"
-#include "extra_assertions.h"
 #include "mock_environment_helpers.h"
 #include "mock_settings.h"
 #include "mock_standard_paths.h"
@@ -38,9 +38,6 @@
 #include <QStringList>
 #include <QTemporaryFile>
 #include <QtCore/QTemporaryDir>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <chrono>
 #include <initializer_list>

--- a/tests/test_client_cert_store.cpp
+++ b/tests/test_client_cert_store.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,13 +15,12 @@
  *
  */
 
-#include <multipass/client_cert_store.h>
-#include <multipass/utils.h>
-
+#include "common.h"
 #include "file_operations.h"
 #include "temp_dir.h"
 
-#include <gmock/gmock.h>
+#include <multipass/client_cert_store.h>
+#include <multipass/utils.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,11 +15,10 @@
  *
  */
 
-#include <multipass/cloud_init_iso.h>
-
+#include "common.h"
 #include "temp_dir.h"
 
-#include <gmock/gmock.h>
+#include <multipass/cloud_init_iso.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_constants.cpp
+++ b/tests/test_constants.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,10 +15,10 @@
  *
  */
 
+#include "common.h"
+
 #include <multipass/constants.h>
 #include <multipass/memory_size.h>
-
-#include <gtest/gtest.h>
 
 namespace mp = multipass;
 using namespace testing;

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2018-2021 Canonical, Ltd.
  *
@@ -15,9 +16,7 @@
  *
  */
 
-#include "src/daemon/custom_image_host.h"
-
-#include "extra_assertions.h"
+#include "common.h"
 #include "image_host_remote_count.h"
 #include "mischievous_url_downloader.h"
 #include "mock_platform.h"
@@ -27,10 +26,9 @@
 #include <multipass/exceptions/unsupported_remote_exception.h>
 #include <multipass/format.h>
 #include <multipass/query.h>
+#include <src/daemon/custom_image_host.h>
 
 #include <QUrl>
-
-#include <gmock/gmock.h>
 
 #include <cstddef>
 #include <unordered_set>

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -22,11 +22,12 @@
 #include "mock_platform.h"
 #include "path.h"
 
+#include <src/daemon/custom_image_host.h>
+
 #include <multipass/exceptions/unsupported_alias_exception.h>
 #include <multipass/exceptions/unsupported_remote_exception.h>
 #include <multipass/format.h>
 #include <multipass/query.h>
-#include <src/daemon/custom_image_host.h>
 
 #include <QUrl>
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -15,16 +15,9 @@
  *
  */
 
-#include <multipass/constants.h>
-#include <multipass/default_vm_workflow_provider.h>
-#include <multipass/logging/log.h>
-#include <multipass/name_generator.h>
-#include <multipass/version.h>
-#include <multipass/virtual_machine_factory.h>
-
+#include "common.h"
 #include "daemon_test_fixture.h"
 #include "dummy_ssh_key_provider.h"
-#include "extra_assertions.h"
 #include "file_operations.h"
 #include "mock_daemon.h"
 #include "mock_environment_helpers.h"
@@ -40,9 +33,15 @@
 #include "path.h"
 #include "tracking_url_downloader.h"
 
-#include <yaml-cpp/yaml.h>
+#include <multipass/constants.h>
+#include <multipass/default_vm_workflow_provider.h>
+#include <multipass/logging/log.h>
+#include <multipass/name_generator.h>
+#include <multipass/version.h>
+#include <multipass/virtual_machine_factory.h>
+#include <multipass/vm_image_host.h>
 
-#include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
 
 #include <QCoreApplication>
 #include <QJsonDocument>

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -24,7 +24,6 @@
 #include "mock_image_host.h"
 #include "mock_logger.h"
 #include "mock_platform.h"
-#include "mock_process_factory.h"
 #include "mock_settings.h"
 #include "mock_utils.h"
 #include "mock_virtual_machine.h"
@@ -43,15 +42,13 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <QCoreApplication>
+#include <scope_guard.hpp>
+
 #include <QJsonDocument>
-#include <QJsonObject>
 #include <QNetworkProxyFactory>
 #include <QStorageInfo>
 #include <QString>
 #include <QSysInfo>
-
-#include <scope_guard.hpp>
 
 #include <memory>
 #include <ostream>

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -15,15 +15,15 @@
  *
  */
 
-#include <src/daemon/daemon.h>
-#include <src/daemon/daemon_rpc.h>
-
+#include "common.h"
 #include "daemon_test_fixture.h"
 #include "mock_image_host.h"
 #include "mock_vm_image_vault.h"
 #include "mock_vm_workflow_provider.h"
 
 #include <multipass/format.h>
+#include <src/daemon/daemon.h>
+#include <src/daemon/daemon_rpc.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -21,9 +21,9 @@
 #include "mock_vm_image_vault.h"
 #include "mock_vm_workflow_provider.h"
 
-#include <multipass/format.h>
 #include <src/daemon/daemon.h>
-#include <src/daemon/daemon_rpc.h>
+
+#include <multipass/format.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_delayed_shutdown.cpp
+++ b/tests/test_delayed_shutdown.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
  *
  */
 
+#include "common.h"
 #include "mock_ssh.h"
 #include "signal.h"
 #include "stub_virtual_machine.h"
@@ -24,8 +25,6 @@
 #include <QEventLoop>
 
 #include <chrono>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_format_utils.cpp
+++ b/tests/test_format_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,10 +15,10 @@
  *
  */
 
+#include "common.h"
+
 #include <multipass/cli/format_utils.h>
 #include <multipass/rpc/multipass.grpc.pb.h>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 using namespace testing;

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -15,10 +15,8 @@
  *
  */
 
-#include "src/daemon/default_vm_image_vault.h"
-
+#include "common.h"
 #include "disabling_macros.h"
-#include "extra_assertions.h"
 #include "file_operations.h"
 #include "mock_image_host.h"
 #include "mock_process_factory.h"
@@ -28,6 +26,7 @@
 #include "temp_file.h"
 #include "tracking_url_downloader.h"
 
+#include "src/daemon/default_vm_image_vault.h"
 #include <multipass/exceptions/aborted_download_exception.h>
 #include <multipass/exceptions/create_image_exception.h>
 #include <multipass/format.h>
@@ -38,8 +37,6 @@
 #include <QDateTime>
 #include <QThread>
 #include <QUrl>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -26,7 +26,8 @@
 #include "temp_file.h"
 #include "tracking_url_downloader.h"
 
-#include "src/daemon/default_vm_image_vault.h"
+#include <src/daemon/default_vm_image_vault.h>
+
 #include <multipass/exceptions/aborted_download_exception.h>
 #include <multipass/exceptions/create_image_exception.h>
 #include <multipass/format.h>

--- a/tests/test_ip_address.cpp
+++ b/tests/test_ip_address.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,9 +15,9 @@
  *
  */
 
-#include <multipass/ip_address.h>
+#include "common.h"
 
-#include <gmock/gmock.h>
+#include <multipass/ip_address.h>
 
 namespace mp = multipass;
 using namespace testing;

--- a/tests/test_memory_size.cpp
+++ b/tests/test_memory_size.cpp
@@ -1,5 +1,6 @@
+
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,10 +16,10 @@
  *
  */
 
+#include "common.h"
+
 #include <multipass/exceptions/invalid_memory_size_exception.h>
 #include <multipass/memory_size.h>
-
-#include <gtest/gtest.h>
 
 #include <string>
 #include <tuple>

--- a/tests/test_metrics_provider.cpp
+++ b/tests/test_metrics_provider.cpp
@@ -23,10 +23,8 @@
 #include <multipass/utils.h>
 
 #include <QDateTime>
-#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QUrl>
 #include <QUuid>
 
 namespace mp = multipass;

--- a/tests/test_metrics_provider.cpp
+++ b/tests/test_metrics_provider.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,11 +15,12 @@
  *
  */
 
-#include <multipass/metrics_provider.h>
-#include <multipass/utils.h>
-
+#include "common.h"
 #include "temp_dir.h"
 #include "temp_file.h"
+
+#include <multipass/metrics_provider.h>
+#include <multipass/utils.h>
 
 #include <QDateTime>
 #include <QJsonArray>
@@ -27,8 +28,6 @@
 #include <QJsonObject>
 #include <QUrl>
 #include <QUuid>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_mock_settings.cpp
+++ b/tests/test_mock_settings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,15 +15,13 @@
  *
  */
 
+#include "common.h"
 #include "mock_settings.h"
 
 #include <multipass/constants.h>
 #include <multipass/settings.h>
 
 #include <QString>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 namespace mp = multipass;
 namespace mpt = mp::test;

--- a/tests/test_mock_standard_paths.cpp
+++ b/tests/test_mock_standard_paths.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,15 +15,13 @@
  *
  */
 
+#include "common.h"
 #include "mock_standard_paths.h"
 
 #include <multipass/standard_paths.h>
 
 #include <QStandardPaths>
 #include <QTemporaryDir>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 namespace mp = multipass;
 namespace mpt = mp::test;

--- a/tests/test_new_release_monitor.cpp
+++ b/tests/test_new_release_monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,14 +15,14 @@
  *
  */
 
+#include "common.h"
+
 #include "src/platform/update/new_release_monitor.h"
 
 #include <QEventLoop>
 #include <QTemporaryFile>
 #include <QTimer>
 #include <QUrl>
-
-#include <gtest/gtest.h>
 
 #include <chrono>
 

--- a/tests/test_new_release_monitor.cpp
+++ b/tests/test_new_release_monitor.cpp
@@ -17,7 +17,7 @@
 
 #include "common.h"
 
-#include "src/platform/update/new_release_monitor.h"
+#include <src/platform/update/new_release_monitor.h>
 
 #include <QEventLoop>
 #include <QTemporaryFile>

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
  *
  */
 
+#include "common.h"
 #include "mock_settings.h"
 
 #include <multipass/cli/csv_formatter.h>
@@ -26,8 +27,6 @@
 #include <multipass/settings.h>
 
 #include <multipass/format.h>
-
-#include <gmock/gmock.h>
 
 #include <locale>
 

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -25,7 +25,6 @@
 #include <multipass/constants.h>
 #include <multipass/rpc/multipass.grpc.pb.h>
 #include <multipass/settings.h>
-
 #include <multipass/format.h>
 
 #include <locale>

--- a/tests/test_petname.cpp
+++ b/tests/test_petname.cpp
@@ -19,7 +19,7 @@
 
 #include "common.h"
 
-#include "src/petname/petname.h"
+#include <src/petname/petname.h>
 
 #include <regex>
 #include <string>

--- a/tests/test_petname.cpp
+++ b/tests/test_petname.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,9 +17,9 @@
  *
  */
 
-#include "src/petname/petname.h"
+#include "common.h"
 
-#include <gmock/gmock.h>
+#include "src/petname/petname.h"
 
 #include <regex>
 #include <string>

--- a/tests/test_platform_shared.cpp
+++ b/tests/test_platform_shared.cpp
@@ -15,15 +15,12 @@
  *
  */
 
-#include "extra_assertions.h"
+#include "common.h"
 
 #include <multipass/constants.h>
 #include <multipass/platform.h>
 
 #include <src/platform/platform_shared.h>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <QKeySequence>
 #include <multipass/exceptions/settings_exceptions.h>

--- a/tests/test_platform_shared.cpp
+++ b/tests/test_platform_shared.cpp
@@ -17,13 +17,13 @@
 
 #include "common.h"
 
-#include <multipass/constants.h>
-#include <multipass/platform.h>
-
 #include <src/platform/platform_shared.h>
 
-#include <QKeySequence>
+#include <multipass/constants.h>
 #include <multipass/exceptions/settings_exceptions.h>
+#include <multipass/platform.h>
+
+#include <QKeySequence>
 
 namespace mp = multipass;
 namespace mpt = mp::test;

--- a/tests/test_private_pass_provider.cpp
+++ b/tests/test_private_pass_provider.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,9 +15,9 @@
  *
  */
 
-#include <multipass/private_pass_provider.h>
+#include "common.h"
 
-#include <gtest/gtest.h>
+#include <multipass/private_pass_provider.h>
 
 #include <string>
 

--- a/tests/test_qemuimg_process_spec.cpp
+++ b/tests/test_qemuimg_process_spec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,12 +15,11 @@
  *
  */
 
+#include "common.h"
 #include "disabling_macros.h"
 #include "mock_environment_helpers.h"
 
 #include <multipass/process/qemuimg_process_spec.h>
-
-#include <gmock/gmock.h>
 
 #include <QFile>
 #include <QTemporaryDir>

--- a/tests/test_scp_client.cpp
+++ b/tests/test_scp_client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,17 +15,15 @@
  *
  */
 
+#include "common.h"
+#include "file_operations.h"
 #include "mock_scp.h"
 #include "mock_ssh.h"
-
-#include "file_operations.h"
 #include "path.h"
 #include "temp_dir.h"
 
 #include <multipass/ssh/scp_client.h>
 #include <multipass/ssh/ssh_session.h>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_sftp_client.cpp
+++ b/tests/test_sftp_client.cpp
@@ -15,6 +15,7 @@
  *
  */
 
+#include "common.h"
 #include "file_operations.h"
 #include "mock_sftp.h"
 #include "mock_ssh.h"
@@ -23,8 +24,6 @@
 
 #include <multipass/ssh/sftp_client.h>
 #include <multipass/ssh/ssh_session.h>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -15,14 +15,14 @@
  *
  */
 
-#include "sftp_server_test_fixture.h"
-
+#include "common.h"
 #include "file_operations.h"
 #include "mock_file_ops.h"
 #include "mock_logger.h"
 #include "mock_platform.h"
 #include "mock_ssh_process_exit_status.h"
 #include "path.h"
+#include "sftp_server_test_fixture.h"
 #include "temp_dir.h"
 #include "temp_file.h"
 
@@ -30,8 +30,6 @@
 #include <multipass/platform.h>
 #include <multipass/ssh/ssh_session.h>
 #include <multipass/sshfs_mount/sftp_server.h>
-
-#include <gmock/gmock.h>
 
 #include <queue>
 

--- a/tests/test_simple_streams_index.cpp
+++ b/tests/test_simple_streams_index.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -13,14 +13,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
+#include "common.h"
 #include "file_operations.h"
 #include <multipass/simple_streams_index.h>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_simple_streams_index.cpp
+++ b/tests/test_simple_streams_index.cpp
@@ -17,6 +17,7 @@
 
 #include "common.h"
 #include "file_operations.h"
+
 #include <multipass/simple_streams_index.h>
 
 namespace mp = multipass;

--- a/tests/test_simple_streams_manifest.cpp
+++ b/tests/test_simple_streams_manifest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,14 +15,13 @@
  *
  */
 
+#include "common.h"
 #include "file_operations.h"
 #include "mock_settings.h"
 
 #include <multipass/constants.h>
 #include <multipass/exceptions/manifest_exceptions.h>
 #include <multipass/simple_streams_manifest.h>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_singleton.cpp
+++ b/tests/test_singleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,10 +15,9 @@
  *
  */
 
-#include <multipass/singleton.h>
+#include "common.h"
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <multipass/singleton.h>
 
 #include <string>
 

--- a/tests/test_ssh_client.cpp
+++ b/tests/test_ssh_client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,14 +15,13 @@
  *
  */
 
+#include "common.h"
 #include "mock_ssh.h"
 #include "mock_ssh_client.h"
 #include "stub_console.h"
 
 #include <multipass/ssh/ssh_client.h>
 #include <multipass/ssh/ssh_session.h>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_ssh_key_provider.cpp
+++ b/tests/test_ssh_key_provider.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,13 +15,12 @@
  *
  */
 
-#include <multipass/ssh/openssh_key_provider.h>
-#include <multipass/utils.h>
-
+#include "common.h"
 #include "file_operations.h"
 #include "temp_dir.h"
 
-#include <gmock/gmock.h>
+#include <multipass/ssh/openssh_key_provider.h>
+#include <multipass/utils.h>
 
 #include <thread>
 

--- a/tests/test_ssh_process.cpp
+++ b/tests/test_ssh_process.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,11 +15,10 @@
  *
  */
 
+#include "common.h"
 #include "mock_ssh.h"
 
 #include <multipass/ssh/ssh_session.h>
-
-#include <gmock/gmock.h>
 
 #include <algorithm>
 #include <thread>

--- a/tests/test_ssh_session.cpp
+++ b/tests/test_ssh_session.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,12 +15,11 @@
  *
  */
 
+#include "common.h"
 #include "mock_ssh.h"
 #include "stub_ssh_key_provider.h"
 
 #include <multipass/ssh/ssh_session.h>
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 using namespace testing;

--- a/tests/test_sshfs_server_process_spec.cpp
+++ b/tests/test_sshfs_server_process_spec.cpp
@@ -15,14 +15,13 @@
  *
  */
 
-#include <src/platform/backends/shared/sshfs_server_process_spec.h>
-
-#include <multipass/sshfs_server_config.h>
-
+#include "common.h"
 #include "mock_environment_helpers.h"
 #include "temp_dir.h"
 
-#include <gmock/gmock.h>
+#include <src/platform/backends/shared/sshfs_server_process_spec.h>
+
+#include <multipass/sshfs_server_config.h>
 
 #include <QCoreApplication>
 

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -15,6 +15,7 @@
  *
  */
 
+#include "common.h"
 #include "mock_logger.h"
 #include "mock_ssh_process_exit_status.h"
 #include "sftp_server_test_fixture.h"
@@ -27,9 +28,7 @@
 #include <multipass/sshfs_mount/sshfs_mount.h>
 #include <multipass/utils.h>
 
-#include "extra_assertions.h"
 #include <algorithm>
-#include <gmock/gmock.h>
 #include <iterator>
 #include <tuple>
 #include <unordered_set>

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -15,18 +15,18 @@
  *
  */
 
-#include <multipass/exceptions/sshfs_missing_error.h>
-#include <multipass/sshfs_mount/sshfs_mounts.h>
-
+#include "common.h"
 #include "mock_environment_helpers.h"
 #include "mock_logger.h"
 #include "mock_process_factory.h"
 #include "mock_virtual_machine.h"
 #include "stub_ssh_key_provider.h"
 
+#include <multipass/exceptions/sshfs_missing_error.h>
+#include <multipass/sshfs_mount/sshfs_mounts.h>
+
 #include <QCoreApplication>
 #include <QTimer>
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_ssl_cert_provider.cpp
+++ b/tests/test_ssl_cert_provider.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,13 +15,12 @@
  *
  */
 
-#include <multipass/ssl_cert_provider.h>
-#include <multipass/utils.h>
-
+#include "common.h"
 #include "file_operations.h"
 #include "temp_dir.h"
 
-#include <gmock/gmock.h>
+#include <multipass/ssl_cert_provider.h>
+#include <multipass/utils.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -15,9 +15,9 @@
  *
  */
 
-#include <multipass/timer.h>
+#include "common.h"
 
-#include <gtest/gtest.h>
+#include <multipass/timer.h>
 
 #include <atomic>
 #include <chrono>

--- a/tests/test_top_catch_all.cpp
+++ b/tests/test_top_catch_all.cpp
@@ -15,13 +15,11 @@
  *
  */
 
+#include "common.h"
 #include "mock_logger.h"
 
 #include <multipass/logging/log.h>
 #include <multipass/top_catch_all.h>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <stdexcept>
 #include <string>

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -15,9 +15,7 @@
  *
  */
 
-#include "src/daemon/ubuntu_image_host.h"
-
-#include "extra_assertions.h"
+#include "common.h"
 #include "image_host_remote_count.h"
 #include "mischievous_url_downloader.h"
 #include "mock_platform.h"
@@ -28,10 +26,9 @@
 #include <multipass/exceptions/unsupported_image_exception.h>
 #include <multipass/exceptions/unsupported_remote_exception.h>
 #include <multipass/query.h>
+#include <src/daemon/ubuntu_image_host.h>
 
 #include <QUrl>
-
-#include <gmock/gmock.h>
 
 #include <cstddef>
 #include <unordered_set>

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -22,11 +22,12 @@
 #include "path.h"
 #include "stub_url_downloader.h"
 
+#include <src/daemon/ubuntu_image_host.h>
+
 #include <multipass/exceptions/unsupported_alias_exception.h>
 #include <multipass/exceptions/unsupported_image_exception.h>
 #include <multipass/exceptions/unsupported_remote_exception.h>
 #include <multipass/query.h>
-#include <src/daemon/ubuntu_image_host.h>
 
 #include <QUrl>
 

--- a/tests/test_url_downloader.cpp
+++ b/tests/test_url_downloader.cpp
@@ -15,19 +15,16 @@
  *
  */
 
-#include <multipass/exceptions/aborted_download_exception.h>
-#include <multipass/exceptions/download_exception.h>
-#include <multipass/format.h>
-
-#include "extra_assertions.h"
+#include "common.h"
 #include "mock_file_ops.h"
 #include "mock_logger.h"
 #include "mock_network.h"
 #include "temp_dir.h"
 
-#include <QTimer>
+#include <multipass/exceptions/aborted_download_exception.h>
+#include <multipass/exceptions/download_exception.h>
 
-#include <gtest/gtest.h>
+#include <QTimer>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -15,11 +15,7 @@
  *
  */
 
-#include <multipass/format.h>
-#include <multipass/utils.h>
-#include <multipass/vm_image_vault.h>
-
-#include "extra_assertions.h"
+#include "common.h"
 #include "file_operations.h"
 #include "mock_logger.h"
 #include "mock_ssh.h"
@@ -29,12 +25,14 @@
 #include "temp_dir.h"
 #include "temp_file.h"
 
+#include <multipass/format.h>
+#include <multipass/utils.h>
+#include <multipass/vm_image_vault.h>
+
 #include <QDateTime>
 #include <QRegExp>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest-death-test.h>
-#include <gtest/gtest.h>
 
 #include <sstream>
 #include <string>

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -29,7 +29,6 @@
 #include <multipass/utils.h>
 #include <multipass/vm_image_vault.h>
 
-#include <QDateTime>
 #include <QRegExp>
 
 #include <gtest/gtest-death-test.h>

--- a/tests/test_with_mocked_bin_path.cpp
+++ b/tests/test_with_mocked_bin_path.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 
 #include "test_with_mocked_bin_path.h"
 #include "path.h"
+
 #include <QDir>
 
 namespace mp = multipass;

--- a/tests/test_with_mocked_bin_path.h
+++ b/tests/test_with_mocked_bin_path.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Canonical, Ltd.
+ * Copyright (C) 2018-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 #ifndef MULTIPASS_TEST_WITH_MOCKED_BIN_PATH
 #define MULTIPASS_TEST_WITH_MOCKED_BIN_PATH
 
-#include <gmock/gmock.h>
+#include "common.h"
 #include "mock_environment_helpers.h"
 
 namespace multipass

--- a/tests/test_workflow_provider.cpp
+++ b/tests/test_workflow_provider.cpp
@@ -29,9 +29,9 @@
 #include <multipass/url_downloader.h>
 #include <multipass/utils.h>
 
-#include <QFileInfo>
-
 #include <Poco/Exception.h>
+
+#include <QFileInfo>
 
 #include <chrono>
 

--- a/tests/test_workflow_provider.cpp
+++ b/tests/test_workflow_provider.cpp
@@ -15,6 +15,13 @@
  *
  */
 
+#include "common.h"
+#include "mock_logger.h"
+#include "mock_poco_zip_utils.h"
+#include "mock_url_downloader.h"
+#include "path.h"
+#include "temp_dir.h"
+
 #include <multipass/default_vm_workflow_provider.h>
 #include <multipass/exceptions/download_exception.h>
 #include <multipass/exceptions/workflow_exceptions.h>
@@ -22,19 +29,9 @@
 #include <multipass/url_downloader.h>
 #include <multipass/utils.h>
 
-#include "extra_assertions.h"
-#include "mock_logger.h"
-#include "mock_poco_zip_utils.h"
-#include "mock_url_downloader.h"
-#include "path.h"
-#include "temp_dir.h"
-
 #include <QFileInfo>
 
 #include <Poco/Exception.h>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <chrono>
 


### PR DESCRIPTION
The motivation for this is to teach Google Test to print `QStrings` and other types (e.g. when things fail). I had attempted QString a few times before with no luck. It turns out that the printers need to be visible to all files that declare tests, to [avoid breaking ODR](https://stackoverflow.com/a/36941270). 

So, this replaces the usual gmock/gtest includes with a single `common.h` include which includes those and defines the extra prints. It also provides the extra assertions and matchers. Note that this applies to all printers, namely ones we implement in the future and the ones for network structs introduced in #2137, although in that case things seemed to work locally (but still UB).

Since I needed to change the include order in a bunch of files, I went all the way and organized includes consistently and in [increasing order of specificity](https://www.accu.org/journals/overload/24/133/overload133.pdf#page=9), fixed ensuing compilation problems and dropped a few unused includes that CLion identified.