### PR TITLE
[gui] Update available multiple msgs bugfix

### DIFF
--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -269,7 +269,7 @@ void cmd::GuiCmd::update_about_menu()
         tray_icon_menu.insertAction(about_menu.menuAction(), &update_action);
         tray_icon.showMessage(QString::fromStdString(reply.update_info().title()),
                               QString("%1\n\nClick here for more information.")
-                              .arg(QString::fromStdString(reply.update_info().description())));
+                                  .arg(QString::fromStdString(reply.update_info().description())));
     }
 }
 


### PR DESCRIPTION
**_Issue #2188:_**
Introducing a check for signal connection to the GUI when an update is available.

We could also, potentially, do the following and move the `disconnect` from the `else` statement out to before the update check - which is what you suggested. It is the same code as the original, but just refactored:
```c++
void cmd::GuiCmd::update_about_menu()
{
    auto reply = version_future.result();

    about_client_version.setText("multipass version: " + QString::fromStdString(multipass::version_string));
    about_daemon_version.setText("multipassd version: " + QString::fromStdString(reply.version()));

    QObject::disconnect(&tray_icon, &QSystemTrayIcon::messageClicked, 0, 0);
    tray_icon_menu.removeAction(&update_action);

    if (update_available(reply.update_info()))
    {
        update_action.setIcon(QApplication::style()->standardIcon(QStyle::SP_MessageBoxInformation));
        update_action.setWhatsThis(QString::fromStdString(reply.update_info().url()));

        QObject::connect(&tray_icon, &QSystemTrayIcon::messageClicked,
                         [this] { QDesktopServices::openUrl(QUrl(update_action.whatsThis())); });

        tray_icon_menu.insertAction(about_menu.menuAction(), &update_action);
        tray_icon.showMessage(QString::fromStdString(reply.update_info().title()),
                              QString("%1\n\nClick here for more information.")
                                  .arg(QString::fromStdString(reply.update_info().description())));
    }
}
```

My rationale for performing the check to see if there is a connected signal is because it might be more efficient than a potentially needless attempt to disconnect. I am open to suggestions and the above code is sitting on the `dev` branch waiting to be merged if required.