### PR TITLE
[client] Revise `Command` dependencies on RPC to facilitate mocking/testing

### DIFF
--- a/include/multipass/cli/command.h
+++ b/include/multipass/cli/command.h
@@ -41,13 +41,11 @@ class Command : private DisabledCopyMove
 {
 public:
     using UPtr = std::unique_ptr<Command>;
-    Command(grpc::Channel& channel, Rpc::Stub& stub, std::ostream& cout, std::ostream& cerr)
-        : rpc_channel{&channel}, stub{&stub}, cout{cout}, cerr{cerr}
+    Command(Rpc::Stub& stub, std::ostream& cout, std::ostream& cerr) : stub{&stub}, cout{cout}, cerr{cerr}
     {
     }
 
-    Command(grpc::Channel& channel, Rpc::Stub& stub, Terminal* term)
-        : rpc_channel{&channel}, stub{&stub}, term{term}, cout{term->cout()}, cerr{term->cerr()}
+    Command(Rpc::Stub& stub, Terminal* term) : stub{&stub}, term{term}, cout{term->cout()}, cerr{term->cerr()}
     {
     }
     virtual ~Command() = default;
@@ -136,7 +134,6 @@ protected:
         });
     }
 
-    grpc::Channel* rpc_channel;
     Rpc::Stub* stub;
     Terminal* term;
     std::ostream& cout;

--- a/include/multipass/cli/command.h
+++ b/include/multipass/cli/command.h
@@ -41,11 +41,11 @@ class Command : private DisabledCopyMove
 {
 public:
     using UPtr = std::unique_ptr<Command>;
-    Command(Rpc::Stub& stub, std::ostream& cout, std::ostream& cerr) : stub{&stub}, cout{cout}, cerr{cerr}
+    Command(Rpc::StubInterface& stub, std::ostream& cout, std::ostream& cerr) : stub{&stub}, cout{cout}, cerr{cerr}
     {
     }
 
-    Command(Rpc::Stub& stub, Terminal* term) : stub{&stub}, term{term}, cout{term->cout()}, cerr{term->cerr()}
+    Command(Rpc::StubInterface& stub, Terminal* term) : stub{&stub}, term{term}, cout{term->cout()}, cerr{term->cerr()}
     {
     }
     virtual ~Command() = default;
@@ -76,7 +76,7 @@ protected:
         auto rpc_method = std::bind(rpc_func, stub, std::placeholders::_1, std::placeholders::_2);
 
         grpc::ClientContext context;
-        std::unique_ptr<grpc::ClientReader<ReplyType>> reader = rpc_method(&context, request);
+        std::unique_ptr<grpc::ClientReaderInterface<ReplyType>> reader = rpc_method(&context, request);
 
         while (reader->Read(&reply))
         {
@@ -134,7 +134,7 @@ protected:
         });
     }
 
-    Rpc::Stub* stub;
+    Rpc::StubInterface* stub;
     Terminal* term;
     std::ostream& cout;
     std::ostream& cerr;

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -53,8 +53,7 @@ namespace mp = multipass;
 namespace mpl = multipass::logging;
 
 mp::Client::Client(ClientConfig& config)
