### PR TITLE
Fix non-bridging check for images

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2102,6 +2102,10 @@ std::string mp::Daemon::check_instance_exists(const std::string& instance_name) 
 void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriter<CreateReply>* server,
                            std::promise<grpc::Status>* status_promise, bool start)
 {
+    // Try to get info for the requested image. This will throw out if the requested image is not found. This check
+    // needs to be done before the other checks.
+    config->vault->all_info_for(query_from(request, ""));
+
     auto checked_args = validate_create_arguments(request, *config->factory);
 
     if (!checked_args.option_errors.error_codes().empty())

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1071,8 +1071,11 @@ std::vector<std::string> old_releases{"10.04",   "lucid",  "11.10",   "oneiric",
                                       "14.10",   "utopic", "15.04",   "vivid",   "15.10", "wily",    "16.04",
                                       "xenial",  "16.10",  "yakkety", "17.04",   "zesty"};
 
+std::vector<std::string> old_remoteless_rels{"core", "core16"};
+
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseRelease, RefuseBridging, Combine(Values("release", ""), ValuesIn(old_releases)));
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseSnapcraft, RefuseBridging, Values(std::make_tuple("snapcraft", "core")));
+INSTANTIATE_TEST_SUITE_P(DaemonRefuseRemoteless, RefuseBridging, Combine(Values(""), ValuesIn(old_remoteless_rels)));
 
 constexpr auto ghost_template = R"(
 "{}": {{

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1073,7 +1073,8 @@ std::vector<std::string> old_releases{"10.04",   "lucid",  "11.10",   "oneiric",
 
 std::vector<std::string> old_remoteless_rels{"core", "core16"};
 
-INSTANTIATE_TEST_SUITE_P(DaemonRefuseRelease, RefuseBridging, Combine(Values("release", ""), ValuesIn(old_releases)));
+INSTANTIATE_TEST_SUITE_P(DaemonRefuseRelease, RefuseBridging,
+                         Combine(Values("release", "daily", ""), ValuesIn(old_releases)));
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseSnapcraft, RefuseBridging, Values(std::make_tuple("snapcraft", "core")));
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseRemoteless, RefuseBridging, Combine(Values(""), ValuesIn(old_remoteless_rels)));
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -21,7 +21,6 @@
 #include <multipass/name_generator.h>
 #include <multipass/version.h>
 #include <multipass/virtual_machine_factory.h>
-#include <multipass/vm_image_host.h>
 
 #include "daemon_test_fixture.h"
 #include "dummy_ssh_key_provider.h"
@@ -29,6 +28,7 @@
 #include "file_operations.h"
 #include "mock_daemon.h"
 #include "mock_environment_helpers.h"
+#include "mock_image_host.h"
 #include "mock_logger.h"
 #include "mock_platform.h"
 #include "mock_process_factory.h"
@@ -1077,6 +1077,32 @@ INSTANTIATE_TEST_SUITE_P(DaemonRefuseRelease, RefuseBridging,
                          Combine(Values("release", "daily", ""), ValuesIn(old_releases)));
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseSnapcraft, RefuseBridging, Values(std::make_tuple("snapcraft", "core")));
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseRemoteless, RefuseBridging, Combine(Values(""), ValuesIn(old_remoteless_rels)));
+
+TEST_F(Daemon, fails_with_image_not_found_also_if_image_is_also_non_bridgeable)
+{
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+    auto mock_image_host_ptr = mock_image_host.get();
+
+    std::vector<mp::VMImageHost*> hosts;
+    hosts.push_back(mock_image_host_ptr);
+
+    mp::URLDownloader downloader(std::chrono::milliseconds(1));
+    mp::DefaultVMImageVault default_vault(hosts, &downloader, mp::Path("/"), mp::Path("/"), mp::days(1));
+
+    auto mock_image_vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+    auto mock_image_vault_ptr = mock_image_vault.get();
+
+    EXPECT_CALL(*mock_image_vault_ptr, all_info_for(_)).WillOnce([&default_vault](const mp::Query& query) {
+        return default_vault.all_info_for(query);
+    });
+
+    config_builder.vault = std::move(mock_image_vault);
+    mp::Daemon daemon{config_builder.build()};
+
+    std::stringstream err_stream;
+    send_command({"launch", "release:xenial", "--network", "eth0"}, std::cout, err_stream);
+    EXPECT_THAT(err_stream.str(), HasSubstr("Unable to find an image matching \"xenial\""));
+}
 
 constexpr auto ghost_template = R"(
 "{}": {{


### PR DESCRIPTION
This PR fixes https://github.com/canonical/multipass/issues/1953.

The check assumed the remote to be `release` when the user did not specify one. This is not true, because there are images which do not accept a remote name (such as `core`). This worked but it was confusing in the code. It was fixed to check separately such images (called 'remoteless images' in the code). The error message was corrected as well, not showing a remote name if the user did not specify one.