### PR TITLE
Release 1.7.0

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -151,7 +151,7 @@ _multipass_complete()
             opts="${opts} --all --purge"
         ;;
         "launch")
-            opts="${opts} --cpus --disk --mem --name --cloud-init --network"
+            opts="${opts} --cpus --disk --mem --name --cloud-init --network --bridged"
         ;;
         "mount")
             opts="${opts} --gid-map --uid-map"
@@ -180,9 +180,9 @@ _multipass_complete()
             "--network")
                 _multipass_networks
                 if [[ "${opts}" != "" ]]; then
-                    opts="${opts} id= mode= mac="
+                    opts="${opts} bridged id= mode= mac="
                 fi
-                # TODO: Do use spaces after the completion of an interface name.
+                # TODO: Do use spaces after the completion of an interface name or "bridged".
                 compopt -o nospace
         esac
     else

--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -45,6 +45,7 @@ constexpr auto petenv_key = "client.primary-name";     // This will eventually b
 constexpr auto driver_key = "local.driver";            // idem
 constexpr auto bridged_interface_key = "local.bridged-network"; // idem
 constexpr auto bridged_network_name = "bridged";
+constexpr auto mounts_key = "local.privileged-mounts"; // idem
 constexpr auto autostart_key = "client.gui.autostart"; // idem
 constexpr auto winterm_key = "client.apps.windows-terminal.profiles"; // idem
 constexpr auto hotkey_key = "client.gui.hotkey";                      // idem

--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -24,6 +24,7 @@
 #include <QDir>
 #include <QFile>
 #include <QString>
+#include <QTextStream>
 
 #define MP_FILEOPS multipass::FileOps::instance()
 
@@ -40,7 +41,9 @@ public:
 
     // QFile operations
     virtual bool open(QFile& file, QIODevice::OpenMode mode);
+    virtual bool is_open(const QFile& file) const;
     virtual qint64 read(QFile& file, char* data, qint64 maxSize);
+    virtual QString read_line(QTextStream& text_stream) const;
     virtual bool remove(QFile& file);
     virtual bool rename(QFile& file, const QString& newName);
     virtual bool resize(QFile& file, qint64 sz);

--- a/include/multipass/network_interface_info.h
+++ b/include/multipass/network_interface_info.h
@@ -41,5 +41,12 @@ struct NetworkInterfaceInfo
     std::vector<std::string> links = {}; // default initializer allows aggregate init of the other 3
     bool needs_authorization = false;    // idem
 };
+
+inline bool operator==(const NetworkInterfaceInfo& a, const NetworkInterfaceInfo& b)
+{
+    return std::tie(a.id, a.type, a.description, a.links, a.needs_authorization) ==
+           std::tie(b.id, b.type, b.description, b.links, b.needs_authorization);
+}
+
 } // namespace multipass
 #endif // MULTIPASS_NETWORK_INTERFACE_INFO_H

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -70,7 +70,7 @@ void setup_gui_autostart_prerequisites();
 std::string default_server_address();
 QString default_driver();
 
-QString daemon_config_home();                      // temporary
+QString daemon_config_home(); // temporary
 
 bool is_backend_supported(const QString& backend); // temporary
 VirtualMachineFactory::UPtr vm_backend(const Path& data_dir);
@@ -84,6 +84,8 @@ bool is_image_url_supported();
 std::function<int()> make_quit_watchdog(); // call while single-threaded; call result later, in dedicated thread
 
 std::string reinterpret_interface_id(const std::string& ux_id); // give platforms a chance to reinterpret network IDs
+
+std::string host_version();
 
 } // namespace platform
 } // namespace multipass

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -69,6 +69,7 @@ void setup_gui_autostart_prerequisites();
 
 std::string default_server_address();
 QString default_driver();
+QString default_privileged_mounts();
 
 QString daemon_config_home(); // temporary
 

--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -72,6 +72,8 @@ protected:
     VirtualMachineFactory() = default;
     VirtualMachineFactory(const VirtualMachineFactory&) = delete;
     VirtualMachineFactory& operator=(const VirtualMachineFactory&) = delete;
+
+    virtual std::string create_bridge_with(const NetworkInterfaceInfo& interface) = 0;
 };
 }
 #endif // MULTIPASS_VIRTUAL_MACHINE_FACTORY_H

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,6 +48,7 @@ apps:
       - network-observe # for network listing (to read `/sys/devices/**/net/*`)
       - lxd
       - removable-media
+      - system-observe  # to read the host's os-release
   multipass:
     environment:
       <<: &client-environment

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -525,9 +525,9 @@ auto cmd::Launch::ask_metrics_permission(const mp::LaunchReply& reply) -> OptInS
 bool cmd::Launch::ask_bridge_permission(multipass::LaunchReply& reply)
 {
     static constexpr auto plural = "Multipass needs to create {} to connect to {}.\nThis will temporarily disrupt "
-                                   "connectivity on those interfaces.\n\nDo you want to continue (yes/no)?";
+                                   "connectivity on those interfaces.\n\nDo you want to continue (yes/no)? ";
     static constexpr auto singular = "Multipass needs to create a {} to connect to {}.\nThis will temporarily disrupt "
-                                     "connectivity on that interface.\n\nDo you want to continue (yes/no)?";
+                                     "connectivity on that interface.\n\nDo you want to continue (yes/no)? ";
     static constexpr auto nodes = on_windows() ? "switches" : "bridges";
     static constexpr auto node = on_windows() ? "switch" : "bridge";
 

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -125,32 +125,16 @@ mp::ReturnCode cmd::Launch::run(mp::ArgParser* parser)
         return parser->returnCodeFrom(ret);
     }
 
-    request.set_time_zone(QTimeZone::systemTimeZoneId().toStdString());
-
     auto ret = request_launch(parser);
     if (ret == ReturnCode::Ok && request.instance_name() == petenv_name.toStdString())
     {
-        if (!MP_SETTINGS.get_as<bool>(mounts_key))
+        std::string mounts_value;
+        if (std::tie(ret, mounts_value) = request_mounts_setting_from_daemon(parser); ret == ReturnCode::Ok)
         {
-            cout << fmt::format("Skipping '{}' mount due to disabled mounts feature\n", mp::home_automount_dir);
-        }
-        else
-        {
-            QString mount_source{};
-            try
-            {
-                mount_source = QString::fromLocal8Bit(mpu::snap_real_home_dir());
-            }
-            catch (const mp::SnapEnvironmentException&)
-            {
-                mount_source = QDir::toNativeSeparators(QDir::homePath());
-            }
-
-            const auto mount_target = QString{"%1:%2"}.arg(petenv_name, mp::home_automount_dir);
-
-            ret = run_cmd({"multipass", "mount", mount_source, mount_target}, parser, cout, cerr);
-            if (ret == ReturnCode::Ok)
-                cout << fmt::format("Mounted '{}' into '{}'\n", mount_source, mount_target);
+            if (mounts_value != "true")
+                cout << fmt::format("Skipping '{}' mount due to disabled mounts feature\n", mp::home_automount_dir);
+            else
+                ret = mount_home(parser);
         }
     }
 
@@ -348,6 +332,7 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
         return ParseCode::CommandLineError;
     }
 
+    request.set_time_zone(QTimeZone::systemTimeZoneId().toStdString());
     request.set_verbosity_level(parser->verbosityLevel());
 
     return status;
@@ -473,6 +458,47 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
     };
 
     return dispatch(&RpcMethod::launch, request, on_success, on_failure, streaming_callback);
+}
+
+auto cmd::Launch::mount_home(const mp::ArgParser* parser) -> ReturnCode
+{
+    QString mount_source{};
+    try
+    {
+        mount_source = QString::fromLocal8Bit(mpu::snap_real_home_dir());
+    }
+    catch (const SnapEnvironmentException&)
+    {
+        mount_source = QDir::toNativeSeparators(QDir::homePath());
+    }
+
+    const auto mount_target = QString{"%1:%2"}.arg(petenv_name, home_automount_dir);
+
+    auto ret = run_cmd({"multipass", "mount", mount_source, mount_target}, parser, cout, cerr);
+    if (ret == Ok)
+        cout << fmt::format("Mounted '{}' into '{}'\n", mount_source, mount_target);
+
+    return ret;
+}
+
+auto cmd::Launch::request_mounts_setting_from_daemon(const ArgParser* parser) -> std::pair<ReturnCode, std::string>
+{
+    // TODO: This needs wrapping in mp::Settings
+    std::string mounts_value = "false";
+    mp::GetRequest get_request;
+
+    auto on_success = [&mounts_value](mp::GetReply& reply) {
+        mounts_value = reply.value();
+        return ReturnCode::Ok;
+    };
+
+    auto on_failure = [this](grpc::Status& status) { return standard_failure_handler_for(name(), cerr, status); };
+
+    get_request.set_key(mp::mounts_key);
+    get_request.set_verbosity_level(parser->verbosityLevel());
+    auto ret = dispatch(&RpcMethod::get, get_request, on_success, on_failure);
+
+    return {ret, mounts_value};
 }
 
 auto cmd::Launch::ask_metrics_permission(const mp::LaunchReply& reply) -> OptInStatus::Status

