### PR TITLE
Download image from mirror site

### DIFF
--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -51,14 +51,15 @@ constexpr auto bridged_network_name = "bridged";
 constexpr auto settings_extension = ".conf";
 constexpr auto daemon_settings_root = "local";
 
-constexpr auto petenv_key = "client.primary-name";     // This will eventually be moved to some dynamic settings schema
-constexpr auto driver_key = "local.driver";            // idem
-constexpr auto passphrase_key = "local.passphrase";    // idem
-constexpr auto bridged_interface_key = "local.bridged-network"; // idem
-constexpr auto mounts_key = "local.privileged-mounts"; // idem
-constexpr auto autostart_key = "client.gui.autostart"; // idem
+constexpr auto petenv_key = "client.primary-name";  // This will eventually be moved to some dynamic settings schema
+constexpr auto driver_key = "local.driver";         // idem
+constexpr auto passphrase_key = "local.passphrase"; // idem
+constexpr auto bridged_interface_key = "local.bridged-network";       // idem
+constexpr auto mounts_key = "local.privileged-mounts";                // idem
+constexpr auto autostart_key = "client.gui.autostart";                // idem
 constexpr auto winterm_key = "client.apps.windows-terminal.profiles"; // idem
 constexpr auto hotkey_key = "client.gui.hotkey";                      // idem
+constexpr auto mirror_key = "local.image.mirror";                     // idem; this defines the mirror of simple streams
 
 [[maybe_unused]] // hands off clang-format
 constexpr auto key_examples = {autostart_key, driver_key, mounts_key};

--- a/include/multipass/simple_streams_manifest.h
+++ b/include/multipass/simple_streams_manifest.h
@@ -28,6 +28,7 @@
 #include <QString>
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace multipass
@@ -35,11 +36,12 @@ namespace multipass
 
 struct SimpleStreamsManifest
 {
-    static std::unique_ptr<SimpleStreamsManifest> fromJson(const QByteArray& json, const QString& host_url);
+    static std::unique_ptr<SimpleStreamsManifest>
+    fromJson(const QByteArray& json, const std::optional<QByteArray>& json_from_mirror, const QString& host_url);
 
     const QString updated_at;
     const std::vector<VMImageInfo> products;
     const QMap<QString, const VMImageInfo*> image_records;
 };
-}
+} // namespace multipass
 #endif // MULTIPASS_SIMPLE_STREAMS_MANIFEST_H

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -38,6 +38,7 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -134,10 +135,12 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
         image_hosts.push_back(std::make_unique<mp::CustomVMImageHost>(QSysInfo::currentCpuArchitecture(),
                                                                       url_downloader.get(), manifest_ttl));
         image_hosts.push_back(std::make_unique<mp::UbuntuVMImageHost>(
-            std::vector<std::pair<std::string, std::string>>{
-                {mp::release_remote, "https://cloud-images.ubuntu.com/releases/"},
-                {mp::daily_remote, "https://cloud-images.ubuntu.com/daily/"},
-                {mp::appliance_remote, "https://cdimage.ubuntu.com/ubuntu-core/appliances/"}},
+            std::vector<std::pair<std::string, UbuntuVMImageRemote>>{
+                {mp::release_remote, UbuntuVMImageRemote{"https://cloud-images.ubuntu.com/", "releases/",
+                                                         std::make_optional<QString>(mp::mirror_key)}},
+                {mp::daily_remote, UbuntuVMImageRemote{"https://cloud-images.ubuntu.com/", "daily/",
+                                                       std::make_optional<QString>(mp::mirror_key)}},
+                {mp::appliance_remote, UbuntuVMImageRemote{"https://cdimage.ubuntu.com/", "ubuntu-core/appliances/"}}},
             url_downloader.get(), manifest_ttl));
     }
     if (vault == nullptr)

--- a/src/daemon/daemon_init_settings.cpp
+++ b/src/daemon/daemon_init_settings.cpp
@@ -59,6 +59,26 @@ QString driver_interpreter(QString val)
     return val;
 }
 
