### PR TITLE
Get `--keys` and prepare the ground for wildcards

### DIFF
--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -19,6 +19,7 @@
 #define MULTIPASS_CONSTANTS_H
 
 #include <chrono>
+#include <initializer_list>
 
 using namespace std::chrono_literals;
 
@@ -58,6 +59,9 @@ constexpr auto mounts_key = "local.privileged-mounts"; // idem
 constexpr auto autostart_key = "client.gui.autostart"; // idem
 constexpr auto winterm_key = "client.apps.windows-terminal.profiles"; // idem
 constexpr auto hotkey_key = "client.gui.hotkey";                      // idem
+
+[[maybe_unused]] // hands off clang-format
+constexpr auto key_examples = {autostart_key, driver_key, mounts_key};
 
 constexpr auto petenv_default = "primary";
 constexpr auto hotkey_default = "Ctrl+Alt+U";                         // idem; translates to Cmd+Opt+U on macOS

--- a/include/multipass/settings/settings.h
+++ b/include/multipass/settings/settings.h
@@ -41,10 +41,8 @@ public:
     virtual void unregister_handler(SettingsHandler* handler); // no-op if handler isn't registered
 
     /**
-     * Obtain the keys, or key templates, that this Settings singleton knows about.
-     * @warning These are meant for human interpretation and may include templates and descriptions that cannot be used
-     * in get/set as actual keys (e.g. <tt>local.@<instance@>.cpus</tt>).
-     * @return The set of keys, key templates, or key descriptions that this Settings singleton knows about.
+     * Obtain the keys that this Settings singleton knows about.
+     * @return The set of keys that this Settings singleton knows about.
      */
     virtual std::set<QString> keys() const;
 

--- a/include/multipass/settings/settings_handler.h
+++ b/include/multipass/settings/settings_handler.h
@@ -33,10 +33,8 @@ public:
     virtual ~SettingsHandler() = default;
 
     /**
-     * Obtain the keys, or key templates, that this SettingHandler handles.
-     * @warning These are meant for human interpretation and may include templates and descriptions that cannot be used
-     * in get/set as actual keys (e.g. <tt>local.@<instance@>.cpus</tt>).
-     * @return The set of keys, key templates, or key descriptions that this SettingHandler handles.
+     * Obtain the keys that this SettingsHandler handles.
+     * @return The set of keys that this SettingsHandler handles.
      */
     virtual std::set<QString> keys() const = 0;
 

--- a/src/client/cli/cmd/common_cli.cpp
+++ b/src/client/cli/cmd/common_cli.cpp
@@ -24,7 +24,6 @@
 #include <multipass/constants.h>
 #include <multipass/exceptions/cmd_exceptions.h>
 #include <multipass/exceptions/settings_exceptions.h>
-#include <multipass/settings/settings.h>
 
 #include <QCommandLineOption>
 #include <QString>
@@ -139,11 +138,12 @@ auto cmd::return_code_from(const mp::SettingsException& e) -> mp::ReturnCode
     return ReturnCode::CommandFail;
 }
 
-QString multipass::cmd::describe_settings_keys()
+QString multipass::cmd::describe_common_settings_keys()
 {
-    const auto keys = MP_SETTINGS.keys();
-    return std::accumulate(cbegin(keys), cend(keys), QStringLiteral("Keys:"),
-                           [](const auto& a, const auto& b) { return a + "\n  " + b; });
+    return std::accumulate(cbegin(mp::key_examples), cend(mp::key_examples),
+                           QStringLiteral("Some common settings keys are:"),
+                           [](const auto& a, const auto& b) { return a + "\n  - " + b; }) +
+           "\n\nUse `multipass get --keys` to obtain the full list of available settings at any given time.";
 }
 
 void multipass::cmd::add_timeout(multipass::ArgParser* parser)

--- a/src/client/cli/cmd/common_cli.cpp
+++ b/src/client/cli/cmd/common_cli.cpp
@@ -143,7 +143,8 @@ QString multipass::cmd::describe_common_settings_keys()
     return std::accumulate(cbegin(mp::key_examples), cend(mp::key_examples),
                            QStringLiteral("Some common settings keys are:"),
                            [](const auto& a, const auto& b) { return a + "\n  - " + b; }) +
-           "\n\nUse `multipass get --keys` to obtain the full list of available settings at any given time.";
+           "\n\nUse `" + mp::client_name +
+           " get --keys` to obtain the full list of available settings at any given time.";
 }
 
 void multipass::cmd::add_timeout(multipass::ArgParser* parser)