--- a/src/client/cli/cmd/launch.h
+++ b/src/client/cli/cmd/launch.h
@@ -26,6 +26,8 @@
 #include <QString>
 
 #include <memory>
+#include <string>
+#include <utility>
 
 namespace multipass
 {
@@ -44,6 +46,8 @@ public:
 private:
     ParseCode parse_args(ArgParser* parser) override;
     ReturnCode request_launch(const ArgParser* parser);
+    ReturnCode mount_home(const ArgParser* parser);
+    std::pair<ReturnCode, std::string> request_mounts_setting_from_daemon(const ArgParser* parser);
     OptInStatus::Status ask_metrics_permission(const LaunchReply& reply);
     bool ask_bridge_permission(multipass::LaunchReply& reply);
 

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -294,7 +294,7 @@ void cmd::GuiCmd::create_menu()
 
     about_client_version.setEnabled(false);
     about_daemon_version.setEnabled(false);
-    about_copyright.setText("Copyright © 2017-2020 Canonical Ltd.");
+    about_copyright.setText("Copyright © 2017-2021 Canonical Ltd.");
     about_copyright.setEnabled(false);
 
     about_menu.insertActions(0, {&autostart_option, &about_client_version, &about_daemon_version, &about_copyright});

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -123,8 +123,8 @@ auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider, const
     auto pollinate_user_agent_string =
         fmt::format("multipass/version/{} # written by Multipass\n", multipass::version_string);
     pollinate_user_agent_string += fmt::format("multipass/driver/{} # written by Multipass\n", backend_version_string);
-    pollinate_user_agent_string += fmt::format("multipass/host/{}-{} # written by Multipass\n", QSysInfo::productType(),
-                                               QSysInfo::productVersion());
+    pollinate_user_agent_string +=
+        fmt::format("multipass/host/{} # written by Multipass\n", multipass::platform::host_version());
 
     YAML::Node pollinate_user_agent_node;
     pollinate_user_agent_node["path"] = "/etc/pollinate/add-user-agent";

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2132,7 +2132,9 @@ void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriter<Crea
 {
     // Try to get info for the requested image. This will throw out if the requested image is not found. This check
     // needs to be done before the other checks.
-    config->vault->all_info_for(query_from(request, ""));
+    auto image_query = query_from(request, "");
+    if (image_query.query_type == Query::Type::Alias)
+        config->vault->all_info_for(image_query);
 
     auto checked_args = validate_create_arguments(request, *config->factory);
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -612,6 +612,7 @@ auto connect_rpc(mp::DaemonRpc& rpc, mp::Daemon& daemon)
     QObject::connect(&rpc, &mp::DaemonRpc::on_delete, &daemon, &mp::Daemon::delet);
     QObject::connect(&rpc, &mp::DaemonRpc::on_umount, &daemon, &mp::Daemon::umount);
     QObject::connect(&rpc, &mp::DaemonRpc::on_version, &daemon, &mp::Daemon::version);
+    QObject::connect(&rpc, &mp::DaemonRpc::on_get, &daemon, &mp::Daemon::get);
 }
 
 template <typename Instances, typename InstanceMap, typename InstanceCheck>
@@ -1967,6 +1968,31 @@ void mp::Daemon::version(const VersionRequest* request, grpc::ServerWriter<Versi
     config->update_prompt->populate(reply.mutable_update_info());
     server->Write(reply);
     status_promise->set_value(grpc::Status::OK);
+}
+
+void mp::Daemon::get(const GetRequest* request, grpc::ServerWriter<GetReply>* server,
+                     std::promise<grpc::Status>* status_promise)
+try
+{
+    mpl::ClientLogger<GetReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
+    GetReply reply;
+
+    auto key = request->key();
+    auto val = MP_SETTINGS.get(QString::fromStdString(key)).toStdString();
+    mpl::log(mpl::Level::debug, category, fmt::format("Returning setting {}={}", key, val));
+
+    reply.set_value(val);
+    server->Write(reply);
+    status_promise->set_value(grpc::Status::OK);
+}
+catch (const mp::InvalidSettingsException& e)
+{
+    status_promise->set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, e.what(), ""));
+}
+catch (const std::exception& e)
+{
+    status_promise->set_value(grpc::Status(grpc::StatusCode::INTERNAL, e.what(), ""));
 }
 
 void mp::Daemon::on_shutdown()

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1432,6 +1432,9 @@ try // clang-format on
     NetworksReply response;
     config->update_prompt->populate_if_time_to_show(response.mutable_update_info());
 
+    if (!instances_running(vm_instances))
+        config->factory->hypervisor_health_check();
+
     const auto& iface_list = config->factory->networks();
 
     for (const auto& iface : iface_list)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -451,8 +451,28 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(const mp::LaunchRequ
     return interfaces;
 }
 