+QString image_mirror_interpreter(QString val)
+{
+    if (val.size() == 0)
+    {
+        return val;
+    }
+
+    if (!val.startsWith("https://"))
+    {
+        throw mp::InvalidSettingException(mp::mirror_key, val,
+                                          "The hostname of mirror must contain protocol name: https");
+    }
+
+    if (!val.endsWith("/"))
+    {
+        val.append("/");
+    }
+    return val;
+}
+
 } // namespace
 
 void mp::daemon::monitor_and_quit_on_settings_change() // temporary
@@ -79,6 +99,7 @@ void mp::daemon::register_global_settings_handlers()
     settings.insert(std::make_unique<CustomSettingSpec>(mp::passphrase_key, "", [](QString val) {
         return val.isEmpty() ? val : MP_UTILS.generate_scrypt_hash_for(val);
     }));
+    settings.insert(std::make_unique<CustomSettingSpec>(mp::mirror_key, "", image_mirror_interpreter));
 
     MP_SETTINGS.register_handler(
         std::make_unique<PersistentSettingsHandler>(persistent_settings_filename(), std::move(settings)));

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -326,7 +326,8 @@ std::string mp::UbuntuVMImageHost::remote_url_from(const std::string& remote_nam
     return url;
 }
 
-mp::UbuntuVMImageRemote::UbuntuVMImageRemote(std::string official_host, std::string uri, std::optional<QString> mirror_key)
+mp::UbuntuVMImageRemote::UbuntuVMImageRemote(std::string official_host, std::string uri,
+                                             std::optional<QString> mirror_key)
     : official_host(std::move(official_host)), uri(std::move(uri)), mirror_key(std::move(mirror_key))
 {
 }

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -34,10 +34,11 @@ constexpr auto daily_remote = "daily";
 constexpr auto appliance_remote = "appliance";
 
 class URLDownloader;
+class UbuntuVMImageRemote;
 class UbuntuVMImageHost final : public CommonVMImageHost
 {
 public:
-    UbuntuVMImageHost(std::vector<std::pair<std::string, std::string>> remotes, URLDownloader* downloader,
+    UbuntuVMImageHost(std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes, URLDownloader* downloader,
                       std::chrono::seconds manifest_time_to_live);
 
     std::optional<VMImageInfo> info_for(const Query& query) override;
@@ -56,9 +57,22 @@ private:
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> manifests;
     URLDownloader* const url_downloader;
-    std::vector<std::pair<std::string, std::string>> remotes;
+    std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes;
     std::string remote_url_from(const std::string& remote_name);
     QString index_path;
+};
+class UbuntuVMImageRemote
+{
+public:
+    UbuntuVMImageRemote(std::string official_host, std::string uri, std::optional<QString> mirror_key = std::nullopt);
+    const QString get_url() const;
+    const QString get_official_url() const;
+    const std::optional<QString> get_mirror_url() const;
+
+private:
+    const std::string official_host;
+    const std::string uri;
+    const std::optional<QString> mirror_key;
 };
 } // namespace multipass
 #endif // MULTIPASS_UBUNTU_IMAGE_HOST_H

--- a/tests/path.cpp
+++ b/tests/path.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "path.h"
+#include <multipass/format.h>
 
 #include <QCoreApplication>
 #include <QDir>
@@ -37,6 +38,14 @@ QString mpt::test_data_path_for(const char* file_name)
 {
     QDir dir{test_data_path()};
     return dir.filePath(file_name);
+}
+
+QString mpt::test_data_sub_dir_path(const char* dir_name)
+{
+    QDir dir{test_data_path()};
+    if (!dir.cd(dir_name))
+        throw std::runtime_error(fmt::format("could not find sub dir '{}' under test_data directory", dir_name));
+    return QDir::toNativeSeparators(dir.path()) + QDir::separator();
 }
 
 std::string mpt::mock_bin_path()

--- a/tests/path.h
+++ b/tests/path.h
@@ -28,7 +28,8 @@ namespace test
 {
 QString test_data_path();
 QString test_data_path_for(const char* file_name);
+QString test_data_sub_dir_path(const char* dir_name);
 std::string mock_bin_path();
-}
-}
+} // namespace test
+} // namespace multipass
 #endif // MULTIPASS_TEST_DATA_PATH_H

