### PR TITLE
Add cpu count to info cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ State:          RUNNING
 IPv4:           10.125.174.247
 Release:        Ubuntu 18.04.1 LTS
 Image hash:     19e9853d8267 (Ubuntu 18.04 LTS)
+CPU(s):         1
 Load:           0.97 0.30 0.10
 Disk usage:     1.1G out of 4.7G
 Memory usage:   85.1M out of 985.4M

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -27,8 +27,9 @@ std::string mp::CSVFormatter::format(const InfoReply& reply) const
 {
     fmt::memory_buffer buf;
     fmt::format_to(
-        buf, "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory usage,Memory "
-             "total,Mounts,AllIPv4\n");
+        buf,
+        "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory usage,Memory "
+        "total,Mounts,AllIPv4\n");
 
     for (const auto& info : format::sorted(reply.info()))
     {
@@ -93,7 +94,9 @@ std::string mp::CSVFormatter::format(const FindReply& reply) const
 
         mp::format::filter_aliases(aliases);
 
-        auto image_id = aliases[0].remote_name().empty() ? aliases[0].alias() : fmt::format("{}:{}", aliases[0].remote_name(), aliases[0].alias());
+        auto image_id = aliases[0].remote_name().empty()
+                            ? aliases[0].alias()
+                            : fmt::format("{}:{}", aliases[0].remote_name(), aliases[0].alias());
         fmt::format_to(buf, "{},{},{},{},{},{}\n", image_id, aliases[0].remote_name(),
                        fmt::join(aliases.cbegin() + 1, aliases.cend(), ";"), image.os(), image.release(),
                        image.version());

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -27,15 +27,16 @@ std::string mp::CSVFormatter::format(const InfoReply& reply) const
 {
     fmt::memory_buffer buf;
     fmt::format_to(
-        buf, "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,Load,Disk usage,Disk total,Memory usage,Memory "
+        buf, "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory usage,Memory "
              "total,Mounts,AllIPv4\n");
 
     for (const auto& info : format::sorted(reply.info()))
     {
-        fmt::format_to(buf, "{},{},{},{},{},{},{},{},{},{},{},{},", info.name(),
+        fmt::format_to(buf, "{},{},{},{},{},{},{},{},{},{},{},{},{},", info.name(),
                        mp::format::status_string_for(info.instance_status()), info.ipv4_size() ? info.ipv4(0) : "",
                        info.ipv6_size() ? info.ipv6(0) : "", info.current_release(), info.id(), info.image_release(),
-                       info.load(), info.disk_usage(), info.disk_total(), info.memory_usage(), info.memory_total());
+                       info.cpu_count(), info.load(), info.disk_usage(), info.disk_total(), info.memory_usage(),
+                       info.memory_total());
 
         auto mount_paths = info.mount_info().mount_paths();
         for (auto mount = mount_paths.cbegin(); mount != mount_paths.cend(); ++mount)

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -27,17 +27,15 @@ std::string mp::CSVFormatter::format(const InfoReply& reply) const
 {
     fmt::memory_buffer buf;
     fmt::format_to(
-        buf,
-        "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory usage,Memory "
-        "total,Mounts,AllIPv4\n");
+        buf, "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,Load,Disk usage,Disk total,Memory usage,Memory "
+             "total,Mounts,AllIPv4,CPU(s)\n");
 
     for (const auto& info : format::sorted(reply.info()))
     {
-        fmt::format_to(buf, "{},{},{},{},{},{},{},{},{},{},{},{},{},", info.name(),
+        fmt::format_to(buf, "{},{},{},{},{},{},{},{},{},{},{},{},", info.name(),
                        mp::format::status_string_for(info.instance_status()), info.ipv4_size() ? info.ipv4(0) : "",
                        info.ipv6_size() ? info.ipv6(0) : "", info.current_release(), info.id(), info.image_release(),
-                       info.cpu_count(), info.load(), info.disk_usage(), info.disk_total(), info.memory_usage(),
-                       info.memory_total());
+                       info.load(), info.disk_usage(), info.disk_total(), info.memory_usage(), info.memory_total());
 
         auto mount_paths = info.mount_info().mount_paths();
         for (auto mount = mount_paths.cbegin(); mount != mount_paths.cend(); ++mount)
@@ -45,7 +43,7 @@ std::string mp::CSVFormatter::format(const InfoReply& reply) const
             fmt::format_to(buf, "{} => {};", mount->source_path(), mount->target_path());
         }
 
-        fmt::format_to(buf, ",\"{}\"\n", fmt::join(info.ipv4(), ","));
+        fmt::format_to(buf, ",\"{}\";,{}\n", fmt::join(info.ipv4(), ","), info.cpu_count());
     }
     return fmt::to_string(buf);
 }

--- a/src/client/cli/formatter/json_formatter.cpp
+++ b/src/client/cli/formatter/json_formatter.cpp
@@ -41,6 +41,7 @@ std::string mp::JsonFormatter::format(const InfoReply& reply) const
         instance_info.insert("image_hash", QString::fromStdString(info.id()));
         instance_info.insert("image_release", QString::fromStdString(info.image_release()));
         instance_info.insert("release", QString::fromStdString(info.current_release()));
+        instance_info.insert("cpu_count", QString::fromStdString(info.cpu_count()));
 
         QJsonArray load;
         if (!info.load().empty())

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -82,6 +82,7 @@ std::string mp::TableFormatter::format(const InfoReply& reply) const
         else
             fmt::format_to(buf, "{}{}\n", info.id().substr(0, 12),
                            !info.image_release().empty() ? fmt::format(" (Ubuntu {})", info.image_release()) : "");
+        fmt::format_to(buf, "{:<16}{}\n", "CPU(s):", info.cpu_count().empty() ? "--" : info.cpu_count());
         fmt::format_to(buf, "{:<16}{}\n", "Load:", info.load().empty() ? "--" : info.load());
         fmt::format_to(buf, "{:<16}{}\n", "Disk usage:", to_usage(info.disk_usage(), info.disk_total()));
         fmt::format_to(buf, "{:<16}{}\n", "Memory usage:", to_usage(info.memory_usage(), info.memory_total()));

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -48,6 +48,10 @@ std::string mp::YamlFormatter::format(const InfoReply& reply) const
             instance_node["release"] = YAML::Null;
         else
             instance_node["release"] = info.current_release();
+        
+        instance_node["cpu_count"] = YAML::Null;
+        if (!info.cpu_count().empty())
+            instance_node["cpu_count"] = info.cpu_count();
 
         if (!info.load().empty())
         {

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -48,7 +48,7 @@ std::string mp::YamlFormatter::format(const InfoReply& reply) const
             instance_node["release"] = YAML::Null;
         else
             instance_node["release"] = info.current_release();
-        
+
         instance_node["cpu_count"] = YAML::Null;
         if (!info.cpu_count().empty())
             instance_node["cpu_count"] = info.cpu_count();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1293,6 +1293,8 @@ try // clang-format on
                 session, "df --output=used `awk '$2 == \"/\" { print $1 }' /proc/mounts` -B1 | sed 1d"));
             info->set_disk_total(mpu::run_in_ssh_session(
                 session, "df --output=size `awk '$2 == \"/\" { print $1 }' /proc/mounts` -B1 | sed 1d"));