-auto validate_create_arguments(const mp::LaunchRequest* request, const mp::VirtualMachineFactory& factory)
+void validate_image(const mp::LaunchRequest* request, const mp::VMImageVault& vault,
+                    mp::VMWorkflowProvider& workflow_provider)
 {
+    // TODO: Refactor this in such a way that we can use info returned here instead of ignoring it to avoid calls
+    //       later that accomplish the same thing.
+    try
+    {
+        workflow_provider.info_for(request->image());
+    }
+    catch (const std::out_of_range&)
+    {
+        auto image_query = query_from(request, "");
+        if (image_query.query_type == mp::Query::Type::Alias)
+            vault.all_info_for(image_query);
+    }
+}
+
+auto validate_create_arguments(const mp::LaunchRequest* request, const mp::DaemonConfig* config)
+{
+    assert(config && config->factory && config->workflow_provider && config->vault && "null ptr somewhere...");
+    validate_image(request, *config->vault, *config->workflow_provider);
+
     static const auto min_mem = try_mem_size(mp::min_memory_size);
     static const auto min_disk = try_mem_size(mp::min_disk_size);
     assert(min_mem && min_disk);
@@ -490,7 +510,7 @@ auto validate_create_arguments(const mp::LaunchRequest* request, const mp::Virtu
         option_errors.add_error_codes(mp::LaunchError::INVALID_HOSTNAME);
 
     std::vector<std::string> nets_need_bridging;
-    auto extra_interfaces = validate_extra_interfaces(request, factory, nets_need_bridging, option_errors);
+    auto extra_interfaces = validate_extra_interfaces(request, *config->factory, nets_need_bridging, option_errors);
 
     struct CheckedArguments
     {
@@ -2159,13 +2179,7 @@ std::string mp::Daemon::check_instance_exists(const std::string& instance_name) 
 void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriter<CreateReply>* server,
                            std::promise<grpc::Status>* status_promise, bool start)
 {
-    // Try to get info for the requested image. This will throw out if the requested image is not found. This check
-    // needs to be done before the other checks.
-    auto image_query = query_from(request, "");
-    if (image_query.query_type == Query::Type::Alias)
-        config->vault->all_info_for(image_query);
-
-    auto checked_args = validate_create_arguments(request, *config->factory);
+    auto checked_args = validate_create_arguments(request, config.get());
 
     if (!checked_args.option_errors.error_codes().empty())
     {

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -139,6 +139,9 @@ public slots:
     virtual void version(const VersionRequest* request, grpc::ServerWriter<VersionReply>* response,
                          std::promise<grpc::Status>* status_promise);
 
+    virtual void get(const GetRequest* request, grpc::ServerWriter<GetReply>* response,
+                     std::promise<grpc::Status>* status_promise);
+
 private:
     void persist_instances();
     void release_resources(const std::string& instance);

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2017-2020 Canonical, Ltd.
+ * Copyright (C) 2017-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -224,4 +224,11 @@ grpc::Status mp::DaemonRpc::version(grpc::ServerContext* context, const VersionR
 grpc::Status mp::DaemonRpc::ping(grpc::ServerContext* context, const PingRequest* request, PingReply* response)
 {
     return grpc::Status::OK;
+}
+
+grpc::Status mp::DaemonRpc::get(grpc::ServerContext* context, const GetRequest* request,
+                                grpc::ServerWriter<GetReply>* response)
+{
+    return emit_signal_and_wait_for_result(
+        std::bind(&DaemonRpc::on_get, this, request, response, std::placeholders::_1));
 }

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -83,6 +83,8 @@ signals:
                    std::promise<grpc::Status>* status_promise);
     void on_version(const VersionRequest* request, grpc::ServerWriter<VersionReply>* response,
                     std::promise<grpc::Status>* status_promise);
+    void on_get(const GetRequest* request, grpc::ServerWriter<GetReply>* response,
+                std::promise<grpc::Status>* status_promise);
 
 private:
     const std::string server_address;
@@ -124,6 +126,8 @@ protected:
     grpc::Status version(grpc::ServerContext* context, const VersionRequest* request,
                          grpc::ServerWriter<VersionReply>* response) override;
     grpc::Status ping(grpc::ServerContext* context, const PingRequest* request, PingReply* response) override;
+    grpc::Status get(grpc::ServerContext* context, const GetRequest* request,
+                     grpc::ServerWriter<GetReply>* response) override;
 };
 } // namespace multipass
 #endif // MULTIPASS_DAEMON_RPC_H

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -213,15 +213,11 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
 
 void mp::LXDVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
 {
-    auto host_nets = networks();
-    for (auto& net : extra_interfaces)
-    {
-        auto it = std::find_if(host_nets.cbegin(), host_nets.cend(),
-                               [&net](const mp::NetworkInterfaceInfo& info) { return info.id == net.id; });
-        if (it != host_nets.end() && it->type == "ethernet")
-        {
-            it = find_bridge_with(host_nets, net.id);
-            net.id = it != host_nets.cend() ? it->id : mp::backend::create_bridge_with(net.id);
-        }
-    }
+    prepare_networking_guts(extra_interfaces, "bridge");
+}
+
+std::string mp::LXDVirtualMachineFactory::create_bridge_with(const NetworkInterfaceInfo& interface)
+{
+    assert(interface.type == "ethernet");
+    return MP_BACKEND.create_bridge_with(interface.id);
 }

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -27,7 +27,7 @@
 
 namespace multipass
 {
-class LXDVirtualMachineFactory final : public BaseVirtualMachineFactory
+class LXDVirtualMachineFactory : public BaseVirtualMachineFactory
 {
 public:
     explicit LXDVirtualMachineFactory(const Path& data_dir, const QUrl& base_url = lxd_socket_url);
@@ -55,6 +55,9 @@ public:
     void configure(VirtualMachineDescription& vm_desc) override{};
 
     std::vector<NetworkInterfaceInfo> networks() const override;
+
+protected:
+    std::string create_bridge_with(const NetworkInterfaceInfo& interface) override;
 
 private:
     NetworkAccessManager::UPtr manager;

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -228,8 +228,6 @@ mp::QemuVirtualMachine::~QemuVirtualMachine()
         {
             shutdown();
         }
-
-        vm_process->wait_for_finished();
     }
 
     remove_tap_device(QString::fromStdString(tap_device_name));
@@ -318,11 +316,11 @@ void mp::QemuVirtualMachine::suspend()
             state = State::suspending;
             update_state();
             update_shutdown_status = false;
-
-            vm_process->write(hmc_to_qmp_json("savevm " + QString::fromStdString(suspend_tag)));
-            vm_process->wait_for_finished();
-            vm_process.reset(nullptr);
         }
+
+        vm_process->write(hmc_to_qmp_json("savevm " + QString::fromStdString(suspend_tag)));
+        vm_process->wait_for_finished();
+        vm_process.reset(nullptr);
     }
     else if (state == State::off || state == State::suspended)
     {

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -71,7 +71,7 @@ void mp::BaseVirtualMachineFactory::prepare_networking_guts(std::vector<NetworkI
 }
 
 void mp::BaseVirtualMachineFactory::prepare_interface(NetworkInterface& net,
-                                                      const std::vector<NetworkInterfaceInfo>& host_nets,
+                                                      std::vector<NetworkInterfaceInfo>& host_nets,
                                                       const std::string& bridge_type)
 {
     auto net_it = std::find_if(host_nets.cbegin(), host_nets.cend(),
@@ -79,7 +79,14 @@ void mp::BaseVirtualMachineFactory::prepare_interface(NetworkInterface& net,
 
     if (net_it != host_nets.end() && net_it->type != bridge_type)
     {
-        auto bridge_it = find_bridge_with(host_nets, net.id, bridge_type);
-        net.id = bridge_it != host_nets.cend() ? bridge_it->id : create_bridge_with(*net_it);
+        if (auto bridge_it = find_bridge_with(host_nets, net.id, bridge_type); bridge_it != host_nets.cend())
+        {
+            net.id = bridge_it->id;
+        }
+        else
+        {
+            net.id = create_bridge_with(*net_it);
+            host_nets.push_back({net.id, bridge_type, "new bridge", {net_it->id}});
+        }
     }
 }

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -18,11 +18,26 @@
 #include "base_virtual_machine_factory.h"
 
 #include <multipass/cloud_init_iso.h>
+#include <multipass/network_interface.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/utils.h>
 #include <multipass/virtual_machine_description.h>
 
 namespace mp = multipass;
 namespace mpu = multipass::utils;
+
+namespace
+{
+template <typename NetworkContainer>
+auto find_bridge_with(const NetworkContainer& networks, const std::string& member_network,
+                      const std::string& bridge_type)
+{
+    return std::find_if(std::cbegin(networks), std::cend(networks),
+                        [&member_network, &bridge_type](const mp::NetworkInterfaceInfo& info) {
+                            return info.type == bridge_type && info.has_link(member_network);
+                        });
+}
+} // namespace
 
 void mp::BaseVirtualMachineFactory::configure(VirtualMachineDescription& vm_desc)
 {
@@ -42,4 +57,29 @@ void mp::BaseVirtualMachineFactory::configure(VirtualMachineDescription& vm_desc
     }
 
     vm_desc.cloud_init_iso = cloud_init_iso;
+}
+
+void mp::BaseVirtualMachineFactory::prepare_networking_guts(std::vector<NetworkInterface>& extra_interfaces,
+                                                            const std::string& bridge_type)
+{
+    if (!extra_interfaces.empty())
+    {
+        auto host_nets = networks(); // expensive
+        for (auto& net : extra_interfaces)
+            prepare_interface(net, host_nets, bridge_type);
+    }
+}
+
+void mp::BaseVirtualMachineFactory::prepare_interface(NetworkInterface& net,
+                                                      const std::vector<NetworkInterfaceInfo>& host_nets,
+                                                      const std::string& bridge_type)
+{
+    auto net_it = std::find_if(host_nets.cbegin(), host_nets.cend(),
+                               [&net](const mp::NetworkInterfaceInfo& info) { return info.id == net.id; });
+
+    if (net_it != host_nets.end() && net_it->type != bridge_type)
+    {
+        auto bridge_it = find_bridge_with(host_nets, net.id, bridge_type);
+        net.id = bridge_it != host_nets.cend() ? bridge_it->id : create_bridge_with(*net_it);
+    }
 }

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -73,7 +73,7 @@ protected:
     virtual void prepare_networking_guts(std::vector<NetworkInterface>& extra_interfaces,
                                          const std::string& bridge_type);
 
-    virtual void prepare_interface(NetworkInterface& net, const std::vector<NetworkInterfaceInfo>& host_nets,
+    virtual void prepare_interface(NetworkInterface& net, std::vector<NetworkInterfaceInfo>& host_nets,
                                    const std::string& bridge_type);
 };
 } // namespace multipass

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -64,6 +64,17 @@ public:
         throw NotImplementedOnThisBackendException("networks");
     };
 
+protected:
+    std::string create_bridge_with(const NetworkInterfaceInfo& interface) override
+    {
+        throw NotImplementedOnThisBackendException{"bridge creation"};
+    }
+
+    virtual void prepare_networking_guts(std::vector<NetworkInterface>& extra_interfaces,
+                                         const std::string& bridge_type);
+
+    virtual void prepare_interface(NetworkInterface& net, const std::vector<NetworkInterfaceInfo>& host_nets,
+                                   const std::string& bridge_type);
 };
 } // namespace multipass
 

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -322,7 +322,7 @@ void mp::backend::check_if_kvm_is_in_use()
 
 // @precondition no bridge exists for this interface
 // @precondition interface identifies an ethernet device
