### PR TITLE
[daemon] Call hypervisor_health_check() in ctor

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1053,6 +1053,15 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
         }
     });
     source_images_maintenance_task.start(config->image_refresh_timer);
+
+    try
+    {
+        config->factory->hypervisor_health_check();
+    }
+    catch (const std::runtime_error& e)
+    {
+        mpl::log(mpl::Level::warning, category, fmt::format("Hypervisor health check failed: {}", e.what()));
+    }
 }
 
 void mp::Daemon::create(const CreateRequest* request, grpc::ServerWriterInterface<CreateReply>* server,


### PR DESCRIPTION
This will try to ensure the backend is set up before launching any instances.

Fixes #2401