--- a/tests/test_data/invalid_image_mirror/releases/multiple_versions_manifest.json.in
+++ b/tests/test_data/invalid_image_mirror/releases/multiple_versions_manifest.json.in
@@ -1,0 +1,145 @@
+{
+  "content_id": "com.ubuntu.cloud:released:download",
+  "datatype": "image-downloads",
+  "format": "products:1.0",
+  "license": "http://www.canonical.com/intellectual-property-policy",
+  "products": {
+    "com.ubuntu.cloud:server:16.04:@MANIFEST_ARCH@": {
+      "aliases": "16.04,default,lts,x,xenial",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "xenial",
+      "release_codename": "Xenial Xerus",
+      "release_title": "16.04 LTS",
+      "support_eol": "2021-04-21",
+      "supported": true,
+      "version": "16.04",
+      "versions": {
+        "20170516": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "7388b8e7e0e114b941a04aca591e2d64",
+              "path": "test_image.img",
+              "sha256": "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac-invalid",
+              "size": 287440896
+            },
+            "lxd.tar.xz": {
+              "combined_rootxz_sha256": "b3c610b6111725a05ae3089e177281695d10a64cfc75ce03b0a17e0f999519e6",
+              "combined_sha256": "b3c610b6111725a05ae3089e177281695d10a64cfc75ce03b0a17e0f999519e6",
+              "combined_squashfs_sha256": "8fa08537ae51c880966626561987153e72d073cbe19dfe5abc062713d929254d",
+              "ftype": "lxd.tar.xz",
+              "md5": "c63c6c383e656348a2db25ad31f1bda9",
+              "path": "server/releases/xenial/release-20170516/ubuntu-16.04-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "0f95800385b5e6ab5fec7d3ca88a6a070cd0da1130c9219713980c365ea82613-invalid",
+              "size": 840
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-xenial-16.04-@MANIFEST_ARCH@-server-20170516"
+        },
+        "20170619.1": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "d242cdf7b3857befd3b0271f5189ce76",
+              "path": "newest_image.img",
+              "sha256": "8842e7a8adb01c7a30cc702b01a5330a1951b12042816e87efd24b61c5e2239f-invalid",
+              "size": 287506432
+            }
+          }
+        }
+      }
+    },
+    "com.ubuntu.cloud:server:17.04:@MANIFEST_ARCH@": {
+      "aliases": "17.04,z,zesty",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "zesty",
+      "release_codename": "Zesty Zapus",
+      "release_title": "17.04",
+      "support_eol": "2018-01-25",
+      "supported": true,
+      "version": "17.04",
+      "versions": {
+        "20170615": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "09c2956086ac88c73be7d9bb232b6137",
+              "path": "server/releases/zesty/release-20170615/ubuntu-17.04-server-cloudimg-@MANIFEST_ARCH@.img",
+              "sha256": "1507bd2b3288ef4bacd3e699fe71b827b7ccf321ec4487e168a30d7089d3c8e4-invalid",
+              "size": 346423296
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "55a10140362cd682ea21b5093209c480916bea18eef53598f62d05c41f61121b",
+              "ftype": "lxd.tar.xz",
+              "md5": "3fbdb62ade9b4271eadccee0297cc399",
+              "path": "server/releases/zesty/release-20170615/ubuntu-17.04-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "d201d07d85eb84371d598cb74a34ab4664bec60f6a3b3467bf81d520448124a5-invalid",
+              "size": 844
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-zesty-17.04-@MANIFEST_ARCH@-server-20170615"
+        },
+        "20170619.1": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "cc2bc360fec3086edcd4e69d7d8113fc",
+              "path": "zesty_newest.img",
+              "sha256": "ab115b83e7a8bebf3d3a02bf55ad0cb75a0ed515fcbc65fb0c9abe76c752921c",
+              "size": 346882048
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "f50337be60f7fce4ddd71397285490115e208aeb37565b8d77529cb352cdad05",
+              "ftype": "lxd.tar.xz",
+              "md5": "21a945923eff127e1553d581c8872bb6",
+              "path": "server/releases/zesty/release-20170619.1/ubuntu-17.04-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "c258ec70a733b5ea22c7b8a608d2b2e95fb1cf6ec01e0ffba367bd46baf1f8e1-invalid",
+              "size": 848
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-zesty-17.04-@MANIFEST_ARCH@-server-20170619.1"
+        }
+      }
+    },
+    "com.ubuntu.cloud:server:17.10:@MANIFEST_ARCH@": {
+      "aliases": "17.10,a,artful",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "artful",
+      "release_codename": "Artful Aardvark",
+      "release_title": "17.10",
+      "support_eol": "2018-07-19",
+      "supported": false,
+      "version": "17.10",
+      "versions": {
+        "20171017": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "2d011144148d71d2745d0c5be6e785ab",
+              "path": "server/releases/artful/release-20171017/ubuntu-17.10-server-cloudimg-@MANIFEST_ARCH@.img",
+              "sha256": "520224efaaf49b15a976b49c7ce7f2bd2e5b161470d684b37a838933595c0520-invalid",
+              "size": 317849600
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "d6b33e50f42d129cdd0d3ef0b267d79012e382380deb30f6e22b5f9910a1e8ec",
+              "ftype": "lxd.tar.xz",
+              "md5": "15241f00869ffebbeff53bc020b562c7",
+              "path": "server/releases/artful/release-20171017/ubuntu-17.10-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "d421060416078ea4ec3a25953dd66b87efc937ef5edb16e64f9cb7ba9b8fad0a-invalid",
+              "size": 776
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-artful-17.10-@MANIFEST_ARCH@-server-20171017"
+        }
+      }
+    }
+  },
+  "updated": "Thu, 18 May 2017 09:18:01 +0000"
+}