--- a/src/client/cli/cmd/common_cli.h
+++ b/src/client/cli/cmd/common_cli.h
@@ -48,7 +48,7 @@ std::string instance_action_message_for(const InstanceNames& instance_names, con
 ReturnCode run_cmd(const QStringList& args, const ArgParser* parser, std::ostream& cout, std::ostream& cerr);
 ReturnCode run_cmd_and_retry(const QStringList& args, const ArgParser* parser, std::ostream& cout, std::ostream& cerr);
 ReturnCode return_code_from(const SettingsException& e);
-QString describe_settings_keys();
+QString describe_common_settings_keys();
 
 // parser helpers
 void add_timeout(multipass::ArgParser*);

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -96,10 +96,10 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
         {
             arg = args.at(0);
         }
-        else if (!keys_opt)
+        else if (!keys_opt || args.count()) // support 0 or 1 positional arg when --keys is given
         {
-            cerr << "Multiple settings values not implemented yet. Please try again with one single settings key for "
-                    "now.\n";
+            cerr << "Multiple settings not implemented yet. Please try again with either a single key or just the "
+                    "`--keys` flag for now.\n";
             status = ParseCode::CommandLineError;
         }
     }

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -120,7 +120,7 @@ void cmd::Get::print_settings() const
 
 void multipass::cmd::Get::print_keys() const
 {
-    const auto keys = MP_SETTINGS.keys(); // TODO@ricab update this to remove fuzziness (i.e. local.*)
+    const auto keys = MP_SETTINGS.keys();
     const auto format = "{}\n";
 
     if (arg.isEmpty())

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -38,10 +38,10 @@ mp::ReturnCode cmd::Get::run(mp::ArgParser* parser)
         {
             if (keys)
                 print_keys();
-            else if (!key.isEmpty())
+            else if (!arg.isEmpty())
             {
-                if (const auto val = MP_SETTINGS.get(key);
-                    key == mp::passphrase_key) // TODO integrate into setting specs
+                if (const auto val = MP_SETTINGS.get(arg);
+                    arg == mp::passphrase_key) // TODO integrate into setting specs
                     cout << (val.isEmpty() ? "false" : "true");
                 else if (val.isEmpty() && !raw)
                     cout << "<empty>";
@@ -80,8 +80,8 @@ QString cmd::Get::description() const
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
 {
-    parser->addPositionalArgument("key", "Path(s) to the setting(s) whose configured value(s) should be obtained.",
-                                  "[<key> ...]");
+    parser->addPositionalArgument("arg", "Path(s) to the setting(s) whose configured value(s) should be obtained.",
+                                  "[<arg> ...]");
 
     QCommandLineOption raw_option("raw", "Output in raw format. For now, this affects only the representation of empty "
                                          "values (i.e. \"\" instead of \"<empty>\").");
@@ -99,7 +99,7 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
         const auto args = parser->positionalArguments();
         if (args.count() == 1)
         {
-            key = args.at(0);
+            arg = args.at(0);
         }
         else if (!keys)
         {

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -127,9 +127,9 @@ void multipass::cmd::Get::print_keys() const
     const auto format = "{}\n";
 
     if (arg.isEmpty())
-        fmt::print(format, fmt::join(keys, "\n"));
+        fmt::print(cout, format, fmt::join(keys, "\n"));
     else if (std::find(keys.cbegin(), keys.cend(), arg) != keys.cend()) // TODO implement key globing
-        fmt::print(format, arg); // not very useful, but just a particular case of (intended) glob matching
+        fmt::print(cout, format, arg); // not very useful, but just a particular case of (intended) glob matching
     else
         throw mp::UnrecognizedSettingException(arg); // wildcards not implemented yet
 }

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -67,7 +67,7 @@ QString cmd::Get::description() const
 {
     auto desc = QStringLiteral("Get the configuration setting corresponding to the given key(s), or all settings if no "
                                "key is specified.");
-    return desc + "\n\n" + describe_settings_keys();
+    return desc + "\n\n" + describe_common_settings_keys();
 }
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -120,4 +120,13 @@ void cmd::Get::print_settings() const
 
 void multipass::cmd::Get::print_keys() const
 {
+    const auto keys = MP_SETTINGS.keys(); // TODO@ricab update this to remove fuzziness (i.e. local.*)
+    const auto format = "{}\n";
+
+    if (arg.isEmpty())
+        fmt::print(format, fmt::join(keys, "\n"));
+    else if (std::find(keys.cbegin(), keys.cend(), arg) != keys.cend()) // TODO implement key globing
+        fmt::print(format, arg); // not very useful, but just a particular case of (intended) glob matching
+    else
+        throw mp::UnrecognizedSettingException(arg); // wildcards not implemented yet
 }

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -38,7 +38,7 @@ mp::ReturnCode cmd::Get::run(mp::ArgParser* parser)
     {
         try
         {
-            if (keys)
+            if (keys_opt)
                 print_keys();
             else
                 print_settings();
@@ -85,15 +85,15 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
     auto status = parser->commandParse(this);
     if (status == ParseCode::Ok)
     {
-        keys = parser->isSet(keys_option);
-        raw = parser->isSet(raw_option);
+        keys_opt = parser->isSet(keys_option);
+        raw_opt = parser->isSet(raw_option);
 
         const auto args = parser->positionalArguments();
         if (args.count() == 1)
         {
             arg = args.at(0);
         }
-        else if (!keys)
+        else if (!keys_opt)
         {
             cerr << "Multiple settings values not implemented yet. Please try again with one single settings key for "
                     "now.\n";
@@ -110,7 +110,7 @@ void cmd::Get::print_settings() const
 
     if (const auto val = MP_SETTINGS.get(arg); arg == passphrase_key) // TODO integrate into setting specs
         cout << (val.isEmpty() ? "false" : "true");
-    else if (val.isEmpty() && !raw)
+    else if (val.isEmpty() && !raw_opt)
         cout << "<empty>";
     else
         cout << qUtf8Printable(val);

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -65,19 +65,22 @@ QString cmd::Get::short_help() const
 
 QString cmd::Get::description() const
 {
-    auto desc = QStringLiteral("Get the configuration setting corresponding to the given key(s), or all settings if no "
-                               "key is specified.");
+    auto desc = QStringLiteral("Get the configuration setting(s) corresponding to the given key(s), or all settings if "
+                               "no key is specified.");
     return desc + "\n\n" + describe_common_settings_keys();
 }
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
 {
-    parser->addPositionalArgument("arg", "Path(s) to the setting(s) whose configured value(s) should be obtained.",
-                                  "[<arg> ...]");
+    parser->addPositionalArgument(
+        "arg", "Setting(s) key(s), i.e. path(s) to the setting(s) whose configured value(s) should be obtained.",
+        "[<arg> ...]");
 
     QCommandLineOption raw_option("raw", "Output in raw format. For now, this affects only the representation of empty "
                                          "values (i.e. \"\" instead of \"<empty>\").");
-    QCommandLineOption keys_option("keys", "List available settings keys.");
+    QCommandLineOption keys_option("keys", "List available settings keys. This outputs the whole list of currently "
+                                           "available settings keys, or a matching subset when <arg>... is(are) "
+                                           "provided");
 
     parser->addOption(raw_option);
     parser->addOption(keys_option);

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -36,14 +36,20 @@ mp::ReturnCode cmd::Get::run(mp::ArgParser* parser)
     {
         try
         {
-            if (const auto val = MP_SETTINGS.get(key); key == mp::passphrase_key) // TODO integrate into setting specs
-                cout << (val.isEmpty() ? "false" : "true");
-            else if (val.isEmpty() && !raw)
-                cout << "<empty>";
-            else
-                cout << qUtf8Printable(val);
+            if (keys)
+                print_keys();
+            else if (!key.isEmpty())
+            {
+                if (const auto val = MP_SETTINGS.get(key);
+                    key == mp::passphrase_key) // TODO integrate into setting specs
+                    cout << (val.isEmpty() ? "false" : "true");
+                else if (val.isEmpty() && !raw)
+                    cout << "<empty>";
+                else
+                    cout << qUtf8Printable(val);
 
-            cout << "\n";
+                cout << "\n";
+            }
         }
         catch (const SettingsException& e)
         {
@@ -79,24 +85,33 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
 
     QCommandLineOption raw_option("raw", "Output in raw format. For now, this affects only the representation of empty "
                                          "values (i.e. \"\" instead of \"<empty>\").");
+    QCommandLineOption keys_option("keys", "List available settings keys.");
+
     parser->addOption(raw_option);
+    parser->addOption(keys_option);
 
     auto status = parser->commandParse(this);
     if (status == ParseCode::Ok)
     {
+        keys = parser->isSet(keys_option);
+        raw = parser->isSet(raw_option);
+
         const auto args = parser->positionalArguments();
         if (args.count() == 1)
         {
             key = args.at(0);
         }
-        else
+        else if (!keys)
         {
-            cerr << "Multiple settings not implemented yet. Please try again with one single settings key for now.\n";
+            cerr << "Multiple settings values not implemented yet. Please try again with one single settings key for "
+                    "now.\n";
             status = ParseCode::CommandLineError;
         }
-
-        raw = parser->isSet(raw_option);
     }
 
     return status;
+}
+
+void multipass::cmd::Get::print_keys() const
+{
 }

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -41,19 +41,7 @@ mp::ReturnCode cmd::Get::run(mp::ArgParser* parser)
             if (keys)
                 print_keys();
             else
-            {
-                assert(!arg.isEmpty() && "Need single arg until we implement multiple settings");
-
-                if (const auto val = MP_SETTINGS.get(arg);
-                    arg == mp::passphrase_key) // TODO integrate into setting specs
-                    cout << (val.isEmpty() ? "false" : "true");
-                else if (val.isEmpty() && !raw)
-                    cout << "<empty>";
-                else
-                    cout << qUtf8Printable(val);
-
-                cout << "\n";
-            }
+                print_settings();
         }
         catch (const SettingsException& e)
         {
@@ -114,6 +102,20 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
     }
 
     return status;
+}
+
+void cmd::Get::print_settings() const
+{
+    assert(!arg.isEmpty() && "Need single arg until we implement multiple settings");
+
+    if (const auto val = MP_SETTINGS.get(arg); arg == passphrase_key) // TODO integrate into setting specs
+        cout << (val.isEmpty() ? "false" : "true");
+    else if (val.isEmpty() && !raw)
+        cout << "<empty>";
+    else
+        cout << qUtf8Printable(val);
+
+    cout << "\n";
 }
 
 void multipass::cmd::Get::print_keys() const

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -67,13 +67,15 @@ QString cmd::Get::short_help() const
 
 QString cmd::Get::description() const
 {
-    auto desc = QStringLiteral("Get the configuration setting corresponding to the given key.");
+    auto desc = QStringLiteral("Get the configuration setting corresponding to the given key(s), or all settings if no "
+                               "key is specified.");
     return desc + "\n\n" + describe_settings_keys();
 }
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
 {
-    parser->addPositionalArgument("key", "Path to the setting whose configured value should be obtained.", "<key>");
+    parser->addPositionalArgument("key", "Path(s) to the setting(s) whose configured value(s) should be obtained.",
+                                  "[<key> ...]");
 
     QCommandLineOption raw_option("raw", "Output in raw format. For now, this affects only the representation of empty "
                                          "values (i.e. \"\" instead of \"<empty>\").");
@@ -89,7 +91,7 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
         }
         else
         {
-            cerr << "Need exactly one setting key.\n";
+            cerr << "Multiple settings not implemented yet. Please try again with one single settings key for now.\n";
             status = ParseCode::CommandLineError;
         }
 

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -25,6 +25,8 @@
 
 #include <QtGlobal>
 
+#include <cassert>
+
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
 
@@ -38,8 +40,10 @@ mp::ReturnCode cmd::Get::run(mp::ArgParser* parser)
         {
             if (keys)
                 print_keys();
-            else if (!arg.isEmpty())
+            else
             {
+                assert(!arg.isEmpty() && "Need single arg until we implement multiple settings");
+
                 if (const auto val = MP_SETTINGS.get(arg);
                     arg == mp::passphrase_key) // TODO integrate into setting specs
                     cout << (val.isEmpty() ? "false" : "true");

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -79,7 +79,7 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
     QCommandLineOption raw_option("raw", "Output in raw format. For now, this affects only the representation of empty "
                                          "values (i.e. \"\" instead of \"<empty>\").");
     QCommandLineOption keys_option("keys", "List available settings keys. This outputs the whole list of currently "
-                                           "available settings keys, or a matching subset when <arg>... is(are) "
+                                           "available settings keys, or a matching subset when any <arg> are "
                                            "provided");
 
     parser->addOption(raw_option);
@@ -99,7 +99,7 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
         else if (!keys_opt || args.count()) // support 0 or 1 positional arg when --keys is given
         {
             cerr << "Multiple settings not implemented yet. Please try again with either a single key or just the "
-                    "`--keys` flag for now.\n";
+                    "`--keys` option for now.\n";
             status = ParseCode::CommandLineError;
         }
     }

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -65,20 +65,19 @@ QString cmd::Get::short_help() const
 
 QString cmd::Get::description() const
 {
-    auto desc = QStringLiteral("Get the configuration setting(s) corresponding to the given key(s), or all settings if "
-                               "no key is specified.");
+    auto desc = QStringLiteral("Get the configuration setting corresponding to the given key, or all settings if "
+                               "no key is specified.\n(Support for multiple keys and wildcards coming...)");
     return desc + "\n\n" + describe_common_settings_keys();
 }
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
 {
-    parser->addPositionalArgument("arg", "Setting(s) key(s), i.e. path(s) to the intended setting(s).", "[<arg> ...]");
+    parser->addPositionalArgument("arg", "Setting key, i.e. path to the intended setting.", "[<arg>]");
 
     QCommandLineOption raw_option("raw", "Output in raw format. For now, this affects only the representation of empty "
                                          "values (i.e. \"\" instead of \"<empty>\").");
     QCommandLineOption keys_option("keys", "List available settings keys. This outputs the whole list of currently "
-                                           "available settings keys, or a matching subset when any <arg> are "
-                                           "provided");
+                                           "available settings keys, or just <arg>, if provided and a valid key.");
 
     parser->addOption(raw_option);
     parser->addOption(keys_option);
@@ -94,9 +93,14 @@ mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
         {
             arg = args.at(0);
         }
-        else if (!keys_opt || args.count()) // support 0 or 1 positional arg when --keys is given
+        else if (args.count() > 1)
         {
-            cerr << "Multiple settings not implemented yet. Please try again with either a single key or just the "
+            cerr << "Need at most one setting key.\n";
+            status = ParseCode::CommandLineError;
+        }
+        else if (!keys_opt) // support 0 or 1 positional arg when --keys is given
+        {
+            cerr << "Multiple settings not implemented yet. Please try again with one setting key or just the "
                     "`--keys` option for now.\n";
             status = ParseCode::CommandLineError;
         }

--- a/src/client/cli/cmd/get.cpp
+++ b/src/client/cli/cmd/get.cpp
@@ -72,9 +72,7 @@ QString cmd::Get::description() const
 
 mp::ParseCode cmd::Get::parse_args(mp::ArgParser* parser)
 {
-    parser->addPositionalArgument(
-        "arg", "Setting(s) key(s), i.e. path(s) to the setting(s) whose configured value(s) should be obtained.",
-        "[<arg> ...]");
+    parser->addPositionalArgument("arg", "Setting(s) key(s), i.e. path(s) to the intended setting(s).", "[<arg> ...]");
 
     QCommandLineOption raw_option("raw", "Output in raw format. For now, this affects only the representation of empty "
                                          "values (i.e. \"\" instead of \"<empty>\").");

--- a/src/client/cli/cmd/get.h
+++ b/src/client/cli/cmd/get.h
@@ -38,9 +38,11 @@ public:
 
 private:
     ParseCode parse_args(ArgParser* parser);
+    void print_keys() const;
 
     QString key;
     bool raw = false;
+    bool keys = false;
 };
 } // namespace cmd
 } // namespace multipass

--- a/src/client/cli/cmd/get.h
+++ b/src/client/cli/cmd/get.h
@@ -38,6 +38,7 @@ public:
 
 private:
     ParseCode parse_args(ArgParser* parser);
+    void print_settings() const;
     void print_keys() const;
 
     QString arg;

--- a/src/client/cli/cmd/get.h
+++ b/src/client/cli/cmd/get.h
@@ -40,7 +40,7 @@ private:
     ParseCode parse_args(ArgParser* parser);
     void print_keys() const;
 
-    QString key;
+    QString arg;
     bool raw = false;
     bool keys = false;
 };

--- a/src/client/cli/cmd/get.h
+++ b/src/client/cli/cmd/get.h
@@ -42,8 +42,8 @@ private:
     void print_keys() const;
 
     QString arg;
-    bool raw = false;
-    bool keys = false;
+    bool raw_opt = false;
+    bool keys_opt = false;
 };
 } // namespace cmd
 } // namespace multipass

--- a/src/client/cli/cmd/remote_settings_handler.cpp
+++ b/src/client/cli/cmd/remote_settings_handler.cpp
@@ -140,7 +140,7 @@ public:
         auto custom_on_failure = [](grpc::Status& status) {
             if (auto code = status.error_code(); code == grpc::NOT_FOUND)
             {
-                mpl::log(mpl::Level::warning, category, "Could not reach daemon.");
+                mpl::log(mpl::Level::error, category, "Could not reach daemon.");
                 return mp::ReturnCode::Ok;
             }
 

--- a/src/client/cli/cmd/set.cpp
+++ b/src/client/cli/cmd/set.cpp
@@ -64,7 +64,7 @@ QString cmd::Set::short_help() const
 QString cmd::Set::description() const
 {
     auto desc = QStringLiteral("Set, to the given value, the configuration setting corresponding to the given key.");
-    return desc + "\n\n" + describe_settings_keys();
+    return desc + "\n\n" + describe_common_settings_keys();
 }
 
 mp::ParseCode cmd::Set::parse_args(mp::ArgParser* parser)

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -2080,6 +2080,20 @@ TEST_F(Client, find_cmd_unsupported_option_ok)
 }
 
 // get/set cli tests
+struct TestGetSetHelp : Client, WithParamInterface<std::string>
+{
+};
+
+TEST_P(TestGetSetHelp, helpIncludesKeyExamplesAndHowToGetFullList)
+{
+    std::ostringstream cout;
+
+    EXPECT_THAT(send_command({GetParam(), "--help"}, cout), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(cout.str(), AllOf(HasSubstr("local."), HasSubstr("client."), HasSubstr("get --keys")));
+}
+
+INSTANTIATE_TEST_SUITE_P(Client, TestGetSetHelp, Values("get", "set"));
+
 struct TestBasicGetSetOptions : Client, WithParamInterface<const char*>
 {
 };

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -2238,6 +2238,15 @@ TEST_F(Client, get_keeps_other_values_untouched_with_raw_option)
     }
 }
 
+TEST_F(Client, getKeysNoArgReturnsAllSettingsKeys)
+{
+    const auto key_set = std::set<QString>{"asdf", "sdfg", "dfgh"};
+    EXPECT_CALL(mock_settings, keys).WillOnce(Return(key_set));
+
+    auto got_keys = QString::fromStdString(get_setting("--keys")).split('\n');
+    EXPECT_THAT(got_keys, UnorderedElementsAreArray(key_set));
+}
+
 TEST_F(Client, set_handles_persistent_settings_errors)
 {
     const auto key = mp::petenv_key;

--- a/tests/test_remote_settings_handler.cpp
+++ b/tests/test_remote_settings_handler.cpp
@@ -143,7 +143,7 @@ TEST_F(RemoteSettingsTest, keysReturnsRemoteKeys)
     EXPECT_THAT(handler.keys(), UnorderedElementsAreArray(some_keys));
 }
 
-TEST_F(RemoteSettingsTest, keysReturnsPlaceholderKeysWhenDaemonNotFound)
+TEST_F(RemoteSettingsTest, keysReturnsNoKeysWhenDaemonNotAround)
 {
     auto mock_client_reader = make_mock_reader<mp::KeysReply>();
     EXPECT_CALL(*mock_client_reader, Finish)
@@ -154,7 +154,7 @@ TEST_F(RemoteSettingsTest, keysReturnsPlaceholderKeysWhenDaemonNotFound)
     auto prefix = "remote.";
     mp::RemoteSettingsHandler handler{prefix, mock_stub, &mock_term, 0};
 
-    EXPECT_THAT(handler.keys(), ElementsAre(mpt::match_qstring(StartsWith(std::string{prefix} + "*"))));
+    EXPECT_THAT(handler.keys(), IsEmpty());
 }
 
 TEST_F(RemoteSettingsTest, keysThrowsOnOtherErrorFromRemote)


### PR DESCRIPTION
Expand the `get` command in a couple of ways:

1. Expand the command's syntax to
    - accept multiple keys;
    - accommodate wildcards instead of concrete keys.
2. Add a `--keys` option, to obtain available settings at any given time;
    1. restrict the output to the specified single key, if given.

As discussed, parts of the implementation are postponed for now (so we can prioritize instance mod). Step 1 above opens the command for future support of multiple keys and wildcards (which are meant to work with and without the `--keys` flag) but stops short of implementing that support for now. Step 2 is implemented in a way that will accommodate the same wildcard arg(s) for `--keys`, but interprets only a single key arg at the moment. That's a particular case of wildcard matching which, although not very useful for the time being, is consistent with the end goal.