### PR TITLE
[backends/qemu] Allow suspending instance on Apple M1

### DIFF
--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -202,9 +202,7 @@ mp::QemuVirtualMachine::~QemuVirtualMachine()
     {
         update_shutdown_status = false;
 
-        // The "cortex-a72" part below is a workaround for disabling suspend support on Apple M1 due
-        // QEMU crashing when running "savevm".
-        if (state == State::running && !qemu_platform->vm_platform_args(desc).contains("cortex-a72"))
+        if (state == State::running)
         {
             suspend();
         }
@@ -294,11 +292,6 @@ void mp::QemuVirtualMachine::shutdown()
 
 void mp::QemuVirtualMachine::suspend()
 {
-    // The "cortex-a72" part below is a workaround for disabling suspend support on Apple M1 due
-    // QEMU crashing when running "savevm".
-    if (qemu_platform->vm_platform_args(desc).contains("cortex-a72"))
-        throw std::runtime_error("suspend is currently not supported");
-
     if ((state == State::running || state == State::delayed_shutdown) && vm_process->running())
     {
         if (update_shutdown_status)


### PR DESCRIPTION
Updating our qemu branch to v6.2.0 fixes suspend on M1.

Fixes #2308