### PR TITLE
[client/common] Throw when unable to connect to daemon

### DIFF
--- a/src/client/common/client_common.cpp
+++ b/src/client/common/client_common.cpp
@@ -104,6 +104,15 @@ std::shared_ptr<grpc::Channel> create_channel_and_validate(const std::string& se
     mp::PingReply reply;
     auto status = stub.ping(&context, request, &reply);
 
+    // If the daemon cannot be connected to, throw here to keep the client from doing anything else and not
+    // create a new certificate.  The client will show an "unhandled exception", but that is OK in this
+    // instance since it's addressing a corner case and this code path will only run until the client
+    // establishes its cert for the daemon authentication. This whole function will be deprecated in the future.
+    if (status.error_code() == grpc::StatusCode::UNAVAILABLE)
+    {
+        throw std::runtime_error("Could not connect to the Multipass daemon. Please try again in a few moments.");
+    }
+
     return status.ok() ? rpc_channel : nullptr;
 }
 


### PR DESCRIPTION
In the logic to figure out if a cert has been accepted by the daemon, if the client cannot
establish a connection and get status if it's authenticated or not, it should just throw.

This will avoid the client from generating a new cert until communication with the daemon
is established.

Fixes #2552