### PR TITLE
[prompter] Add echoless passphrase prompt

### DIFF
--- a/include/multipass/cli/prompters.h
+++ b/include/multipass/cli/prompters.h
@@ -58,10 +58,27 @@ public:
 class PassphrasePrompter : public PlainPrompter
 {
 public:
-    explicit PassphrasePrompter(Terminal* term);
-    virtual ~PassphrasePrompter();
+    using PlainPrompter::PlainPrompter;
 
     std::string prompt(const std::string& text = "Please enter passphrase") const override;
+
+private:
+    class ScopedEcholessInput
+    {
+    public:
+        explicit ScopedEcholessInput(Terminal* term) : term(term)
+        {
+            term->set_cin_echo(false);
+        };
+
+        virtual ~ScopedEcholessInput()
+        {
+            term->set_cin_echo(true);
+        }
+
+    private:
+        Terminal* term;
+    };
 };
 
 class NewPassphrasePrompter : public PassphrasePrompter

--- a/include/multipass/cli/prompters.h
+++ b/include/multipass/cli/prompters.h
@@ -63,6 +63,15 @@ public:
 
     std::string prompt(const std::string&) const override;
 };
+
+class NewPassphrasePrompter : public PassphrasePrompter
+{
+public:
+    using PassphrasePrompter::PassphrasePrompter;
+    using PassphrasePrompter::prompt;
+
+    std::string prompt(const std::string&, const std::string&) const;
+};
 } // namespace multipass
 
 #endif // MULTIPASS_CLI_PROMPTERS_H

--- a/include/multipass/cli/prompters.h
+++ b/include/multipass/cli/prompters.h
@@ -55,6 +55,14 @@ public:
     std::string prompt(const std::string&) const override;
 };
 
+class PassphrasePrompter : public BasePrompter
+{
+public:
+    explicit PassphrasePrompter(Terminal* term);
+    virtual ~PassphrasePrompter();
+
+    std::string prompt(const std::string&) const override;
+};
 } // namespace multipass
 
 #endif // MULTIPASS_CLI_PROMPTERS_H

--- a/include/multipass/cli/prompters.h
+++ b/include/multipass/cli/prompters.h
@@ -55,22 +55,21 @@ public:
     std::string prompt(const std::string&) const override;
 };
 
-class PassphrasePrompter : public BasePrompter
+class PassphrasePrompter : public PlainPrompter
 {
 public:
     explicit PassphrasePrompter(Terminal* term);
     virtual ~PassphrasePrompter();
 
-    std::string prompt(const std::string&) const override;
+    std::string prompt(const std::string& text = "Please enter passphrase") const override;
 };
 
 class NewPassphrasePrompter : public PassphrasePrompter
 {
 public:
     using PassphrasePrompter::PassphrasePrompter;
-    using PassphrasePrompter::prompt;
 
-    std::string prompt(const std::string&, const std::string&) const;
+    std::string prompt(const std::string& text = "Please re-enter passphrase") const override;
 };
 } // namespace multipass
 

--- a/include/multipass/terminal.h
+++ b/include/multipass/terminal.h
@@ -40,6 +40,7 @@ public:
     bool is_live() const;
 
     virtual std::string read_all_cin();
+    virtual void set_cin_echo(const bool enable) = 0;
 
     using UPtr = std::unique_ptr<Terminal>;
     static UPtr make_terminal();

