### PR TITLE
Fix LXD not updating state

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -196,6 +196,7 @@ mp::LXDVirtualMachine::~LXDVirtualMachine()
 {
     update_shutdown_status = false;
 
+    current_state();
     if (state == State::running)
     {
         try
@@ -207,6 +208,10 @@ mp::LXDVirtualMachine::~LXDVirtualMachine()
         {
             stop();
         }
+    }
+    else
+    {
+        update_state();
     }
 }
 

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -495,7 +495,7 @@ TEST_F(LXDBackend, machine_persists_and_sets_state_on_start)
     mp::LXDVirtualMachine machine{default_description, mock_monitor,        mock_network_access_manager.get(), base_url,
                                   bridge_name,         default_storage_pool};
 
-    EXPECT_CALL(mock_monitor, persist_state_for(_, _));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(2);
     machine.start();
 
     EXPECT_EQ(machine.current_state(), mp::VirtualMachine::State::starting);
@@ -545,7 +545,7 @@ TEST_F(LXDBackend, machine_persists_and_sets_state_on_shutdown)
     mp::LXDVirtualMachine machine{default_description, mock_monitor,        mock_network_access_manager.get(), base_url,
                                   bridge_name,         default_storage_pool};
 
-    EXPECT_CALL(mock_monitor, persist_state_for(_, _));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(2);
     machine.shutdown();
 
     EXPECT_TRUE(vm_shutdown);
@@ -1485,7 +1485,7 @@ TEST_F(LXDBackend, shutdown_while_stopped_does_nothing_and_logs_debug)
 
     ASSERT_EQ(machine.current_state(), mp::VirtualMachine::State::stopped);
 
-    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(0);
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _));
     EXPECT_CALL(
         *logger_scope.mock_logger,
         log(Eq(mpl::Level::debug), mpt::MockLogger::make_cstring_matcher(StrEq("pied-piper-valley")),
@@ -1517,7 +1517,7 @@ TEST_F(LXDBackend, shutdown_while_frozen_does_nothing_and_logs_info)
 
     ASSERT_EQ(machine.current_state(), mp::VirtualMachine::State::suspended);
 
-    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(0);
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _));
     EXPECT_CALL(*logger_scope.mock_logger,
                 log(Eq(mpl::Level::info), mpt::MockLogger::make_cstring_matcher(StrEq("pied-piper-valley")),
                     mpt::MockLogger::make_cstring_matcher(StrEq("Ignoring shutdown issued while suspended"))));
@@ -1751,7 +1751,8 @@ TEST_F(LXDBackend, current_state_connection_error_logs_warning_and_sets_unknown_
 
     EXPECT_CALL(*logger_scope.mock_logger,
                 log(Eq(mpl::Level::warning), mpt::MockLogger::make_cstring_matcher(StrEq("pied-piper-valley")),
-                    mpt::MockLogger::make_cstring_matcher(StrEq(exception_message))));
+                    mpt::MockLogger::make_cstring_matcher(StrEq(exception_message))))
+        .Times(2);
 
     EXPECT_EQ(machine.current_state(), mp::VirtualMachine::State::unknown);
 }
@@ -1838,7 +1839,7 @@ TEST_P(LXDNetworksBadJson, handles_gibberish_networks_reply)
 {
     auto log_matcher =
         mpt::MockLogger::make_cstring_matcher(AnyOf(HasSubstr("Error parsing JSON"), HasSubstr("Empty reply")));
-    EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::debug), _, log_matcher)).Times(1);
+    EXPECT_CALL(*logger_scope.mock_logger, log(Eq(mpl::Level::debug), _, log_matcher));
     EXPECT_CALL(*mock_network_access_manager,
                 createRequest(QNetworkAccessManager::CustomOperation, network_request_matcher, _))
         .WillOnce(Return(new mpt::MockLocalSocketReply{GetParam()}));
@@ -2001,8 +2002,9 @@ void setup_vm_creation_expectations(mpt::MockNetworkAccessManager& mock_network_
 {
     EXPECT_CALL(mock_network_access_mgr, createRequest(QNetworkAccessManager::CustomOperation,
                                                        custom_request_matcher("GET", "pied-piper-valley/state"), _))
+        .Times(3)
         .WillOnce(Return(new mpt::MockLocalSocketReply{mpt::not_found_data, QNetworkReply::ContentNotFoundError}))
-        .WillOnce(Return(new mpt::MockLocalSocketReply{mpt::vm_info_data}));
+        .WillRepeatedly(Return(new mpt::MockLocalSocketReply{mpt::vm_info_data}));
 
     EXPECT_CALL(mock_network_access_mgr,
                 createRequest(QNetworkAccessManager::CustomOperation,


### PR DESCRIPTION
LXD instances do not update instance state within multipass when they are externally shutdown (ie. `sudo poweroff` within the instance) and so will reboot them when the daemon restarts. To fix this, we force multipass to update the state of LXD instances before shutting down to ensure that they are put into the correct state when multipass reboots.

Fixes #2672 