### PR TITLE
[cloud-init] set `cloud-name` to `multipass`

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -145,6 +145,7 @@ auto make_cloud_init_meta_config(const std::string& name)
 
     meta_data["instance-id"] = name;
     meta_data["local-hostname"] = name;
+    meta_data["cloud-name"] = "multipass";
 
     return meta_data;
 }


### PR DESCRIPTION
SnapD sends that to the store, so we could use that to filter installed snaps through that.