### PR TITLE
 [snap] Use Release cmake build type

### DIFF
--- a/.github/workflows/linux-Coverage.patch
+++ b/.github/workflows/linux-Coverage.patch
@@ -12,7 +12,7 @@
      - dnsmasq-utils
      source: .
      cmake-parameters:
--    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+-    - -DCMAKE_BUILD_TYPE=Release
 +    - -DCMAKE_BUILD_TYPE=Coverage
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off

--- a/.github/workflows/linux-Debug.patch
+++ b/.github/workflows/linux-Debug.patch
@@ -4,7 +4,7 @@
      - dnsmasq-utils
      source: .
      cmake-parameters:
--    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+-    - -DCMAKE_BUILD_TYPE=Release
 +    - -DCMAKE_BUILD_TYPE=Debug
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        build-type: [Debug, Clang, RelWithDebInfo, Coverage]
+        build-type: [Debug, Clang, Release, Coverage]
 
     runs-on: ubuntu-latest
 
@@ -150,7 +150,7 @@ jobs:
 
     - name: Build and verify the snap
       id: build-snap
-      if: ${{ matrix.build-type == 'RelWithDebInfo' }}
+      if: ${{ matrix.build-type == 'Release' }}
       env:
         SNAP_ENFORCE_RESQUASHFS: 0
       run: |
@@ -164,7 +164,7 @@ jobs:
 
     - name: Upload the snap
       uses: actions/upload-artifact@v2
-      if: ${{ matrix.build-type == 'RelWithDebInfo' }}
+      if: ${{ matrix.build-type == 'Release' }}
       with:
         name: ${{ steps.build-snap.outputs.snap-file }}
         path: ${{ steps.build-snap.outputs.snap-file }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,7 +129,7 @@ parts:
     - dnsmasq-utils
     source: .
     cmake-parameters:
-    - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    - -DCMAKE_BUILD_TYPE=Release
     - -DCMAKE_INSTALL_PREFIX=/
     - -DMULTIPASS_ENABLE_TESTS=off
     - -DMULTIPASS_UPSTREAM=origin


### PR DESCRIPTION
This will build the Multipass binaries without debug symbols and cut the Snap down ~240MB in size.