--- a/src/client/cli/cmd/register.cpp
+++ b/src/client/cli/cmd/register.cpp
@@ -83,12 +83,6 @@ mp::ParseCode cmd::Register::parse_args(mp::ArgParser* parser)
 
     if (parser->positionalArguments().empty())
     {
-        if (!term->is_live())
-        {
-            cerr << "The terminal is not live: The passphrase argument is required\n";
-            return ParseCode::CommandLineError;
-        }
-
         try
         {
             mp::PassphrasePrompter prompter(term);

--- a/src/client/cli/cmd/register.cpp
+++ b/src/client/cli/cmd/register.cpp
@@ -69,7 +69,7 @@ mp::ParseCode cmd::Register::parse_args(mp::ArgParser* parser)
     parser->addPositionalArgument("passphrase",
                                   "Passphrase to register with the Multipass service. If omitted, a prompt will be "
                                   "displayed for entering the passphrase.",
-                                  "<passphrase>");
+                                  "[<passphrase>]");
 
     auto status = parser->commandParse(this);
     if (status != ParseCode::Ok)

--- a/src/client/cli/cmd/register.cpp
+++ b/src/client/cli/cmd/register.cpp
@@ -86,7 +86,7 @@ mp::ParseCode cmd::Register::parse_args(mp::ArgParser* parser)
         try
         {
             mp::PassphrasePrompter prompter(term);
-            auto passphrase = prompter.prompt("Please enter passphrase: ");
+            auto passphrase = prompter.prompt();
 
             if (passphrase.empty())
             {

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -115,7 +115,7 @@ mp::ParseCode cmd::Set::checked_prompt(const QString& key)
         if (key == passphrase_key)
         {
             mp::NewPassphrasePrompter prompter(term);
-            val = QString::fromStdString(prompter.prompt("Enter passphrase", "Re-enter passphrase"));
+            val = QString::fromStdString(prompter.prompt("Enter passphrase: ", "Re-enter passphrase: "));
         }
         else
         {

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -110,10 +110,19 @@ mp::ParseCode cmd::Set::parse_args(mp::ArgParser* parser)
 
 mp::ParseCode cmd::Set::checked_prompt(const QString& key)
 {
-    mp::PlainPrompter prompter(term);
     try
     {
-        val = QString::fromStdString(prompter.prompt(key.toStdString()));
+        if (key == passphrase_key)
+        {
+            mp::NewPassphrasePrompter prompter(term);
+            val = QString::fromStdString(prompter.prompt("Enter passphrase", "Re-enter passphrase"));
+        }
+        else
+        {
+            mp::PlainPrompter prompter(term);
+            val = QString::fromStdString(prompter.prompt(key.toStdString()));
+        }
+
         return ParseCode::Ok;
     }
     catch (const mp::PromptException& e)

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -115,7 +115,7 @@ mp::ParseCode cmd::Set::checked_prompt(const QString& key)
         if (key == passphrase_key)
         {
             mp::NewPassphrasePrompter prompter(term);
-            val = QString::fromStdString(prompter.prompt("Enter passphrase: ", "Re-enter passphrase: "));
+            val = QString::fromStdString(prompter.prompt());
         }
         else
         {

--- a/src/client/common/prompters.cpp
+++ b/src/client/common/prompters.cpp
@@ -43,18 +43,10 @@ std::string mp::PlainPrompter::prompt(const std::string& text) const
     return get_input(term->cin());
 }
 
-mp::PassphrasePrompter::PassphrasePrompter(Terminal* term) : PlainPrompter(term)
-{
-    term->set_cin_echo(false);
-}
-
-mp::PassphrasePrompter::~PassphrasePrompter()
-{
-    term->set_cin_echo(true);
-}
-
 std::string mp::PassphrasePrompter::prompt(const std::string& text) const
 {
+    ScopedEcholessInput scoped_echoless_input(term);
+
     auto passphrase = PlainPrompter::prompt(text);
 
     term->cout() << "\n";

--- a/src/client/common/prompters.cpp
+++ b/src/client/common/prompters.cpp
@@ -59,3 +59,36 @@ std::string mp::PassphrasePrompter::prompt(const std::string& text) const
 
     return passphrase;
 }
+
+std::string mp::NewPassphrasePrompter::prompt(const std::string& prompt1, const std::string& prompt2) const
+{
+    std::string passphrase1, passphrase2;
+
+    while (true)
+    {
+        term->cout() << prompt1 << ": ";
+        std::getline(term->cin(), passphrase1);
+
+        if (!term->cin().good())
+            throw PromptException("Failed to read passphrase");
+
+        term->cout() << "\n" << prompt2 << ": ";
+        std::getline(term->cin(), passphrase2);
+
+        if (!term->cin().good())
+            throw PromptException("Failed to read passphrase");
+
+        if (passphrase1 == passphrase2)
+        {
+            break;
+        }
+        else
+        {
+            term->cout() << "\nPassphrases did not match. Please try again.\n";
+        }
+    }
+
+    term->cout() << "\n";
+
+    return passphrase1;
+}

--- a/src/client/common/prompters.cpp
+++ b/src/client/common/prompters.cpp
@@ -34,3 +34,28 @@ std::string mp::PlainPrompter::prompt(const std::string& text) const
 
     return value;
 }
+
+mp::PassphrasePrompter::PassphrasePrompter(Terminal* term) : BasePrompter(term)
+{
+    term->set_cin_echo(false);
+}
+
+mp::PassphrasePrompter::~PassphrasePrompter()
+{
+    term->set_cin_echo(true);
+}
+
+std::string mp::PassphrasePrompter::prompt(const std::string& text) const
+{
+    term->cout() << text;
+
+    std::string passphrase;
+    std::getline(term->cin(), passphrase);
+
+    if (!term->cin().good())
+        throw PromptException("Failed to read passphrase");
+
+    term->cout() << "\n";
+
+    return passphrase;
+}

--- a/src/client/common/prompters.cpp
+++ b/src/client/common/prompters.cpp
@@ -22,15 +22,25 @@
 
 namespace mp = multipass;
 
+namespace
+{
+auto get_input(std::istream& cin)
+{
+    std::string value;
+    std::getline(cin, value);
+
+    if (!cin.good())
+        throw mp::PromptException("Failed to read value");
+
+    return value;
+}
+} // namespace
+
 std::string mp::PlainPrompter::prompt(const std::string& text) const
 {
     term->cout() << text << ": ";
 
-    std::string value;
-    std::getline(term->cin(), value);
-
-    if (!term->cin().good())
-        throw PromptException("Failed to read value");
+    auto value = get_input(term->cin());
 
     return value;
 }
@@ -49,11 +59,7 @@ std::string mp::PassphrasePrompter::prompt(const std::string& text) const
 {
     term->cout() << text;
 
-    std::string passphrase;
-    std::getline(term->cin(), passphrase);
-
-    if (!term->cin().good())
-        throw PromptException("Failed to read passphrase");
+    auto passphrase = get_input(term->cin());
 
     term->cout() << "\n";
 
@@ -62,33 +68,28 @@ std::string mp::PassphrasePrompter::prompt(const std::string& text) const
 
 std::string mp::NewPassphrasePrompter::prompt(const std::string& prompt1, const std::string& prompt2) const
 {
-    std::string passphrase1, passphrase2;
+    std::string passphrase;
 
     while (true)
     {
         term->cout() << prompt1 << ": ";
-        std::getline(term->cin(), passphrase1);
 
-        if (!term->cin().good())
-            throw PromptException("Failed to read passphrase");
+        passphrase = get_input(term->cin());
 
         term->cout() << "\n" << prompt2 << ": ";
-        std::getline(term->cin(), passphrase2);
 
-        if (!term->cin().good())
-            throw PromptException("Failed to read passphrase");
-
-        if (passphrase1 == passphrase2)
+        // Confirm the passphrase is the same by re-entering it
+        if (passphrase == get_input(term->cin()))
         {
             break;
         }
         else
         {
-            term->cout() << "\nPassphrases did not match. Please try again.\n";
+            term->cout() << "\nPassphrases do not match. Please try again.\n";
         }
     }
 
     term->cout() << "\n";
 
-    return passphrase1;
+    return passphrase;
 }

--- a/src/client/common/prompters.cpp
+++ b/src/client/common/prompters.cpp
@@ -72,11 +72,11 @@ std::string mp::NewPassphrasePrompter::prompt(const std::string& prompt1, const 
 
     while (true)
     {
-        term->cout() << prompt1 << ": ";
+        term->cout() << prompt1;
 
         passphrase = get_input(term->cin());
 
-        term->cout() << "\n" << prompt2 << ": ";
+        term->cout() << "\n" << prompt2;
 
         // Confirm the passphrase is the same by re-entering it
         if (passphrase == get_input(term->cin()))

--- a/src/client/common/prompters.cpp
+++ b/src/client/common/prompters.cpp
@@ -40,9 +40,7 @@ std::string mp::PlainPrompter::prompt(const std::string& text) const
 {
     term->cout() << text << ": ";
 
-    auto value = get_input(term->cin());
-
-    return value;
+    return get_input(term->cin());
 }
 
 mp::PassphrasePrompter::PassphrasePrompter(Terminal* term) : BasePrompter(term)

--- a/src/client/common/prompters.cpp
+++ b/src/client/common/prompters.cpp
@@ -43,7 +43,7 @@ std::string mp::PlainPrompter::prompt(const std::string& text) const
     return get_input(term->cin());
 }
 
-mp::PassphrasePrompter::PassphrasePrompter(Terminal* term) : BasePrompter(term)
+mp::PassphrasePrompter::PassphrasePrompter(Terminal* term) : PlainPrompter(term)
 {
     term->set_cin_echo(false);
 }
@@ -55,39 +55,22 @@ mp::PassphrasePrompter::~PassphrasePrompter()
 
 std::string mp::PassphrasePrompter::prompt(const std::string& text) const
 {
-    term->cout() << text;
-
-    auto passphrase = get_input(term->cin());
+    auto passphrase = PlainPrompter::prompt(text);
 
     term->cout() << "\n";
 
     return passphrase;
 }
 
-std::string mp::NewPassphrasePrompter::prompt(const std::string& prompt1, const std::string& prompt2) const
+std::string mp::NewPassphrasePrompter::prompt(const std::string& text) const
 {
-    std::string passphrase;
+    auto passphrase = PassphrasePrompter::prompt();
 
-    while (true)
+    // Confirm the passphrase is the same by re-entering it
+    if (passphrase != PassphrasePrompter::prompt(text))
     {
-        term->cout() << prompt1;
-
-        passphrase = get_input(term->cin());
-
-        term->cout() << "\n" << prompt2;
-
-        // Confirm the passphrase is the same by re-entering it
-        if (passphrase == get_input(term->cin()))
-        {
-            break;
-        }
-        else
-        {
-            term->cout() << "\nPassphrases do not match. Please try again.\n";
-        }
+        throw PromptException("Passphrases do not match");
     }
-
-    term->cout() << "\n";
 
     return passphrase;
 }

--- a/src/client/common/prompters.cpp
+++ b/src/client/common/prompters.cpp
@@ -20,10 +20,9 @@
 
 #include <iostream>
 
-namespace multipass
-{
+namespace mp = multipass;
 
-std::string PlainPrompter::prompt(const std::string& text) const
+std::string mp::PlainPrompter::prompt(const std::string& text) const
 {
     term->cout() << text << ": ";
 
@@ -35,5 +34,3 @@ std::string PlainPrompter::prompt(const std::string& text) const
 
     return value;
 }
-
-} // namespace multipass

--- a/src/platform/console/CMakeLists.txt
+++ b/src/platform/console/CMakeLists.txt
@@ -13,13 +13,20 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-add_library(console STATIC
+function(add_target TARGET_NAME)
+  add_library(${TARGET_NAME} STATIC
     console.cpp
     terminal.cpp
     unix_console.cpp
     unix_terminal.cpp)
 
-target_link_libraries(console
-  client_platform
-  platform
-  libssh)
+  target_link_libraries(${TARGET_NAME}
+    client_platform
+    platform
+    libssh)
+endfunction()
+
+add_target(console)
+if(MULTIPASS_ENABLE_TESTS)
+  add_target(console_test)
+endif()

--- a/src/platform/console/unix_terminal.cpp
+++ b/src/platform/console/unix_terminal.cpp
@@ -24,6 +24,11 @@
 
 namespace mp = multipass;
 
+mp::UnixTerminal::~UnixTerminal()
+{
+    // Ensure echo is always enabled
+    set_cin_echo(true);
+}
 
 int mp::UnixTerminal::cin_fd() const
 {

--- a/src/platform/console/unix_terminal.cpp
+++ b/src/platform/console/unix_terminal.cpp
@@ -33,12 +33,25 @@ bool mp::UnixTerminal::cin_is_live() const
     return (isatty(cin_fd()) == 1);
 }
 
-int multipass::UnixTerminal::cout_fd() const
+int mp::UnixTerminal::cout_fd() const
 {
     return fileno(stdout);
 }
 
-bool multipass::UnixTerminal::cout_is_live() const
+bool mp::UnixTerminal::cout_is_live() const
 {
     return (isatty(cout_fd()) == 1);
+}
+
+void mp::UnixTerminal::set_cin_echo(const bool enable)
+{
+    struct termios tty;
+    tcgetattr(cin_fd(), &tty);
+
+    if (!enable)
+        tty.c_lflag &= ~ECHO;
+    else
+        tty.c_lflag |= ECHO;
+
+    tcsetattr(cin_fd(), TCSANOW, &tty);
 }

--- a/src/platform/console/unix_terminal.cpp
+++ b/src/platform/console/unix_terminal.cpp
@@ -18,6 +18,8 @@
 #include "unix_terminal.h"
 
 #include <iostream>
+
+#include <termios.h>
 #include <unistd.h>
 
 namespace mp = multipass;

--- a/src/platform/console/unix_terminal.cpp
+++ b/src/platform/console/unix_terminal.cpp
@@ -24,12 +24,6 @@
 
 namespace mp = multipass;
 
-mp::UnixTerminal::~UnixTerminal()
-{
-    // Ensure echo is always enabled
-    set_cin_echo(true);
-}
-
 int mp::UnixTerminal::cin_fd() const
 {
     return fileno(stdin);

--- a/src/platform/console/unix_terminal.h
+++ b/src/platform/console/unix_terminal.h
@@ -25,7 +25,7 @@ namespace multipass
 class UnixTerminal : public Terminal
 {
 public:
-    virtual ~UnixTerminal() = default;
+    virtual ~UnixTerminal();
 
     int cin_fd() const;
     bool cin_is_live() const override;

--- a/src/platform/console/unix_terminal.h
+++ b/src/platform/console/unix_terminal.h
@@ -32,6 +32,8 @@ public:
 
     int cout_fd() const;
     bool cout_is_live() const override;
+
+    void set_cin_echo(const bool enable) override;
 };
 } // namespace multipass
 

--- a/src/platform/console/unix_terminal.h
+++ b/src/platform/console/unix_terminal.h
@@ -25,8 +25,6 @@ namespace multipass
 class UnixTerminal : public Terminal
 {
 public:
-    virtual ~UnixTerminal();
-
     int cin_fd() const;
     bool cin_is_live() const override;
 

--- a/tests/mock_terminal.h
+++ b/tests/mock_terminal.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_TERMINAL_H
+#define MULTIPASS_MOCK_TERMINAL_H
+
+#include "common.h"
+
+#include <multipass/terminal.h>
+
+namespace multipass
+{
+namespace test
+{
+struct MockTerminal : public Terminal
+{
+    MOCK_METHOD0(cin, std::istream&());
+    MOCK_METHOD0(cout, std::ostream&());
+    MOCK_METHOD0(cerr, std::ostream&());
+    MOCK_CONST_METHOD0(cin_is_live, bool());
+    MOCK_CONST_METHOD0(cout_is_live, bool());
+    MOCK_METHOD1(set_cin_echo, void(const bool));
+};
+} // namespace test
+} // namespace multipass
+#endif // MULTIPASS_MOCK_TERMINAL_H

--- a/tests/mock_terminal.h
+++ b/tests/mock_terminal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Canonical, Ltd.
+ * Copyright (C) 2021-2022 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/stub_terminal.h
+++ b/tests/stub_terminal.h
@@ -56,6 +56,11 @@ public:
     {
         return false;
     }
+
+    void set_cin_echo(const bool enable) override
+    {
+    }
+
 private:
     std::ostream &cout_stream;
     std::ostream& cerr_stream;

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -2399,20 +2399,6 @@ TEST_F(Client, registerCmdHelpOk)
     EXPECT_EQ(send_command({"register", "--help"}), mp::ReturnCode::Ok);
 }
 
-TEST_F(Client, registerCmdNoPassphraseFailsNoLiveTTY)
-{
-    std::ostringstream cerr, cout;
-    mpt::MockTerminal mock_terminal;
-
-    EXPECT_CALL(mock_terminal, cout).WillRepeatedly(ReturnRef(cout));
-    EXPECT_CALL(mock_terminal, cerr).WillRepeatedly(ReturnRef(cerr));
-    EXPECT_CALL(mock_terminal, cin_is_live).WillOnce(Return(false));
-
-    EXPECT_EQ(setup_client_and_run({"register"}, mock_terminal), mp::ReturnCode::CommandLineError);
-
-    EXPECT_EQ(cerr.str(), "The terminal is not live: The passphrase argument is required\n");
-}
-
 TEST_F(Client, registerCmdAcceptsEnteredPassphrase)
 {
     const std::string passphrase{"foo"};
@@ -2425,8 +2411,6 @@ TEST_F(Client, registerCmdAcceptsEnteredPassphrase)
     EXPECT_CALL(mock_terminal, cout).WillRepeatedly(ReturnRef(cout));
     EXPECT_CALL(mock_terminal, cerr).WillRepeatedly(ReturnRef(cerr));
     EXPECT_CALL(mock_terminal, cin).WillRepeatedly(ReturnRef(cin));
-    EXPECT_CALL(mock_terminal, cin_is_live).WillOnce(Return(true));
-    EXPECT_CALL(mock_terminal, cout_is_live).WillOnce(Return(true));
     EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(1);
     EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(1);
 
@@ -2449,8 +2433,6 @@ TEST_F(Client, registerCmdNoPassphraseEnteredReturnsError)
     EXPECT_CALL(mock_terminal, cout).WillRepeatedly(ReturnRef(cout));
     EXPECT_CALL(mock_terminal, cerr).WillRepeatedly(ReturnRef(cerr));
     EXPECT_CALL(mock_terminal, cin).WillRepeatedly(ReturnRef(cin));
-    EXPECT_CALL(mock_terminal, cin_is_live).WillOnce(Return(true));
-    EXPECT_CALL(mock_terminal, cout_is_live).WillOnce(Return(true));
     EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(1);
     EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(1);
 
@@ -2470,8 +2452,6 @@ TEST_F(Client, registerCmdNoPassphrasePrompterFailsReturnsError)
     EXPECT_CALL(mock_terminal, cout).WillRepeatedly(ReturnRef(cout));
     EXPECT_CALL(mock_terminal, cerr).WillRepeatedly(ReturnRef(cerr));
     EXPECT_CALL(mock_terminal, cin).WillRepeatedly(ReturnRef(cin));
-    EXPECT_CALL(mock_terminal, cin_is_live).WillOnce(Return(true));
-    EXPECT_CALL(mock_terminal, cout_is_live).WillOnce(Return(true));
     EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(1);
     EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(1);
 

--- a/tests/test_cli_prompters.cpp
+++ b/tests/test_cli_prompters.cpp
@@ -81,8 +81,8 @@ TEST_F(CLIPrompters, newPassPhraseCallsEchoAndReturnsExpectedPassphrase)
     const std::string passphrase{"foo"};
     mpt::MockTerminal mock_terminal;
 
-    EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(1);
-    EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(1);
+    EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(2);
+    EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(2);
     EXPECT_CALL(mock_terminal, cout()).WillRepeatedly([this]() -> std::ostream& { return cout; });
     EXPECT_CALL(mock_terminal, cin()).Times(2).WillRepeatedly([this, &passphrase]() -> std::istream& {
         cin.str(passphrase + "\n");
@@ -103,8 +103,8 @@ TEST_F(CLIPrompters, newPassPhraseWrongPassphraseThrows)
     const std::string passphrase{"foo"}, wrong_passphrase{"bar"};
     mpt::MockTerminal mock_terminal;
 
-    EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(1);
-    EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(1);
+    EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(2);
+    EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(2);
 
     auto good_passphrase = [this, &passphrase]() -> std::istream& {
         cin.str(passphrase + "\n");

--- a/tests/test_cli_prompters.cpp
+++ b/tests/test_cli_prompters.cpp
@@ -65,7 +65,7 @@ TEST_F(CLIPrompters, passphraseCallsEchoAndReturnsExpectedPassphrase)
     EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(1);
     EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(1);
     EXPECT_CALL(mock_terminal, cout()).Times(2).WillRepeatedly([this]() -> std::ostream& { return cout; });
-    EXPECT_CALL(mock_terminal, cin()).Times(2).WillRepeatedly([this]() -> std::istream& { return cin; });
+    EXPECT_CALL(mock_terminal, cin()).WillOnce([this]() -> std::istream& { return cin; });
 
     mp::PassphrasePrompter prompter{&mock_terminal};
 

--- a/tests/test_cli_prompters.cpp
+++ b/tests/test_cli_prompters.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "common.h"
+#include "mock_terminal.h"
 #include "stub_terminal.h"
 
 #include <multipass/cli/prompters.h>
@@ -51,11 +52,34 @@ TEST_F(CLIPrompters, PlainReturnsText)
     EXPECT_EQ(prompt.prompt(""), "value");
 }
 
-class CLIPromptersCinState : public CLIPrompters, public WithParamInterface<std::ios_base::iostate>
+// Note that the following test does not actually test if the terminal echos or not-
+// that is specific to platform terminal types.
+TEST_F(CLIPrompters, passphraseCallsEchoAndReturnsExpectedPassphrase)
+{
+    const std::string prompter_string{"Enter passphrase: "};
+    const std::string passphrase{"foo"};
+    mpt::MockTerminal mock_terminal;
+
+    cin.str(passphrase + "\n");
+
+    EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(1);
+    EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(1);
+    EXPECT_CALL(mock_terminal, cout()).Times(2).WillRepeatedly([this]() -> std::ostream& { return cout; });
+    EXPECT_CALL(mock_terminal, cin()).Times(2).WillRepeatedly([this]() -> std::istream& { return cin; });
+
+    mp::PassphrasePrompter prompter{&mock_terminal};
+
+    auto input = prompter.prompt(prompter_string);
+
+    EXPECT_EQ(cout.str(), prompter_string + "\n");
+    EXPECT_EQ(input, passphrase);
+}
+
+class CLIPromptersBadCinState : public CLIPrompters, public WithParamInterface<std::ios_base::iostate>
 {
 };
 
-TEST_P(CLIPromptersCinState, PlainThrows)
+TEST_P(CLIPromptersBadCinState, PlainThrows)
 {
     auto prompt = mp::PlainPrompter{&term};
 
@@ -63,4 +87,5 @@ TEST_P(CLIPromptersCinState, PlainThrows)
     MP_EXPECT_THROW_THAT(prompt.prompt(""), mp::PromptException, mpt::match_what(HasSubstr("Failed to read value")));
 }
 
-INSTANTIATE_TEST_SUITE_P(BadCin, CLIPromptersCinState, Values(std::ios::eofbit, std::ios::failbit, std::ios::badbit));
+INSTANTIATE_TEST_SUITE_P(CLIPrompters, CLIPromptersBadCinState,
+                         Values(std::ios::eofbit, std::ios::failbit, std::ios::badbit));

--- a/tests/test_cli_prompters.cpp
+++ b/tests/test_cli_prompters.cpp
@@ -64,8 +64,8 @@ TEST_F(CLIPrompters, passphraseCallsEchoAndReturnsExpectedPassphrase)
 
     EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(1);
     EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(1);
-    EXPECT_CALL(mock_terminal, cout()).WillRepeatedly([this]() -> std::ostream& { return cout; });
-    EXPECT_CALL(mock_terminal, cin()).WillOnce([this]() -> std::istream& { return cin; });
+    EXPECT_CALL(mock_terminal, cout()).WillRepeatedly(ReturnRef(cout));
+    EXPECT_CALL(mock_terminal, cin()).WillOnce(ReturnRef(cin));
 
     mp::PassphrasePrompter prompter{&mock_terminal};
 
@@ -83,7 +83,8 @@ TEST_F(CLIPrompters, newPassPhraseCallsEchoAndReturnsExpectedPassphrase)
 
     EXPECT_CALL(mock_terminal, set_cin_echo(false)).Times(2);
     EXPECT_CALL(mock_terminal, set_cin_echo(true)).Times(2);
-    EXPECT_CALL(mock_terminal, cout()).WillRepeatedly([this]() -> std::ostream& { return cout; });
+    EXPECT_CALL(mock_terminal, cout()).WillRepeatedly(ReturnRef(cout));
+
     EXPECT_CALL(mock_terminal, cin()).Times(2).WillRepeatedly([this, &passphrase]() -> std::istream& {
         cin.str(passphrase + "\n");
         return cin;
@@ -116,7 +117,7 @@ TEST_F(CLIPrompters, newPassPhraseWrongPassphraseThrows)
         return cin;
     };
 
-    EXPECT_CALL(mock_terminal, cout()).WillRepeatedly([this]() -> std::ostream& { return cout; });
+    EXPECT_CALL(mock_terminal, cout()).WillRepeatedly(ReturnRef(cout));
     EXPECT_CALL(mock_terminal, cin()).WillOnce(Invoke(good_passphrase)).WillOnce(Invoke(bad_passphrase));
 
     mp::NewPassphrasePrompter prompter{&mock_terminal};

--- a/tests/unix/CMakeLists.txt
+++ b/tests/unix/CMakeLists.txt
@@ -13,17 +13,24 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-target_sources(multipass_tests
-  PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/mock_libc_functions.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/test_daemon_rpc.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/test_platform_unix.cpp
+target_sources(multipass_tests PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/mock_libc_functions.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/test_daemon_rpc.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/test_platform_unix.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/test_unix_terminal.cpp
 )
+
+target_compile_definitions(console_test PRIVATE
+  -Disatty=ut_isatty
+  -Dfileno=ut_fileno
+  -Dtcgetattr=ut_tcgetattr
+  -Dtcsetattr=ut_tcsetattr)
 
 target_compile_definitions(platform_test PRIVATE
   -Dgetgrnam=ut_getgrnam
 )
 
 target_link_libraries(multipass_tests
+  console_test
   platform_test
 )

--- a/tests/unix/mock_libc_functions.cpp
+++ b/tests/unix/mock_libc_functions.cpp
@@ -17,4 +17,36 @@
 
 #include "mock_libc_functions.h"
 
-extern "C" IMPL_MOCK_DEFAULT(1, getgrnam);
+#include <stdio.h>
+#include <unistd.h>
+
+extern "C"
+{
+    IMPL_MOCK_DEFAULT(1, getgrnam);
+
+    int ut_isatty(int fd)
+    {
+        return mock_isatty(fd);
+    }
+
+    int ut_fileno(FILE* stream)
+    {
+        return mock_fileno(stream);
+    }
+
+    int ut_tcgetattr(int fd, struct termios* termios_p)
+    {
+        return mock_tcgetattr(fd, termios_p);
+    }
+
+    int ut_tcsetattr(int fd, int optional_actions, const struct termios* termios_p)
+    {
+        return mock_tcsetattr(fd, optional_actions, termios_p);
+    }
+}
+
+// By default, call real functions
+std::function<int(int)> mock_isatty = isatty;
+std::function<int(FILE*)> mock_fileno = fileno;
+std::function<int(int, struct termios*)> mock_tcgetattr = tcgetattr;
+std::function<int(int, int, const struct termios*)> mock_tcsetattr = tcsetattr;

--- a/tests/unix/mock_libc_functions.h
+++ b/tests/unix/mock_libc_functions.h
@@ -21,7 +21,18 @@
 #include <premock.hpp>
 
 #include <grp.h>
+#include <stdio.h>
+#include <termios.h>
 
 DECL_MOCK(getgrnam);
 
+// The following mocks can't use premock directly because they are declared noexcept and the way
+// premock works is that it uses decltype() to get the function types and then uses this when declaring
+// the std::function.  However, in C++17, std::function can no longer be declared with a noexcept type, so
+// to avoid that, we basically do what the premock macros do here but be explicit about the types and
+// not use noexcept.
+extern "C" std::function<int(int)> mock_isatty;
+extern "C" std::function<int(FILE*)> mock_fileno;
+extern "C" std::function<int(int, struct termios*)> mock_tcgetattr;
+extern "C" std::function<int(int, int, const struct termios*)> mock_tcsetattr;
 #endif // MULTIPASS_MOCK_LIBC_FUNCTIONS_H

--- a/tests/unix/test_unix_terminal.cpp
+++ b/tests/unix/test_unix_terminal.cpp
@@ -110,3 +110,19 @@ TEST_F(TestUnixTerminal, unsetsEchoOnTerminal)
 
     unix_terminal.set_cin_echo(false);
 }
+
+TEST_F(TestUnixTerminal, echoEnabledOnDestruction)
+{
+    REPLACE(fileno, [this](auto) { return fake_fd; });
+
+    REPLACE(tcgetattr, [](auto...) { return 0; });
+
+    REPLACE(tcsetattr, [](auto, auto, auto termios_p) {
+        EXPECT_TRUE((termios_p->c_lflag & ECHO) == ECHO);
+        return 0;
+    });
+
+    {
+        mp::UnixTerminal term;
+    }
+}

--- a/tests/unix/test_unix_terminal.cpp
+++ b/tests/unix/test_unix_terminal.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2021 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <tests/common.h>
+
+#include "mock_libc_functions.h"
+
+#include <src/platform/console/unix_terminal.h>
+
+#include <tuple>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+using namespace testing;
+
+namespace
+{
+struct TestUnixTerminal : public Test
+{
+    mp::UnixTerminal unix_terminal;
+    const int fake_fd{42};
+};
+} // namespace
+
+TEST_F(TestUnixTerminal, cinFdReturnsExpectedFd)
+{
+    REPLACE(fileno, [this](auto stream) {
+        EXPECT_EQ(stream, stdin);
+        return fake_fd;
+    });
+
+    EXPECT_EQ(unix_terminal.cin_fd(), fake_fd);
+}
+
+TEST_F(TestUnixTerminal, coutFdReturnsExpectedFd)
+{
+    REPLACE(fileno, [this](auto stream) {
+        EXPECT_EQ(stream, stdout);
+        return fake_fd;
+    });
+
+    EXPECT_EQ(unix_terminal.cout_fd(), fake_fd);
+}
+
+TEST_F(TestUnixTerminal, isLiveReturnsTrueWhenTTY)
+{
+    REPLACE(fileno, [this](auto) { return fake_fd; });
+
+    REPLACE(isatty, [this](auto fd) {
+        EXPECT_EQ(fd, fake_fd);
+        return 1;
+    });
+
+    EXPECT_TRUE(unix_terminal.cin_is_live());
+    EXPECT_TRUE(unix_terminal.cout_is_live());
+}
+
+TEST_F(TestUnixTerminal, isLiveReturnsFalseWhenNotTTY)
+{
+    REPLACE(fileno, [this](auto) { return fake_fd; });
+
+    REPLACE(isatty, [this](auto fd) {
+        EXPECT_EQ(fd, fake_fd);
+        return 0;
+    });
+
+    EXPECT_FALSE(unix_terminal.cin_is_live());
+    EXPECT_FALSE(unix_terminal.cout_is_live());
+}
+
+TEST_F(TestUnixTerminal, setsEchoOnTerminal)
+{
+    REPLACE(fileno, [this](auto) { return fake_fd; });
+
+    REPLACE(tcgetattr, [](auto...) { return 0; });
+
+    REPLACE(tcsetattr, [](auto, auto, auto termios_p) {
+        EXPECT_TRUE((termios_p->c_lflag & ECHO) == ECHO);
+        return 0;
+    });
+
+    unix_terminal.set_cin_echo(true);
+}
+
+TEST_F(TestUnixTerminal, unsetsEchoOnTerminal)
+{
+    REPLACE(fileno, [this](auto) { return fake_fd; });
+
+    REPLACE(tcgetattr, [](auto...) { return 0; });
+
+    REPLACE(tcsetattr, [](auto, auto, auto termios_p) {
+        EXPECT_FALSE((termios_p->c_lflag & ECHO) == ECHO);
+        return 0;
+    });
+
+    unix_terminal.set_cin_echo(false);
+}

--- a/tests/unix/test_unix_terminal.cpp
+++ b/tests/unix/test_unix_terminal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Canonical, Ltd.
+ * Copyright (C) 2021-2022 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/unix/test_unix_terminal.cpp
+++ b/tests/unix/test_unix_terminal.cpp
@@ -110,19 +110,3 @@ TEST_F(TestUnixTerminal, unsetsEchoOnTerminal)
 
     unix_terminal.set_cin_echo(false);
 }
-
-TEST_F(TestUnixTerminal, echoEnabledOnDestruction)
-{
-    REPLACE(fileno, [this](auto) { return fake_fd; });
-
-    REPLACE(tcgetattr, [](auto...) { return 0; });
-
-    REPLACE(tcsetattr, [](auto, auto, auto termios_p) {
-        EXPECT_TRUE((termios_p->c_lflag & ECHO) == ECHO);
-        return 0;
-    });
-
-    {
-        mp::UnixTerminal term;
-    }
-}


### PR DESCRIPTION
This allows entering the passphrase for `set local.passphrase` and `register` at the terminal without echo.