### PR TITLE
[cli][transfer] allow for remote target to be a directory

### DIFF
--- a/tests/c_mock_defines.cmake
+++ b/tests/c_mock_defines.cmake
@@ -71,4 +71,5 @@ add_c_mocks(
   sftp_free
   sftp_get_error
   sftp_close
+  sftp_stat
 )

--- a/tests/mock_sftp.cpp
+++ b/tests/mock_sftp.cpp
@@ -26,4 +26,5 @@ extern "C"
     IMPL_MOCK_DEFAULT(3, sftp_read);
     IMPL_MOCK_DEFAULT(1, sftp_get_error);
     IMPL_MOCK_DEFAULT(1, sftp_close);
+    IMPL_MOCK_DEFAULT(2, sftp_stat);
 }

--- a/tests/mock_sftp.h
+++ b/tests/mock_sftp.h
@@ -30,5 +30,6 @@ DECL_MOCK(sftp_write);
 DECL_MOCK(sftp_read);
 DECL_MOCK(sftp_get_error);
 DECL_MOCK(sftp_close);
+DECL_MOCK(sftp_stat);
 
 #endif // MULTIPASS_MOCK_SFTP_H


### PR DESCRIPTION
This PR allow the `transfer` command to have a directory as the target, either locally or on an instance.

fix #1165 