+            info->set_cpu_count(mpu::run_in_ssh_session(
+                session, "cat /proc/cpuinfo | grep -m 1 'cpu cores' | awk '{printf $4}'"));
 
             std::string management_ip = vm->management_ipv4();
             auto all_ipv4 = vm->get_all_ipv4(*config->ssh_key_provider);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1293,8 +1293,8 @@ try // clang-format on
                 session, "df --output=used `awk '$2 == \"/\" { print $1 }' /proc/mounts` -B1 | sed 1d"));
             info->set_disk_total(mpu::run_in_ssh_session(
                 session, "df --output=size `awk '$2 == \"/\" { print $1 }' /proc/mounts` -B1 | sed 1d"));
-            info->set_cpu_count(mpu::run_in_ssh_session(
-                session, "cat /proc/cpuinfo | grep -m 1 'cpu cores' | awk '{printf $4}'"));
+            info->set_cpu_count(
+                mpu::run_in_ssh_session(session, "cat /proc/cpuinfo | grep -m 1 'cpu cores' | awk '{printf $4}'"));
 
             std::string management_ip = vm->management_ipv4();
             auto all_ipv4 = vm->get_all_ipv4(*config->ssh_key_provider);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1293,8 +1293,7 @@ try // clang-format on
                 session, "df --output=used `awk '$2 == \"/\" { print $1 }' /proc/mounts` -B1 | sed 1d"));
             info->set_disk_total(mpu::run_in_ssh_session(
                 session, "df --output=size `awk '$2 == \"/\" { print $1 }' /proc/mounts` -B1 | sed 1d"));
-            info->set_cpu_count(
-                mpu::run_in_ssh_session(session, "cat /proc/cpuinfo | grep -m 1 'cpu cores' | awk '{printf $4}'"));
+            info->set_cpu_count(mpu::run_in_ssh_session(session, "nproc"));
 
             std::string management_ip = vm->management_ipv4();
             auto all_ipv4 = vm->get_all_ipv4(*config->ssh_key_provider);

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -203,6 +203,7 @@ message InfoReply {
         repeated string ipv4 = 11;
         repeated string ipv6 = 12;
         MountInfo mount_info = 13;
+        string cpu_count = 14;
     }
     repeated Info info = 1;
     string log_line = 2;

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -185,6 +185,7 @@ auto construct_single_instance_info_reply()
     gid_map_pair->set_host_id(1000);
     gid_map_pair->set_instance_id(1000);
 
