### PR TITLE
[snap] Use Release cmake build type

### DIFF
--- a/.github/workflows/linux-Coverage.patch
+++ b/.github/workflows/linux-Coverage.patch
@@ -12,7 +12,7 @@
      - dnsmasq-utils
      source: .
      cmake-parameters:
--    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+-    - -DCMAKE_BUILD_TYPE=Release
 +    - -DCMAKE_BUILD_TYPE=Coverage
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off

--- a/.github/workflows/linux-Debug.patch
+++ b/.github/workflows/linux-Debug.patch
@@ -4,7 +4,7 @@
      - dnsmasq-utils
      source: .
      cmake-parameters:
--    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+-    - -DCMAKE_BUILD_TYPE=Release
 +    - -DCMAKE_BUILD_TYPE=Debug
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,7 +129,7 @@ parts:
     - dnsmasq-utils
     source: .
     cmake-parameters:
-    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    - -DCMAKE_BUILD_TYPE=Release
     - -DCMAKE_INSTALL_PREFIX=/
     - -DMULTIPASS_ENABLE_TESTS=off
     - -DMULTIPASS_UPSTREAM=origin


### PR DESCRIPTION
This will build the Multipass binaries without debug symbols and cut the Snap down ~240MB in size.