### PR TITLE
Fix double bridging

### DIFF
--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -71,7 +71,7 @@ void mp::BaseVirtualMachineFactory::prepare_networking_guts(std::vector<NetworkI
 }
 
 void mp::BaseVirtualMachineFactory::prepare_interface(NetworkInterface& net,
-                                                      const std::vector<NetworkInterfaceInfo>& host_nets,
+                                                      std::vector<NetworkInterfaceInfo>& host_nets,
                                                       const std::string& bridge_type)
 {
     auto net_it = std::find_if(host_nets.cbegin(), host_nets.cend(),
@@ -79,7 +79,14 @@ void mp::BaseVirtualMachineFactory::prepare_interface(NetworkInterface& net,
 
     if (net_it != host_nets.end() && net_it->type != bridge_type)
     {
-        auto bridge_it = find_bridge_with(host_nets, net.id, bridge_type);
-        net.id = bridge_it != host_nets.cend() ? bridge_it->id : create_bridge_with(*net_it);
+        if (auto bridge_it = find_bridge_with(host_nets, net.id, bridge_type); bridge_it != host_nets.cend())
+        {
+            net.id = bridge_it->id;
+        }
+        else
+        {
+            net.id = create_bridge_with(*net_it);
+            host_nets.push_back({net.id, bridge_type, "new bridge", {net_it->id}});
+        }
     }
 }

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -73,7 +73,7 @@ protected:
     virtual void prepare_networking_guts(std::vector<NetworkInterface>& extra_interfaces,
                                          const std::string& bridge_type);
 
-    virtual void prepare_interface(NetworkInterface& net, const std::vector<NetworkInterfaceInfo>& host_nets,
+    virtual void prepare_interface(NetworkInterface& net, std::vector<NetworkInterfaceInfo>& host_nets,
                                    const std::string& bridge_type);
 };
 } // namespace multipass

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -48,9 +48,8 @@ struct MockBaseFactory : mp::BaseVirtualMachineFactory
     MOCK_METHOD1(prepare_networking, void(std::vector<mp::NetworkInterface>&));
     MOCK_CONST_METHOD0(networks, std::vector<mp::NetworkInterfaceInfo>());
     MOCK_METHOD1(create_bridge_with, std::string(const mp::NetworkInterfaceInfo&));
-    MOCK_METHOD3(prepare_interface,
-                 void(mp::NetworkInterface& net, const std::vector<mp::NetworkInterfaceInfo>& host_nets,
-                      const std::string& bridge_type));
+    MOCK_METHOD3(prepare_interface, void(mp::NetworkInterface& net, std::vector<mp::NetworkInterfaceInfo>& host_nets,
+                                         const std::string& bridge_type));
 
     std::string base_create_bridge_with(const mp::NetworkInterfaceInfo& interface)
     {
@@ -63,7 +62,7 @@ struct MockBaseFactory : mp::BaseVirtualMachineFactory
         return mp::BaseVirtualMachineFactory::prepare_networking_guts(extra_interfaces, bridge_type); // protected
     }
 
-    void base_prepare_interface(mp::NetworkInterface& net, const std::vector<mp::NetworkInterfaceInfo>& host_nets,
+    void base_prepare_interface(mp::NetworkInterface& net, std::vector<mp::NetworkInterfaceInfo>& host_nets,
                                 const std::string& bridge_type)
     {
         return mp::BaseVirtualMachineFactory::prepare_interface(net, host_nets, bridge_type); // protected
@@ -172,7 +171,7 @@ TEST_F(BaseFactory, prepareInterfaceLeavesUnrecognizedNetworkAlone)
 {
     StrictMock<MockBaseFactory> factory;
 
-    const auto host_nets = std::vector<mp::NetworkInterfaceInfo>{{"eth0", "ethernet", "asd"}, {"wlan0", "wifi", "asd"}};
+    auto host_nets = std::vector<mp::NetworkInterfaceInfo>{{"eth0", "ethernet", "asd"}, {"wlan0", "wifi", "asd"}};
     auto extra_net = mp::NetworkInterface{"eth1", "fa:se:ma:c0:12:23", false};
     const auto extra_copy = extra_net;
 
@@ -185,8 +184,7 @@ TEST_F(BaseFactory, prepareInterfaceLeavesExistingBridgeAlone)
     StrictMock<MockBaseFactory> factory;
     constexpr auto bridge_type = "arbitrary";
 
-    const auto host_nets =
-        std::vector<mp::NetworkInterfaceInfo>{{"br0", bridge_type, "foo"}, {"xyz", bridge_type, "bar"}};
+    auto host_nets = std::vector<mp::NetworkInterfaceInfo>{{"br0", bridge_type, "foo"}, {"xyz", bridge_type, "bar"}};
     auto extra_net = mp::NetworkInterface{"xyz", "fake mac", true};
     const auto extra_copy = extra_net;
 
@@ -200,10 +198,10 @@ TEST_F(BaseFactory, prepareInterfaceReplacesBridgedNetworkWithCorrespongingBridg
     constexpr auto bridge_type = "tunnel";
     constexpr auto bridge = "br";
 
-    const auto host_nets = std::vector<mp::NetworkInterfaceInfo>{{"eth", "ethernet", "already bridged"},
-                                                                 {"wlan", "wifi", "something else"},
-                                                                 {bridge, bridge_type, "bridge to eth", {"eth"}},
-                                                                 {"different", bridge_type, "uninteresting", {"wlan"}}};
+    auto host_nets = std::vector<mp::NetworkInterfaceInfo>{{"eth", "ethernet", "already bridged"},
+                                                           {"wlan", "wifi", "something else"},
+                                                           {bridge, bridge_type, "bridge to eth", {"eth"}},
+                                                           {"different", bridge_type, "uninteresting", {"wlan"}}};
     auto extra_net = mp::NetworkInterface{"eth", "fake mac", false};
     auto extra_check = extra_net;
     extra_check.id = bridge;
@@ -218,9 +216,9 @@ TEST_F(BaseFactory, prepareInterfaceCreatesBridgeForUnbridgedNetwork)
     constexpr auto bridge_type = "gagah";
     constexpr auto bridge = "newbr";
 
-    const auto host_nets = std::vector<mp::NetworkInterfaceInfo>{{"eth", "ethernet", "already bridged"},
-                                                                 {"wlan", "wifi", "something else"},
-                                                                 {"br0", bridge_type, "bridge to wlan", {"wlan"}}};
+    auto host_nets = std::vector<mp::NetworkInterfaceInfo>{{"eth", "ethernet", "already bridged"},
+                                                           {"wlan", "wifi", "something else"},
+                                                           {"br0", bridge_type, "bridge to wlan", {"wlan"}}};
 
     auto extra_net = mp::NetworkInterface{"eth", "maccc", true};
     auto extra_check = extra_net;


### PR DESCRIPTION
When creating a new bridge, update the internal host-networks reference, so that the new bridge is considered for ensuing interfaces. Fixes #2159