+    info_entry->set_cpu_count("1");
     info_entry->set_load("0.45 0.51 0.15");
     info_entry->set_memory_usage("60817408");
     info_entry->set_memory_total("1503238554");
@@ -224,6 +225,7 @@ auto construct_multiple_instances_info_reply()
     gid_map_pair->set_host_id(1000);
     gid_map_pair->set_instance_id(501);
 
+    info_entry->set_cpu_count("4");
     info_entry->set_load("0.03 0.10 0.15");
     info_entry->set_memory_usage("38797312");
     info_entry->set_memory_total("1610612736");
@@ -457,6 +459,7 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "                fd52:2ccf:f758:0:a342:79b5:e2ba:e05e\n"
      "Release:        Ubuntu 16.04.3 LTS\n"
      "Image hash:     1797c5c82016 (Ubuntu 16.04 LTS)\n"
+     "CPU(s):         1\n"
      "Load:           0.45 0.51 0.15\n"
      "Disk usage:     1.2G out of 4.8G\n"
      "Memory usage:   58.0M out of 1.4G\n"
@@ -473,6 +476,7 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "IPv4:           10.21.124.56\n"
      "Release:        Ubuntu 16.04.3 LTS\n"
      "Image hash:     1797c5c82016 (Ubuntu 16.04 LTS)\n"
+     "CPU(s):         4\n"
      "Load:           0.03 0.10 0.15\n"
      "Disk usage:     1.8G out of 6.3G\n"
      "Memory usage:   37.0M out of 1.5G\n"
@@ -484,6 +488,7 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "IPv4:           --\n"
      "Release:        --\n"
      "Image hash:     ab5191cc1725 (Ubuntu 18.04 LTS)\n"
+     "CPU(s):         --\n"
      "Load:           --\n"
      "Disk usage:     --\n"
      "Memory usage:   --\n"
@@ -509,23 +514,23 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "csv_list_unsorted"},
 
     {&csv_formatter, &empty_info_reply,
-     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,Load,Disk usage,Disk total,Memory "
+     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory "
      "usage,Memory total,Mounts,AllIPv4\n",
      "csv_info_empty"},
     {&csv_formatter, &single_instance_info_reply,
-     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,Load,Disk usage,Disk total,Memory "
+     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory "
      "usage,Memory total,Mounts,AllIPv4\nfoo,Running,10.168.32.2,2001:67c:1562:8007::aac:423a,Ubuntu 16.04.3 "
-     "LTS,1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac,16.04 LTS,0.45 0.51 "
+     "LTS,1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac,16.04 LTS,1,0.45 0.51 "
      "0.15,1288490188,5153960756,60817408,1503238554,/home/user/foo => foo;/home/user/test_dir "
      "=> test_dir;,\"10.168.32.2,200.3.123.29\"\n",
      "csv_info_single"},
     {&csv_formatter, &multiple_instances_info_reply,
-     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,Load,Disk usage,Disk total,Memory "
+     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory "
      "usage,Memory total,Mounts,AllIPv4\nbogus-instance,Running,10.21.124.56,,Ubuntu 16.04.3 "
-     "LTS,1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac,16.04 LTS,0.03 0.10 "
+     "LTS,1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac,16.04 LTS,4,0.03 0.10 "
      "0.15,1932735284,6764573492,38797312,1610612736,/home/user/source => "
      "source;,\"10.21.124.56\"\nbombastic,Stopped,,,,"
-     "ab5191cc172564e7cc0eafd397312a32598823e645279c820f0935393aead509,18.04 LTS,,,,,,,\"\"\n",
+     "ab5191cc172564e7cc0eafd397312a32598823e645279c820f0935393aead509,18.04 LTS,,,,,,,,\"\"\n",
      "csv_info_multiple"},
 
     {&yaml_formatter, &empty_list_reply, "\n", "yaml_list_empty"},
@@ -581,6 +586,7 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "    image_hash: 1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac\n"
      "    image_release: 16.04 LTS\n"
      "    release: Ubuntu 16.04.3 LTS\n"
+     "    cpu_count: 1\n"
      "    load:\n"
      "      - 0.45\n"
      "      - 0.51\n"
@@ -617,6 +623,7 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "    image_hash: 1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac\n"
      "    image_release: 16.04 LTS\n"
      "    release: Ubuntu 16.04.3 LTS\n"
+     "    cpu_count: 4\n"
      "    load:\n"
      "      - 0.03\n"
      "      - 0.10\n"
@@ -642,6 +649,7 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "    image_hash: ab5191cc172564e7cc0eafd397312a32598823e645279c820f0935393aead509\n"
      "    image_release: 18.04 LTS\n"
      "    release: ~\n"