-std::string mp::backend::create_bridge_with(const std::string& interface)
+std::string mp::Backend::create_bridge_with(const std::string& interface)
 {
     static constexpr auto log_category_create = "create bridge";
     static constexpr auto log_category_rollback = "rollback bridge";

--- a/src/platform/backends/shared/linux/backend_utils.h
+++ b/src/platform/backends/shared/linux/backend_utils.h
@@ -19,10 +19,13 @@
 #define MULTIPASS_BACKEND_UTILS_H
 
 #include <multipass/path.h>
+#include <multipass/singleton.h>
 
 #include <chrono>
 #include <stdexcept>
 #include <string>
+
+#define MP_BACKEND multipass::Backend::instance()
 
 class QDBusError;
 
@@ -40,7 +43,6 @@ Path convert_to_qcow_if_necessary(const Path& image_path);
 QString cpu_arch();
 void check_for_kvm_support();
 void check_if_kvm_is_in_use();
-std::string create_bridge_with(const std::string& interface);
 
 class CreateBridgeException : public std::runtime_error
 {
@@ -48,5 +50,13 @@ public:
     CreateBridgeException(const std::string& detail, const QDBusError& dbus_error, bool rollback = false);
 };
 } // namespace backend
+
+class Backend : public Singleton<Backend>
+{
+public:
+    using Singleton<Backend>::Singleton;
+
+    virtual std::string create_bridge_with(const std::string& interface);
+};
 } // namespace multipass
 #endif // MULTIPASS_BACKEND_UTILS_H

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -19,6 +19,7 @@
 #include <multipass/exceptions/autostart_setup_exception.h>
 #include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/exceptions/snap_environment_exception.h>
+#include <multipass/file_ops.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
@@ -153,6 +154,69 @@ void update_bridges(std::map<std::string, mp::NetworkInterfaceInfo>& networks)
     }
 }
 } // namespace
+
+std::unique_ptr<QFile> multipass::platform::detail::find_os_release()
+{
+    const std::array<QString, 3> options{QStringLiteral("/var/lib/snapd/hostfs/etc/os-release"),
+                                         QStringLiteral("/var/lib/snapd/hostfs/usr/lib/os-release"),
+                                         QStringLiteral("")};
+
+    auto it = options.cbegin();
+    auto ret = std::make_unique<QFile>(*it);
+    while (++it != options.cend() && !MP_FILEOPS.open(*ret, QIODevice::ReadOnly | QIODevice::Text))
+        ret->setFileName(*it);
+
+    return ret;
+}
+
+std::pair<QString, QString> multipass::platform::detail::parse_os_release(const QStringList& os_data)
+{
+    const QString id_field = "NAME";
+    const QString version_field = "VERSION_ID";
+
+    QString distro_id = "unknown";
+    QString distro_rel = "unknown";
+
+    auto strip_quotes = [](const QString& val) -> QString { return val.mid(1, val.length() - 2); };
+
+    for (const QString& line : os_data)
+    {
+        QStringList split = line.split('=', QString::KeepEmptyParts);
+        if (split.length() == 2 && split[1].length() > 2) // Check for at least 1 char between quotes.
+        {
+            if (split[0] == id_field)
+                distro_id = strip_quotes(split[1]);
+            else if (split[0] == version_field)
+                distro_rel = strip_quotes(split[1]);
+        }
+    }
+
+    return std::pair(distro_id, distro_rel);
+}
+
+std::string multipass::platform::detail::read_os_release()
+{
+    std::unique_ptr<QFile> os_release = find_os_release();
+
+    QStringList os_info;
+    if (MP_FILEOPS.is_open(*os_release))
+    {
+        QTextStream input(os_release.get());
+        QString line = MP_FILEOPS.read_line(input);
+        while (!line.isNull())
+        {
+            os_info.append(line);
+            line = MP_FILEOPS.read_line(input);
+        }
+        os_release->close();
+
+        auto parsed = parse_os_release(os_info);
+
+        return fmt::format("{}-{}", parsed.first, parsed.second);
+    }
+
+    return "unknown-unknown";
+}
 
 std::map<std::string, mp::NetworkInterfaceInfo> mp::platform::Platform::get_network_interfaces_info() const
 {
@@ -307,4 +371,10 @@ bool mp::platform::is_image_url_supported()
 std::string mp::platform::reinterpret_interface_id(const std::string& ux_id)
 {
     return ux_id;
+}
+
+std::string multipass::platform::host_version()
+{
+    return mu::in_multipass_snap() ? multipass::platform::detail::read_os_release()
+                                   : fmt::format("{}-{}", QSysInfo::productType(), QSysInfo::productVersion());
 }

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -315,6 +315,11 @@ QString mp::platform::default_driver()
     return QStringLiteral("qemu");
 }
 
+QString mp::platform::default_privileged_mounts()
+{
+    return QStringLiteral("true");
+}
+
 QString mp::platform::daemon_config_home() // temporary
 {
     auto ret = QString{qgetenv("DAEMON_CONFIG_HOME")};

--- a/src/platform/platform_linux_detail.h
+++ b/src/platform/platform_linux_detail.h
@@ -25,6 +25,9 @@
 namespace multipass::platform::detail
 {
 std::map<std::string, NetworkInterfaceInfo> get_network_interfaces_from(const QDir& sys_dir);
-}
+std::unique_ptr<QFile> find_os_release();
+std::pair<QString, QString> parse_os_release(const QStringList& os_data);
+std::string read_os_release();
+} // namespace multipass::platform::detail
 
 #endif // MULTIPASS_PLATFORM_LINUX_DETAIL_H

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -35,6 +35,7 @@ service Rpc {
     rpc delet (DeleteRequest) returns (stream DeleteReply);
     rpc umount (UmountRequest) returns (stream UmountReply);
     rpc version (VersionRequest) returns (stream VersionReply);
+    rpc get (GetRequest) returns (stream GetReply);
 }
 
 message OptInStatus {
@@ -390,4 +391,14 @@ message VersionReply {
     string version = 1;
     string log_line = 2;
     UpdateInfo update_info = 3;
+}
+
+message GetRequest {
+    string key = 1;
+    int32 verbosity_level = 2;
+}
+
+message GetReply {
+    string value = 1;
+    string log_line = 2;
 }

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -38,9 +38,19 @@ bool mp::FileOps::open(QFile& file, QIODevice::OpenMode mode)
     return file.open(mode);
 }
 
+bool mp::FileOps::is_open(const QFile& file) const
+{
+    return file.isOpen();
+}
+
 qint64 mp::FileOps::read(QFile& file, char* data, qint64 maxSize)
 {
     return file.read(data, maxSize);
+}
+
+QString mp::FileOps::read_line(QTextStream& text_stream) const
+{
+    return text_stream.readLine();
 }
 
 bool mp::FileOps::remove(QFile& file)

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -54,7 +54,8 @@ std::map<QString, QString> make_defaults()
                                           {mp::driver_key, mp::platform::default_driver()},
                                           {mp::autostart_key, autostart_default},
                                           {mp::hotkey_key, default_hotkey()},
-                                          {mp::bridged_interface_key, ""}};
+                                          {mp::bridged_interface_key, ""},
+                                          {mp::mounts_key, mp::platform::default_privileged_mounts()}};
 
     for(const auto& [k, v] : mp::platform::extra_settings_defaults())
         ret.insert_or_assign(k, v);
@@ -206,7 +207,7 @@ void multipass::Settings::set_aux(const QString& key, QString val) // work with 
         throw InvalidSettingsException{key, val, "Invalid hostname"};
     else if (key == driver_key && !mp::platform::is_backend_supported(val))
         throw InvalidSettingsException(key, val, "Invalid driver");
-    else if (key == autostart_key && (val = interpret_bool(val)) != "true" && val != "false")
+    else if ((key == autostart_key || key == mounts_key) && (val = interpret_bool(val)) != "true" && val != "false")
         throw InvalidSettingsException(key, val, "Invalid flag, try \"true\" or \"false\"");
     else if (key == winterm_key || key == hotkey_key)
         val = mp::platform::interpret_setting(key, val);

--- a/tests/daemon_test_fixture.h
+++ b/tests/daemon_test_fixture.h
@@ -28,6 +28,7 @@
 #include <multipass/cli/command.h>
 #include <multipass/rpc/multipass.grpc.pb.h>
 