--- a/tests/test_data/invalid_image_mirror/releases/streams/v1/index.json.in
+++ b/tests/test_data/invalid_image_mirror/releases/streams/v1/index.json.in
@@ -1,0 +1,15 @@
+{
+  "index": {
+    "com.ubuntu.cloud:released:download": {
+      "datatype": "image-downloads",
+      "path": "multiple_versions_manifest.json",
+      "updated": "Thu, 18 May 2017 09:18:01 +0000",
+      "products": [
+        "com.ubuntu.cloud:server:16.04:@MANIFEST_ARCH@"
+      ],
+      "format": "products:1.0"
+    },
+    "updated": "Thu, 18 May 2017 12:08:59 +0000",
+    "format": "index:1.0"
+  }
+}

--- a/tests/test_data/valid_image_mirror/releases/multiple_versions_manifest.json.in
+++ b/tests/test_data/valid_image_mirror/releases/multiple_versions_manifest.json.in
@@ -1,0 +1,145 @@
+{
+  "content_id": "com.ubuntu.cloud:released:download",
+  "datatype": "image-downloads",
+  "format": "products:1.0",
+  "license": "http://www.canonical.com/intellectual-property-policy",
+  "products": {
+    "com.ubuntu.cloud:server:16.04:@MANIFEST_ARCH@": {
+      "aliases": "16.04,default,lts,x,xenial",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "xenial",
+      "release_codename": "Xenial Xerus",
+      "release_title": "16.04 LTS",
+      "support_eol": "2021-04-21",
+      "supported": true,
+      "version": "16.04",
+      "versions": {
+        "20170516": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "7388b8e7e0e114b941a04aca591e2d64",
+              "path": "test_image.img",
+              "sha256": "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac",
+              "size": 287440896
+            },
+            "lxd.tar.xz": {
+              "combined_rootxz_sha256": "b3c610b6111725a05ae3089e177281695d10a64cfc75ce03b0a17e0f999519e6",
+              "combined_sha256": "b3c610b6111725a05ae3089e177281695d10a64cfc75ce03b0a17e0f999519e6",
+              "combined_squashfs_sha256": "8fa08537ae51c880966626561987153e72d073cbe19dfe5abc062713d929254d",
+              "ftype": "lxd.tar.xz",
+              "md5": "c63c6c383e656348a2db25ad31f1bda9",
+              "path": "server/releases/xenial/release-20170516/ubuntu-16.04-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "0f95800385b5e6ab5fec7d3ca88a6a070cd0da1130c9219713980c365ea82613",
+              "size": 840
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-xenial-16.04-@MANIFEST_ARCH@-server-20170516"
+        },
+        "20170619.1": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "d242cdf7b3857befd3b0271f5189ce76",
+              "path": "newest_image.img",
+              "sha256": "8842e7a8adb01c7a30cc702b01a5330a1951b12042816e87efd24b61c5e2239f",
+              "size": 287506432
+            }
+          }
+        }
+      }
+    },
+    "com.ubuntu.cloud:server:17.04:@MANIFEST_ARCH@": {
+      "aliases": "17.04,z,zesty",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "zesty",
+      "release_codename": "Zesty Zapus",
+      "release_title": "17.04",
+      "support_eol": "2018-01-25",
+      "supported": true,
+      "version": "17.04",
+      "versions": {
+        "20170615": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "09c2956086ac88c73be7d9bb232b6137",
+              "path": "server/releases/zesty/release-20170615/ubuntu-17.04-server-cloudimg-@MANIFEST_ARCH@.img",
+              "sha256": "1507bd2b3288ef4bacd3e699fe71b827b7ccf321ec4487e168a30d7089d3c8e4",
+              "size": 346423296
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "55a10140362cd682ea21b5093209c480916bea18eef53598f62d05c41f61121b",
+              "ftype": "lxd.tar.xz",
+              "md5": "3fbdb62ade9b4271eadccee0297cc399",
+              "path": "server/releases/zesty/release-20170615/ubuntu-17.04-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "d201d07d85eb84371d598cb74a34ab4664bec60f6a3b3467bf81d520448124a5",
+              "size": 844
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-zesty-17.04-@MANIFEST_ARCH@-server-20170615"
+        },
+        "20170619.1": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "cc2bc360fec3086edcd4e69d7d8113fc",
+              "path": "zesty_newest.img",
+              "sha256": "ab115b83e7a8bebf3d3a02bf55ad0cb75a0ed515fcbc65fb0c9abe76c752921c",
+              "size": 346882048
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "f50337be60f7fce4ddd71397285490115e208aeb37565b8d77529cb352cdad05",
+              "ftype": "lxd.tar.xz",
+              "md5": "21a945923eff127e1553d581c8872bb6",
+              "path": "server/releases/zesty/release-20170619.1/ubuntu-17.04-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "c258ec70a733b5ea22c7b8a608d2b2e95fb1cf6ec01e0ffba367bd46baf1f8e1",
+              "size": 848
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-zesty-17.04-@MANIFEST_ARCH@-server-20170619.1"
+        }
+      }
+    },
+    "com.ubuntu.cloud:server:17.10:@MANIFEST_ARCH@": {
+      "aliases": "17.10,a,artful",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "artful",
+      "release_codename": "Artful Aardvark",
+      "release_title": "17.10",
+      "support_eol": "2018-07-19",
+      "supported": false,
+      "version": "17.10",
+      "versions": {
+        "20171017": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "2d011144148d71d2745d0c5be6e785ab",
+              "path": "server/releases/artful/release-20171017/ubuntu-17.10-server-cloudimg-@MANIFEST_ARCH@.img",
+              "sha256": "520224efaaf49b15a976b49c7ce7f2bd2e5b161470d684b37a838933595c0520",
+              "size": 317849600
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "d6b33e50f42d129cdd0d3ef0b267d79012e382380deb30f6e22b5f9910a1e8ec",
+              "ftype": "lxd.tar.xz",
+              "md5": "15241f00869ffebbeff53bc020b562c7",
+              "path": "server/releases/artful/release-20171017/ubuntu-17.10-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "d421060416078ea4ec3a25953dd66b87efc937ef5edb16e64f9cb7ba9b8fad0a",
+              "size": 776
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-artful-17.10-@MANIFEST_ARCH@-server-20171017"
+        }
+      }
+    }
+  },
+  "updated": "Thu, 18 May 2017 09:18:01 +0000"
+}

