### PR TITLE
[test] Dropped unused matchers

### DIFF
--- a/tests/common.h
+++ b/tests/common.h
@@ -78,19 +78,6 @@ void PrintTo(const NetworkInterfaceInfo& net, std::ostream* os);
 // Matchers
 namespace multipass::test
 {
-MATCHER_P(ContainedIn, container, "")
-{
-    return std::find(std::cbegin(container), std::cend(container), arg) != std::cend(container);
-}
-
-MATCHER_P2(HasCorrespondentIn, container, binary_pred,
-           fmt::format("{} a corresponding element in {} that pairs with it according to the given binary predicate",
-                       negation ? "has" : "doesn't have", testing::PrintToString(container)))
-{
-    return std::any_of(std::cbegin(container), std::cend(container),
-                       [this, &arg](const auto& elem) { return binary_pred(arg, elem); });
-}
-
 template <typename MsgMatcher>
 auto match_what(MsgMatcher&& matcher)
 {


### PR DESCRIPTION
These ended up unused (after changes requested in review). They are in history, so we can always get them back if we need them.