+#include "extra_assertions.h"
 #include "mock_standard_paths.h"
 #include "mock_virtual_machine_factory.h"
 #include "stub_cert_store.h"
@@ -163,8 +164,7 @@ struct DaemonTestFixture : public ::Test
     {
         EXPECT_CALL(MockStandardPaths::mock_instance(), locate(_, _, _))
             .Times(AnyNumber()); // needed to allow general calls once we have added the specific expectation below
-        EXPECT_CALL(MockStandardPaths::mock_instance(),
-                    locate(_, Property(&QString::toStdString, EndsWith("settings.json")), _))
+        EXPECT_CALL(MockStandardPaths::mock_instance(), locate(_, match_qstring(EndsWith("settings.json")), _))
             .Times(AnyNumber())
             .WillRepeatedly(Return("")); /* Avoid writing to Windows Terminal settings. We use an "expectation" so that
                                             it gets reset at the end of each test (by VerifyAndClearExpectations) */

--- a/tests/extra_assertions.h
+++ b/tests/extra_assertions.h
@@ -21,6 +21,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <QString>
+
 // Extra macros for testing exceptions.
 //
 //    * MP_{ASSERT|EXPECT}_THROW_THAT(statement, expected_exception, matcher):
@@ -61,6 +63,12 @@ template <typename MsgMatcher>
 auto match_what(MsgMatcher&& matcher)
 {
     return testing::Property(&std::exception::what, std::forward<MsgMatcher>(matcher));
+}
+
+template <typename StrMatcher>
+auto match_qstring(StrMatcher&& matcher)
+{
+    return testing::Property(&QString::toStdString, std::forward<StrMatcher>(matcher));
 }
 } // namespace multipass::test
 

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -347,7 +347,7 @@ struct CreateBridgeTest : public Test
     static auto make_object_path_matcher(const char* path)
     {
         return Property(&QVariant::value<QDBusObjectPath>,
-                        Property(&QDBusObjectPath::path, Property(&QString::toStdString, Eq(path))));
+                        Property(&QDBusObjectPath::path, mpt::match_qstring(Eq(path))));
     }
 
     static QString get_bridge_name(const char* child)

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -389,7 +389,7 @@ TEST_F(CreateBridgeTest, creates_and_activates_connections) // success case
     }
 
     inject_dbus_interfaces();
-    EXPECT_EQ(mp::backend::create_bridge_with(network), get_bridge_name(network).toStdString());
+    EXPECT_EQ(MP_BACKEND.create_bridge_with(network), get_bridge_name(network).toStdString());
 }
 
 TEST_F(CreateBridgeTest, throws_if_bus_disconnected)
@@ -399,7 +399,7 @@ TEST_F(CreateBridgeTest, throws_if_bus_disconnected)
     EXPECT_CALL(mock_bus, last_error).WillOnce(Return(QDBusError{QDBusError::BadAddress, msg}));
 
     MP_EXPECT_THROW_THAT(
-        mp::backend::create_bridge_with("asdf"), mp::backend::CreateBridgeException,
+        MP_BACKEND.create_bridge_with("asdf"), mp::backend::CreateBridgeException,
         mpt::match_what(AllOf(HasSubstr("Could not create bridge"), HasSubstr("Failed to connect to D-Bus system bus"),
                               HasSubstr(msg.toStdString()))));
 }
@@ -421,7 +421,7 @@ TEST_P(CreateBridgeInvalidInterfaceTest, throws_if_interface_invalid)
         inject_settings_interface();
 
     MP_ASSERT_THROW_THAT(
-        mp::backend::create_bridge_with("whatever"), mp::backend::CreateBridgeException,
+        MP_BACKEND.create_bridge_with("whatever"), mp::backend::CreateBridgeException,
         mpt::match_what(AllOf(HasSubstr("Could not reach remote D-Bus object"), HasSubstr(msg.toStdString()))));
 }
 
@@ -441,7 +441,7 @@ TEST_F(CreateBridgeTest, throws_on_failure_to_create_first_connection)
     EXPECT_CALL(*mock_nm_settings, service).WillOnce(Return(svc));
 
     inject_dbus_interfaces();
-    MP_ASSERT_THROW_THAT(mp::backend::create_bridge_with("umdolita"), mp::backend::CreateBridgeException,
+    MP_ASSERT_THROW_THAT(MP_BACKEND.create_bridge_with("umdolita"), mp::backend::CreateBridgeException,
                          mpt::match_what(AllOf(HasSubstr(msg.toStdString()), HasSubstr(ifc.toStdString()),
                                                HasSubstr(obj.toStdString()), HasSubstr(svc.toStdString()))));
 }
@@ -469,7 +469,7 @@ TEST_F(CreateBridgeTest, throws_on_failure_to_create_second_connection)
                                         Eq("org.freedesktop.NetworkManager.Settings.Connection")))
         .WillOnce(Return(ByMove(std::move(mock_nm_connection))));
 
-    MP_ASSERT_THROW_THAT(mp::backend::create_bridge_with("abc"), mp::backend::CreateBridgeException,
+    MP_ASSERT_THROW_THAT(MP_BACKEND.create_bridge_with("abc"), mp::backend::CreateBridgeException,
                          mpt::match_what(AllOf(HasSubstr(msg.toStdString()), HasSubstr(ifc.toStdString()),
                                                HasSubstr(obj.toStdString()), HasSubstr(svc.toStdString()))));
 }
@@ -506,7 +506,7 @@ TEST_F(CreateBridgeTest, throws_on_failure_to_activate_second_connection)
                                         Eq("org.freedesktop.NetworkManager.Settings.Connection")))
         .WillOnce(Return(ByMove(std::move(mock_nm_connection2))));
 
-    MP_ASSERT_THROW_THAT(mp::backend::create_bridge_with("kaka"), mp::backend::CreateBridgeException,
+    MP_ASSERT_THROW_THAT(MP_BACKEND.create_bridge_with("kaka"), mp::backend::CreateBridgeException,
                          mpt::match_what(AllOf(HasSubstr(msg.toStdString()), HasSubstr(ifc.toStdString()),
                                                HasSubstr(obj.toStdString()), HasSubstr(svc.toStdString()))));
 }
@@ -532,7 +532,7 @@ TEST_F(CreateBridgeTest, logs_on_failure_to_rollback)
         .WillOnce(Return(ByMove(std::move(mock_nm_connection1))));
 
     logger_scope.mock_logger->expect_log(mpl::Level::error, rollback_error);
-    MP_ASSERT_THROW_THAT(mp::backend::create_bridge_with("gigi"), int, Eq(original_error));
+    MP_ASSERT_THROW_THAT(MP_BACKEND.create_bridge_with("gigi"), int, Eq(original_error));
 }
 
 struct CreateBridgeExceptionTest : public CreateBridgeTest, WithParamInterface<bool>

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -23,6 +23,7 @@
 #include "mock_lxd_server_responses.h"
 #include "mock_network_access_manager.h"
 #include "tests/extra_assertions.h"
+#include "tests/mock_backend_utils.h"
 #include "tests/mock_environment_helpers.h"
 #include "tests/mock_logger.h"
 #include "tests/mock_status_monitor.h"
@@ -1896,4 +1897,39 @@ TEST_F(LXDBackend, posts_network_data_config_if_available)
 
     mp::LXDVirtualMachine machine{default_description, stub_monitor, mock_network_access_manager.get(), base_url,
                                   bridge_name};
+}
+
+namespace
+{
+class CustomLXDFactory : public mp::LXDVirtualMachineFactory
+{
+public:
+    using mp::LXDVirtualMachineFactory::create_bridge_with;
+    using mp::LXDVirtualMachineFactory::LXDVirtualMachineFactory;
+
+    MOCK_METHOD2(prepare_networking_guts,
+                 void(std::vector<mp::NetworkInterface>& extra_interfaces, const std::string& bridge_type));
+};
+} // namespace
+
+TEST_F(LXDBackend, prepares_networking_via_base_factory)
+{
+    CustomLXDFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
+    std::vector<mp::NetworkInterface> extra_networks{{"netid", "mac", false}};
+
+    auto address = [](const auto& v) { return &v; }; // replace with Address matcher once available
+    EXPECT_CALL(backend, prepare_networking_guts(ResultOf(address, Eq(&extra_networks)), Eq("bridge")));
+    backend.prepare_networking(extra_networks);
+}
+
+TEST_F(LXDBackend, createsBridgesViaBackendUtils)
+{
+    const auto net = mp::NetworkInterfaceInfo{"bla", "ethernet", "ble"};
+    const auto bridge = "bli";
+    auto [mock_backend, guard] = mpt::MockBackend::inject();
+
+    CustomLXDFactory factory{std::move(mock_network_access_manager), data_dir.path(), base_url};
+
+    EXPECT_CALL(*mock_backend, create_bridge_with(net.id)).WillOnce(Return(bridge));
+    EXPECT_EQ(factory.create_bridge_with(net), bridge);
 }

