### PR TITLE
[tests] Remove superfluous `get` test

### DIFF
--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -221,7 +221,6 @@ TEST_F(Daemon, receives_commands_and_calls_corresponding_slot)
                    {"find", "something"},
                    {"mount", ".", "target"},
                    {"umount", "instance"},
-                   {"get", "foo"},
                    {"networks"}});
 }
 


### PR DESCRIPTION
It is already covered by `test_get` above.