### PR TITLE
[daemon] Perform a health check on `networks`

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1432,6 +1432,9 @@ try // clang-format on
     NetworksReply response;
     config->update_prompt->populate_if_time_to_show(response.mutable_update_info());
 
+    if (!instances_running(vm_instances))
+        config->factory->hypervisor_health_check();
+
     const auto& iface_list = config->factory->networks();
 
     for (const auto& iface : iface_list)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1495,6 +1495,27 @@ TEST_F(Daemon, getReportsException)
     EXPECT_THAT(err_stream.str(), HasSubstr("exception"));
 }
 
+TEST_F(Daemon, requests_networks)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    mp::Daemon daemon{config_builder.build()};
+
+    std::vector<mp::NetworkInterfaceInfo> nets{{"net_a", "type_a", "description_a"},
+                                               {"net_b", "type_b", "description_b"}};
+    EXPECT_CALL(*mock_factory, networks).WillOnce(Return(nets));
+
+    std::stringstream stream;
+    send_command({"networks"}, stream);
+
+    auto got = stream.str();
+    for (const auto& net : nets)
+    {
+        EXPECT_THAT(got, HasSubstr(net.id));
+        EXPECT_THAT(got, HasSubstr(net.type));
+        EXPECT_THAT(got, HasSubstr(net.description));
+    }
+}
+
 TEST_F(Daemon, performs_health_check_on_networks)
 {
     auto mock_factory = use_a_mock_vm_factory();

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1495,4 +1495,13 @@ TEST_F(Daemon, getReportsException)
     EXPECT_THAT(err_stream.str(), HasSubstr("exception"));
 }
 
+TEST_F(Daemon, performs_health_check_on_networks)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    mp::Daemon daemon{config_builder.build()};
+
+    EXPECT_CALL(*mock_factory, hypervisor_health_check);
+    send_command({"networks"});
+}
+
 } // namespace


### PR DESCRIPTION
Perform a hypervisor health check before inspecting networks. This is
required in the particular case of LXD because `mp::lxd_request` assumes
that the "multipass" project already exists, and that project is created
in the health check. More generally, it makes sense to require a healthy
backend before asking it for the network inspection. Fixes #2139.