--- a/tests/mock_backend_utils.h
+++ b/tests/mock_backend_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Canonical, Ltd.
+ * Copyright (C) 2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,25 +15,25 @@
  *
  */
 
-#ifndef MULTIPASS_NETWORK_INTERFACE_H
-#define MULTIPASS_NETWORK_INTERFACE_H
+#ifndef MULTIPASS_MOCK_BACKEND_UTILS_H
+#define MULTIPASS_MOCK_BACKEND_UTILS_H
 
-#include <string>
-#include <tuple>
+#include "mock_singleton_helpers.h"
 
-namespace multipass
+#include <src/platform/backends/shared/linux/backend_utils.h>
+
+#include <gmock/gmock.h>
+
+namespace multipass::test
 {
-struct NetworkInterface
+class MockBackend : public Backend
 {
-    std::string id;
-    std::string mac_address;
-    bool auto_mode;
+public:
+    using Backend::Backend;
+    MOCK_METHOD1(create_bridge_with, std::string(const std::string&));
+
+    MP_MOCK_SINGLETON_BOILERPLATE(MockBackend, Backend);
 };
+} // namespace multipass::test
 
-inline bool operator==(const NetworkInterface& a, const NetworkInterface& b)
-{
-    return std::tie(a.id, a.auto_mode, a.mac_address) == std::tie(b.id, b.auto_mode, b.mac_address);
-}
-} // namespace multipass
-
-#endif // MULTIPASS_NETWORK_INTERFACE_H
+#endif // MULTIPASS_MOCK_BACKEND_UTILS_H

--- a/tests/mock_daemon.h
+++ b/tests/mock_daemon.h
@@ -48,6 +48,7 @@ struct MockDaemon : public Daemon
     MOCK_METHOD3(delet, void(const DeleteRequest*, grpc::ServerWriter<DeleteReply>*, std::promise<grpc::Status>*));
     MOCK_METHOD3(umount, void(const UmountRequest*, grpc::ServerWriter<UmountReply>*, std::promise<grpc::Status>*));
     MOCK_METHOD3(version, void(const VersionRequest*, grpc::ServerWriter<VersionReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(get, void(const GetRequest*, grpc::ServerWriter<GetReply>*, std::promise<grpc::Status>*));
 
     template <typename Request, typename Reply>
     void set_promise_value(const Request*, grpc::ServerWriter<Reply>*, std::promise<grpc::Status>* status_promise)

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -34,7 +34,9 @@ public:
     MOCK_METHOD1(isReadable, bool(QDir&));
     MOCK_METHOD2(rmdir, bool(QDir&, const QString& dirName));
     MOCK_METHOD2(open, bool(QFile&, QIODevice::OpenMode));
+    MOCK_CONST_METHOD1(is_open, bool(const QFile&));
     MOCK_METHOD3(read, qint64(QFile&, char*, qint64));
+    MOCK_CONST_METHOD1(read_line, QString(QTextStream&));
     MOCK_METHOD1(remove, bool(QFile&));
     MOCK_METHOD2(rename, bool(QFile&, const QString& newName));
     MOCK_METHOD2(resize, bool(QFile&, qint64 sz));

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -45,6 +45,9 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
                  VMImageVault::UPtr(std::vector<VMImageHost*>, URLDownloader*, const Path&, const Path&, const days&));
     MOCK_METHOD1(configure, void(VirtualMachineDescription&));
     MOCK_CONST_METHOD0(networks, std::vector<NetworkInterfaceInfo>());
+
+    // originally protected:
+    MOCK_METHOD1(create_bridge_with, std::string(const NetworkInterfaceInfo&));
 };
 }
 }

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -100,6 +100,8 @@ struct QemuBackend : public mpt::TestWithMockedBinPath
                 emit process->started();
             });
 
+            EXPECT_CALL(*process, wait_for_finished(_)).WillRepeatedly(Return(true));
+
             EXPECT_CALL(*process, write(_)).WillRepeatedly([process](const QByteArray& data) {
                 QJsonParseError parse_error;
                 auto json = QJsonDocument::fromJson(data, &parse_error);

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "disabling_macros.h"
+#include "extra_assertions.h"
 #include "mock_environment_helpers.h"
 #include "mock_settings.h"
 #include "mock_standard_paths.h"
@@ -108,7 +109,7 @@ struct Client : public Test
         EXPECT_CALL(mpt::MockStandardPaths::mock_instance(), locate(_, _, _))
             .Times(AnyNumber()); // needed to allow general calls once we have added the specific expectation below
         EXPECT_CALL(mpt::MockStandardPaths::mock_instance(),
-                    locate(_, Property(&QString::toStdString, EndsWith("settings.json")), _))
+                    locate(_, mpt::match_qstring(EndsWith("settings.json")), _))
             .Times(AnyNumber())
             .WillRepeatedly(Return("")); /* Avoid writing to Windows Terminal settings. We use an "expectation" so that
                                             it gets reset at the end of each test (by VerifyAndClearExpectations) */

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -106,6 +106,8 @@ struct Client : public Test
         EXPECT_CALL(mock_settings, get(_)).Times(AnyNumber()); /* Admit get calls beyond explicitly expected in tests.
                                                                   This allows general actions to consult settings
                                                                   (e.g. Windows Terminal profile sync) */
+        EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key)))
+            .WillRepeatedly(Return("true")); // Tests assume this default, but platforms may override.
         EXPECT_CALL(mpt::MockStandardPaths::mock_instance(), locate(_, _, _))
             .Times(AnyNumber()); // needed to allow general calls once we have added the specific expectation below
         EXPECT_CALL(mpt::MockStandardPaths::mock_instance(),
@@ -428,6 +430,21 @@ TEST_F(Client, shell_cmd_automounts_when_launching_petenv)
     EXPECT_CALL(mock_daemon, mount(_, _, _)).WillOnce(Return(ok));
     EXPECT_CALL(mock_daemon, ssh_info(_, _, _)).WillOnce(Return(ok));
     EXPECT_THAT(send_command({"shell", petenv_name()}), Eq(mp::ReturnCode::Ok));
+}
+
+TEST_F(Client, shellCmdSkipsAutomountWhenDisabled)
+{
+    std::stringstream cout_stream;
+    const grpc::Status ok{}, notfound{grpc::StatusCode::NOT_FOUND, "msg"};
+    EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key))).WillRepeatedly(Return("false"));
+
+    InSequence seq;
+    EXPECT_CALL(mock_daemon, ssh_info(_, _, _)).WillOnce(Return(notfound));
+    EXPECT_CALL(mock_daemon, launch(_, _, _)).WillOnce(Return(ok));
+    EXPECT_CALL(mock_daemon, mount(_, _, _)).Times(0);
+    EXPECT_CALL(mock_daemon, ssh_info(_, _, _)).WillOnce(Return(ok));
+    EXPECT_THAT(send_command({"shell", petenv_name()}, cout_stream, trash_stream), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(cout_stream.str(), HasSubstr("Skipping 'Home' mount due to disabled mounts feature\n"));
 }
 
 TEST_F(Client, shell_cmd_forwards_verbosity_to_subcommands)
@@ -1145,6 +1162,33 @@ TEST_F(Client, start_cmd_automounts_when_launching_petenv)
     EXPECT_THAT(send_command({"start", petenv_name()}), Eq(mp::ReturnCode::Ok));
 }
 
