### PR TITLE
Request driver in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,6 +25,7 @@ Please provide logs from the daemon, see [accessing logs](https://multipass.run/
  - OS: [e.g. macOS 10.15]
 - `multipass version`
 - `multipass info --all`
+- `multipass get local.driver`
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
Currently we often need to follow up with a request for this. Better get it from the get go.