--- a/tests/test_data/valid_image_mirror/releases/streams/v1/index.json.in
+++ b/tests/test_data/valid_image_mirror/releases/streams/v1/index.json.in
@@ -1,0 +1,15 @@
+{
+  "index": {
+    "com.ubuntu.cloud:released:download": {
+      "datatype": "image-downloads",
+      "path": "multiple_versions_manifest.json",
+      "updated": "Thu, 18 May 2017 09:18:01 +0000",
+      "products": [
+        "com.ubuntu.cloud:server:16.04:@MANIFEST_ARCH@"
+      ],
+      "format": "products:1.0"
+    },
+    "updated": "Thu, 18 May 2017 12:08:59 +0000",
+    "format": "index:1.0"
+  }
+}

--- a/tests/test_data/valid_outdated_image_mirror/releases/multiple_versions_manifest.json.in
+++ b/tests/test_data/valid_outdated_image_mirror/releases/multiple_versions_manifest.json.in
@@ -1,0 +1,113 @@
+{
+  "content_id": "com.ubuntu.cloud:released:download",
+  "datatype": "image-downloads",
+  "format": "products:1.0",
+  "license": "http://www.canonical.com/intellectual-property-policy",
+  "products": {
+    "com.ubuntu.cloud:server:16.04:@MANIFEST_ARCH@": {
+      "aliases": "16.04,default,lts,x,xenial",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "xenial",
+      "release_codename": "Xenial Xerus",
+      "release_title": "16.04 LTS",
+      "support_eol": "2021-04-21",
+      "supported": true,
+      "version": "16.04",
+      "versions": {
+        "20170516": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "7388b8e7e0e114b941a04aca591e2d64",
+              "path": "test_image.img",
+              "sha256": "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac",
+              "size": 287440896
+            },
+            "lxd.tar.xz": {
+              "combined_rootxz_sha256": "b3c610b6111725a05ae3089e177281695d10a64cfc75ce03b0a17e0f999519e6",
+              "combined_sha256": "b3c610b6111725a05ae3089e177281695d10a64cfc75ce03b0a17e0f999519e6",
+              "combined_squashfs_sha256": "8fa08537ae51c880966626561987153e72d073cbe19dfe5abc062713d929254d",
+              "ftype": "lxd.tar.xz",
+              "md5": "c63c6c383e656348a2db25ad31f1bda9",
+              "path": "server/releases/xenial/release-20170516/ubuntu-16.04-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "0f95800385b5e6ab5fec7d3ca88a6a070cd0da1130c9219713980c365ea82613",
+              "size": 840
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-xenial-16.04-@MANIFEST_ARCH@-server-20170516"
+        }
+      }
+    },
+    "com.ubuntu.cloud:server:17.04:@MANIFEST_ARCH@": {
+      "aliases": "17.04,z,zesty",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "zesty",
+      "release_codename": "Zesty Zapus",
+      "release_title": "17.04",
+      "support_eol": "2018-01-25",
+      "supported": true,
+      "version": "17.04",
+      "versions": {
+        "20170615": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "09c2956086ac88c73be7d9bb232b6137",
+              "path": "server/releases/zesty/release-20170615/ubuntu-17.04-server-cloudimg-@MANIFEST_ARCH@.img",
+              "sha256": "1507bd2b3288ef4bacd3e699fe71b827b7ccf321ec4487e168a30d7089d3c8e4",
+              "size": 346423296
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "55a10140362cd682ea21b5093209c480916bea18eef53598f62d05c41f61121b",
+              "ftype": "lxd.tar.xz",
+              "md5": "3fbdb62ade9b4271eadccee0297cc399",
+              "path": "server/releases/zesty/release-20170615/ubuntu-17.04-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "d201d07d85eb84371d598cb74a34ab4664bec60f6a3b3467bf81d520448124a5",
+              "size": 844
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-zesty-17.04-@MANIFEST_ARCH@-server-20170615"
+        }
+      }
+    },
+    "com.ubuntu.cloud:server:17.10:@MANIFEST_ARCH@": {
+      "aliases": "17.10,a,artful",
+      "arch": "@MANIFEST_ARCH@",
+      "os": "ubuntu",
+      "release": "artful",
+      "release_codename": "Artful Aardvark",
+      "release_title": "17.10",
+      "support_eol": "2018-07-19",
+      "supported": false,
+      "version": "17.10",
+      "versions": {
+        "20171017": {
+          "items": {
+            "disk1.img": {
+              "ftype": "disk1.img",
+              "md5": "2d011144148d71d2745d0c5be6e785ab",
+              "path": "server/releases/artful/release-20171017/ubuntu-17.10-server-cloudimg-@MANIFEST_ARCH@.img",
+              "sha256": "520224efaaf49b15a976b49c7ce7f2bd2e5b161470d684b37a838933595c0520",
+              "size": 317849600
+            },
+            "lxd.tar.xz": {
+              "combined_squashfs_sha256": "d6b33e50f42d129cdd0d3ef0b267d79012e382380deb30f6e22b5f9910a1e8ec",
+              "ftype": "lxd.tar.xz",
+              "md5": "15241f00869ffebbeff53bc020b562c7",
+              "path": "server/releases/artful/release-20171017/ubuntu-17.10-server-cloudimg-@MANIFEST_ARCH@-lxd.tar.xz",
+              "sha256": "d421060416078ea4ec3a25953dd66b87efc937ef5edb16e64f9cb7ba9b8fad0a",
+              "size": 776
+            }
+          },
+          "label": "release",
+          "pubname": "ubuntu-artful-17.10-@MANIFEST_ARCH@-server-20171017"
+        }
+      }
+    }
+  },
+  "updated": "Thu, 18 May 2017 09:18:01 +0000"
+}

