### PR TITLE
Point dnsmasq to custom file location

### DIFF
--- a/src/platform/backends/qemu/linux/dnsmasq_process_spec.cpp
+++ b/src/platform/backends/qemu/linux/dnsmasq_process_spec.cpp
@@ -21,6 +21,8 @@
 #include <multipass/format.h>
 #include <multipass/snap_utils.h>
 
+#include <QStandardPaths>
+
 namespace mp = multipass;
 namespace mu = multipass::utils;
 
@@ -40,6 +42,7 @@ QStringList mp::DNSMasqProcessSpec::arguments() const
     const auto bridge_addr = mp::IPAddress{fmt::format("{}.1", subnet)};
     const auto start_ip = mp::IPAddress{fmt::format("{}.2", subnet)};
     const auto end_ip = mp::IPAddress{fmt::format("{}.254", subnet)};
+    conf_file_path = QStandardPaths::locate(QStandardPaths::writableLocation, QString("${XDG_DATA_HOME}/dnsmasq.d/dnsmasq.conf"), QStandardPaths::LocateFile);
 
     return QStringList() << "--keep-in-foreground"
                          << "--strict-order"


### PR DESCRIPTION
Fixes #1205.

Attempt to prevent `multipass` from trying to read `/etc/dnsmasq.conf` for the `dnsmasq` configuration by pointing it to the location at `${XDG_DATA_HOME}/dnsmasq.d` (a directory) assuming that it is set, presuming set by the following:

```shell
export XDG_DATA_HOME=${XDG_DATA_HOME:="$HOME/.local/share"}
```

Currently it is found that the line(s) below does not seem to work as intended: https://github.com/canonical/multipass/blob/a1ea65fb63184fc778e277d3c9e2920ef2a9fb3d/src/platform/backends/qemu/linux/dnsmasq_process_spec.cpp#L56-L57