### PR TITLE
Test settings

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -26,7 +26,7 @@
 #include <QString>
 #include <QTextStream>
 
-#include <cstdio>
+#include <fstream>
 
 #define MP_FILEOPS multipass::FileOps::instance()
 
@@ -60,7 +60,7 @@ public:
     virtual qint64 write(QFile& file, const QByteArray& data) const;
 
     // std operations
-    virtual std::FILE* fopen(const char* filename, const char* mode) const;
+    virtual void open(std::fstream& stream, const char* filename, std::ios_base::openmode mode) const;
 };
 } // namespace multipass
 

--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -26,6 +26,8 @@
 #include <QString>
 #include <QTextStream>
 
+#include <cstdio>
+
 #define MP_FILEOPS multipass::FileOps::instance()
 
 namespace multipass
@@ -56,6 +58,9 @@ public:
     virtual qint64 size(QFile& file) const;
     virtual qint64 write(QFile& file, const char* data, qint64 maxSize) const;
     virtual qint64 write(QFile& file, const QByteArray& data) const;
+
+    // std operations
+    virtual std::FILE* fopen(const char* filename, const char* mode) const;
 };
 } // namespace multipass
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -55,6 +55,7 @@ public:
     virtual QString get_workflows_url_override() const;
     virtual bool is_alias_supported(const std::string& alias, const std::string& remote) const;
     virtual bool is_remote_supported(const std::string& remote) const;
+    virtual bool is_backend_supported(const QString& backend) const; // temporary (?)
     virtual int chown(const char* path, unsigned int uid, unsigned int gid) const;
     virtual bool link(const char* target, const char* link) const;
     virtual bool symlink(const char* target, const char* link, bool is_dir) const;
@@ -79,7 +80,6 @@ QString default_privileged_mounts();
 
 QString daemon_config_home(); // temporary
 
-bool is_backend_supported(const QString& backend); // temporary
 VirtualMachineFactory::UPtr vm_backend(const Path& data_dir);
 logging::Logger::UPtr make_logger(logging::Level level);
 UpdatePrompt::UPtr make_update_prompt();

--- a/include/multipass/settings.h
+++ b/include/multipass/settings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/multipass/settings.h
+++ b/include/multipass/settings.h
@@ -41,6 +41,20 @@ public:
     virtual QString get(const QString& key) const;            // throws on unknown key
     virtual void set(const QString& key, const QString& val); // throws on unknown key or bad settings
 
+    /**
+     * Obtain a setting as a certain type
+     * @tparam T The type to obtain the setting as
+     * @param key The Key that identifies the setting
+     * @return The value that the setting converts to, when interpreted as type @p T. Follows the conversion rules used
+     * by @c QVariant.
+     * If the current @em value cannot be converted, a default @p T value is returned.
+     * @note QVariant's conversion rules may be surprising and not always correctly documented. For instance according
+     * to Qt's documentation at the time of writing, @c "False" would convert to @c bool as @c true, but it actually
+     * converts to @c false. However, @c "no" converts to @c true.
+     * @throws UnsupportedSettingValueType@<T@> If QVariant cannot convert from a @c QString to type @p T. Note that
+     * this is only thrown when the type itself can't be converted to. The actual value may still fail to convert, in
+     * which case a default @c T value is returned.
+     */
     template <typename T>
     T get_as(const QString& key) const;
 
@@ -62,7 +76,7 @@ template <typename T>
 T multipass::Settings::get_as(const QString& key) const
 {
     auto var = QVariant{get(key)};
-    if (var.canConvert<T>())
+    if (var.canConvert<T>()) // Note: this only checks if the types themselves are convertible, not the values
         return var.value<T>();
     throw UnsupportedSettingValueType<T>(key);
 }

--- a/include/multipass/settings.h
+++ b/include/multipass/settings.h
@@ -44,13 +44,10 @@ public:
     /**
      * Obtain a setting as a certain type
      * @tparam T The type to obtain the setting as
-     * @param key The Key that identifies the setting
+     * @param key The key that identifies the setting
      * @return The value that the setting converts to, when interpreted as type @p T. Follows the conversion rules used
      * by @c QVariant.
      * If the current @em value cannot be converted, a default @p T value is returned.
-     * @note QVariant's conversion rules may be surprising and not always correctly documented. For instance according
-     * to Qt's documentation at the time of writing, @c "False" would convert to @c bool as @c true, but it actually
-     * converts to @c false. However, @c "no" converts to @c true.
      * @throws UnsupportedSettingValueType<T> If QVariant cannot convert from a @c QString to type @c T. Note that
      * this is only thrown when the type itself can't be converted to. The actual value may still fail to convert, in
      * which case a default @c T value is returned.

--- a/include/multipass/settings.h
+++ b/include/multipass/settings.h
@@ -51,7 +51,7 @@ public:
      * @note QVariant's conversion rules may be surprising and not always correctly documented. For instance according
      * to Qt's documentation at the time of writing, @c "False" would convert to @c bool as @c true, but it actually
      * converts to @c false. However, @c "no" converts to @c true.
-     * @throws UnsupportedSettingValueType@<T@> If QVariant cannot convert from a @c QString to type @p T. Note that
+     * @throws UnsupportedSettingValueType<T> If QVariant cannot convert from a @c QString to type @c T. Note that
      * this is only thrown when the type itself can't be converted to. The actual value may still fail to convert, in
      * which case a default @c T value is returned.
      */

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Canonical, Ltd.
+ * Copyright (C) 2019-2021 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@ namespace
 {
 bool allow_only_stopped_instances(const QString& key, const QString& val) // temporary
 {
-    return key == mp::driver_key && mp::platform::is_backend_supported(val) && (val == "qemu" || val == "libvirt") &&
+    return key == mp::driver_key && MP_PLATFORM.is_backend_supported(val) && (val == "qemu" || val == "libvirt") &&
            val != MP_SETTINGS.get(key); /* if we are switching between qemu and libvirt drivers (on linux),
                                                         we can only have stopped instances */
 }

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -259,6 +259,11 @@ bool mp::platform::Platform::is_remote_supported(const std::string& remote) cons
     return true;
 }
 
+bool mp::platform::Platform::is_backend_supported(const QString& backend) const
+{
+    return (backend == "qemu" && QEMU_ENABLED) || backend == "libvirt" || backend == "lxd";
+}
+
 bool mp::platform::Platform::link(const char* target, const char* link) const
 {
     return ::link(target, link) == 0;
@@ -395,11 +400,6 @@ QString mp::platform::daemon_config_home() // temporary
 
     ret = QDir{ret}.absoluteFilePath(mp::daemon_name);
     return ret;
-}
-
-bool mp::platform::is_backend_supported(const QString& backend)
-{
-    return (backend == "qemu" && QEMU_ENABLED) || backend == "libvirt" || backend == "lxd";
 }
 
 mp::VirtualMachineFactory::UPtr mp::platform::vm_backend(const mp::Path& data_dir)

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -113,7 +113,7 @@ qint64 mp::FileOps::write(QFile& file, const QByteArray& data) const
     return file.write(data);
 }
 
