### PR TITLE
[daemon] Move hypervisor health check sooner in ctor

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -856,6 +856,15 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     connect_rpc(daemon_rpc, *this);
     std::vector<std::string> invalid_specs;
 
+    try
+    {
+        config->factory->hypervisor_health_check();
+    }
+    catch (const std::runtime_error& e)
+    {
+        mpl::log(mpl::Level::warning, category, fmt::format("Hypervisor health check failed: {}", e.what()));
+    }
+
     for (auto& entry : vm_instance_specs)
     {
         const auto& name = entry.first;
@@ -986,15 +995,6 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
         }
     });
     source_images_maintenance_task.start(config->image_refresh_timer);
-
-    try
-    {
-        config->factory->hypervisor_health_check();
-    }
-    catch (const std::runtime_error& e)
-    {
-        mpl::log(mpl::Level::warning, category, fmt::format("Hypervisor health check failed: {}", e.what()));
-    }
 }
 
 void mp::Daemon::create(const CreateRequest* request, grpc::ServerWriterInterface<CreateReply>* server,


### PR DESCRIPTION
This allows any initialization of any hypervisor specific primitives to be complete
before any existing instances are instantiated.

Fixes #2519