+TEST_F(Client, startCmdSkipsAutomountWhenDisabled)
+{
+    std::stringstream cout_stream;
+    const grpc::Status ok{}, aborted = aborted_start_status({petenv_name()});
+    EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key))).WillRepeatedly(Return("false"));
+
+    InSequence seq;
+    EXPECT_CALL(mock_daemon, start(_, _, _)).WillOnce(Return(aborted));
+    EXPECT_CALL(mock_daemon, launch(_, _, _)).WillOnce(Return(ok));
+    EXPECT_CALL(mock_daemon, mount(_, _, _)).Times(0);
+    EXPECT_CALL(mock_daemon, start(_, _, _)).WillOnce(Return(ok));
+    EXPECT_THAT(send_command({"start", petenv_name()}, cout_stream, trash_stream), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(cout_stream.str(), HasSubstr("Skipping 'Home' mount due to disabled mounts feature\n"));
+}
+
+TEST_F(Client, launchCmdOnlyWarnsMountForPetEnv)
+{
+    const auto invalid_argument = grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, "msg"};
+    std::stringstream cout_stream;
+    EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key))).WillRepeatedly(Return("false"));
+    EXPECT_CALL(mock_daemon, launch(_, _, _)).WillOnce(Return(invalid_argument));
+
+    EXPECT_THAT(send_command({"launch", "--name", ".asdf"}, cout_stream, trash_stream),
+                Eq(mp::ReturnCode::CommandFail));
+    EXPECT_THAT(cout_stream.str(), Not(HasSubstr("Skipping 'Home' mount due to disabled mounts feature\n")));
+}
+
 TEST_F(Client, start_cmd_forwards_verbosity_to_subcommands)
 {
     const grpc::Status ok{}, aborted = aborted_start_status({petenv_name()});
@@ -1680,7 +1724,7 @@ TEST_P(TestBasicGetSetOptions, set_cmd_allows_empty_val)
 
 INSTANTIATE_TEST_SUITE_P(Client, TestBasicGetSetOptions,
                          Values(mp::petenv_key, mp::driver_key, mp::autostart_key, mp::hotkey_key,
-                                mp::bridged_interface_key));
+                                mp::bridged_interface_key, mp::mounts_key));
 
 TEST_F(Client, get_cmd_fails_with_no_arguments)
 {
@@ -1942,6 +1986,31 @@ TEST_F(Client, get_and_set_can_read_and_write_winterm_integration)
 }
 
 #endif // #ifndef MULTIPASS_PLATFORM_WINDOWS
+
+TEST_F(Client, getReturnsAcceptableMountsValueByDefault)
+{
+    EXPECT_THAT(get_setting(mp::mounts_key), AnyOf("true", "false"));
+}
+
+TEST_F(Client, setCmdRejectsBadMountsValues)
+{
+    aux_set_cmd_rejects_bad_val(mp::mounts_key, "asdf");
+    aux_set_cmd_rejects_bad_val(mp::mounts_key, "trueasdf");
+    aux_set_cmd_rejects_bad_val(mp::mounts_key, "123");
+    aux_set_cmd_rejects_bad_val(mp::mounts_key, "");
+}
+
+TEST_F(Client, getAndSetCanReadAndWriteMountsFlag)
+{
+    const auto orig = get_setting((mp::mounts_key));
+    const auto novel = negate_flag_string(orig);
+
+    EXPECT_CALL(mock_settings, set(Eq(mp::mounts_key), Eq(QString::fromStdString(novel))));
+    EXPECT_THAT(send_command({"set", keyval_arg(mp::mounts_key, novel)}), Eq(mp::ReturnCode::Ok));
+
+    EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key))).WillRepeatedly(Return(QString::fromStdString(novel)));
+    EXPECT_THAT(get_setting(mp::mounts_key), Eq(novel));
+}
 
 // general help tests
 TEST_F(Client, help_returns_ok_return_code)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -127,6 +127,8 @@ TEST_F(Daemon, receives_commands)
 {
     mpt::MockDaemon daemon{config_builder.build()};
 
+    EXPECT_CALL(daemon, get)
+        .WillOnce(Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::GetRequest, mp::GetReply>));
     EXPECT_CALL(daemon, create(_, _, _))
         .WillOnce(Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::CreateRequest, mp::CreateReply>));
     EXPECT_CALL(daemon, launch(_, _, _))
@@ -160,7 +162,8 @@ TEST_F(Daemon, receives_commands)
     EXPECT_CALL(daemon, umount(_, _, _))
         .WillOnce(Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::UmountRequest, mp::UmountReply>));
 
-    send_commands({{"test_create", "foo"},
+    send_commands({{"test_get", "foo"},
+                   {"test_create", "foo"},
                    {"launch", "foo"},
                    {"delete", "foo"},
                    {"exec", "foo", "--", "cmd"},
@@ -798,7 +801,7 @@ TEST_P(MinSpaceViolatedSuite, refuses_launch_with_memory_below_threshold)
     const auto& opt_value = std::get<2>(param);
 
     EXPECT_CALL(*mock_factory, create_virtual_machine(_, _)).Times(0); // expect *no* call
-    send_command({cmd, opt_name, opt_value}, std::cout, stream);
+    send_command({cmd, opt_name, opt_value}, trash_stream, stream);
     EXPECT_THAT(stream.str(), AllOf(HasSubstr("fail"), AnyOf(HasSubstr("memory"), HasSubstr("disk"))));
 }
 
@@ -1036,7 +1039,7 @@ TEST_F(Daemon, refuses_launch_with_invalid_network_interface)
     EXPECT_CALL(*mock_factory, networks());
 
     std::stringstream err_stream;
-    send_command({"launch", "--network", "eth2"}, std::cout, err_stream);
+    send_command({"launch", "--network", "eth2"}, trash_stream, err_stream);
     EXPECT_THAT(err_stream.str(), HasSubstr("Invalid network options supplied"));
 }
 
@@ -1046,7 +1049,7 @@ TEST_F(Daemon, refuses_launch_because_bridging_is_not_implemented)
     mp::Daemon daemon{config_builder.build()};
 
     std::stringstream err_stream;
-    send_command({"launch", "--network", "eth0"}, std::cout, err_stream);
+    send_command({"launch", "--network", "eth0"}, trash_stream, err_stream);
     EXPECT_THAT(err_stream.str(), HasSubstr("The bridging feature is not implemented on this backend"));
 }
 
@@ -1062,7 +1065,7 @@ TEST_P(RefuseBridging, old_image)
     EXPECT_CALL(*mock_factory, networks());
 
     std::stringstream err_stream;
-    send_command({"launch", full_image_name, "--network", "eth0"}, std::cout, err_stream);
+    send_command({"launch", full_image_name, "--network", "eth0"}, trash_stream, err_stream);
     EXPECT_THAT(err_stream.str(), HasSubstr("Automatic network configuration not available for"));
 }
 
@@ -1100,7 +1103,7 @@ TEST_F(Daemon, fails_with_image_not_found_also_if_image_is_also_non_bridgeable)
     mp::Daemon daemon{config_builder.build()};
 
     std::stringstream err_stream;
-    send_command({"launch", "release:xenial", "--network", "eth0"}, std::cout, err_stream);
+    send_command({"launch", "release:xenial", "--network", "eth0"}, trash_stream, err_stream);
     EXPECT_THAT(err_stream.str(), HasSubstr("Unable to find an image matching \"xenial\""));
 }
 
@@ -1251,7 +1254,7 @@ TEST_F(Daemon, prevents_repetition_of_loaded_mac_addresses)
 
     std::stringstream stream;
     EXPECT_CALL(*mock_factory, create_virtual_machine).Times(0); // expect *no* call
-    send_command({"launch", "--network", fmt::format("name=eth0,mac={}", repeated_mac)}, std::cout, stream);
+    send_command({"launch", "--network", fmt::format("name=eth0,mac={}", repeated_mac)}, trash_stream, stream);
     EXPECT_THAT(stream.str(), AllOf(HasSubstr("fail"), HasSubstr("Repeated MAC"), HasSubstr(repeated_mac)));
 }
 
@@ -1415,7 +1418,7 @@ TEST_F(Daemon, refuses_launch_bridged_without_setting)
     EXPECT_CALL(*mock_factory, networks()).Times(0);
 
     std::stringstream err_stream;
-    send_command({"launch", "--network", "bridged"}, std::cout, err_stream);
+    send_command({"launch", "--network", "bridged"}, trash_stream, err_stream);
     EXPECT_THAT(err_stream.str(),
                 HasSubstr("You have to `multipass set local.bridged-network=<name>` to use the `--bridged` shortcut."));
 }
@@ -1430,7 +1433,7 @@ TEST_F(Daemon, refuses_launch_with_invalid_bridged_interface)
     EXPECT_CALL(mock_settings, get(Eq(mp::bridged_interface_key))).WillRepeatedly(Return("invalid"));
 
     std::stringstream err_stream;
-    send_command({"launch", "--network", "bridged"}, std::cout, err_stream);
+    send_command({"launch", "--network", "bridged"}, trash_stream, err_stream);
     EXPECT_THAT(err_stream.str(),
                 HasSubstr("Invalid network 'invalid' set as bridged interface, use `multipass set "
                           "local.bridged-network=<name>` to correct. See `multipass networks` for valid names."));
