### PR TITLE
Fix error message when not using `--` for alias arguments

### DIFF
--- a/src/client/cli/cmd/exec.cpp
+++ b/src/client/cli/cmd/exec.cpp
@@ -106,9 +106,10 @@ mp::ParseCode cmd::Exec::parse_args(mp::ArgParser* parser)
     {
         if (!parser->unknownOptionNames().empty() && !parser->containsArgument("--"))
         {
-            cerr << fmt::format("\nOptions to the inner command should come after \"--\", like this:\nmultipass {} -- "
-                                "<command> <arguments>\n",
-                                parser->executeAlias() ? "<alias>" : "exec <instance>");
+            bool is_alias = parser->executeAlias() != mp::nullopt;
+            cerr << fmt::format("\nOptions to the {} should come after \"--\", like this:\nmultipass {} <arguments>\n",
+                                is_alias ? "alias" : "inner command",
+                                is_alias ? "<alias> --" : "exec <instance> -- <command>");
         }
         return status;
     }

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -2796,7 +2796,8 @@ TEST_F(ClientAlias, fails_executing_alias_without_separator)
     std::stringstream cerr_stream;
     EXPECT_EQ(send_command({"some_alias", "--some-option"}, trash_stream, cerr_stream),
               mp::ReturnCode::CommandLineError);
-    EXPECT_THAT(cerr_stream.str(), HasSubstr("<alias> --"));
+    EXPECT_THAT(cerr_stream.str(), HasSubstr("Options to the alias should come after \"--\", like this:\n"
+                                             "multipass <alias> -- <arguments>\n"));
 }
 
 TEST_F(ClientAlias, alias_refuses_creation_unexisting_instance)


### PR DESCRIPTION
The error message when launching an alias using `multipass` was incorrect. This PR fixes https://github.com/canonical/multipass/issues/2317 by improving the error message.