### PR TITLE
[build] Use FetchContent for getting gRPC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "3rd-party/grpc"]
-	path = 3rd-party/grpc
-	url = https://github.com/CanonicalLtd/grpc.git
-	ignore = dirty
 [submodule "3rd-party/yaml-cpp"]
 	path = 3rd-party/yaml-cpp
 	url = https://github.com/canonical/yaml-cpp.git

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -1,11 +1,23 @@
-# Workaround for zlib placing its generated zconf.h file in the build dir,
-# and protobuf not knowing so finding the system version instead
-include_directories(${CMAKE_BINARY_DIR}/3rd-party/grpc/third_party/zlib)
+include(FetchContent)
+set(FETCHCONTENT_QUIET FALSE)
 
+FetchContent_Declare(gRPC
+  GIT_REPOSITORY https://github.com/CanonicalLtd/grpc.git
+  GIT_TAG multipass
+  GIT_SHALLOW TRUE
+  GIT_SUBMODULES "third_party/abseil-cpp third_party/cares/cares third_party/protobuf third_party/re2 third_party/zlib"
+  GIT_SUBMODULES_RECURSE false
+  GIT_PROGRESS TRUE
+)
 set(gRPC_SSL_PROVIDER "package" CACHE STRING "Provider of ssl library")
 
-# Add the subdir here to avoid polluting their cmake scope
-add_subdirectory(grpc EXCLUDE_FROM_ALL)
+FetchContent_MakeAvailable(gRPC)
+
+# Workaround for zlib placing its generated zconf.h file in the build dir,
+# and protobuf not knowing so finding the system version instead
+include_directories(${grpc_SOURCE_DIR}/third_party/zlib)
+
+set_property(DIRECTORY ${grpc_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
 
 # Generates gRPC and protobuf C++ sources and headers from the given .proto files
 #

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -19,6 +19,10 @@ include_directories(${grpc_SOURCE_DIR}/third_party/zlib)
 
 set_property(DIRECTORY ${grpc_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
 
+if (MSVC)
+  add_compile_options(-wd5045) #Disable warning about Spectre mitigation
+endif()
+
 # Generates gRPC and protobuf C++ sources and headers from the given .proto files
 #
 # generate_grpc_cpp (<SRCS> <DEST> [<ARGN>...])
@@ -71,7 +75,9 @@ target_link_libraries(gRPC INTERFACE
   libprotobuf
   zlibstatic)
 
-target_compile_options(gRPC INTERFACE "-Wno-unused-parameter")
+if (NOT MSVC)
+  target_compile_options(gRPC INTERFACE "-Wno-unused-parameter")
+endif ()
 
 # YAML C++
 # Disable tests here to avoid double-including gtest

--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -3,7 +3,7 @@ set(FETCHCONTENT_QUIET FALSE)
 
 FetchContent_Declare(gRPC
   GIT_REPOSITORY https://github.com/CanonicalLtd/grpc.git
-  GIT_TAG multipass
+  GIT_TAG ba8e7f72
   GIT_SHALLOW TRUE
   GIT_SUBMODULES "third_party/abseil-cpp third_party/cares/cares third_party/protobuf third_party/re2 third_party/zlib"
   GIT_SUBMODULES_RECURSE false
@@ -76,7 +76,7 @@ target_link_libraries(gRPC INTERFACE
   zlibstatic)
 
 if (NOT MSVC)
-  target_compile_options(gRPC INTERFACE "-Wno-unused-parameter")
+  target_compile_options(gRPC INTERFACE "-Wno-unused-parameter" "-Wno-non-virtual-dtor")
 endif ()
 
 # YAML C++

--- a/3rd-party/submodule_info.md
+++ b/3rd-party/submodule_info.md
@@ -7,7 +7,7 @@ info on where to find release information about the submodule.
 **This file needs updating when a submodule is updated!**
 
 ### gRPC
-Version: 1.41.0 (+[our patches](https://github.com/CanonicalLtd/grpc/compare/v1.41.0..64647dc0)) |
+Version: 1.52.1 (+[our patches](https://github.com/CanonicalLtd/grpc/compare/v1.52.1..ba8e7f72)) |
 <https://github.com/CanonicalLtd/grpc.git> |
 <https://github.com/grpc/grpc/releases>
 


### PR DESCRIPTION
Remove gRPC as a git submodule and be explicit about what gRPC submodules to fetch.

Fixes #2927