### PR TITLE
[daemon] Remove `snapcraft:core` remote

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -92,7 +92,7 @@ const std::unordered_set<std::string> no_bridging_release = { // images to check
     "10.04",  "lucid", "11.10", "oneiric", "12.04",  "precise", "12.10",  "quantal", "13.04",
     "raring", "13.10", "saucy", "14.04",   "trusty", "14.10",   "utopic", "15.04",   "vivid",
     "15.10",  "wily",  "16.04", "xenial",  "16.10",  "yakkety", "17.04",  "zesty"};
-const std::unordered_set<std::string> no_bridging_remote = {"snapcraft:core"};     // images with other remote specified
+const std::unordered_set<std::string> no_bridging_remote = {};                     // images with other remote specified
 const std::unordered_set<std::string> no_bridging_remoteless = {"core", "core16"}; // images which do not use remote
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1171,7 +1171,6 @@ std::vector<std::string> old_remoteless_rels{"core", "core16"};
 
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseRelease, RefuseBridging,
                          Combine(Values("release", "daily", ""), ValuesIn(old_releases)));
-INSTANTIATE_TEST_SUITE_P(DaemonRefuseSnapcraft, RefuseBridging, Values(std::make_tuple("snapcraft", "core")));
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseRemoteless, RefuseBridging, Combine(Values(""), ValuesIn(old_remoteless_rels)));
 
 TEST_F(Daemon, fails_with_image_not_found_also_if_image_is_also_non_bridgeable)


### PR DESCRIPTION
It was on the non-bridging remote list. Since we don't support it anymore, it doesn't make sense for it to stay there.