### PR TITLE
[cli] add mount option on launch command

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -408,7 +408,8 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
             timer->pause();
 
         cout << "Launched: " << reply.vm_instance_name() << "\n";
-        instance_name = QString::fromStdString(reply.vm_instance_name());
+        instance_name = QString::fromStdString(request.instance_name().empty() ? reply.vm_instance_name()
+                                                                               : request.instance_name());
 
         if (term->is_live() && update_available(reply.update_info()))
         {

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -36,7 +36,7 @@
 #include <QFileInfo>
 #include <QTimeZone>
 
-#include <cstdlib>
+#include <QRegularExpression>
 #include <regex>
 #include <unordered_map>
 
@@ -316,9 +316,13 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
     {
         for (const auto& value : parser->values(mountOption))
         {
-            auto mount_values = value.split(':');
-            auto mount_source = mount_values.first();
-            auto mount_target = mount_values.size() == 1 ? mount_source : mount_values.at(1);
+            auto colon_split = 0;
+#ifdef WIN32
+            QRegularExpression absolutePathRegex{R"(^[A-Za-z]:[\\/].*)"};
+            colon_split = absolutePathRegex.match(value).hasMatch();
+#endif
+            auto mount_source = value.section(':', 0, colon_split);
+            auto mount_target = value.section(':', colon_split + 1);
             mount_routes.insert({mount_target, mount_source});
         }
     }

--- a/src/client/cli/cmd/launch.h
+++ b/src/client/cli/cmd/launch.h
@@ -46,13 +46,16 @@ public:
 private:
     ParseCode parse_args(ArgParser* parser);
     ReturnCode request_launch(const ArgParser* parser);
-    ReturnCode mount_home(const ArgParser* parser);
+    ReturnCode mount(const ArgParser* parser, QString mount_source, QString mount_target);
     bool ask_bridge_permission(multipass::LaunchReply& reply);
 
     LaunchRequest request;
     QString petenv_name;
     std::unique_ptr<multipass::AnimatedSpinner> spinner;
     std::unique_ptr<multipass::utils::Timer> timer;
+
+    std::map<QString, QString> mount_routes;
+    QString instance_name;
 };
 } // namespace cmd
 } // namespace multipass

--- a/src/client/cli/cmd/launch.h
+++ b/src/client/cli/cmd/launch.h
@@ -46,7 +46,7 @@ public:
 private:
     ParseCode parse_args(ArgParser* parser);
     ReturnCode request_launch(const ArgParser* parser);
-    ReturnCode mount(const ArgParser* parser, QString mount_source, QString mount_target);
+    ReturnCode mount(const ArgParser* parser, const QString& mount_source, const QString& mount_target);
     bool ask_bridge_permission(multipass::LaunchReply& reply);
 
     LaunchRequest request;

--- a/src/client/cli/cmd/launch.h
+++ b/src/client/cli/cmd/launch.h
@@ -54,7 +54,7 @@ private:
     std::unique_ptr<multipass::AnimatedSpinner> spinner;
     std::unique_ptr<multipass::utils::Timer> timer;
 
-    std::map<QString, QString> mount_routes;
+    std::vector<std::pair<QString, QString>> mount_routes;
     QString instance_name;
 };
 } // namespace cmd

--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -58,14 +58,17 @@ mp::ReturnCode cmd::Mount::run(mp::ArgParser* parser)
 
     mp::AnimatedSpinner spinner{cout};
 
