### PR TITLE
[tests] move to upstream googletest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,8 +17,17 @@ set (CMAKE_AUTOMOC ON)
 
 include(c_mock_defines.cmake)
 
-set(MULTIPASS_GMOCK_DIR ${CMAKE_SOURCE_DIR}/3rd-party/grpc/third_party/googletest/googlemock)
-set(MULTIPASS_GTEST_DIR ${CMAKE_SOURCE_DIR}/3rd-party/grpc/third_party/googletest/googletest)
+include(FetchContent)
+set(FETCHCONTENT_QUIET FALSE)
+
+FetchContent_Declare(googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG main
+  GIT_SHALLOW TRUE
+  GIT_PROGRESS TRUE
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
 
 add_executable(multipass_tests
   common.cpp
@@ -91,19 +100,12 @@ add_executable(multipass_tests
   test_utils.cpp
   test_with_mocked_bin_path.cpp
   test_workflow_provider.cpp
-
-  ${MULTIPASS_GMOCK_DIR}/src/gmock-all.cc
-  ${MULTIPASS_GTEST_DIR}/src/gtest-all.cc
 )
 
 target_include_directories(multipass_tests
   PRIVATE ${CMAKE_SOURCE_DIR}
   PRIVATE ${CMAKE_SOURCE_DIR}/src
   PRIVATE ${CMAKE_SOURCE_DIR}/src/platform/backends
-  PRIVATE ${MULTIPASS_GTEST_DIR}
-  PRIVATE ${MULTIPASS_GTEST_DIR}/include
-  PRIVATE ${MULTIPASS_GMOCK_DIR}
-  PRIVATE ${MULTIPASS_GMOCK_DIR}/include
 )
 
 add_definitions(-DWITH_SERVER)
@@ -124,6 +126,8 @@ target_link_libraries(multipass_tests
   client
   daemon
   delayed_shutdown
+  gmock_main
+  gtest_main
   ip_address
   iso
   metrics


### PR DESCRIPTION
Relying on gRPC's submodule does not give us the control over googletest
versions we'd like.

Let's "[Live at head](https://github.com/google/googletest#live-at-head)" instead, using CMake's FetchContent.

Based on [GTests's Quickstart: Building with CMake](https://google.github.io/googletest/quickstart-cmake.html).