-    : rpc_channel{mp::client::make_channel(config.server_address, config.cert_provider.get())},
-      stub{mp::Rpc::NewStub(rpc_channel)},
+    : stub{mp::Rpc::NewStub(mp::client::make_channel(config.server_address, config.cert_provider.get()))},
       term{config.term},
       aliases{config.term}
 {

--- a/src/client/cli/client.h
+++ b/src/client/cli/client.h
@@ -50,7 +50,6 @@ protected:
     void sort_commands();
 
 private:
-    std::shared_ptr<grpc::Channel> rpc_channel;
     std::unique_ptr<multipass::Rpc::Stub> stub;
 
     std::vector<cmd::Command::UPtr> commands;
@@ -63,7 +62,7 @@ private:
 template <typename T, typename... Ts>
 void multipass::Client::add_command(Ts&&... params)
 {
-    auto cmd = std::make_unique<T>(*rpc_channel, *stub, term, std::forward<Ts>(params)...);
+    auto cmd = std::make_unique<T>(*stub, term, std::forward<Ts>(params)...);
     commands.push_back(std::move(cmd));
 }
 

--- a/src/client/cli/cmd/alias.cpp
+++ b/src/client/cli/cmd/alias.cpp
@@ -26,7 +26,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Alias::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/alias.h
+++ b/src/client/cli/cmd/alias.h
@@ -32,8 +32,7 @@ class Alias final : public Command
 public:
     using Command::Command;
 
-    Alias(grpc::Channel& channel, Rpc::Stub& stub, Terminal* term, AliasDict& dict)
-        : Command(channel, stub, term), aliases(dict)
+    Alias(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/alias.h
+++ b/src/client/cli/cmd/alias.h
@@ -32,7 +32,7 @@ class Alias final : public Command
 public:
     using Command::Command;
 
-    Alias(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
+    Alias(Rpc::StubInterface& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/aliases.h
+++ b/src/client/cli/cmd/aliases.h
@@ -34,8 +34,7 @@ class Aliases final : public Command
 public:
     using Command::Command;
 
-    Aliases(grpc::Channel& channel, Rpc::Stub& stub, Terminal* term, AliasDict& dict)
-        : Command(channel, stub, term), aliases(dict)
+    Aliases(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/aliases.h
+++ b/src/client/cli/cmd/aliases.h
@@ -34,7 +34,7 @@ class Aliases final : public Command
 public:
     using Command::Command;
 
-    Aliases(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
+    Aliases(Rpc::StubInterface& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/common_cli.h
+++ b/src/client/cli/cmd/common_cli.h
@@ -26,7 +26,7 @@
 
 #include <QString>
 
-using RpcMethod = multipass::Rpc::Stub;
+using RpcMethod = multipass::Rpc::StubInterface;
 
 namespace multipass
 {

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -23,7 +23,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/delete.h
+++ b/src/client/cli/cmd/delete.h
@@ -30,8 +30,7 @@ class Delete final : public Command
 public:
     using Command::Command;
 
-    Delete(grpc::Channel& channel, Rpc::Stub& stub, Terminal* term, AliasDict& dict)
-        : Command(channel, stub, term), aliases(dict)
+    Delete(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/delete.h
+++ b/src/client/cli/cmd/delete.h
@@ -30,7 +30,7 @@ class Delete final : public Command
 public:
     using Command::Command;
 
-    Delete(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
+    Delete(Rpc::StubInterface& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/exec.cpp
+++ b/src/client/cli/cmd/exec.cpp
@@ -23,7 +23,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Exec::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/exec.h
+++ b/src/client/cli/cmd/exec.h
@@ -32,8 +32,7 @@ class Exec final : public Command
 public:
     using Command::Command;
 
-    Exec(grpc::Channel& channel, Rpc::Stub& stub, Terminal* term, AliasDict& dict)
-        : Command(channel, stub, term), aliases(dict)
+    Exec(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/exec.h
+++ b/src/client/cli/cmd/exec.h
@@ -32,7 +32,7 @@ class Exec final : public Command
 public:
     using Command::Command;
 
-    Exec(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
+    Exec(Rpc::StubInterface& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -23,7 +23,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Find::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/info.cpp
+++ b/src/client/cli/cmd/info.cpp
@@ -23,7 +23,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Info::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -44,7 +44,6 @@ namespace mp = multipass;
 namespace mpu = multipass::utils;
 namespace cmd = multipass::cmd;
 namespace mcp = multipass::cli::platform;
-using RpcMethod = mp::Rpc::Stub;
 
 namespace
 {

--- a/src/client/cli/cmd/list.cpp
+++ b/src/client/cli/cmd/list.cpp
@@ -23,7 +23,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::List::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -31,7 +31,6 @@ namespace mp = multipass;
 namespace mcp = multipass::cli::platform;
 namespace mpl = multipass::logging;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 namespace
 {

--- a/src/client/cli/cmd/networks.cpp
+++ b/src/client/cli/cmd/networks.cpp
@@ -23,7 +23,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Networks::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/purge.cpp
+++ b/src/client/cli/cmd/purge.cpp
@@ -23,7 +23,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Purge::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/purge.h
+++ b/src/client/cli/cmd/purge.h
@@ -30,8 +30,7 @@ class Purge final : public Command
 public:
     using Command::Command;
 
-    Purge(grpc::Channel& channel, Rpc::Stub& stub, Terminal* term, AliasDict& dict)
-        : Command(channel, stub, term), aliases(dict)
+    Purge(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/purge.h
+++ b/src/client/cli/cmd/purge.h
@@ -30,7 +30,7 @@ class Purge final : public Command
 public:
     using Command::Command;
 
-    Purge(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
+    Purge(Rpc::StubInterface& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/recover.cpp
+++ b/src/client/cli/cmd/recover.cpp
@@ -22,7 +22,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Recover::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/restart.cpp
+++ b/src/client/cli/cmd/restart.cpp
@@ -31,7 +31,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Restart::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/shell.cpp
+++ b/src/client/cli/cmd/shell.cpp
@@ -31,7 +31,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Shell::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/start.cpp
+++ b/src/client/cli/cmd/start.cpp
@@ -33,8 +33,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
-
 using namespace std::chrono_literals;
 
 namespace

--- a/src/client/cli/cmd/stop.cpp
+++ b/src/client/cli/cmd/stop.cpp
@@ -27,7 +27,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Stop::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/suspend.cpp
+++ b/src/client/cli/cmd/suspend.cpp
@@ -26,7 +26,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Suspend::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/transfer.cpp
+++ b/src/client/cli/cmd/transfer.cpp
@@ -27,7 +27,6 @@
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
 namespace mcp = multipass::cli::platform;
-using RpcMethod = mp::Rpc::Stub;
 
 namespace
 {

--- a/src/client/cli/cmd/umount.cpp
+++ b/src/client/cli/cmd/umount.cpp
@@ -22,7 +22,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Umount::run(mp::ArgParser* parser)
 {

--- a/src/client/cli/cmd/unalias.h
+++ b/src/client/cli/cmd/unalias.h
@@ -32,7 +32,7 @@ class Unalias final : public Command
 public:
     using Command::Command;
 
-    Unalias(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
+    Unalias(Rpc::StubInterface& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/unalias.h
+++ b/src/client/cli/cmd/unalias.h
@@ -32,8 +32,7 @@ class Unalias final : public Command
 public:
     using Command::Command;
 
-    Unalias(grpc::Channel& channel, Rpc::Stub& stub, Terminal* term, AliasDict& dict)
-        : Command(channel, stub, term), aliases(dict)
+    Unalias(Rpc::Stub& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
     {
     }
 

--- a/src/client/cli/cmd/version.cpp
+++ b/src/client/cli/cmd/version.cpp
@@ -23,7 +23,6 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
 
 mp::ReturnCode cmd::Version::run(mp::ArgParser* parser)
 {

--- a/src/client/gui/client_gui.cpp
+++ b/src/client/gui/client_gui.cpp
@@ -27,9 +27,8 @@ namespace mp = multipass;
 namespace mpl = multipass::logging;
 
 mp::ClientGui::ClientGui(ClientConfig& config)
-    : rpc_channel{mp::client::make_channel(config.server_address, config.cert_provider.get())},
-      stub{mp::Rpc::NewStub(rpc_channel)},
-      gui_cmd{std::make_unique<cmd::GuiCmd>(*rpc_channel, *stub, null_stream, null_stream)}
+    : stub{mp::Rpc::NewStub(mp::client::make_channel(config.server_address, config.cert_provider.get()))},
+      gui_cmd{std::make_unique<cmd::GuiCmd>(*stub, null_stream, null_stream)}
 {
 }
 

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -33,7 +33,7 @@
 
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
-using RpcMethod = mp::Rpc::Stub;
+using RpcMethod = mp::Rpc::StubInterface;
 using namespace std::chrono_literals;
 
 namespace

--- a/tests/daemon_test_fixture.h
+++ b/tests/daemon_test_fixture.h
@@ -85,7 +85,7 @@ public:
 
         auto ret = parse_args(parser);
         return ret == multipass::ParseCode::Ok
-                   ? dispatch(&multipass::Rpc::Stub::create, request, on_success, on_failure, streaming_callback)
+                   ? dispatch(&mp::Rpc::StubInterface::create, request, on_success, on_failure, streaming_callback)
                    : parser->returnCodeFrom(ret);
     }
 
@@ -145,7 +145,7 @@ public:
 
         if (auto parse_result = parse_args(parser); parse_result == mp::ParseCode::Ok)
         {
-            auto ret = dispatch(&mp::Rpc::Stub::get, request, on_success, on_failure);
+            auto ret = dispatch(&mp::Rpc::StubInterface::get, request, on_success, on_failure);
             cout << fmt::format("{}={}", request.key(), val);
             return ret;
         }


### PR DESCRIPTION
Remove the `rpc_channel` attribute from the `Command` base class, along with the corresponding c'tor param. This wasn't used anywhere. Also, require an RPC `StubInterface` rather than an actual `Stub` in `Command`s. Both changes enable mocking to test commands (namely for remote settings).