### PR TITLE
[client] Remove logging message that is always printed

### DIFF
--- a/src/client/common/client_common.cpp
+++ b/src/client/common/client_common.cpp
@@ -193,7 +193,6 @@ std::unique_ptr<mp::SSLCertProvider> mp::client::get_cert_provider()
 
     if (client_certs_exist(common_client_cert_dir_path))
     {
-        mpl::log(mpl::Level::trace, "client", fmt::format("Found cert provider at {}", common_client_cert_dir_path));
         return std::make_unique<mp::SSLCertProvider>(common_client_cert_dir_path);
     }
 


### PR DESCRIPTION
This is due to this log message being called before the logger is actually set up to
match the passed in verbosity.

Fixes #2499