### PR TITLE
Fix slow daemon tests on Windows

### DIFF
--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -38,7 +38,7 @@ void throw_if_server_exists(const std::string& address)
     auto stub = mp::Rpc::NewStub(channel);
 
     grpc::ClientContext context;
-    auto deadline = std::chrono::system_clock::now() + std::chrono::seconds(1);
+    auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(100); // should be enough...
     context.set_deadline(deadline);
 
     mp::PingRequest request;

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -32,7 +32,7 @@ namespace
 {
 constexpr auto category = "rpc";
 
-bool see_if_im_in_the_kitchen(const std::string& address)
+bool check_is_server_running(const std::string& address)
 {
     auto channel = grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
     auto stub = mp::Rpc::NewStub(channel);
@@ -75,7 +75,7 @@ auto make_server(const std::string& server_address, mp::RpcConnectionType conn_t
     std::unique_ptr<grpc::Server> server{builder.BuildAndStart()};
     if (server == nullptr)
     {
-        auto detail = see_if_im_in_the_kitchen(server_address) ? " A multipass daemon is already running there." : "";
+        auto detail = check_is_server_running(server_address) ? " A multipass daemon is already running there." : "";
         throw std::runtime_error(
             fmt::format("Failed to start multipass gRPC service at {}.{}", server_address, detail));
     }


### PR DESCRIPTION
This addresses the 1 second each daemon test has been taking on Windows. Basically that was how much time we were waiting in the check for an existing daemon. I'm not sure why we don't see the same on other platforms, but I suppose it fails immediately when using unix sockets.

BTW, GRPC itself already logs an error when trying to create the second server, mentioning:

> Only one usage of each socket address (protocol/network address/port) is normally permitted

I am not sure if that's a default message whenever it can't open the port, or if it somehow knows that it is being used for another server of its own. I looked for some sort of API to get that error info, but I didn't find any.

