### PR TITLE
[issue] A different default memory size

### DIFF
--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -29,7 +29,7 @@ constexpr auto min_memory_size = "128M";
 constexpr auto min_disk_size = "512M";
 constexpr auto min_cpu_cores = "1";
 
-constexpr auto default_memory_size = "1G";
+constexpr auto default_memory_size = "512M";
 constexpr auto default_disk_size = "5G";
 constexpr auto default_cpu_cores = min_cpu_cores;
 constexpr auto default_timeout = std::chrono::seconds(300);


### PR DESCRIPTION
The memory size of an instance is still non-configurable in multipass, and changing `multipassd-vm-instances.json` has no effect for me. As a current workaround I will need to change the memory value in `constants.h` and get a build with a different default memory size. I was not able to get Qt5 X11 properly configured when trying to build locally on macOS, so I am using the CI build system here to generate the binary. I don't know why multipass-ci that generates the binary for macOS cannot be installed in my fork, so I am now creating this pull request in order to trigger the build system that generates the build that I want.