### PR TITLE
Fix ownership of a folder created under a mount

### DIFF
--- a/include/multipass/sshfs_mount/sftp_server.h
+++ b/include/multipass/sshfs_mount/sftp_server.h
@@ -55,8 +55,8 @@ private:
     sftp_attributes_struct attr_from(const QFileInfo& file_info);
     int mapped_uid_for(const int uid);
     int mapped_gid_for(const int gid);
-    int reverse_uid_for(const int uid, const int rev_uid_if_not_found = -1);
-    int reverse_gid_for(const int gid, const int rev_gid_if_not_found = -1);
+    int reverse_uid_for(const int uid, const int rev_uid_if_not_found);
+    int reverse_gid_for(const int gid, const int rev_gid_if_not_found);
 
     int handle_close(sftp_client_message msg);
     int handle_fstat(sftp_client_message msg);

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -531,9 +531,8 @@ int mp::SftpServer::handle_mkdir(sftp_client_message msg)
 
     QFileInfo current_dir(filename);
     QFileInfo parent_dir(current_dir.path());
-
-    int rev_uid = reverse_uid_for(msg->attr->uid);
-    int rev_gid = reverse_gid_for(msg->attr->gid);
+    int rev_uid = reverse_uid_for(msg->attr->uid, parent_dir.ownerId());
+    int rev_gid = reverse_gid_for(msg->attr->gid, parent_dir.groupId());
 
     if (MP_PLATFORM.chown(filename, rev_uid, rev_gid) < 0)
     {

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -930,8 +930,8 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
     }
 
     if ((msg->attr->flags & SSH_FILEXFER_ATTR_UIDGID) &&
-        (MP_PLATFORM.chown(filename.toStdString().c_str(), reverse_uid_for(msg->attr->uid),
-                           reverse_gid_for(msg->attr->gid)) < 0))
+        (MP_PLATFORM.chown(filename.toStdString().c_str(), reverse_uid_for(msg->attr->uid, msg->attr->uid),
+                           reverse_gid_for(msg->attr->gid, msg->attr->gid)) < 0))
     {
         mpl::log(mpl::Level::trace, category,
                  fmt::format("{}: cannot set ownership for \'{}\'", __FUNCTION__, filename));

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -2318,7 +2318,9 @@ TEST_F(SftpServer, DISABLE_ON_WINDOWS(mkdir_chown_works_when_ids_are_not_mapped)
 
     REPLACE(sftp_get_client_message, make_msg_handler());
 
-    EXPECT_CALL(*mock_platform, chown(_, -1, -1)).Times(1);
+    QFileInfo parent_dir(temp_dir.path());
+
+    EXPECT_CALL(*mock_platform, chown(_, parent_dir.ownerId(), parent_dir.groupId())).Times(1);
 
     sftp.run();
 }


### PR DESCRIPTION
The reverse id mapping function returned `-1` if the current user was not found on the reverse mappings. Since the folder is created as root, when `0` did not exist in the reverse mappings the new folder retained the `0` id, because `-1` makes `chown` to keep the owner.

We use now the user/groups id's of the parent folder if the current user is not found on the reverse mappings. This was the behavior before implementing reverse id mapping.

Fixes https://github.com/canonical/multipass/issues/2553.