### PR TITLE
[tests] Fix "Uninteresting mock function call" messages

### DIFF
--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -702,6 +702,7 @@ TEST_F(PlatformLinux, read_os_release_from_file_not_found)
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
     EXPECT_CALL(*mock_file_ops, open(_, _)).Times(2).WillRepeatedly(Return(false));
+    EXPECT_CALL(*mock_file_ops, is_open(_)).WillOnce(Return(false));
 
     auto output = multipass::platform::detail::read_os_release();
 

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -30,7 +30,9 @@ class MockPlatform : public platform::Platform
 public:
     MockPlatform(const PrivatePass& pass) : platform::Platform(pass)
     {
-        ON_CALL(*this, set_server_socket_restrictions).WillByDefault(testing::Return());
+        EXPECT_CALL(*this, set_server_socket_restrictions)
+            .Times(testing::AnyNumber())
+            .WillRepeatedly(testing::Return());
     };
 
     MOCK_CONST_METHOD0(get_network_interfaces_info, std::map<std::string, NetworkInterfaceInfo>());

--- a/tests/qemu/mock_qemu_platform.h
+++ b/tests/qemu/mock_qemu_platform.h
@@ -29,7 +29,12 @@ namespace test
 {
 struct MockQemuPlatform : public QemuPlatform
 {
-    using QemuPlatform::QemuPlatform; // ctor
+    MockQemuPlatform()
+    {
+        EXPECT_CALL(*this, vmstate_platform_args())
+            .Times(testing::AnyNumber())
+            .WillRepeatedly(testing::Return(QStringList()));
+    }
 
     MOCK_METHOD1(get_ip_for, optional<IPAddress>(const std::string&));
     MOCK_METHOD1(remove_resources_for, void(const std::string&));


### PR DESCRIPTION
This is to get rid of all of the "Uninteresting calls" when tests run.

---
This is needed as a prerequisite for #2485.