### PR TITLE
[gui] Add system-observe plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,6 +90,7 @@ apps:
       - unity7
       - wayland
       - x11
+      - system-observe
 
 parts:
   multipass:


### PR DESCRIPTION
Fix #2258 by enabling [Qt to work around limited appindicator support for icons over DBus (IIUC)](https://code.woboq.org/qt6/qtbase/src/gui/platform/unix/dbustray/qdbustrayicon.cpp.html#_ZN13QDBusTrayIcon8tempIconERK5QIcon). To that end, plug `system-observe` to allow inspecting running processes.

The icon is cropped, but at least it shows now.