-    auto on_success = [&spinner](mp::MountReply& reply) {
+    auto on_success = [this, &spinner](mp::MountReply& reply) {
         spinner.stop();
+        this->request.clear_target_paths();
+        this->request.clear_mount_maps();
         return ReturnCode::Ok;
     };
 
     auto on_failure = [this, &spinner](grpc::Status& status) {
         spinner.stop();
-
+        this->request.clear_target_paths();
+        this->request.clear_mount_maps();
         return standard_failure_handler_for(name(), cerr, status);
     };
 

--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -58,17 +58,13 @@ mp::ReturnCode cmd::Mount::run(mp::ArgParser* parser)
 
     mp::AnimatedSpinner spinner{cout};
 
-    auto on_success = [this, &spinner](mp::MountReply& reply) {
+    auto on_success = [&spinner](mp::MountReply& reply) {
         spinner.stop();
-        this->request.clear_target_paths();
-        this->request.clear_mount_maps();
         return ReturnCode::Ok;
     };
 
     auto on_failure = [this, &spinner](grpc::Status& status) {
         spinner.stop();
-        this->request.clear_target_paths();
-        this->request.clear_mount_maps();
         return standard_failure_handler_for(name(), cerr, status);
     };
 
@@ -160,25 +156,29 @@ mp::ParseCode cmd::Mount::parse_args(mp::ArgParser* parser)
     source_path = QDir(source_path).absolutePath();
     request.set_source_path(source_path.toStdString());
 
+    request.clear_target_paths();
     for (auto i = 1; i < parser->positionalArguments().count(); ++i)
     {
-        auto parsed_target = QString(parser->positionalArguments().at(i)).split(":", QString::SkipEmptyParts);
+        auto argument = parser->positionalArguments().at(i);
+        auto instance_name = argument.section(':', 0, 0, QString::SectionSkipEmpty);
+        auto target_path = argument.section(':', 1, -1, QString::SectionSkipEmpty);
 
         auto entry = request.add_target_paths();
-        entry->set_instance_name(parsed_target.at(0).toStdString());
+        entry->set_instance_name(instance_name.toStdString());
 
-        if (parsed_target.count() == 1)
+        if (target_path.isEmpty())
         {
             entry->set_target_path(source_path.toStdString());
         }
         else
         {
-            entry->set_target_path(parsed_target.at(1).toStdString());
+            entry->set_target_path(target_path.toStdString());
         }
     }
 
     QRegExp map_matcher("^([0-9]+[:][0-9]+)$");
 
+    request.clear_mount_maps();
     auto mount_maps = request.mutable_mount_maps();
 
     if (parser->isSet(uid_mappings))

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -532,7 +532,7 @@ TEST_F(Client, shellCmdSkipsAutomountWhenDisabled)
     EXPECT_CALL(mock_daemon, mount(_, _, _)).Times(0);
     EXPECT_CALL(mock_daemon, ssh_info(_, _, _)).WillOnce(Return(ok));
     EXPECT_THAT(send_command({"shell", petenv_name}, cout_stream), Eq(mp::ReturnCode::Ok));
-    EXPECT_THAT(cout_stream.str(), HasSubstr("Skipping 'Home' mount due to disabled mounts feature\n"));
+    EXPECT_THAT(cout_stream.str(), HasSubstr("Skipping mount due to disabled mounts feature\n"));
 }
 
 TEST_F(Client, shell_cmd_forwards_verbosity_to_subcommands)
@@ -845,7 +845,7 @@ TEST_F(Client, launchCmdSkipsAutomountWhenDisabled)
     EXPECT_CALL(mock_daemon, mount).Times(0);
 
     EXPECT_THAT(send_command({"launch", "--name", petenv_name}, cout_stream), Eq(mp::ReturnCode::Ok));
-    EXPECT_THAT(cout_stream.str(), HasSubstr("Skipping 'Home' mount due to disabled mounts feature\n"));
+    EXPECT_THAT(cout_stream.str(), HasSubstr("Skipping mount due to disabled mounts feature\n"));
 }
 
 TEST_F(Client, launchCmdOnlyWarnsMountForPetEnv)
@@ -856,7 +856,7 @@ TEST_F(Client, launchCmdOnlyWarnsMountForPetEnv)
     EXPECT_CALL(mock_daemon, launch(_, _, _)).WillOnce(Return(invalid_argument));
 
     EXPECT_THAT(send_command({"launch", "--name", ".asdf"}, cout_stream), Eq(mp::ReturnCode::CommandFail));
-    EXPECT_THAT(cout_stream.str(), Not(HasSubstr("Skipping 'Home' mount due to disabled mounts feature\n")));
+    EXPECT_THAT(cout_stream.str(), Not(HasSubstr("Skipping mount due to disabled mounts feature\n")));
 }
 
 TEST_F(Client, launchCmdFailsWhenUnableToRetrieveAutomountSetting)
@@ -1456,7 +1456,7 @@ TEST_F(Client, startCmdSkipsAutomountWhenDisabled)
     EXPECT_CALL(mock_daemon, mount(_, _, _)).Times(0);
     EXPECT_CALL(mock_daemon, start(_, _, _)).WillOnce(Return(ok));
     EXPECT_THAT(send_command({"start", petenv_name}, cout_stream), Eq(mp::ReturnCode::Ok));
-    EXPECT_THAT(cout_stream.str(), HasSubstr("Skipping 'Home' mount due to disabled mounts feature\n"));
+    EXPECT_THAT(cout_stream.str(), HasSubstr("Skipping mount due to disabled mounts feature\n"));
 }
 
 TEST_F(Client, start_cmd_forwards_verbosity_to_subcommands)


### PR DESCRIPTION
This adds the `--mount` option to the `launch` command. The syntax is `--mount <local-path>[:<instance-path>]`. If `<instance-path>` is omitted, it is the same as the absolute path of `<local-path>`. This option can be specified multiple times e.g. `multipass launch --mount /path/one --mount /path/two:two`.

In the case of the primary instance, which mounts the user's home directory to the `Home` directory inside the instance (`/home/user => Home`), if we specify the option `--mount /some/path:Home`, it will override the default mounting route of the primary instance (`/some/path => Home`).

fix #833