--- a/tests/test_data/valid_outdated_image_mirror/releases/streams/v1/index.json.in
+++ b/tests/test_data/valid_outdated_image_mirror/releases/streams/v1/index.json.in
@@ -1,0 +1,15 @@
+{
+  "index": {
+    "com.ubuntu.cloud:released:download": {
+      "datatype": "image-downloads",
+      "path": "multiple_versions_manifest.json",
+      "updated": "Thu, 18 May 2017 09:18:01 +0000",
+      "products": [
+        "com.ubuntu.cloud:server:16.04:@MANIFEST_ARCH@"
+      ],
+      "format": "products:1.0"
+    },
+    "updated": "Thu, 18 May 2017 12:08:59 +0000",
+    "format": "index:1.0"
+  }
+}

--- a/tests/test_simple_streams_manifest.cpp
+++ b/tests/test_simple_streams_manifest.cpp
@@ -23,6 +23,8 @@
 #include <multipass/exceptions/manifest_exceptions.h>
 #include <multipass/simple_streams_manifest.h>
 
+#include <optional>
+
 namespace mp = multipass;
 namespace mpt = multipass::test;
 
@@ -46,7 +48,7 @@ struct TestSimpleStreamsManifest : public Test
 TEST_F(TestSimpleStreamsManifest, can_parse_image_info)
 {
     auto json = mpt::load_test_file("good_manifest.json");
-    auto manifest = mp::SimpleStreamsManifest::fromJson(json, "");
+    auto manifest = mp::SimpleStreamsManifest::fromJson(json, std::nullopt, "");
 
     EXPECT_THAT(manifest->updated_at, Eq("Wed, 20 May 2020 16:47:50 +0000"));
     EXPECT_THAT(manifest->products.size(), Eq(2u));
@@ -60,7 +62,7 @@ TEST_F(TestSimpleStreamsManifest, can_find_info_by_alias)
 {
     auto json = mpt::load_test_file("good_manifest.json");
     const auto host_url{"http://stream/url"};
-    auto manifest = mp::SimpleStreamsManifest::fromJson(json, host_url);
+    auto manifest = mp::SimpleStreamsManifest::fromJson(json, std::nullopt, host_url);
 
     const QString expected_id{"1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac"};
     const QString expected_location =
@@ -76,34 +78,34 @@ TEST_F(TestSimpleStreamsManifest, can_find_info_by_alias)
 TEST_F(TestSimpleStreamsManifest, throws_on_invalid_json)
 {
     QByteArray json;
-    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, ""), mp::GenericManifestException);
+    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, std::nullopt, ""), mp::GenericManifestException);
 }
 
 TEST_F(TestSimpleStreamsManifest, throws_on_invalid_top_level_type)
 {
     auto json = mpt::load_test_file("invalid_top_level.json");
-    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, ""), mp::GenericManifestException);
+    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, std::nullopt, ""), mp::GenericManifestException);
 }
 
 TEST_F(TestSimpleStreamsManifest, throws_when_missing_products)
 {
     auto json = mpt::load_test_file("missing_products_manifest.json");
-    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, ""), mp::GenericManifestException);
+    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, std::nullopt, ""), mp::GenericManifestException);
 }
 
 TEST_F(TestSimpleStreamsManifest, throws_when_failed_to_parse_any_products)
 {
     auto json = mpt::load_test_file("missing_versions_manifest.json");
-    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, ""), mp::EmptyManifestException);
+    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, std::nullopt, ""), mp::EmptyManifestException);
 
     json = mpt::load_test_file("missing_versions_manifest.json");
