### PR TITLE
[cmake] Remove obsolete variable

### DIFF
--- a/src/client/cli/cmd/CMakeLists.txt
+++ b/src/client/cli/cmd/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(commands STATIC
   umount.cpp
   unalias.cpp
   version.cpp
-  ${PLATFORM_COMMANDS})
+)
 
 target_link_libraries(commands
   client_common


### PR DESCRIPTION
PLATFORM_COMMANDS is nowhere to be found.