+     "    cpu_count: ~\n"
      "    disks:\n"
      "      - sda1:\n"
      "          used: ~\n"
@@ -711,6 +719,7 @@ const std::vector<FormatterParamType> non_orderable_list_info_formatter_outputs{
      "    ],\n"
      "    \"info\": {\n"
      "        \"foo\": {\n"
+     "            \"cpu_count\": \"1\",\n"
      "            \"disks\": {\n"
      "                \"sda1\": {\n"
      "                    \"total\": \"5153960756\",\n"
@@ -764,6 +773,7 @@ const std::vector<FormatterParamType> non_orderable_list_info_formatter_outputs{
      "    ],\n"
      "    \"info\": {\n"
      "        \"bogus-instance\": {\n"
+     "            \"cpu_count\": \"4\",\n"
      "            \"disks\": {\n"
      "                \"sda1\": {\n"
      "                    \"total\": \"6764573492\",\n"
@@ -799,6 +809,7 @@ const std::vector<FormatterParamType> non_orderable_list_info_formatter_outputs{
      "            \"state\": \"Running\"\n"
      "        },\n"
      "        \"bombastic\": {\n"
+     "            \"cpu_count\": \"\",\n"
      "            \"disks\": {\n"
      "                \"sda1\": {\n"
      "                }\n"

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -514,23 +514,23 @@ const std::vector<FormatterParamType> orderable_list_info_formatter_outputs{
      "csv_list_unsorted"},
 
     {&csv_formatter, &empty_info_reply,
-     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory "
-     "usage,Memory total,Mounts,AllIPv4\n",
+     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,Load,Disk usage,Disk total,Memory "
+     "usage,Memory total,Mounts,AllIPv4,CPU(s)\n",
      "csv_info_empty"},
     {&csv_formatter, &single_instance_info_reply,
-     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory "
-     "usage,Memory total,Mounts,AllIPv4\nfoo,Running,10.168.32.2,2001:67c:1562:8007::aac:423a,Ubuntu 16.04.3 "
-     "LTS,1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac,16.04 LTS,1,0.45 0.51 "
+     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,Load,Disk usage,Disk total,Memory "
+     "usage,Memory total,Mounts,AllIPv4,CPU(s)\nfoo,Running,10.168.32.2,2001:67c:1562:8007::aac:423a,Ubuntu 16.04.3 "
+     "LTS,1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac,16.04 LTS,0.45 0.51 "
      "0.15,1288490188,5153960756,60817408,1503238554,/home/user/foo => foo;/home/user/test_dir "
-     "=> test_dir;,\"10.168.32.2,200.3.123.29\"\n",
+     "=> test_dir;,\"10.168.32.2,200.3.123.29\";,1\n",
      "csv_info_single"},
     {&csv_formatter, &multiple_instances_info_reply,
-     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,CPU(s),Load,Disk usage,Disk total,Memory "
-     "usage,Memory total,Mounts,AllIPv4\nbogus-instance,Running,10.21.124.56,,Ubuntu 16.04.3 "
-     "LTS,1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac,16.04 LTS,4,0.03 0.10 "
+     "Name,State,Ipv4,Ipv6,Release,Image hash,Image release,Load,Disk usage,Disk total,Memory "
+     "usage,Memory total,Mounts,AllIPv4,CPU(s)\nbogus-instance,Running,10.21.124.56,,Ubuntu 16.04.3 "
+     "LTS,1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac,16.04 LTS,0.03 0.10 "
      "0.15,1932735284,6764573492,38797312,1610612736,/home/user/source => "
-     "source;,\"10.21.124.56\"\nbombastic,Stopped,,,,"
-     "ab5191cc172564e7cc0eafd397312a32598823e645279c820f0935393aead509,18.04 LTS,,,,,,,,\"\"\n",
+     "source;,\"10.21.124.56\";,4\nbombastic,Stopped,,,,"
+     "ab5191cc172564e7cc0eafd397312a32598823e645279c820f0935393aead509,18.04 LTS,,,,,,,\"\";,\n",
      "csv_info_multiple"},
 
     {&yaml_formatter, &empty_list_reply, "\n", "yaml_list_empty"},


### PR DESCRIPTION
This PR adds a CPU count to the `info` command. Displayed CPU count is based on the number of processing units.
Sample output:

```
ubuntu:~$ multipass info foo
Name:           foo
State:          Running
IPv4:           192.168.1.1
Release:        Ubuntu 20.04.4 LTS
Image hash:     692406940d6a (Ubuntu 20.04 LTS)
CPU(s):         1
Load:           0.00 0.00 0.00
Disk usage:     1.4G out of 4.7G
Memory usage:   137.2M out of 976.8M
Mounts:         --
```

Fixes #1804 for original change request.