@@ -1443,8 +1446,53 @@ TEST_F(Daemon, refusesDisabledMount)
     EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key))).WillRepeatedly(Return("false"));
 
     std::stringstream err_stream;
-    send_command({"mount", ".", "target"}, std::cout, err_stream);
+    send_command({"mount", ".", "target"}, trash_stream, err_stream);
     EXPECT_THAT(err_stream.str(), HasSubstr("Mounts are disabled on this installation of Multipass."));
+}
+
+TEST_F(Daemon, getReturnsSetting)
+{
+    mp::Daemon daemon{config_builder.build()};
+
+    const auto key = "foo";
+    const auto val = "bar";
+    EXPECT_CALL(mock_settings, get(Eq(key))).WillOnce(Return(val));
+
+    std::stringstream stream;
+    send_command({"test_get", key}, stream);
+    EXPECT_THAT(stream.str(), AllOf(HasSubstr(key), HasSubstr(val)));
+}
+
+TEST_F(Daemon, getHandlesEmptyKey)
+{
+    mp::Daemon daemon{config_builder.build()};
+
+    std::stringstream err_stream;
+    send_command({"test_get", ""}, trash_stream, err_stream);
+    EXPECT_THAT(err_stream.str(), AllOf(HasSubstr("Unrecognized"), HasSubstr("''")));
+}
+
+TEST_F(Daemon, getHandlesInvalidKey)
+{
+    mp::Daemon daemon{config_builder.build()};
+
+    const auto bad_key = "bad";
+
+    std::stringstream err_stream;
+    send_command({"test_get", bad_key}, trash_stream, err_stream);
+    EXPECT_THAT(err_stream.str(), AllOf(HasSubstr("Unrecognized"), HasSubstr(bad_key)));
+}
+
+TEST_F(Daemon, getReportsException)
+{
+    mp::Daemon daemon{config_builder.build()};
+
+    const auto key = "foo";
+    EXPECT_CALL(mock_settings, get(Eq(key))).WillOnce(Throw(std::runtime_error{"exception"}));
+
+    std::stringstream err_stream;
+    send_command({"test_get", key}, trash_stream, err_stream);
+    EXPECT_THAT(err_stream.str(), HasSubstr("exception"));
 }
 
 } // namespace

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1495,4 +1495,34 @@ TEST_F(Daemon, getReportsException)
     EXPECT_THAT(err_stream.str(), HasSubstr("exception"));
 }
 
+TEST_F(Daemon, requests_networks)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    mp::Daemon daemon{config_builder.build()};
+
+    std::vector<mp::NetworkInterfaceInfo> nets{{"net_a", "type_a", "description_a"},
+                                               {"net_b", "type_b", "description_b"}};
+    EXPECT_CALL(*mock_factory, networks).WillOnce(Return(nets));
+
+    std::stringstream stream;
+    send_command({"networks"}, stream);
+
+    auto got = stream.str();
+    for (const auto& net : nets)
+    {
+        EXPECT_THAT(got, HasSubstr(net.id));
+        EXPECT_THAT(got, HasSubstr(net.type));
+        EXPECT_THAT(got, HasSubstr(net.description));
+    }
+}
+
+TEST_F(Daemon, performs_health_check_on_networks)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    mp::Daemon daemon{config_builder.build()};
+
+    EXPECT_CALL(*mock_factory, hypervisor_health_check);
+    send_command({"networks"});
+}
+
 } // namespace

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1099,7 +1099,12 @@ TEST_F(Daemon, fails_with_image_not_found_also_if_image_is_also_non_bridgeable)
         return default_vault.all_info_for(query);
     });
 
+    auto mock_workflow_provider = std::make_unique<NiceMock<mpt::MockVMWorkflowProvider>>();
+    EXPECT_CALL(*mock_workflow_provider, info_for(_)).WillOnce(Throw(std::out_of_range("")));
+
     config_builder.vault = std::move(mock_image_vault);
+    config_builder.workflow_provider = std::move(mock_workflow_provider);
+
     mp::Daemon daemon{config_builder.build()};
 
     std::stringstream err_stream;

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -21,7 +21,6 @@
 #include <multipass/name_generator.h>
 #include <multipass/version.h>
 #include <multipass/virtual_machine_factory.h>
-#include <multipass/vm_image_host.h>
 
 #include "daemon_test_fixture.h"
 #include "dummy_ssh_key_provider.h"
@@ -29,6 +28,7 @@
 #include "file_operations.h"
 #include "mock_daemon.h"
 #include "mock_environment_helpers.h"
+#include "mock_image_host.h"
 #include "mock_logger.h"
 #include "mock_platform.h"
 #include "mock_process_factory.h"
@@ -1071,8 +1071,38 @@ std::vector<std::string> old_releases{"10.04",   "lucid",  "11.10",   "oneiric",
                                       "14.10",   "utopic", "15.04",   "vivid",   "15.10", "wily",    "16.04",
                                       "xenial",  "16.10",  "yakkety", "17.04",   "zesty"};
 
-INSTANTIATE_TEST_SUITE_P(DaemonRefuseRelease, RefuseBridging, Combine(Values("release", ""), ValuesIn(old_releases)));
+std::vector<std::string> old_remoteless_rels{"core", "core16"};
+
+INSTANTIATE_TEST_SUITE_P(DaemonRefuseRelease, RefuseBridging,
+                         Combine(Values("release", "daily", ""), ValuesIn(old_releases)));
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseSnapcraft, RefuseBridging, Values(std::make_tuple("snapcraft", "core")));
+INSTANTIATE_TEST_SUITE_P(DaemonRefuseRemoteless, RefuseBridging, Combine(Values(""), ValuesIn(old_remoteless_rels)));
+
+TEST_F(Daemon, fails_with_image_not_found_also_if_image_is_also_non_bridgeable)
+{
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+    auto mock_image_host_ptr = mock_image_host.get();
+
+    std::vector<mp::VMImageHost*> hosts;
+    hosts.push_back(mock_image_host_ptr);
+
+    mp::URLDownloader downloader(std::chrono::milliseconds(1));
+    mp::DefaultVMImageVault default_vault(hosts, &downloader, mp::Path("/"), mp::Path("/"), mp::days(1));
+
+    auto mock_image_vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+    auto mock_image_vault_ptr = mock_image_vault.get();
+
+    EXPECT_CALL(*mock_image_vault_ptr, all_info_for(_)).WillOnce([&default_vault](const mp::Query& query) {
+        return default_vault.all_info_for(query);
+    });
+
+    config_builder.vault = std::move(mock_image_vault);
+    mp::Daemon daemon{config_builder.build()};
+
+    std::stringstream err_stream;
+    send_command({"launch", "release:xenial", "--network", "eth0"}, std::cout, err_stream);
+    EXPECT_THAT(err_stream.str(), HasSubstr("Unable to find an image matching \"xenial\""));
+}
 
 constexpr auto ghost_template = R"(
 "{}": {{

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1436,4 +1436,15 @@ TEST_F(Daemon, refuses_launch_with_invalid_bridged_interface)
                           "local.bridged-network=<name>` to correct. See `multipass networks` for valid names."));
 }
 
+TEST_F(Daemon, refusesDisabledMount)
+{
+    mp::Daemon daemon{config_builder.build()};
+
+    EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key))).WillRepeatedly(Return("false"));
+
+    std::stringstream err_stream;
+    send_command({"mount", ".", "target"}, std::cout, err_stream);
+    EXPECT_THAT(err_stream.str(), HasSubstr("Mounts are disabled on this installation of Multipass."));
+}
+
 } // namespace


### PR DESCRIPTION
Test platforms:
- [x] Ubuntu@qemu (Luis)
- [x] Ubuntu@LXD (Chris)
- [x] Ubuntu@libvirt (Chris)
- [x] macOS@hyperkit (Chris)
- [x] macOS@VirtualBox (Chris)
- [x] Windows@Hyper-V (Luis)
- [x] Windows@VirtualBox (Luis)

Test plan:
1. [install previous release](https://multipass.run/#install)
2. launch a couple instances (including `primary`) and stop/suspend them
3. update to the RC, verify instances around and in the expected state
4. uninstall / purge and install new
5. launch instances (with, and without `--network`, `--bridged`, verify bridge creation on LXD and Hyper-V)
   - `primary`
   - older Ubuntu
   - Ubuntu Core
   - file / http
   - workflows (`minikube`)