### PR TITLE
[settings] Do not return hash when getting local.passphrase

### DIFF
--- a/src/utils/settings.cpp
+++ b/src/utils/settings.cpp
@@ -124,6 +124,10 @@ QString checked_get(const mp::WrappedQSettings& settings, const QString& key, co
     auto ret = settings.value(key, fallback).toString();
 
     check_status(settings, QStringLiteral("read"));
+
+    if (key == mp::passphrase_key)
+        ret = ret.isEmpty() ? QStringLiteral("false") : QStringLiteral("true");
+
     return ret;
 }
 


### PR DESCRIPTION
Instead return "true" or "false" depending on if it's set or not.

Fixes #2398