### PR TITLE
[settings] Do not generate a hash for an empty passphrase

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2072,7 +2072,7 @@ try
 
     auto stored_hash = MP_SETTINGS.get(mp::passphrase_key);
 
-    if (stored_hash.isNull())
+    if (stored_hash.isNull() || stored_hash.isEmpty())
     {
         return status_promise->set_value(
             grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,

--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -215,7 +215,10 @@ void multipass::Settings::set_aux(const QString& key, QString val) // work with 
     else if (key == winterm_key || key == hotkey_key)
         val = mp::platform::interpret_setting(key, val);
     else if (key == passphrase_key)
-        val = MP_UTILS.generate_scrypt_hash_for(val);
+    {
+        if (!val.isEmpty())
+            val = MP_UTILS.generate_scrypt_hash_for(val);
+    }
 
     auto settings = persistent_settings(key);
     checked_set(*settings, key, val, mutex);


### PR DESCRIPTION
This will instead unset the passphrase.

Fixes #2410