-std::FILE* mp::FileOps::fopen(const char* filename, const char* mode) const
+void mp::FileOps::open(std::fstream& stream, const char* filename, std::ios_base::openmode mode) const
 {
-    return std::fopen(filename, mode);
+    stream.open(filename, mode);
 }

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -112,3 +112,8 @@ qint64 mp::FileOps::write(QFile& file, const QByteArray& data) const
 {
     return file.write(data);
 }
+
+std::FILE* mp::FileOps::fopen(const char* filename, const char* mode) const
+{
+    return std::fopen(filename, mode);
+}

--- a/src/utils/qsettings_wrapper.h
+++ b/src/utils/qsettings_wrapper.h
@@ -23,6 +23,8 @@
 
 #include <QSettings>
 
+#include <cassert>
+
 namespace multipass
 {
 class WrappedQSettingsFactory;

--- a/src/utils/qsettings_wrapper.h
+++ b/src/utils/qsettings_wrapper.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_QSETTINGS_WRAPPER_H
+#define MULTIPASS_QSETTINGS_WRAPPER_H
+
+#include <multipass/disabled_copy_move.h>
+#include <multipass/singleton.h>
+
+#include <QSettings>
+
+namespace multipass
+{
+class QSettingsProvider;
+class QSettingsWrapper : private DisabledCopyMove
+{
+public:
+    virtual ~QSettingsWrapper() = default;
+
+    virtual void setIniCodec(const char* codecName)
+    {
+        assert(qsettings);
+        qsettings->setIniCodec(codecName);
+    }
+
+protected:
+    QSettingsWrapper() = default;
+
+private:
+    friend class QSettingsProvider;
+    explicit QSettingsWrapper(std::unique_ptr<QSettings>&& qsettings) noexcept : qsettings{std::move(qsettings)}
+    {
+    }
+
+    std::unique_ptr<QSettings> qsettings;
+};
+
+class QSettingsProvider : public Singleton<QSettingsProvider>
+{
+public:
+    explicit QSettingsProvider(const Singleton::PrivatePass& pass) : Singleton{pass}
+    {
+    }
+
+    virtual std::unique_ptr<QSettingsWrapper> make_qsettings_wrapper(const QString& file_path, QSettings::Format format)
+    {
+        auto qsettings = std::make_unique<QSettings>(file_path, format);
+        return std::unique_ptr<QSettingsWrapper>(new QSettingsWrapper(std::move(qsettings))); /* std::make_unique can't
+                                   call private ctors, so we call it ourselves; but the ctor is noexcept, so no leaks */
+    }
+};
+} // namespace multipass
+
+#endif // MULTIPASS_QSETTINGS_WRAPPER_H

--- a/src/utils/qsettings_wrapper.h
+++ b/src/utils/qsettings_wrapper.h
@@ -91,7 +91,8 @@ public:
     {
     }
 
-    virtual std::unique_ptr<QSettingsWrapper> make_qsettings_wrapper(const QString& file_path, QSettings::Format format)
+    virtual std::unique_ptr<QSettingsWrapper> make_qsettings_wrapper(const QString& file_path,
+                                                                     QSettings::Format format) const
     {
         auto qsettings = std::make_unique<QSettings>(file_path, format);
         return std::unique_ptr<QSettingsWrapper>(new QSettingsWrapper(std::move(qsettings))); /* std::make_unique can't

--- a/src/utils/qsettings_wrapper.h
+++ b/src/utils/qsettings_wrapper.h
@@ -31,14 +31,49 @@ class QSettingsWrapper : private DisabledCopyMove
 public:
     virtual ~QSettingsWrapper() = default;
 
-    virtual void setIniCodec(const char* codecName)
+    virtual QSettings::Status status() const
     {
         assert(qsettings);
-        qsettings->setIniCodec(codecName);
+        return qsettings->status();
+    }
+
+    virtual QString fileName() const
+    {
+        assert(qsettings);
+        return qsettings->fileName();
+    }
+
+    virtual void setIniCodec(const char* codec_name)
+    {
+        assert(qsettings);
+        qsettings->setIniCodec(codec_name);
+    }
+
+    virtual void sync()
+    {
+        assert(qsettings);
+        qsettings->sync();
+    }
+
+    virtual void setValue(const QString& key, const QVariant& value)
+    {
+        assert(qsettings);
+        qsettings->setValue(key, value);
+    }
+
+    QVariant value(const QString& key, const QVariant& default_value = QVariant()) const
+    {
+        return value_impl(key, default_value); // indirection avoids default args in virtual method
     }
 
 protected:
-    QSettingsWrapper() = default;
+    QSettingsWrapper() = default; // for mocks
+
+    virtual QVariant value_impl(const QString& key, const QVariant& default_value) const
+    {
+        assert(qsettings);
+        return qsettings->value(key, default_value);
+    }
 
 private:
     friend class QSettingsProvider;

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cerrno>
+#include <fstream>
 #include <memory>
 #include <stdexcept>
 
@@ -95,7 +96,9 @@ std::unique_ptr<mp::WrappedQSettings> persistent_settings(const QString& key)
 
 bool exists_but_unreadable(const QString& filename)
 {
-    return !MP_FILEOPS.fopen(qPrintable(filename), "r") && errno && errno != ENOENT; /*
+    std::fstream in_stream;
+    MP_FILEOPS.open(in_stream, qPrintable(filename), std::ios_base::in);
+    return in_stream.fail() && errno && errno != ENOENT; /*
         Note: QFile::error() not enough for us: it would not distinguish the actual cause of failure;
         Note: errno is only set on some platforms, but those were experimentally verified to be the only ones that do
             not set a bad QSettings status on permission denied; to make this code portable, we need to account for a

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -18,6 +18,7 @@
 #include "qsettings_wrapper.h"
 
 #include <multipass/constants.h>
+#include <multipass/file_ops.h>
 #include <multipass/platform.h>
 #include <multipass/settings.h>
 #include <multipass/standard_paths.h>
@@ -29,10 +30,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cerrno>
-#include <fstream>
-#include <iterator>
 #include <memory>
-#include <multipass/file_ops.h>
 #include <stdexcept>
 
 namespace mp = multipass;

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -207,7 +207,7 @@ void multipass::Settings::set_aux(const QString& key, QString val) // work with 
     // TODO we should have handler callbacks instead
     if (key == petenv_key && !val.isEmpty() && !mp::utils::valid_hostname(val.toStdString()))
         throw InvalidSettingsException{key, val, "Invalid hostname"};
-    else if (key == driver_key && !mp::platform::is_backend_supported(val))
+    else if (key == driver_key && !MP_PLATFORM.is_backend_supported(val))
         throw InvalidSettingsException(key, val, "Invalid driver");
     else if ((key == autostart_key || key == mounts_key) && (val = interpret_bool(val)) != "true" && val != "false")
         throw InvalidSettingsException(key, val, "Invalid flag, try \"true\" or \"false\"");

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -86,9 +86,9 @@ QString file_for(const QString& key) // the key should have passed checks at thi
     return key.startsWith(daemon_root) ? daemon_file_path : client_file_path;
 }
 
-std::unique_ptr<mp::QSettingsWrapper> persistent_settings(const QString& key)
+std::unique_ptr<mp::WrappedQSettings> persistent_settings(const QString& key)
 {
-    auto ret = mp::QSettingsProvider::instance().make_qsettings_wrapper(file_for(key), QSettings::IniFormat);
+    auto ret = mp::WrappedQSettingsFactory::instance().make_wrapped_qsettings(file_for(key), QSettings::IniFormat);
     ret->setIniCodec("UTF-8");
 
     return ret;
@@ -105,7 +105,7 @@ bool exists_but_unreadable(const QString& filename)
             zero errno on the remaining platforms */
 }
 
-void check_status(const mp::QSettingsWrapper& settings, const QString& attempted_operation)
+void check_status(const mp::WrappedQSettings& settings, const QString& attempted_operation)
 {
     auto status = settings.status();
     if (status || exists_but_unreadable(settings.fileName()))
@@ -115,7 +115,7 @@ void check_status(const mp::QSettingsWrapper& settings, const QString& attempted
                                      : QStringLiteral("access error (consider running with an administrative role)")};
 }
 
-QString checked_get(const mp::QSettingsWrapper& settings, const QString& key, const QString& fallback,
+QString checked_get(const mp::WrappedQSettings& settings, const QString& key, const QString& fallback,
                     std::mutex& mutex)
 {
     std::lock_guard<std::mutex> lock{mutex};
@@ -126,7 +126,7 @@ QString checked_get(const mp::QSettingsWrapper& settings, const QString& key, co
     return ret;
 }
 
-void checked_set(mp::QSettingsWrapper& settings, const QString& key, const QString& val, std::mutex& mutex)
+void checked_set(mp::WrappedQSettings& settings, const QString& key, const QString& val, std::mutex& mutex)
 {
     std::lock_guard<std::mutex> lock{mutex};
 

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -15,7 +15,7 @@
  *
  */
 
-#include "qsettings_wrapper.h"
+#include "wrapped_qsettings.h"
 
 #include <multipass/constants.h>
 #include <multipass/file_ops.h>

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -32,6 +32,7 @@
 #include <fstream>
 #include <iterator>
 #include <memory>
+#include <multipass/file_ops.h>
 #include <stdexcept>
 
 namespace mp = multipass;
@@ -96,9 +97,7 @@ std::unique_ptr<mp::WrappedQSettings> persistent_settings(const QString& key)
 
 bool exists_but_unreadable(const QString& filename)
 {
-    std::ifstream stream;
-    stream.open(filename.toStdString(), std::ios_base::in);
-    return stream.fail() && errno && errno != ENOENT; /*
+    return !MP_FILEOPS.fopen(qPrintable(filename), "r") && errno && errno != ENOENT; /*
         Note: QFile::error() not enough for us: it would not distinguish the actual cause of failure;
         Note: errno is only set on some platforms, but those were experimentally verified to be the only ones that do
             not set a bad QSettings status on permission denied; to make this code portable, we need to account for a

--- a/src/utils/wrapped_qsettings.h
+++ b/src/utils/wrapped_qsettings.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef MULTIPASS_QSETTINGS_WRAPPER_H
-#define MULTIPASS_QSETTINGS_WRAPPER_H
+#ifndef MULTIPASS_WRAPPED_QSETTINGS_H
+#define MULTIPASS_WRAPPED_QSETTINGS_H
 
 #include <multipass/disabled_copy_move.h>
 #include <multipass/singleton.h>
@@ -103,4 +103,4 @@ public:
 };
 } // namespace multipass
 
-#endif // MULTIPASS_QSETTINGS_WRAPPER_H
+#endif // MULTIPASS_WRAPPED_QSETTINGS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,12 +64,12 @@ add_executable(multipass_tests
   test_petname.cpp
   test_platform_shared.cpp
   test_private_pass_provider.cpp
-  test_mock_settings.cpp
   test_mock_standard_paths.cpp
   test_qemuimg_process_spec.cpp
   test_simple_streams_index.cpp
   test_simple_streams_manifest.cpp
   test_singleton.cpp
+  test_settings.cpp
   test_sftp_client.cpp
   test_sftpserver.cpp
   test_ssl_cert_provider.cpp

--- a/tests/common.h
+++ b/tests/common.h
@@ -59,6 +59,9 @@
         },                                                                                                             \
         expected_exception)
 
+// work around warning: https://github.com/google/googletest/issues/2271#issuecomment-665742471
+#define MP_TYPED_TEST_SUITE(suite_name, types_param) TYPED_TEST_SUITE(suite_name, types_param, )
+
 // Teach GTest to print Qt stuff
 QT_BEGIN_NAMESPACE
 class QString;

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -415,7 +415,7 @@ struct TestUnsupportedDrivers : public TestWithParam<QString>
 
 TEST_P(TestUnsupportedDrivers, test_unsupported_driver)
 {
-    ASSERT_FALSE(mp::platform::is_backend_supported(GetParam()));
+    ASSERT_FALSE(MP_PLATFORM.is_backend_supported(GetParam()));
 
     setup_driver_settings(GetParam());
     EXPECT_THROW(mp::platform::vm_backend(backend_path), std::runtime_error);

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -681,7 +681,7 @@ TEST_F(PlatformLinux, find_os_release_etc)
                 open(Property(&QFile::fileName, Eq(expected_filename)), QIODevice::ReadOnly | QIODevice::Text))
         .Times(1)
         .WillOnce(Return(true));
-    EXPECT_CALL(*mock_file_ops, open).Times(0); // no other open attempts
+    EXPECT_CALL(*mock_file_ops, open(_, _)).Times(0); // no other open attempts
 
     auto output = multipass::platform::detail::find_os_release();
     EXPECT_EQ(output->fileName(), expected_filename);
@@ -700,7 +700,7 @@ TEST_F(PlatformLinux, find_os_release_usr_lib)
     EXPECT_CALL(*mock_file_ops,
                 open(Property(&QFile::fileName, Eq(expected_filename)), QIODevice::ReadOnly | QIODevice::Text))
         .WillOnce(Return(true));
-    EXPECT_CALL(*mock_file_ops, open).Times(0); // no other open attempts
+    EXPECT_CALL(*mock_file_ops, open(_, _)).Times(0); // no other open attempts
 
     auto output = multipass::platform::detail::find_os_release();
     EXPECT_EQ(output->fileName(), expected_filename);
@@ -726,7 +726,7 @@ TEST_F(PlatformLinux, read_os_release_from_file)
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
     InSequence seq;
-    EXPECT_CALL(*mock_file_ops, open).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, open(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, is_open).WillOnce(Return(true));
 
     for (const auto& line : input)

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -48,6 +48,7 @@ public:
     MOCK_CONST_METHOD1(size, qint64(QFile&));
     MOCK_CONST_METHOD3(write, qint64(QFile&, const char*, qint64));
     MOCK_CONST_METHOD2(write, qint64(QFile&, const QByteArray&));
+    MOCK_CONST_METHOD2(fopen, FILE*(const char*, const char*));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockFileOps, FileOps);
 };

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -48,7 +48,7 @@ public:
     MOCK_CONST_METHOD1(size, qint64(QFile&));
     MOCK_CONST_METHOD3(write, qint64(QFile&, const char*, qint64));
     MOCK_CONST_METHOD2(write, qint64(QFile&, const QByteArray&));
-    MOCK_CONST_METHOD2(fopen, FILE*(const char*, const char*));
+    MOCK_CONST_METHOD3(open, void(std::fstream&, const char*, std::ios_base::openmode));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockFileOps, FileOps);
 };

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -32,6 +32,7 @@ public:
     MOCK_CONST_METHOD0(get_network_interfaces_info, std::map<std::string, NetworkInterfaceInfo>());
     MOCK_CONST_METHOD0(get_workflows_url_override, QString());
     MOCK_CONST_METHOD1(is_remote_supported, bool(const std::string&));
+    MOCK_CONST_METHOD1(is_backend_supported, bool(const QString&));
     MOCK_CONST_METHOD2(is_alias_supported, bool(const std::string&, const std::string&));
     MOCK_CONST_METHOD3(chown, int(const char*, unsigned int, unsigned int));
     MOCK_CONST_METHOD2(link, bool(const char*, const char*));

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -96,12 +96,13 @@ TEST_F(SettingsTest, get_returns_recorded_setting)
 }
 
 TEST(Settings, provides_get_default_as_get_by_default)
+TEST(MockSettings, provides_get_default_as_get_by_default)
 {
     const auto& key = mp::driver_key;
     ASSERT_EQ(MP_SETTINGS.get(key), mpt::MockSettings::mock_instance().get_default(key));
 }
 
-TEST(Settings, can_have_get_mocked)
+TEST(MockSettings, can_have_get_mocked)
 {
     const auto test = QStringLiteral("abc"), proof = QStringLiteral("xyz");
     auto& mock = mpt::MockSettings::mock_instance();

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -21,6 +21,7 @@
 #include <src/utils/qsettings_wrapper.h>
 
 #include <multipass/constants.h>
+#include <multipass/platform.h>
 #include <multipass/settings.h>
 
 #include <QString>
@@ -95,9 +96,19 @@ TEST_P(SettingsTest, get_returns_recorded_setting)
     EXPECT_EQ(MP_SETTINGS.get(key), QString{val});
 }
 
-INSTANTIATE_TEST_SUITE_P(SettingsTestAllKeys, SettingsTest,
-                         Values(mp::petenv_key, mp::driver_key, mp::autostart_key, mp::hotkey_key,
-                                mp::bridged_interface_key, mp::mounts_key));
+std::vector<QString> get_regular_keys()
+{
+    std::vector<QString> ret{
+        mp::petenv_key, mp::driver_key, mp::autostart_key, mp::hotkey_key, mp::bridged_interface_key, mp::mounts_key};
+
+    for (const auto& item : mp::platform::extra_settings_defaults())
+        ret.push_back(item.first);
+
+    return ret;
+}
+
+INSTANTIATE_TEST_SUITE_P(SettingsTestAllKeys, SettingsTest, ValuesIn(get_regular_keys()));
+
 TEST(MockSettings, provides_get_default_as_get_by_default)
 {
     const auto& key = mp::driver_key;

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -18,6 +18,8 @@
 #include "common.h"
 #include "mock_settings.h"
 
+#include <src/utils/qsettings_wrapper.h>
+
 #include <multipass/constants.h>
 #include <multipass/settings.h>
 
@@ -29,6 +31,21 @@ using namespace testing;
 
 namespace
 {
+class MockQSettingsProvider : public mp::QSettingsProvider
+{
+public:
+    using QSettingsProvider::QSettingsProvider;
+    MOCK_CONST_METHOD2(make_qsettings_wrapper,
+                       std::unique_ptr<mp::QSettingsWrapper>(const QString&, QSettings::Format));
+
+    MP_MOCK_SINGLETON_BOILERPLATE(MockQSettingsProvider, QSettingsProvider);
+};
+
+struct SettingsTest : public Test
+{
+    MockQSettingsProvider::GuardedMock mock_qsettings_injection = MockQSettingsProvider::inject();
+    MockQSettingsProvider* mock_qsettings_provider = mock_qsettings_injection.first;
+};
 
 TEST(Settings, provides_get_default_as_get_by_default)
 {

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -187,14 +187,14 @@ std::vector<SettingValueRepresentation<QKeySequence>> setting_val_reprs()
 }
 
 template <typename T>
-struct TestSettingsGetAs : public TestSettings
+struct TestSuccessfulSettingsGetAs : public TestSettings
 {
 };
 
 using GetAsTestTypes = ::testing::Types<bool, int, QKeySequence>; // to add more, specialize setting_val_reprs above
-MP_TYPED_TEST_SUITE(TestSettingsGetAs, GetAsTestTypes);
+MP_TYPED_TEST_SUITE(TestSuccessfulSettingsGetAs, GetAsTestTypes);
 
-TYPED_TEST(TestSettingsGetAs, getAsConvertsValues)
+TYPED_TEST(TestSuccessfulSettingsGetAs, getAsConvertsValues)
 {
     InSequence seq;
     auto key = "whatever";
@@ -206,6 +206,15 @@ TYPED_TEST(TestSettingsGetAs, getAsConvertsValues)
             EXPECT_EQ(MP_SETTINGS.get_as<TypeParam>(key), val);
         }
     }
+}
+
+TEST_F(TestSettings, getAsThrowsOnUnsupportedTypeConversion)
+{
+    auto key = "the.key";
+    auto bad_repr = "#$%!@";
+    EXPECT_CALL(mpt::MockSettings::mock_instance(), get(Eq(key))).WillOnce(Return(bad_repr));
+    MP_ASSERT_THROW_THAT(MP_SETTINGS.get_as<QVariant>(key), mp::UnsupportedSettingValueType<QVariant>,
+                         mpt::match_what(HasSubstr(key)));
 }
 
 TEST(MockSettings, providesGetDefaultAsGetByDefault)

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -81,7 +81,7 @@ struct TestSettings : public Test
 
 TEST_F(TestSettings, getReadsUtf8)
 {
-    auto key = mp::petenv_key;
+    const auto key = mp::petenv_key;
     EXPECT_CALL(*mock_qsettings, setIniCodec(StrEq("UTF-8"))).Times(1);
 
     inject_mock_qsettings();
@@ -92,7 +92,7 @@ TEST_F(TestSettings, getReadsUtf8)
 
 TEST_F(TestSettings, setWritesUtf8)
 {
-    auto key = mp::bridged_interface_key, val = "foo";
+    const auto key = mp::bridged_interface_key, val = "foo";
     EXPECT_CALL(*mock_qsettings, setIniCodec(StrEq("UTF-8"))).Times(1);
 
     inject_mock_qsettings();
@@ -103,7 +103,7 @@ TEST_F(TestSettings, setWritesUtf8)
 
 TEST_F(TestSettings, DISABLE_ON_WINDOWS(getThrowsOnUnreadableFile))
 {
-    auto key = mp::hotkey_key;
+    const auto key = mp::hotkey_key;
     EXPECT_CALL(*mock_qsettings, fileName).WillOnce(Return("/root/asdf"));
 
     inject_mock_qsettings();
@@ -117,7 +117,7 @@ TEST_F(TestSettings, DISABLE_ON_WINDOWS(getThrowsOnUnreadableFile))
 
 TEST_F(TestSettings, DISABLE_ON_WINDOWS(setThrowsOnUnwritableFile))
 {
-    auto key = mp::mounts_key, val = "yes";
+    const auto key = mp::mounts_key, val = "yes";
     EXPECT_CALL(*mock_qsettings, fileName).WillOnce(Return("/root/fdsa"));
 
     inject_mock_qsettings();
@@ -140,7 +140,7 @@ struct TestSettingsReadWriteError : public TestSettings, public WithParamInterfa
 TEST_P(TestSettingsReadWriteError, getThrowsOnFileReadError)
 {
     const auto& [status, desc] = GetParam();
-    auto key = multipass::driver_key;
+    const auto key = multipass::driver_key;
     EXPECT_CALL(*mock_qsettings, status).WillOnce(Return(status));
 
     inject_mock_qsettings();
@@ -153,7 +153,7 @@ TEST_P(TestSettingsReadWriteError, getThrowsOnFileReadError)
 TEST_P(TestSettingsReadWriteError, setThrowsOnFileWriteError)
 {
     const auto& [status, desc] = GetParam();
-    auto key = mp::hotkey_key, val = "Esc";
+    const auto key = mp::hotkey_key, val = "Esc";
     EXPECT_CALL(*mock_qsettings, status).WillOnce(Return(status));
 
     inject_mock_qsettings();
@@ -173,8 +173,8 @@ struct TestSettingsKeyParam : public TestSettings, public WithParamInterface<QSt
 
 TEST_P(TestSettingsKeyParam, getReturnsRecordedSetting)
 {
-    auto key = GetParam();
-    auto val = "asdf";
+    const auto key = GetParam();
+    const auto val = "asdf";
     EXPECT_CALL(*mock_qsettings, value_impl(Eq(key), _)).WillOnce(Return(val));
 
     inject_mock_qsettings();
@@ -238,7 +238,7 @@ MP_TYPED_TEST_SUITE(TestSuccessfulSettingsGetAs, GetAsTestTypes);
 TYPED_TEST(TestSuccessfulSettingsGetAs, getAsConvertsValues)
 {
     InSequence seq;
-    auto key = "whatever";
+    const auto key = "whatever";
     for (const auto& [val, reprs] : setting_val_reprs<TypeParam>())
     {
         for (const auto& repr : reprs)
@@ -251,8 +251,8 @@ TYPED_TEST(TestSuccessfulSettingsGetAs, getAsConvertsValues)
 
 TEST_F(TestSettings, getAsThrowsOnUnsupportedTypeConversion)
 {
-    auto key = "the.key";
-    auto bad_repr = "#$%!@";
+    const auto key = "the.key";
+    const auto bad_repr = "#$%!@";
     EXPECT_CALL(mpt::MockSettings::mock_instance(), get(Eq(key))).WillOnce(Return(bad_repr));
     MP_ASSERT_THROW_THAT(MP_SETTINGS.get_as<QVariant>(key), mp::UnsupportedSettingValueType<QVariant>,
                          mpt::match_what(HasSubstr(key)));
@@ -260,8 +260,8 @@ TEST_F(TestSettings, getAsThrowsOnUnsupportedTypeConversion)
 
 TEST_F(TestSettings, getAsReturnsDefaultOnBadValue)
 {
-    auto key = "a.key";
-    auto bad_int = "ceci n'est pas une int";
+    const auto key = "a.key";
+    const auto bad_int = "ceci n'est pas une int";
     EXPECT_CALL(mpt::MockSettings::mock_instance(), get(Eq(key))).WillOnce(Return(bad_int));
     EXPECT_EQ(MP_SETTINGS.get_as<int>(key), 0);
 }
@@ -276,7 +276,7 @@ TEST(MockSettings, providesGetDefaultAsGetByDefault)
 TEST(MockSettings, canHaveGetMocked)
 {
     const auto test = QStringLiteral("abc"), proof = QStringLiteral("xyz");
-    auto& mock = mpt::MockSettings::mock_instance();
+    const auto& mock = mpt::MockSettings::mock_instance();
 
     EXPECT_CALL(mock, get(test)).WillOnce(Return(proof));
     ASSERT_EQ(MP_SETTINGS.get(test), proof);

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -83,7 +83,31 @@ TEST_P(SettingsTest, get_reads_utf8)
     MP_SETTINGS.get(key);
 }
 
-TEST_P(SettingsTest, get_returns_recorded_setting)
+TEST_P(SettingsTest, get_throws_on_bad_file_format)
+{
+    auto key = GetParam();
+    EXPECT_CALL(*mock_qsettings, status).WillOnce(Return(QSettings::FormatError));
+
+    inject_mock_qsettings();
+    EXPECT_CALL(mpt::MockSettings::mock_instance(), get(Eq(key))).WillOnce(call_real_settings_get);
+
+    MP_EXPECT_THROW_THAT(MP_SETTINGS.get(key), mp::PersistentSettingsException,
+                         mpt::match_what(AllOf(HasSubstr("read"), HasSubstr("format"))));
+}
+
+TEST_P(SettingsTest, get_throws_on_file_access_error)
+{
+    auto key = GetParam();
+    EXPECT_CALL(*mock_qsettings, status).WillOnce(Return(QSettings::AccessError));
+
+    inject_mock_qsettings();
+    EXPECT_CALL(mpt::MockSettings::mock_instance(), get(Eq(key))).WillOnce(call_real_settings_get);
+
+    MP_EXPECT_THROW_THAT(MP_SETTINGS.get(key), mp::PersistentSettingsException,
+                         mpt::match_what(AllOf(HasSubstr("read"), HasSubstr("access"))));
+}
+
+TEST_P(SettingsTest, get_returns_recorded_setting) // TODO@ricab probably only one which should have param
 {
     auto key = GetParam();
     auto val = "asdf";

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -115,6 +115,18 @@ TEST_F(TestSettings, DISABLE_ON_WINDOWS(getThrowsOnUnreadableFile))
     EXPECT_EQ(errno, EACCES) << "errno is " << errno;
 }
 
+TEST_F(TestSettings, DISABLE_ON_WINDOWS(setThrowsOnUnwritableFile))
+{
+    auto key = mp::mounts_key, val = "yes";
+    EXPECT_CALL(*mock_qsettings, fileName).WillOnce(Return("/root/fdsa"));
+
+    inject_mock_qsettings();
+    EXPECT_CALL(mpt::MockSettings::mock_instance(), set(Eq(key), Eq(val))).WillOnce(call_real_settings_set);
+
+    MP_EXPECT_THROW_THAT(MP_SETTINGS.set(key, val), mp::PersistentSettingsException,
+                         mpt::match_what(AllOf(HasSubstr("write"), HasSubstr("access"))));
+}
+
 struct DescribedQSettingsStatus
 {
     QSettings::Status status;

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -169,7 +169,7 @@ std::vector<SettingValueRepresentation<T>> setting_val_reprs();
 template <>
 std::vector<SettingValueRepresentation<bool>> setting_val_reprs()
 {
-    return {{false, {"False", "false", "0"}}, {true, {"True", "true", "1"}}};
+    return {{false, {"False", "false", "0", ""}}, {true, {"True", "true", "1", "no", "anything else"}}};
 }
 
 template <>

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -242,8 +242,22 @@ TEST_P(TestSettingsSetRegularKeys, setRecordsProvidedSetting)
 
 INSTANTIATE_TEST_SUITE_P(TestSettingsSetRegularKeys, TestSettingsSetRegularKeys,
                          Values(KeyVal{mp::petenv_key, "instance-name"}, KeyVal{mp::petenv_key, ""},
-                                KeyVal{mp::autostart_key, "false"}, KeyVal{mp::hotkey_key, "Alt+X"},
-                                KeyVal{mp::bridged_interface_key, "iface"}, KeyVal{mp::mounts_key, "true"}));
+                                KeyVal{mp::autostart_key, "false"}, KeyVal{mp::bridged_interface_key, "iface"},
+                                KeyVal{mp::mounts_key, "true"}));
+
+TEST_F(TestSettings, setTranslatesHotkey)
+{
+    const auto key = mp::hotkey_key;
+    const auto val = "Alt+X";
+    const auto native_val = mp::platform::interpret_setting(key, val);
+
+    EXPECT_CALL(*mock_qsettings, setValue(Eq(key), Eq(native_val))).Times(1);
+
+    inject_mock_qsettings();
+    inject_real_settings_set(key, val);
+
+    ASSERT_NO_THROW(MP_SETTINGS.set(key, val));
+}
 
 TEST_F(TestSettings, setAcceptsValidBackend)
 {

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -56,7 +56,7 @@ public:
     MP_MOCK_SINGLETON_BOILERPLATE(MockQSettingsProvider, WrappedQSettingsFactory);
 };
 
-struct SettingsTest : public Test
+struct TestSettings : public Test
 {
     void inject_mock_qsettings() // moves the mock, so call once only, after setting expectations
     {
@@ -74,7 +74,7 @@ struct SettingsTest : public Test
     std::unique_ptr<MockQSettings> mock_qsettings = std::make_unique<MockQSettings>(); // TODO@ricab nice?
 };
 
-TEST_F(SettingsTest, getReadsUtf8)
+TEST_F(TestSettings, getReadsUtf8)
 {
     auto key = mp::petenv_key;
     EXPECT_CALL(*mock_qsettings, setIniCodec(StrEq("UTF-8"))).Times(1);
@@ -85,7 +85,7 @@ TEST_F(SettingsTest, getReadsUtf8)
     MP_SETTINGS.get(key);
 }
 
-TEST_F(SettingsTest, DISABLE_ON_WINDOWS(getThrowsOnUnreadableFile))
+TEST_F(TestSettings, DISABLE_ON_WINDOWS(getThrowsOnUnreadableFile))
 {
     auto key = multipass::hotkey_key;
     EXPECT_CALL(*mock_qsettings, fileName).WillOnce(Return("/root/asdf"));
@@ -105,11 +105,11 @@ struct DescribedQSettingsStatus
     std::string description;
 };
 
-struct SettingsTestReadError : public SettingsTest, public WithParamInterface<DescribedQSettingsStatus>
+struct TestSettingsReadError : public TestSettings, public WithParamInterface<DescribedQSettingsStatus>
 {
 };
 
-TEST_P(SettingsTestReadError, getThrowsOnFileReadError)
+TEST_P(TestSettingsReadError, getThrowsOnFileReadError)
 {
     const auto& [status, desc] = GetParam();
     auto key = multipass::driver_key;
@@ -122,15 +122,15 @@ TEST_P(SettingsTestReadError, getThrowsOnFileReadError)
                          mpt::match_what(AllOf(HasSubstr("read"), HasSubstr(desc))));
 }
 
-INSTANTIATE_TEST_SUITE_P(SettingsTestAllReadErrors, SettingsTestReadError,
+INSTANTIATE_TEST_SUITE_P(TestSettingsAllReadErrors, TestSettingsReadError,
                          Values(DescribedQSettingsStatus{QSettings::FormatError, "format"},
                                 DescribedQSettingsStatus{QSettings::AccessError, "access"}));
 
-struct SettingsTestKeyParam : public SettingsTest, public WithParamInterface<QString>
+struct TestSettingsKeyParam : public TestSettings, public WithParamInterface<QString>
 {
 };
 
-TEST_P(SettingsTestKeyParam, getReturnsRecordedSetting)
+TEST_P(TestSettingsKeyParam, getReturnsRecordedSetting)
 {
     auto key = GetParam();
     auto val = "asdf";
@@ -154,7 +154,7 @@ std::vector<QString> get_regular_keys()
     return ret;
 }
 
-INSTANTIATE_TEST_SUITE_P(SettingsTestRegularKeys, SettingsTestKeyParam, ValuesIn(get_regular_keys()));
+INSTANTIATE_TEST_SUITE_P(TestSettingsRegularKeys, TestSettingsKeyParam, ValuesIn(get_regular_keys()));
 
 template <typename T>
 struct SettingValueRepresentation
@@ -187,7 +187,7 @@ std::vector<SettingValueRepresentation<QKeySequence>> setting_val_reprs()
 }
 
 template <typename T>
-struct TestSettingsGetAs : public SettingsTest
+struct TestSettingsGetAs : public TestSettings
 {
 };
 

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -53,7 +53,7 @@ public:
     MP_MOCK_SINGLETON_BOILERPLATE(MockQSettingsProvider, QSettingsProvider);
 };
 
-struct SettingsTest : public Test
+struct SettingsTest : public TestWithParam<QString>
 {
     void inject_mock_qsettings() // moves the mock, so call once only, after setting expectations
     {
@@ -71,9 +71,9 @@ struct SettingsTest : public Test
     std::unique_ptr<MockQSettingsWrapper> mock_qsettings = std::make_unique<MockQSettingsWrapper>();
 };
 
-TEST_F(SettingsTest, get_reads_utf8)
+TEST_P(SettingsTest, get_reads_utf8)
 {
-    auto key = mp::petenv_key;
+    auto key = GetParam();
     EXPECT_CALL(*mock_qsettings, setIniCodec(StrEq("UTF-8"))).Times(1);
 
     inject_mock_qsettings();
@@ -82,9 +82,9 @@ TEST_F(SettingsTest, get_reads_utf8)
     MP_SETTINGS.get(key);
 }
 
-TEST_F(SettingsTest, get_returns_recorded_setting)
+TEST_P(SettingsTest, get_returns_recorded_setting)
 {
-    auto key = mp::petenv_key;
+    auto key = GetParam();
     auto val = "asdf";
     EXPECT_CALL(*mock_qsettings, value_impl(Eq(key), _)).WillOnce(Return(val));
 
@@ -95,7 +95,9 @@ TEST_F(SettingsTest, get_returns_recorded_setting)
     EXPECT_EQ(MP_SETTINGS.get(key), QString{val});
 }
 
-TEST(Settings, provides_get_default_as_get_by_default)
+INSTANTIATE_TEST_SUITE_P(SettingsTestAllKeys, SettingsTest,
+                         Values(mp::petenv_key, mp::driver_key, mp::autostart_key, mp::hotkey_key,
+                                mp::bridged_interface_key, mp::mounts_key));
 TEST(MockSettings, provides_get_default_as_get_by_default)
 {
     const auto& key = mp::driver_key;

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -216,9 +216,9 @@ TEST_P(TestSettingsSetRegularKeys, setRecordsProvidedSetting)
 }
 
 INSTANTIATE_TEST_SUITE_P(TestSettingsSetRegularKeys, TestSettingsSetRegularKeys,
-                         Values(KeyVal{mp::petenv_key, "instance-name"}, KeyVal{mp::autostart_key, "false"},
-                                KeyVal{mp::hotkey_key, "Alt+X"}, KeyVal{mp::bridged_interface_key, "iface"},
-                                KeyVal{mp::mounts_key, "true"}));
+                         Values(KeyVal{mp::petenv_key, "instance-name"}, KeyVal{mp::petenv_key, ""},
+                                KeyVal{mp::autostart_key, "false"}, KeyVal{mp::hotkey_key, "Alt+X"},
+                                KeyVal{mp::bridged_interface_key, "iface"}, KeyVal{mp::mounts_key, "true"}));
 
 using KeyReprVal = std::tuple<QString, QString, QString>;
 struct TestSettingsGoodBoolConversion : public TestSettings, public WithParamInterface<KeyReprVal>

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -61,6 +61,11 @@ struct SettingsTest : public Test
             .WillOnce(Return(ByMove(std::move(mock_qsettings))));
     }
 
+    static QString call_real_settings_get(const QString& key)
+    {
+        return MP_SETTINGS.Settings::get(key); // invoke the base
+    }
+
     MockQSettingsProvider::GuardedMock mock_qsettings_injection = MockQSettingsProvider::inject();
     MockQSettingsProvider* mock_qsettings_provider = mock_qsettings_injection.first;
     std::unique_ptr<MockQSettingsWrapper> mock_qsettings = std::make_unique<MockQSettingsWrapper>();
@@ -73,9 +78,7 @@ TEST_F(SettingsTest, get_returns_recorded_setting)
     EXPECT_CALL(*mock_qsettings, value_impl(Eq(key), _)).WillOnce(Return(val));
 
     inject_mock_qsettings();
-    EXPECT_CALL(mpt::MockSettings::mock_instance(), get(Eq(key))).WillOnce(InvokeWithoutArgs([&key] {
-        return MP_SETTINGS.Settings::get(key); // invoke the base
-    }));
+    EXPECT_CALL(mpt::MockSettings::mock_instance(), get(Eq(key))).WillOnce(call_real_settings_get);
 
     ASSERT_NE(val, mpt::MockSettings::mock_instance().get_default(key));
     EXPECT_EQ(MP_SETTINGS.get(key), QString{val});

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -74,7 +74,8 @@ struct TestSettings : public Test
         MP_SETTINGS.Settings::set(key, val); // invoke the base
     }
 
-    MockQSettingsProvider::GuardedMock mock_qsettings_injection = MockQSettingsProvider::inject();
+    MockQSettingsProvider::GuardedMock mock_qsettings_injection = MockQSettingsProvider::inject<StrictMock>(); /* strict
+                                                to ensure that, other than explicitly injected, no QSettings are used */
     MockQSettingsProvider* mock_qsettings_provider = mock_qsettings_injection.first;
     std::unique_ptr<MockQSettings> mock_qsettings = std::make_unique<MockQSettings>(); // TODO@ricab nice?
 };

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -90,10 +90,12 @@ struct TestSettings : public Test
 public:
     mpt::MockFileOps::GuardedMock mock_file_ops_injection = mpt::MockFileOps::inject<NiceMock>();
     mpt::MockFileOps* mock_file_ops = mock_file_ops_injection.first;
+
     MockQSettingsProvider::GuardedMock mock_qsettings_injection = MockQSettingsProvider::inject<StrictMock>(); /* this
     is made strict to ensure that, other than explicitly injected, no QSettings are used; that's particularly important
     when injecting real get and set behavior (don't want tests to be affected, nor themselves affect, disk state) */
     MockQSettingsProvider* mock_qsettings_provider = mock_qsettings_injection.first;
+
     std::unique_ptr<NiceMock<MockQSettings>> mock_qsettings = std::make_unique<NiceMock<MockQSettings>>();
     mpt::MockSettings& mock_settings = mpt::MockSettings::mock_instance();
     FILE fake_file;

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -80,7 +80,7 @@ public:
     is made strict to ensure that, other than explicitly injected, no QSettings are used; that's particularly important
     when injecting real get and set behavior (don't want tests to be affected, nor themselves affect, disk state) */
     MockQSettingsProvider* mock_qsettings_provider = mock_qsettings_injection.first;
-    std::unique_ptr<MockQSettings> mock_qsettings = std::make_unique<MockQSettings>(); // TODO@ricab nice?
+    std::unique_ptr<NiceMock<MockQSettings>> mock_qsettings = std::make_unique<NiceMock<MockQSettings>>();
     mpt::MockSettings& mock_settings = mpt::MockSettings::mock_instance();
 
 private:

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -41,7 +41,7 @@ public:
     MOCK_CONST_METHOD0(fileName, QString());
     MOCK_CONST_METHOD2(value_impl, QVariant(const QString& key, const QVariant& default_value)); // promote visibility
     MOCK_METHOD1(setIniCodec, void(const char* codec_name));
-    MOCK_METHOD0(sync, void());
+    MOCK_METHOD0(sync, void()); // TODO@ricab verify all these
     MOCK_METHOD2(setValue, void(const QString& key, const QVariant& value));
 };
 
@@ -70,10 +70,10 @@ struct SettingsTest : public Test
 
     MockQSettingsProvider::GuardedMock mock_qsettings_injection = MockQSettingsProvider::inject();
     MockQSettingsProvider* mock_qsettings_provider = mock_qsettings_injection.first;
-    std::unique_ptr<MockQSettingsWrapper> mock_qsettings = std::make_unique<MockQSettingsWrapper>();
+    std::unique_ptr<MockQSettingsWrapper> mock_qsettings = std::make_unique<MockQSettingsWrapper>(); // TODO@ricab nice?
 };
 
-TEST_F(SettingsTest, get_reads_utf8)
+TEST_F(SettingsTest, getReadsUtf8)
 {
     auto key = mp::petenv_key;
     EXPECT_CALL(*mock_qsettings, setIniCodec(StrEq("UTF-8"))).Times(1);
@@ -108,7 +108,7 @@ struct SettingsTestReadError : public SettingsTest, public WithParamInterface<De
 {
 };
 
-TEST_P(SettingsTestReadError, get_throws_on_file_read_error)
+TEST_P(SettingsTestReadError, getThrowsOnFileReadError)
 {
     const auto& [status, desc] = GetParam();
     auto key = multipass::driver_key;
@@ -129,7 +129,7 @@ struct SettingsTestKeyParam : public SettingsTest, public WithParamInterface<QSt
 {
 };
 
-TEST_P(SettingsTestKeyParam, get_returns_recorded_setting)
+TEST_P(SettingsTestKeyParam, getReturnsRecordedSetting)
 {
     auto key = GetParam();
     auto val = "asdf";
@@ -155,13 +155,13 @@ std::vector<QString> get_regular_keys()
 
 INSTANTIATE_TEST_SUITE_P(SettingsTestRegularKeys, SettingsTestKeyParam, ValuesIn(get_regular_keys()));
 
-TEST(MockSettings, provides_get_default_as_get_by_default)
+TEST(MockSettings, providesGetDefaultAsGetByDefault)
 {
     const auto& key = mp::driver_key;
     ASSERT_EQ(MP_SETTINGS.get(key), mpt::MockSettings::mock_instance().get_default(key));
 }
 
-TEST(MockSettings, can_have_get_mocked)
+TEST(MockSettings, canHaveGetMocked)
 {
     const auto test = QStringLiteral("abc"), proof = QStringLiteral("xyz");
     auto& mock = mpt::MockSettings::mock_instance();

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -127,7 +127,7 @@ TEST_F(TestSettings, DISABLE_ON_WINDOWS(setThrowsOnUnreadableFile))
                          mpt::match_what(AllOf(HasSubstr("read"), HasSubstr("access"))));
 }
 
-using DescribedQSettingsStatus = std::pair<QSettings::Status, std::string>;
+using DescribedQSettingsStatus = std::tuple<QSettings::Status, std::string>;
 struct TestSettingsReadWriteError : public TestSettings, public WithParamInterface<DescribedQSettingsStatus>
 {
 };
@@ -198,7 +198,7 @@ INSTANTIATE_TEST_SUITE_P(TestSettingsGetRegularKeys, TestSettingsGetRegularKeys,
                              return ret;
                          }()));
 
-using KeyVal = std::pair<QString, QString>;
+using KeyVal = std::tuple<QString, QString>;
 struct TestSettingsSetRegularKeys : public TestSettings, public WithParamInterface<KeyVal>
 {
 };

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -129,7 +129,7 @@ TEST_F(TestSettings, setWritesUtf8)
     MP_SETTINGS.set(key, val);
 }
 
-TEST_F(TestSettings, DISABLE_ON_WINDOWS(getThrowsOnUnreadableFile))
+TEST_F(TestSettings, getThrowsOnUnreadableFile)
 {
     const auto key = mp::hotkey_key;
     auto guard = mock_unreadable_settings_file("/an/unreadable/file");
@@ -141,7 +141,7 @@ TEST_F(TestSettings, DISABLE_ON_WINDOWS(getThrowsOnUnreadableFile))
                          mpt::match_what(AllOf(HasSubstr("read"), HasSubstr("access"))));
 }
 
-TEST_F(TestSettings, DISABLE_ON_WINDOWS(setThrowsOnUnreadableFile))
+TEST_F(TestSettings, setThrowsOnUnreadableFile)
 {
     const auto key = mp::mounts_key, val = "yes";
     auto guard = mock_unreadable_settings_file("unreadable");

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -16,16 +16,15 @@
  */
 
 #include "common.h"
-#include "disabling_macros.h"
 #include "mock_file_ops.h"
 #include "mock_platform.h"
 #include "mock_settings.h"
+#include "mock_singleton_helpers.h"
 
 #include <src/utils/qsettings_wrapper.h>
 
 #include <multipass/constants.h>
 #include <multipass/platform.h>
-#include <multipass/settings.h>
 
 #include <QKeySequence>
 #include <QString>

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -103,7 +103,7 @@ TEST_F(TestSettings, setWritesUtf8)
 
 TEST_F(TestSettings, DISABLE_ON_WINDOWS(getThrowsOnUnreadableFile))
 {
-    auto key = multipass::hotkey_key;
+    auto key = mp::hotkey_key;
     EXPECT_CALL(*mock_qsettings, fileName).WillOnce(Return("/root/asdf"));
 
     inject_mock_qsettings();
@@ -197,7 +197,7 @@ std::vector<SettingValueRepresentation<T>> setting_val_reprs();
 template <>
 std::vector<SettingValueRepresentation<bool>> setting_val_reprs()
 {
-    return {{false, {"False", "false", "0", ""}}, {true, {"True", "true", "1", "no", "anything else"}}};
+    return {{false, {"False", "false", "0", ""}}, {true, {"True", "true", "1", "no", "off", "anything else"}}};
 }
 
 template <>

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -21,7 +21,7 @@
 #include "mock_settings.h"
 #include "mock_singleton_helpers.h"
 
-#include <src/utils/qsettings_wrapper.h>
+#include <src/utils/wrapped_qsettings.h>
 
 #include <multipass/constants.h>
 #include <multipass/platform.h>

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -217,6 +217,14 @@ TEST_F(TestSettings, getAsThrowsOnUnsupportedTypeConversion)
                          mpt::match_what(HasSubstr(key)));
 }
 
+TEST_F(TestSettings, getAsReturnsDefaultOnBadValue)
+{
+    auto key = "a.key";
+    auto bad_int = "ceci n'est pas une int";
+    EXPECT_CALL(mpt::MockSettings::mock_instance(), get(Eq(key))).WillOnce(Return(bad_int));
+    EXPECT_EQ(MP_SETTINGS.get_as<int>(key), 0);
+}
+
 TEST(MockSettings, providesGetDefaultAsGetByDefault)
 {
     const auto& key = mp::driver_key;

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -31,6 +31,18 @@ using namespace testing;
 
 namespace
 {
+class MockQSettingsWrapper : public mp::QSettingsWrapper
+{
+public:
+    using QSettingsWrapper::QSettingsWrapper; // promote visibility
+    MOCK_CONST_METHOD0(status, QSettings::Status());
+    MOCK_CONST_METHOD0(fileName, QString());
+    MOCK_CONST_METHOD2(value_impl, QVariant(const QString& key, const QVariant& default_value)); // promote visibility
+    MOCK_METHOD1(setIniCodec, void(const char* codec_name));
+    MOCK_METHOD0(sync, void());
+    MOCK_METHOD2(setValue, void(const QString& key, const QVariant& value));
+};
+
 class MockQSettingsProvider : public mp::QSettingsProvider
 {
 public:

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -249,11 +249,11 @@ INSTANTIATE_TEST_SUITE_P(TestSettingsGoodBool, TestSettingsGoodBoolConversion, V
                              return ret;
                          }()));
 
-struct TestSettingsBadBoolConversion : public TestSettings, WithParamInterface<KeyVal>
+struct TestSettingsBadValue : public TestSettings, WithParamInterface<KeyVal>
 {
 };
 
-TEST_P(TestSettingsBadBoolConversion, setThrowsOnInvalidBoolRepresentations)
+TEST_P(TestSettingsBadValue, setThrowsOnInvalidSettingValue)
 {
     const auto& [key, val] = GetParam();
 
@@ -263,9 +263,15 @@ TEST_P(TestSettingsBadBoolConversion, setThrowsOnInvalidBoolRepresentations)
                          mpt::match_what(AllOf(HasSubstr(key.toStdString()), HasSubstr(val.toStdString()))));
 }
 
-INSTANTIATE_TEST_SUITE_P(TestSettingsBadBool, TestSettingsBadBoolConversion,
+INSTANTIATE_TEST_SUITE_P(TestSettingsBadBool, TestSettingsBadValue,
                          Combine(Values(mp::autostart_key, mp::mounts_key),
                                  Values("nonsense", "invalid", "", "bool", "representations", "-", "null")));
+
+INSTANTIATE_TEST_SUITE_P(TestSettingsBadPetEnv, TestSettingsBadValue,
+                         Combine(Values(mp::petenv_key), Values("-", "-a-b-", "_asd", "_1", "1-2-3")));
+
+// TODO@ricab accepts disable primary
+// TODO@ricab accepts/rejects driver
 
 template <typename T>
 struct SettingValueRepresentation


### PR DESCRIPTION
Finally get our `Settings` tested. At least the parts we know will have to remain (even if moved to handlers).

Depends on #2277.