### PR TITLE
[tests] Include common.h instead of gmock, gtest

### DIFF
--- a/tests/fake_alias_config.h
+++ b/tests/fake_alias_config.h
@@ -21,11 +21,10 @@
 #include <multipass/cli/alias_dict.h>
 #include <multipass/constants.h>
 
+#include "common.h"
 #include "mock_standard_paths.h"
 #include "stub_terminal.h"
 #include "temp_dir.h"
-
-#include <gmock/gmock.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;

--- a/tests/json_utils.cpp
+++ b/tests/json_utils.cpp
@@ -17,12 +17,11 @@
 
 #include <multipass/utils.h>
 
+#include "common.h"
 #include "file_operations.h"
 #include "json_utils.h"
 
 #include <fmt/format.h>
-
-#include <gtest/gtest.h>
 
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -21,8 +21,6 @@
 #include <multipass/cli/table_formatter.h>
 #include <multipass/cli/yaml_formatter.h>
 
-#include <gmock/gmock.h>
-
 #include "common.h"
 #include "daemon_test_fixture.h"
 #include "fake_alias_config.h"


### PR DESCRIPTION
In a couple of places, plus an old one which fell through the cracks. In order to get us pretty printers without breaking ODR. Related to #2142 .