### PR TITLE
Change long option

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -236,7 +236,7 @@ _multipass_complete()
             opts="${opts} --all --purge"
         ;;
         "launch")
-            opts="${opts} --cpus --disk --mem --name --cloud-init --network --bridged --mount"
+            opts="${opts} --cpus --disk --memory --name --cloud-init --network --bridged --mount"
         ;;
         "mount")
             opts="${opts} --gid-map --uid-map"

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -312,6 +312,17 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
 
     if (parser->isSet(memOption) || parser->isSet(memOptionDeprecated))
     {
+        if (parser->isSet(memOption) && parser->isSet(memOptionDeprecated))
+        {
+            cerr << "error: Invalid option(s) used for memory allocation. Please use \"--memory\" to specify "
+                    "amount of memory to allocate.\n";
+            return ParseCode::CommandLineError;
+        }
+
+        if (parser->isSet(memOptionDeprecated))
+            cout << "warning: \"--mem\" long option will be deprecated in favor of \"--memory\" in a future release."
+                    "Please update any scripts, etc.\n";
+
         auto arg_mem_size = parser->isSet(memOption) ? parser->value(memOption).toStdString()
                                                      : parser->value(memOptionDeprecated).toStdString();
 

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -320,7 +320,7 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
         }
 
         if (parser->isSet(memOptionDeprecated))
-            cout << "warning: \"--mem\" long option will be deprecated in favor of \"--memory\" in a future release."
+            cout << "warning: \"--mem\" long option will be deprecated in favour of \"--memory\" in a future release."
                     "Please update any scripts, etc.\n";
 
         auto arg_mem_size = parser->isSet(memOption) ? parser->value(memOption).toStdString()

--- a/tests/daemon_test_fixture.h
+++ b/tests/daemon_test_fixture.h
@@ -111,7 +111,7 @@ private:
     multipass::ParseCode parse_args(multipass::ArgParser* parser)
     {
         QCommandLineOption diskOption("disk", "", "disk", "");
-        QCommandLineOption memOption("mem", "", "mem", "");
+        QCommandLineOption memOption("memory", "", "memory", "");
         parser->addOptions({diskOption, memOption});
 
         auto status = parser->commandParse(this);

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -783,6 +783,20 @@ TEST_F(Client, launch_cmd_memory_option_fails_no_value)
     EXPECT_THAT(send_command({"launch", "-m"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
+TEST_F(Client, launch_cmd_memory_fails_duplicate_options)
+{
+    EXPECT_THAT(send_command({"launch", "--memory", "2048M", "--mem", "2048M"}), Eq(mp::ReturnCode::CommandLineError));
+}
+
+TEST_F(Client, launch_cmd_memory_deprecated_option_warning)
+{
+    std::stringstream cout_stream;
+
+    EXPECT_CALL(mock_daemon, launch(_, _, _));
+    EXPECT_THAT(send_command({"launch", "--mem", "2048M"}, cout_stream, trash_stream), Eq(mp::ReturnCode::Ok));
+    EXPECT_NE(std::string::npos, cout_stream.str().find("warning: \"--mem\"")) << "cout has: " << cout_stream.str();
+}
+
 TEST_F(Client, launch_cmd_cpu_option_ok)
 {
     EXPECT_CALL(mock_daemon, launch(_, _, _));

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -729,10 +729,10 @@ TEST_F(Client, launch_cmd_wrong_mem_arguments)
     EXPECT_CALL(mock_daemon, launch(_, _, _)).Times(0);
     MP_EXPECT_THROW_THAT(send_command({"launch", "-m", "wrong"}), std::runtime_error,
                          mpt::match_what(HasSubstr("wrong is not a valid memory size")));
-    MP_EXPECT_THROW_THAT(send_command({"launch", "--mem", "1.23f"}), std::runtime_error,
+    MP_EXPECT_THROW_THAT(send_command({"launch", "--memory", "1.23f"}), std::runtime_error,
                          mpt::match_what(HasSubstr("1.23f is not a valid memory size")));
-    MP_EXPECT_THROW_THAT(send_command({"launch", "-mem", "2048M"}), std::runtime_error,
-                         mpt::match_what(HasSubstr("em is not a valid memory size"))); // note single dash
+    MP_EXPECT_THROW_THAT(send_command({"launch", "-memory", "2048M"}), std::runtime_error,
+                         mpt::match_what(HasSubstr("emory is not a valid memory size"))); // note single dash
 }
 
 TEST_F(Client, launch_cmd_wrong_disk_arguments)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -908,10 +908,10 @@ TEST_P(LaunchStorageCheckSuite, launch_fails_with_invalid_data_directory)
 
 INSTANTIATE_TEST_SUITE_P(Daemon, DaemonCreateLaunchTestSuite, Values("launch", "test_create"));
 INSTANTIATE_TEST_SUITE_P(Daemon, MinSpaceRespectedSuite,
-                         Combine(Values("test_create", "launch"), Values("--mem", "--disk"),
+                         Combine(Values("test_create", "launch"), Values("--memory", "--disk"),
                                  Values("1024m", "2Gb", "987654321")));
 INSTANTIATE_TEST_SUITE_P(Daemon, MinSpaceViolatedSuite,
-                         Combine(Values("test_create", "launch"), Values("--mem", "--disk"),
+                         Combine(Values("test_create", "launch"), Values("--memory", "--disk"),
                                  Values("0", "0B", "0GB", "123B", "42kb", "100")));
 INSTANTIATE_TEST_SUITE_P(Daemon, LaunchImgSizeSuite,
                          Combine(Values("test_create", "launch"),


### PR DESCRIPTION
This PR changes the long option for memory allocation of the `launch` command from `--mem` to `--memory`. `--mem` is still supported for backwards compatibility, but will not be displayed in the help text. If both options are used, `--memory` will take precedence.

Fixes #2490 for original change request.