-    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, ""), mp::EmptyManifestException);
+    EXPECT_THROW(mp::SimpleStreamsManifest::fromJson(json, std::nullopt, ""), mp::EmptyManifestException);
 }
 
 TEST_F(TestSimpleStreamsManifest, chooses_newest_version)
 {
     auto json = mpt::load_test_file("releases/multiple_versions_manifest.json");
-    auto manifest = mp::SimpleStreamsManifest::fromJson(json, "");
+    auto manifest = mp::SimpleStreamsManifest::fromJson(json, std::nullopt, "");
 
     const QString expected_id{"8842e7a8adb01c7a30cc702b01a5330a1951b12042816e87efd24b61c5e2239f"};
     const QString expected_location{"newest_image.img"};
@@ -117,7 +119,7 @@ TEST_F(TestSimpleStreamsManifest, chooses_newest_version)
 TEST_F(TestSimpleStreamsManifest, can_query_all_versions)
 {
     auto json = mpt::load_test_file("releases/multiple_versions_manifest.json");
-    auto manifest = mp::SimpleStreamsManifest::fromJson(json, "");
+    auto manifest = mp::SimpleStreamsManifest::fromJson(json, std::nullopt, "");
 
     QStringList all_known_hashes;
     all_known_hashes << "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac"
@@ -135,7 +137,7 @@ TEST_F(TestSimpleStreamsManifest, can_query_all_versions)
 TEST_F(TestSimpleStreamsManifest, info_has_kernel_and_initrd_paths)
 {
     auto json = mpt::load_test_file("good_manifest.json");
-    auto manifest = mp::SimpleStreamsManifest::fromJson(json, "");
+    auto manifest = mp::SimpleStreamsManifest::fromJson(json, std::nullopt, "");
 
     const auto info = manifest->image_records["default"];
     ASSERT_THAT(info, NotNull());
@@ -149,7 +151,7 @@ TEST_F(TestSimpleStreamsManifest, LXDDriverReturnsExpectedData)
     EXPECT_CALL(mock_settings, get(Eq(mp::driver_key))).WillRepeatedly(Return("lxd"));
 
     auto json = mpt::load_test_file("lxd_test_manifest.json");
-    auto manifest = mp::SimpleStreamsManifest::fromJson(json, "");
+    auto manifest = mp::SimpleStreamsManifest::fromJson(json, std::nullopt, "");
 
     EXPECT_EQ(manifest->products.size(), 2u);
 


### PR DESCRIPTION
Hi team, I would like to present a PR for issue: https://github.com/canonical/multipass/issues/717

**Feature: mirror of cloud images**

By setting `local.image.mirror`, users can download images from mirror sites instead of the official one. The feature can be disabled by leaving the config empty.

**Implementation**

When updating product versions, it will choose the manifest from mirror site if possible. Since mirror sites is syncing with official site periodically, the latest version in official site may not exist in mirror sites.

Only if the content of a version is *identical* to the same version from official site, it will be updated into the `manifests` cache of `UbuntuVMImageHost` instance.