### PR TITLE
Daemon testing with RPC mocking

### DIFF
--- a/include/multipass/logging/client_logger.h
+++ b/include/multipass/logging/client_logger.h
@@ -33,7 +33,7 @@ template <typename T>
 class ClientLogger : public Logger
 {
 public:
-    ClientLogger(Level level, MultiplexingLogger& mpx, grpc::ServerWriter<T>* server)
+    ClientLogger(Level level, MultiplexingLogger& mpx, grpc::ServerWriterInterface<T>* server)
         : logging_level{level}, server{server}, mpx_logger{mpx}
     {
         mpx_logger.add_logger(this);
@@ -57,7 +57,7 @@ public:
 
 private:
     Level logging_level;
-    grpc::ServerWriter<T>* server;
+    grpc::ServerWriterInterface<T>* server;
     MultiplexingLogger& mpx_logger;
 };
 } // namespace logging

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1043,7 +1043,7 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     source_images_maintenance_task.start(config->image_refresh_timer);
 }
 
-void mp::Daemon::create(const CreateRequest* request, grpc::ServerWriter<CreateReply>* server,
+void mp::Daemon::create(const CreateRequest* request, grpc::ServerWriterInterface<CreateReply>* server,
                         std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1055,7 +1055,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::launch(const LaunchRequest* request, grpc::ServerWriter<LaunchReply>* server,
+void mp::Daemon::launch(const LaunchRequest* request, grpc::ServerWriterInterface<LaunchReply>* server,
                         std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1108,7 +1108,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::purge(const PurgeRequest* request, grpc::ServerWriter<PurgeReply>* server,
+void mp::Daemon::purge(const PurgeRequest* request, grpc::ServerWriterInterface<PurgeReply>* server,
                        std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1125,7 +1125,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::find(const FindRequest* request, grpc::ServerWriter<FindReply>* server,
+void mp::Daemon::find(const FindRequest* request, grpc::ServerWriterInterface<FindReply>* server,
                       std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1226,7 +1226,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::info(const InfoRequest* request, grpc::ServerWriter<InfoReply>* server,
+void mp::Daemon::info(const InfoRequest* request, grpc::ServerWriterInterface<InfoReply>* server,
                       std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1372,7 +1372,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::list(const ListRequest* request, grpc::ServerWriter<ListReply>* server,
+void mp::Daemon::list(const ListRequest* request, grpc::ServerWriterInterface<ListReply>* server,
                       std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1440,7 +1440,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::networks(const NetworksRequest* request, grpc::ServerWriter<NetworksReply>* server,
+void mp::Daemon::networks(const NetworksRequest* request, grpc::ServerWriterInterface<NetworksReply>* server,
                           std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1469,7 +1469,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::mount(const MountRequest* request, grpc::ServerWriter<MountReply>* server,
+void mp::Daemon::mount(const MountRequest* request, grpc::ServerWriterInterface<MountReply>* server,
                        std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1592,7 +1592,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::recover(const RecoverRequest* request, grpc::ServerWriter<RecoverReply>* server,
+void mp::Daemon::recover(const RecoverRequest* request, grpc::ServerWriterInterface<RecoverReply>* server,
                          std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1631,7 +1631,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::ssh_info(const SSHInfoRequest* request, grpc::ServerWriter<SSHInfoReply>* server,
+void mp::Daemon::ssh_info(const SSHInfoRequest* request, grpc::ServerWriterInterface<SSHInfoReply>* server,
                           std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1690,7 +1690,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::start(const StartRequest* request, grpc::ServerWriter<StartReply>* server,
+void mp::Daemon::start(const StartRequest* request, grpc::ServerWriterInterface<StartReply>* server,
                        std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1758,7 +1758,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::stop(const StopRequest* request, grpc::ServerWriter<StopReply>* server,
+void mp::Daemon::stop(const StopRequest* request, grpc::ServerWriterInterface<StopReply>* server,
                       std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1787,7 +1787,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::suspend(const SuspendRequest* request, grpc::ServerWriter<SuspendReply>* server,
+void mp::Daemon::suspend(const SuspendRequest* request, grpc::ServerWriterInterface<SuspendReply>* server,
                          std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1833,7 +1833,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::restart(const RestartRequest* request, grpc::ServerWriter<RestartReply>* server,
+void mp::Daemon::restart(const RestartRequest* request, grpc::ServerWriterInterface<RestartReply>* server,
                          std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1867,7 +1867,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::delet(const DeleteRequest* request, grpc::ServerWriter<DeleteReply>* server,
+void mp::Daemon::delet(const DeleteRequest* request, grpc::ServerWriterInterface<DeleteReply>* server,
                        std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1923,7 +1923,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::umount(const UmountRequest* request, grpc::ServerWriter<UmountReply>* server,
+void mp::Daemon::umount(const UmountRequest* request, grpc::ServerWriterInterface<UmountReply>* server,
                         std::promise<grpc::Status>* status_promise) // clang-format off
 try // clang-format on
 {
@@ -1977,7 +1977,7 @@ catch (const std::exception& e)
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
 }
 
-void mp::Daemon::version(const VersionRequest* request, grpc::ServerWriter<VersionReply>* server,
+void mp::Daemon::version(const VersionRequest* request, grpc::ServerWriterInterface<VersionReply>* server,
                          std::promise<grpc::Status>* status_promise)
 {
     mpl::ClientLogger<VersionReply> logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
@@ -1989,7 +1989,7 @@ void mp::Daemon::version(const VersionRequest* request, grpc::ServerWriter<Versi
     status_promise->set_value(grpc::Status::OK);
 }
 
-void mp::Daemon::get(const GetRequest* request, grpc::ServerWriter<GetReply>* server,
+void mp::Daemon::get(const GetRequest* request, grpc::ServerWriterInterface<GetReply>* server,
                      std::promise<grpc::Status>* status_promise)
 try
 {
@@ -2172,7 +2172,7 @@ std::string mp::Daemon::check_instance_exists(const std::string& instance_name) 
     return {};
 }
 
-void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriter<CreateReply>* server,
+void mp::Daemon::create_vm(const CreateRequest* request, grpc::ServerWriterInterface<CreateReply>* server,
                            std::promise<grpc::Status>* status_promise, bool start)
 {
     auto checked_args = validate_create_arguments(request, config.get());
@@ -2500,7 +2500,7 @@ mp::Daemon::create_future_watcher(std::function<void()> const& finished_op)
 template <typename Reply>
 error_string mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::string& name,
                                                                  const std::chrono::seconds& timeout,
-                                                                 grpc::ServerWriter<Reply>* server)
+                                                                 grpc::ServerWriterInterface<Reply>* server)
 {
     fmt::memory_buffer errors;
     try
@@ -2578,7 +2578,7 @@ error_string mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::stri
 
 template <typename Reply>
 mp::Daemon::AsyncOperationStatus
-mp::Daemon::async_wait_for_ready_all(grpc::ServerWriter<Reply>* server, const std::vector<std::string>& vms,
+mp::Daemon::async_wait_for_ready_all(grpc::ServerWriterInterface<Reply>* server, const std::vector<std::string>& vms,
                                      const std::chrono::seconds& timeout, std::promise<grpc::Status>* status_promise)
 {
     QFutureSynchronizer<std::string> start_synchronizer;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -77,6 +77,8 @@ public:
     Daemon(const Daemon&) = delete;
     Daemon& operator=(const Daemon&) = delete;
 
+    void persist_instances();
+
 protected:
     void on_resume() override;
     void on_stop() override;
@@ -143,7 +145,6 @@ public slots:
                      std::promise<grpc::Status>* status_promise);
 
 private:
-    void persist_instances();
     void release_resources(const std::string& instance);
     std::string check_instance_operational(const std::string& instance_name) const;
     std::string check_instance_exists(const std::string& instance_name) const;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -88,58 +88,58 @@ protected:
     QJsonObject retrieve_metadata_for(const std::string& name) override;
 
 public slots:
-    virtual void create(const CreateRequest* request, grpc::ServerWriter<CreateReply>* reply,
+    virtual void create(const CreateRequest* request, grpc::ServerWriterInterface<CreateReply>* reply,
                         std::promise<grpc::Status>* status_promise);
 
-    virtual void launch(const LaunchRequest* request, grpc::ServerWriter<LaunchReply>* reply,
+    virtual void launch(const LaunchRequest* request, grpc::ServerWriterInterface<LaunchReply>* reply,
                         std::promise<grpc::Status>* status_promise);
 
-    virtual void purge(const PurgeRequest* request, grpc::ServerWriter<PurgeReply>* response,
+    virtual void purge(const PurgeRequest* request, grpc::ServerWriterInterface<PurgeReply>* response,
                        std::promise<grpc::Status>* status_promise);
 
-    virtual void find(const FindRequest* request, grpc::ServerWriter<FindReply>* response,
+    virtual void find(const FindRequest* request, grpc::ServerWriterInterface<FindReply>* response,
                       std::promise<grpc::Status>* status_promise);
 
-    virtual void info(const InfoRequest* request, grpc::ServerWriter<InfoReply>* response,
+    virtual void info(const InfoRequest* request, grpc::ServerWriterInterface<InfoReply>* response,
                       std::promise<grpc::Status>* status_promise);
 
-    virtual void list(const ListRequest* request, grpc::ServerWriter<ListReply>* response,
+    virtual void list(const ListRequest* request, grpc::ServerWriterInterface<ListReply>* response,
                       std::promise<grpc::Status>* status_promise);
 
-    virtual void networks(const NetworksRequest* request, grpc::ServerWriter<NetworksReply>* response,
+    virtual void networks(const NetworksRequest* request, grpc::ServerWriterInterface<NetworksReply>* response,
                           std::promise<grpc::Status>* status_promise);
 
-    virtual void mount(const MountRequest* request, grpc::ServerWriter<MountReply>* response,
+    virtual void mount(const MountRequest* request, grpc::ServerWriterInterface<MountReply>* response,
                        std::promise<grpc::Status>* status_promise);
 
-    virtual void recover(const RecoverRequest* request, grpc::ServerWriter<RecoverReply>* response,
+    virtual void recover(const RecoverRequest* request, grpc::ServerWriterInterface<RecoverReply>* response,
                          std::promise<grpc::Status>* status_promise);
 
-    virtual void ssh_info(const SSHInfoRequest* request, grpc::ServerWriter<SSHInfoReply>* response,
+    virtual void ssh_info(const SSHInfoRequest* request, grpc::ServerWriterInterface<SSHInfoReply>* response,
                           std::promise<grpc::Status>* status_promise);
 
-    virtual void start(const StartRequest* request, grpc::ServerWriter<StartReply>* response,
+    virtual void start(const StartRequest* request, grpc::ServerWriterInterface<StartReply>* response,
                        std::promise<grpc::Status>* status_promise);
 
-    virtual void stop(const StopRequest* request, grpc::ServerWriter<StopReply>* response,
+    virtual void stop(const StopRequest* request, grpc::ServerWriterInterface<StopReply>* response,
                       std::promise<grpc::Status>* status_promise);
 
-    virtual void suspend(const SuspendRequest* request, grpc::ServerWriter<SuspendReply>* response,
+    virtual void suspend(const SuspendRequest* request, grpc::ServerWriterInterface<SuspendReply>* response,
                          std::promise<grpc::Status>* status_promise);
 
-    virtual void restart(const RestartRequest* request, grpc::ServerWriter<RestartReply>* response,
+    virtual void restart(const RestartRequest* request, grpc::ServerWriterInterface<RestartReply>* response,
                          std::promise<grpc::Status>* status_promise);
 
-    virtual void delet(const DeleteRequest* request, grpc::ServerWriter<DeleteReply>* response,
+    virtual void delet(const DeleteRequest* request, grpc::ServerWriterInterface<DeleteReply>* response,
                        std::promise<grpc::Status>* status_promise);
 
-    virtual void umount(const UmountRequest* request, grpc::ServerWriter<UmountReply>* response,
+    virtual void umount(const UmountRequest* request, grpc::ServerWriterInterface<UmountReply>* response,
                         std::promise<grpc::Status>* status_promise);
 
-    virtual void version(const VersionRequest* request, grpc::ServerWriter<VersionReply>* response,
+    virtual void version(const VersionRequest* request, grpc::ServerWriterInterface<VersionReply>* response,
                          std::promise<grpc::Status>* status_promise);
 
-    virtual void get(const GetRequest* request, grpc::ServerWriter<GetReply>* response,
+    virtual void get(const GetRequest* request, grpc::ServerWriterInterface<GetReply>* response,
                      std::promise<grpc::Status>* status_promise);
 
 private:
@@ -147,7 +147,7 @@ private:
     void release_resources(const std::string& instance);
     std::string check_instance_operational(const std::string& instance_name) const;
     std::string check_instance_exists(const std::string& instance_name) const;
-    void create_vm(const CreateRequest* request, grpc::ServerWriter<CreateReply>* server,
+    void create_vm(const CreateRequest* request, grpc::ServerWriterInterface<CreateReply>* server,
                    std::promise<grpc::Status>* status_promise, bool start);
     grpc::Status reboot_vm(VirtualMachine& vm);
     grpc::Status shutdown_vm(VirtualMachine& vm, const std::chrono::milliseconds delay);
@@ -163,10 +163,10 @@ private:
 
     template <typename Reply>
     std::string async_wait_for_ssh_and_start_mounts_for(const std::string& name, const std::chrono::seconds& timeout,
-                                                        grpc::ServerWriter<Reply>* server);
+                                                        grpc::ServerWriterInterface<Reply>* server);
     template <typename Reply>
     AsyncOperationStatus
-    async_wait_for_ready_all(grpc::ServerWriter<Reply>* server, const std::vector<std::string>& vms,
+    async_wait_for_ready_all(grpc::ServerWriterInterface<Reply>* server, const std::vector<std::string>& vms,
                              const std::chrono::seconds& timeout, std::promise<grpc::Status>* status_promise);
     void finish_async_operation(QFuture<AsyncOperationStatus> async_future);
     QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});

--- a/tests/common.h
+++ b/tests/common.h
@@ -78,6 +78,21 @@ void PrintTo(const NetworkInterfaceInfo& net, std::ostream* os);
 // Matchers
 namespace multipass::test
 {
+
+/**
+ * Adapt an n-ary callable to a unary callable receiving an n-tuple.
+ * @details This is useful to create matchers with Truly (which expects a unary predicate).
+ * @tparam F The type of the callable.
+ * @param f The n-ary callable we want to adapt. Note that this argument may be copied.
+ * @return A unary callable that receives an n-tuple, calls \c f with that tuple unpacked, and returns what @c f returns
+ */
+template <typename F>
+auto with_arg_tuple(F f)
+{
+    return [f](auto&& arg_tuple) // may copy f, but avoiding forwarding-capture mess (see https://v.gd/2IbEdv)
+    { return std::apply(f, std::forward<decltype(arg_tuple)>(arg_tuple)); };
+}
+
 template <typename MsgMatcher>
 auto match_what(MsgMatcher&& matcher)
 {

--- a/tests/mock_daemon.h
+++ b/tests/mock_daemon.h
@@ -61,6 +61,8 @@ struct MockDaemon : public Daemon
     MOCK_METHOD3(version,
                  void(const VersionRequest*, grpc::ServerWriterInterface<VersionReply>*, std::promise<grpc::Status>*));
     MOCK_METHOD3(get, void(const GetRequest*, grpc::ServerWriterInterface<GetReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(networks, void(const NetworksRequest*, grpc::ServerWriterInterface<NetworksReply>*,
+                                std::promise<grpc::Status>*));
 
     template <typename Request, typename Reply>
     void set_promise_value(const Request*, grpc::ServerWriterInterface<Reply>*,

--- a/tests/mock_daemon.h
+++ b/tests/mock_daemon.h
@@ -31,27 +31,40 @@ struct MockDaemon : public Daemon
 {
     using Daemon::Daemon;
 
-    MOCK_METHOD3(create, void(const CreateRequest*, grpc::ServerWriter<CreateReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(launch, void(const LaunchRequest*, grpc::ServerWriter<LaunchReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(purge, void(const PurgeRequest*, grpc::ServerWriter<PurgeReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(find, void(const FindRequest* request, grpc::ServerWriter<FindReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(info, void(const InfoRequest*, grpc::ServerWriter<InfoReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(list, void(const ListRequest*, grpc::ServerWriter<ListReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(mount,
-                 void(const MountRequest* request, grpc::ServerWriter<MountReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(recover, void(const RecoverRequest*, grpc::ServerWriter<RecoverReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(ssh_info, void(const SSHInfoRequest*, grpc::ServerWriter<SSHInfoReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(start, void(const StartRequest*, grpc::ServerWriter<StartReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(stop, void(const StopRequest*, grpc::ServerWriter<StopReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(suspend, void(const SuspendRequest*, grpc::ServerWriter<SuspendReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(restart, void(const RestartRequest*, grpc::ServerWriter<RestartReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(delet, void(const DeleteRequest*, grpc::ServerWriter<DeleteReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(umount, void(const UmountRequest*, grpc::ServerWriter<UmountReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(version, void(const VersionRequest*, grpc::ServerWriter<VersionReply>*, std::promise<grpc::Status>*));
-    MOCK_METHOD3(get, void(const GetRequest*, grpc::ServerWriter<GetReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(create,
+                 void(const CreateRequest*, grpc::ServerWriterInterface<CreateReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(launch,
+                 void(const LaunchRequest*, grpc::ServerWriterInterface<LaunchReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(purge,
+                 void(const PurgeRequest*, grpc::ServerWriterInterface<PurgeReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(find, void(const FindRequest* request, grpc::ServerWriterInterface<FindReply>*,
+                            std::promise<grpc::Status>*));
+    MOCK_METHOD3(info, void(const InfoRequest*, grpc::ServerWriterInterface<InfoReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(list, void(const ListRequest*, grpc::ServerWriterInterface<ListReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(mount, void(const MountRequest* request, grpc::ServerWriterInterface<MountReply>*,
+                             std::promise<grpc::Status>*));
+    MOCK_METHOD3(recover,
+                 void(const RecoverRequest*, grpc::ServerWriterInterface<RecoverReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(ssh_info,
+                 void(const SSHInfoRequest*, grpc::ServerWriterInterface<SSHInfoReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(start,
+                 void(const StartRequest*, grpc::ServerWriterInterface<StartReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(stop, void(const StopRequest*, grpc::ServerWriterInterface<StopReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(suspend,
+                 void(const SuspendRequest*, grpc::ServerWriterInterface<SuspendReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(restart,
+                 void(const RestartRequest*, grpc::ServerWriterInterface<RestartReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(delet,
+                 void(const DeleteRequest*, grpc::ServerWriterInterface<DeleteReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(umount,
+                 void(const UmountRequest*, grpc::ServerWriterInterface<UmountReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(version,
+                 void(const VersionRequest*, grpc::ServerWriterInterface<VersionReply>*, std::promise<grpc::Status>*));
+    MOCK_METHOD3(get, void(const GetRequest*, grpc::ServerWriterInterface<GetReply>*, std::promise<grpc::Status>*));
 
     template <typename Request, typename Reply>
-    void set_promise_value(const Request*, grpc::ServerWriter<Reply>*, std::promise<grpc::Status>* status_promise)
+    void set_promise_value(const Request*, grpc::ServerWriterInterface<Reply>*,
+                           std::promise<grpc::Status>* status_promise)
     {
         status_promise->set_value(grpc::Status::OK);
     }

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -199,6 +199,8 @@ TEST_F(Daemon, receives_commands_and_calls_corresponding_slot)
         .WillOnce(Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::MountRequest, mp::MountReply>));
     EXPECT_CALL(daemon, umount(_, _, _))
         .WillOnce(Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::UmountRequest, mp::UmountReply>));
+    EXPECT_CALL(daemon, networks(_, _, _))
+        .WillOnce(Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::NetworksRequest, mp::NetworksReply>));
 
     send_commands({{"test_get", "foo"},
                    {"test_create", "foo"},
@@ -216,7 +218,9 @@ TEST_F(Daemon, receives_commands_and_calls_corresponding_slot)
                    {"version"},
                    {"find", "something"},
                    {"mount", ".", "target"},
-                   {"umount", "instance"}});
+                   {"umount", "instance"},
+                   {"get", "foo"},
+                   {"networks"}});
 }
 
 TEST_F(Daemon, provides_version)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -76,9 +76,19 @@ namespace
 {
 const qint64 default_total_bytes{16'106'127'360}; // 15G
 
-template<typename R>
-  bool is_ready(std::future<R> const& f)
-  { return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready; }
+template <typename R>
+bool is_ready(std::future<R> const& f)
+{
+    return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+}
+
+template <typename W>
+class MockServerWriter : public grpc::ServerWriterInterface<W>
+{
+public:
+    MOCK_METHOD0(SendInitialMetadata, void());
+    MOCK_METHOD2_T(Write, bool(const W& msg, grpc::WriteOptions options));
+};
 
 struct StubNameGenerator : public mp::NameGenerator
 {

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -88,7 +88,7 @@ grpc::Status call_daemon_slot(mp::Daemon& daemon, DaemonSlotPtr slot, const Requ
     std::promise<grpc::Status> status_promise;
     auto status_future = status_promise.get_future();
 
-    daemon.get(&request, &server, &status_promise);
+    (daemon.*slot)(&request, &server, &status_promise);
 
     EXPECT_TRUE(is_ready(status_future));
     return status_future.get();

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -161,7 +161,7 @@ struct Daemon : public mpt::DaemonTestFixture
                                                                               reset at the end of each test */
 };
 
-TEST_F(Daemon, receives_commands)
+TEST_F(Daemon, receives_commands_and_calls_corresponding_slot)
 {
     mpt::MockDaemon daemon{config_builder.build()};
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1048,10 +1048,7 @@ TEST_F(Daemon, reads_mac_addresses_from_json)
     // Removing the JSON is possible now because data was already read. This step is not necessary, but doing it we
     // make sure that the file was indeed rewritten after the next step.
     QFile::remove(filename);
-
-    // The purge command will be apparently no-op, because there are no deleted instances. However, it will trigger
-    // a rewriting of the JSON, which will be useful for us to check if the data was correctly read.
-    send_command({"purge"});
+    daemon.persist_instances();
 
     // Finally, check the contents of the file. If they match with what we read, we are done.
     check_interfaces_in_json(filename, mac_addr, extra_interfaces);

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1493,8 +1493,12 @@ TEST_F(Daemon, refusesDisabledMount)
     EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key))).WillRepeatedly(Return("false"));
 
     std::stringstream err_stream;
-    send_command({"mount", ".", "target"}, trash_stream, err_stream);
-    EXPECT_THAT(err_stream.str(), HasSubstr("Mounts are disabled on this installation of Multipass."));
+
+    auto status = call_daemon_slot(daemon, &mp::Daemon::mount, mp::MountRequest{},
+                                   StrictMock<MockServerWriter<mp::MountReply>>{});
+
+    EXPECT_EQ(status.error_code(), grpc::StatusCode::FAILED_PRECONDITION);
+    EXPECT_THAT(status.error_message(), HasSubstr("Mounts are disabled on this installation of Multipass."));
 }
 
 TEST_F(Daemon, getReturnsSetting)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -222,11 +222,11 @@ TEST_F(Daemon, receives_commands_and_calls_corresponding_slot)
 TEST_F(Daemon, provides_version)
 {
     mp::Daemon daemon{config_builder.build()};
+    StrictMock<MockServerWriter<mp::VersionReply>> mock_server;
+    EXPECT_CALL(mock_server, Write(Property(&mp::VersionReply::version, StrEq(mp::version_string)), _))
+        .WillOnce(Return(true));
 
-    std::stringstream stream;
-    send_command({"version"}, stream);
-
-    EXPECT_THAT(stream.str(), HasSubstr(mp::version_string));
+    EXPECT_TRUE(call_daemon_slot(daemon, &mp::Daemon::version, mp::VersionRequest{}, mock_server).ok());
 }
 
 TEST_F(Daemon, failed_restart_command_returns_fulfilled_promise)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -82,9 +82,18 @@ bool is_ready(std::future<R> const& f)
     return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
 }
 
+template <typename W>
+class MockServerWriter : public grpc::ServerWriterInterface<W>
+{
+public:
+    MOCK_METHOD0(SendInitialMetadata, void());
+    MOCK_METHOD2_T(Write, bool(const W& msg, grpc::WriteOptions options));
+};
+
 /**
  * Helper function to call one of the <em>daemon slots</em> that ultimately handle RPC requests
- *  (e.g. @c mp::Daemon::get). It takes care of promise/future boilerplate.
+ *  (e.g. @c mp::Daemon::get). It takes care of promise/future boilerplate. This will generally be given a
+ *  @c mpt::MockServerWriter, which can be used to verify replies.
  * @tparam DaemonSlotPtr The method pointer type for the provided slot. Example:
  *  @code
  *  void (mp::Daemon::*)(const mp::GetRequest *, grpc::ServerWriterInterface<mp::GetReply> *,
@@ -97,7 +106,7 @@ bool is_ready(std::future<R> const& f)
  * @param slot A pointer to the daemon slot method that should be called.
  * @param request The request to call the slot with.
  * @param server The concrete @c grpc::ServerWriterInterface to call the slot with (see doc on Server typename). This
- *  will generally be an @c mpt::MockServerWriter. Notice that this is a <em>universal reference</em>, so it will bind
+ *  will generally be a @c mpt::MockServerWriter. Notice that this is a <em>universal reference</em>, so it will bind
  *  to both lvalue and rvalue references.
  * @return The @c grpc::Status that is produced by the slot
  */
@@ -112,14 +121,6 @@ grpc::Status call_daemon_slot(mp::Daemon& daemon, DaemonSlotPtr slot, const Requ
     EXPECT_TRUE(is_ready(status_future));
     return status_future.get();
 }
-
-template <typename W>
-class MockServerWriter : public grpc::ServerWriterInterface<W>
-{
-public:
-    MOCK_METHOD0(SendInitialMetadata, void());
-    MOCK_METHOD2_T(Write, bool(const W& msg, grpc::WriteOptions options));
-};
 
 struct StubNameGenerator : public mp::NameGenerator
 {

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1584,7 +1584,8 @@ TEST_F(Daemon, performs_health_check_on_networks)
     mp::Daemon daemon{config_builder.build()};
 
     EXPECT_CALL(*mock_factory, hypervisor_health_check);
-    send_command({"networks"});
+    call_daemon_slot(daemon, &mp::Daemon::networks, mp::NetworksRequest{},
+                     NiceMock<MockServerWriter<mp::NetworksReply>>{});
 }
 
 } // namespace

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1576,8 +1576,7 @@ TEST_F(Daemon, requests_networks)
 
     StrictMock<MockServerWriter<mp::NetworksReply>> mock_server;
 
-    auto are_same_net = [](const mp::NetInterface& proto_net, const mp::NetworkInterfaceInfo& net_info)
-    {
+    auto are_same_net = [](const mp::NetInterface& proto_net, const mp::NetworkInterfaceInfo& net_info) {
         return std::tie(proto_net.name(), proto_net.type(), proto_net.description()) ==
                std::tie(net_info.id, net_info.type, net_info.description);
     };


### PR DESCRIPTION
This continues with the approach in #2205 (replacing it) to enable `Daemon` testing by calling its public slots directly, providing a `MockServerWriter`. To allow that, slot signatures are changed to receive a `ServerWriterInterface` param in place of the concrete `ServerWriter` implementation.