### PR TITLE
[gui] Add desktop plug, to access notifications

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,6 +90,7 @@ apps:
       - unity7
       - wayland
       - x11
+      - desktop
 
 parts:
   multipass:


### PR DESCRIPTION
Add desktop plug to our GUI, so that it can do notifications over dbus.

Tentatively fixes #2258.