### PR TITLE
Discern between images and blueprints in `multipass find`

### DIFF
--- a/include/multipass/default_vm_blueprint_provider.h
+++ b/include/multipass/default_vm_blueprint_provider.h
@@ -51,7 +51,7 @@ public:
                               ClientLaunchData& client_launch_data) override;
     Query blueprint_from_file(const std::string& path, const std::string& blueprint_name,
                               VirtualMachineDescription& vm_desc, ClientLaunchData& client_launch_data) override;
-    VMImageInfo info_for(const std::string& blueprint_name) override;
+    std::optional<VMImageInfo> info_for(const std::string& blueprint_name) override;
     std::vector<VMImageInfo> all_blueprints() override;
     std::string name_from_blueprint(const std::string& blueprint_name) override;
     int blueprint_timeout(const std::string& blueprint_name) override;

--- a/include/multipass/exceptions/image_vault_exceptions.h
+++ b/include/multipass/exceptions/image_vault_exceptions.h
@@ -27,10 +27,8 @@ namespace multipass
 class ImageNotFoundException : public std::runtime_error
 {
 public:
-    ImageNotFoundException(const std::string& image)
-        : runtime_error(fmt::format("Unable to find an image matching \"{}\"."
-                                    " Please use `multipass find` for supported remotes and images.",
-                                    image))
+    ImageNotFoundException(const std::string& image, const std::string& remote)
+        : runtime_error(fmt::format("Unable to find an image matching \"{}\" in remote \"{}\".", image, remote))
     {
     }
 };

--- a/include/multipass/vm_blueprint_provider.h
+++ b/include/multipass/vm_blueprint_provider.h
@@ -24,6 +24,7 @@
 #include "virtual_machine_description.h"
 #include "vm_image_info.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ public:
                                       ClientLaunchData& client_launch_data) = 0;
     virtual Query blueprint_from_file(const std::string& path, const std::string& blueprint_name,
                                       VirtualMachineDescription& vm_desc, ClientLaunchData& client_launch_data) = 0;
-    virtual VMImageInfo info_for(const std::string& blueprint_name) = 0;
+    virtual std::optional<VMImageInfo> info_for(const std::string& blueprint_name) = 0;
     virtual std::vector<VMImageInfo> all_blueprints() = 0;
     virtual std::string name_from_blueprint(const std::string& blueprint_name) = 0;
     virtual int blueprint_timeout(const std::string& blueprint_name) = 0;

--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -442,10 +442,11 @@ std::optional<mp::VMImageInfo> mp::DefaultVMBlueprintProvider::info_for(const st
 
     static constexpr auto missing_key_template{"The \'{}\' key is required for the {} Blueprint"};
 
-    if (blueprint_map.find(blueprint_name) == blueprint_map.end())
+    YAML::Node blueprint_config;
+    if (auto it = blueprint_map.find(blueprint_name); it != blueprint_map.end())
+        blueprint_config = it->second;
+    else
         return std::nullopt;
-
-    auto& blueprint_config = blueprint_map.at(blueprint_name);
 
     VMImageInfo image_info;
     image_info.aliases.append(QString::fromStdString(blueprint_name));
@@ -500,10 +501,8 @@ std::vector<mp::VMImageInfo> mp::DefaultVMBlueprintProvider::all_blueprints()
         try
         {
             auto info = info_for(key);
-            if (info)
-                blueprint_info.push_back(*info);
-            else
-                mpl::log(mpl::Level::warning, category, fmt::format("No blueprint found with name: \"{}\"", key));
+            assert(info && "key missing from blueprint map");
+            blueprint_info.push_back(*info);
         }
         catch (const InvalidBlueprintException& e)
         {

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -70,7 +70,7 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
                                   "Ubuntu release version, codename or alias.",
                                   "[<remote:>][<string>]");
     QCommandLineOption unsupportedOption("show-unsupported", "Show unsupported cloud images as well");
-    QCommandLineOption showImagesOption("images", "Show cloud images");
+    QCommandLineOption showImagesOption("images", "Show only images");
     QCommandLineOption showBlueprintsOption("blueprints", "Show only blueprints");
     parser->addOptions({unsupportedOption, showImagesOption, showBlueprintsOption});
 

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -70,7 +70,9 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
                                   "Ubuntu release version, codename or alias.",
                                   "[<remote:>][<string>]");
     QCommandLineOption unsupportedOption("show-unsupported", "Show unsupported cloud images as well");
-    parser->addOptions({unsupportedOption});
+    QCommandLineOption showImagesOption("images", "Show cloud images");
+    QCommandLineOption showBlueprintsOption("blueprints", "Show only blueprints");
+    parser->addOptions({unsupportedOption, showImagesOption, showBlueprintsOption});
 
     QCommandLineOption formatOption(
         "format", "Output list in the requested format.\nValid formats are: table (default), json, csv and yaml",
@@ -85,10 +87,29 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
         return status;
     }
 
+    if (parser->isSet(showImagesOption) && parser->isSet(showBlueprintsOption))
+    {
+        cerr << "Specify one of \"--images\", \"--blueprints\" or omit to fetch both\n";
+        return ParseCode::CommandLineError;
+    }
+
+    request.set_show_images(true);
+    request.set_show_blueprints(true);
+
+    if (parser->isSet(showImagesOption))
+    {
+        request.set_show_blueprints(false);
+    }
+
+    if (parser->isSet(showBlueprintsOption))
+    {
+        request.set_show_images(false);
+    }
+
     if (parser->positionalArguments().count() > 1)
     {
         cerr << "Wrong number of arguments\n";
-        status = ParseCode::CommandLineError;
+        return ParseCode::CommandLineError;
     }
     else if (parser->positionalArguments().count() == 1)
     {

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -70,15 +70,12 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
                                   "Ubuntu release version, codename or alias.",
                                   "[<remote:>][<string>]");
     QCommandLineOption unsupportedOption("show-unsupported", "Show unsupported cloud images as well");
-    QCommandLineOption showImagesOption("images", "Show only images");
-    QCommandLineOption showBlueprintsOption("blueprints", "Show only blueprints");
-    parser->addOptions({unsupportedOption, showImagesOption, showBlueprintsOption});
-
+    QCommandLineOption imagesOnlyOption("only-images", "Show only images");
+    QCommandLineOption blueprintsOnlyOption("only-blueprints", "Show only blueprints");
     QCommandLineOption formatOption(
         "format", "Output list in the requested format.\nValid formats are: table (default), json, csv and yaml",
         "format", "table");
-
-    parser->addOption(formatOption);
+    parser->addOptions({unsupportedOption, imagesOnlyOption, blueprintsOnlyOption, formatOption});
 
     auto status = parser->commandParse(this);
 
@@ -87,14 +84,14 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
         return status;
     }
 
-    if (parser->isSet(showImagesOption) && parser->isSet(showBlueprintsOption))
+    if (parser->isSet(imagesOnlyOption) && parser->isSet(blueprintsOnlyOption))
     {
-        cerr << "Specify one of \"--images\", \"--blueprints\" or omit to fetch both\n";
+        cerr << "Specify one of \"--only-images\", \"--only-blueprints\" or omit to fetch both\n";
         return ParseCode::CommandLineError;
     }
 
-    request.set_show_images(!parser->isSet(showBlueprintsOption));
-    request.set_show_blueprints(!parser->isSet(showImagesOption));
+    request.set_show_images(!parser->isSet(blueprintsOnlyOption));
+    request.set_show_blueprints(!parser->isSet(imagesOnlyOption));
 
     if (parser->positionalArguments().count() > 1)
     {

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -93,18 +93,8 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
         return ParseCode::CommandLineError;
     }
 
-    request.set_show_images(true);
-    request.set_show_blueprints(true);
-
-    if (parser->isSet(showImagesOption))
-    {
-        request.set_show_blueprints(false);
-    }
-
-    if (parser->isSet(showBlueprintsOption))
-    {
-        request.set_show_images(false);
-    }
+    request.set_show_images(!parser->isSet(showBlueprintsOption));
+    request.set_show_blueprints(!parser->isSet(showImagesOption));
 
     if (parser->positionalArguments().count() > 1)
     {

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -88,7 +88,7 @@ std::string mp::CSVFormatter::format(const FindReply& reply) const
 {
     fmt::memory_buffer buf;
 
-    fmt::format_to(std::back_inserter(buf), "Blueprint,Remote,Aliases,OS,Release,Version\n");
+    fmt::format_to(std::back_inserter(buf), "Image,Remote,Aliases,OS,Release,Version,Type\n");
 
     for (const auto& blueprint : reply.blueprints_info())
     {
@@ -99,13 +99,10 @@ std::string mp::CSVFormatter::format(const FindReply& reply) const
         auto blueprint_id = aliases[0].remote_name().empty()
                                 ? aliases[0].alias()
                                 : fmt::format("{}:{}", aliases[0].remote_name(), aliases[0].alias());
-        fmt::format_to(std::back_inserter(buf), "{},{},{},{},{},{}\n", blueprint_id, aliases[0].remote_name(),
+        fmt::format_to(std::back_inserter(buf), "{},{},{},{},{},{},Blueprint\n", blueprint_id, aliases[0].remote_name(),
                        fmt::join(aliases.cbegin() + 1, aliases.cend(), ";"), blueprint.os(), blueprint.release(),
                        blueprint.version());
     }
-    fmt::format_to(std::back_inserter(buf), "\n");
-
-    fmt::format_to(std::back_inserter(buf), "Image,Remote,Aliases,OS,Release,Version\n");
 
     for (const auto& image : reply.images_info())
     {
@@ -116,7 +113,7 @@ std::string mp::CSVFormatter::format(const FindReply& reply) const
         auto image_id = aliases[0].remote_name().empty()
                             ? aliases[0].alias()
                             : fmt::format("{}:{}", aliases[0].remote_name(), aliases[0].alias());
-        fmt::format_to(std::back_inserter(buf), "{},{},{},{},{},{}\n", image_id, aliases[0].remote_name(),
+        fmt::format_to(std::back_inserter(buf), "{},{},{},{},{},{},Cloud Image\n", image_id, aliases[0].remote_name(),
                        fmt::join(aliases.cbegin() + 1, aliases.cend(), ";"), image.os(), image.release(),
                        image.version());
     }

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -88,6 +88,23 @@ std::string mp::CSVFormatter::format(const FindReply& reply) const
 {
     fmt::memory_buffer buf;
 
+    fmt::format_to(std::back_inserter(buf), "Blueprint,Remote,Aliases,OS,Release,Version\n");
+
+    for (const auto& blueprint : reply.blueprints_info())
+    {
+        auto aliases = blueprint.aliases_info();
+
+        mp::format::filter_aliases(aliases);
+
+        auto blueprint_id = aliases[0].remote_name().empty()
+                                ? aliases[0].alias()
+                                : fmt::format("{}:{}", aliases[0].remote_name(), aliases[0].alias());
+        fmt::format_to(std::back_inserter(buf), "{},{},{},{},{},{}\n", blueprint_id, aliases[0].remote_name(),
+                       fmt::join(aliases.cbegin() + 1, aliases.cend(), ";"), blueprint.os(), blueprint.release(),
+                       blueprint.version());
+    }
+    fmt::format_to(std::back_inserter(buf), "\n");
+
     fmt::format_to(std::back_inserter(buf), "Image,Remote,Aliases,OS,Release,Version\n");
 
     for (const auto& image : reply.images_info())

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -113,8 +113,8 @@ std::string mp::CSVFormatter::format(const FindReply& reply) const
     fmt::memory_buffer buf;
 
     fmt::format_to(std::back_inserter(buf), "Image,Remote,Aliases,OS,Release,Version,Type\n");
-    fmt::format_to(std::back_inserter(buf), format_images(reply.blueprints_info(), "Blueprint"));
     fmt::format_to(std::back_inserter(buf), format_images(reply.images_info(), "Cloud Image"));
+    fmt::format_to(std::back_inserter(buf), format_images(reply.blueprints_info(), "Blueprint"));
 
     return fmt::to_string(buf);
 }

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -16,12 +16,36 @@
  */
 
 #include <multipass/cli/csv_formatter.h>
-
 #include <multipass/cli/format_utils.h>
-
 #include <multipass/format.h>
 
 namespace mp = multipass;
+
+namespace
+{
+std::string format_images(const google::protobuf::RepeatedPtrField<mp::FindReply_ImageInfo>& images_info,
+                          std::string type)
+{
+    fmt::memory_buffer buf;
+
+    for (const auto& image : images_info)
+    {
+        auto aliases = image.aliases_info();
+
+        mp::format::filter_aliases(aliases);
+
+        auto image_id = aliases[0].remote_name().empty()
+                            ? aliases[0].alias()
+                            : fmt::format("{}:{}", aliases[0].remote_name(), aliases[0].alias());
+
+        fmt::format_to(std::back_inserter(buf), "{},{},{},{},{},{},{}\n", image_id, aliases[0].remote_name(),
+                       fmt::join(aliases.cbegin() + 1, aliases.cend(), ";"), image.os(), image.release(),
+                       image.version(), type);
+    }
+
+    return fmt::to_string(buf);
+}
+} // namespace
 
 std::string mp::CSVFormatter::format(const InfoReply& reply) const
 {
@@ -89,34 +113,8 @@ std::string mp::CSVFormatter::format(const FindReply& reply) const
     fmt::memory_buffer buf;
 
     fmt::format_to(std::back_inserter(buf), "Image,Remote,Aliases,OS,Release,Version,Type\n");
-
-    for (const auto& blueprint : reply.blueprints_info())
-    {
-        auto aliases = blueprint.aliases_info();
-
-        mp::format::filter_aliases(aliases);
-
-        auto blueprint_id = aliases[0].remote_name().empty()
-                                ? aliases[0].alias()
-                                : fmt::format("{}:{}", aliases[0].remote_name(), aliases[0].alias());
-        fmt::format_to(std::back_inserter(buf), "{},{},{},{},{},{},Blueprint\n", blueprint_id, aliases[0].remote_name(),
-                       fmt::join(aliases.cbegin() + 1, aliases.cend(), ";"), blueprint.os(), blueprint.release(),
-                       blueprint.version());
-    }
-
-    for (const auto& image : reply.images_info())
-    {
-        auto aliases = image.aliases_info();
-
-        mp::format::filter_aliases(aliases);
-
-        auto image_id = aliases[0].remote_name().empty()
-                            ? aliases[0].alias()
-                            : fmt::format("{}:{}", aliases[0].remote_name(), aliases[0].alias());
-        fmt::format_to(std::back_inserter(buf), "{},{},{},{},{},{},Cloud Image\n", image_id, aliases[0].remote_name(),
-                       fmt::join(aliases.cbegin() + 1, aliases.cend(), ";"), image.os(), image.release(),
-                       image.version());
-    }
+    fmt::format_to(std::back_inserter(buf), format_images(reply.blueprints_info(), "Blueprint"));
+    fmt::format_to(std::back_inserter(buf), format_images(reply.images_info(), "Cloud Image"));
 
     return fmt::to_string(buf);
 }

--- a/src/client/cli/formatter/json_formatter.cpp
+++ b/src/client/cli/formatter/json_formatter.cpp
@@ -174,8 +174,33 @@ std::string mp::JsonFormatter::format(const FindReply& reply) const
 {
     QJsonObject find_json;
     QJsonObject images;
+    QJsonObject blueprints;
 
     find_json.insert("errors", QJsonArray());
+
+    for (const auto& blueprint : reply.blueprints_info())
+    {
+        QJsonObject blueprint_obj;
+        blueprint_obj.insert("os", QString::fromStdString(blueprint.os()));
+        blueprint_obj.insert("release", QString::fromStdString(blueprint.release()));
+        blueprint_obj.insert("version", QString::fromStdString(blueprint.version()));
+
+        QJsonArray aliases_arr;
+        auto aliases = blueprint.aliases_info();
+        mp::format::filter_aliases(aliases);
+
+        for (auto alias = aliases.cbegin() + 1; alias != aliases.cend(); alias++)
+        {
+            aliases_arr.append(QString::fromStdString(alias->alias()));
+        }
+        blueprint_obj.insert("aliases", aliases_arr);
+
+        blueprint_obj.insert("remote", QString::fromStdString(aliases[0].remote_name()));
+
+        blueprints.insert(QString::fromStdString(mp::format::image_string_for(aliases[0])), blueprint_obj);
+    }
+
+    find_json.insert("blueprints", blueprints);
 
     for (const auto& image : reply.images_info())
     {

--- a/src/client/cli/formatter/json_formatter.cpp
+++ b/src/client/cli/formatter/json_formatter.cpp
@@ -15,10 +15,9 @@
  *
  */
 
-#include <multipass/cli/json_formatter.h>
-
 #include <multipass/cli/client_common.h>
 #include <multipass/cli/format_utils.h>
+#include <multipass/cli/json_formatter.h>
 #include <multipass/utils.h>
 
 #include <QJsonArray>
@@ -26,6 +25,36 @@
 #include <QJsonObject>
 
 namespace mp = multipass;
+
+namespace
+{
+QJsonObject format_images(const google::protobuf::RepeatedPtrField<mp::FindReply_ImageInfo>& images_info)
+{
+    QJsonObject images_obj;
+
+    for (const auto& image : images_info)
+    {
+        QJsonObject image_obj;
+        image_obj.insert("os", QString::fromStdString(image.os()));
+        image_obj.insert("release", QString::fromStdString(image.release()));
+        image_obj.insert("version", QString::fromStdString(image.version()));
+
+        QJsonArray aliases_arr;
+        auto aliases = image.aliases_info();
+        mp::format::filter_aliases(aliases);
+
+        for (auto alias = aliases.cbegin() + 1; alias != aliases.cend(); alias++)
+            aliases_arr.append(QString::fromStdString(alias->alias()));
+
+        image_obj.insert("aliases", aliases_arr);
+        image_obj.insert("remote", QString::fromStdString(aliases[0].remote_name()));
+
+        images_obj.insert(QString::fromStdString(mp::format::image_string_for(aliases[0])), image_obj);
+    }
+
+    return images_obj;
+}
+} // namespace
 
 std::string mp::JsonFormatter::format(const InfoReply& reply) const
 {
@@ -173,58 +202,10 @@ std::string mp::JsonFormatter::format(const NetworksReply& reply) const
 std::string mp::JsonFormatter::format(const FindReply& reply) const
 {
     QJsonObject find_json;
-    QJsonObject images;
-    QJsonObject blueprints;
 
     find_json.insert("errors", QJsonArray());
-
-    for (const auto& blueprint : reply.blueprints_info())
-    {
-        QJsonObject blueprint_obj;
-        blueprint_obj.insert("os", QString::fromStdString(blueprint.os()));
-        blueprint_obj.insert("release", QString::fromStdString(blueprint.release()));
-        blueprint_obj.insert("version", QString::fromStdString(blueprint.version()));
-
-        QJsonArray aliases_arr;
-        auto aliases = blueprint.aliases_info();
-        mp::format::filter_aliases(aliases);
-
-        for (auto alias = aliases.cbegin() + 1; alias != aliases.cend(); alias++)
-        {
-            aliases_arr.append(QString::fromStdString(alias->alias()));
-        }
-        blueprint_obj.insert("aliases", aliases_arr);
-
-        blueprint_obj.insert("remote", QString::fromStdString(aliases[0].remote_name()));
-
-        blueprints.insert(QString::fromStdString(mp::format::image_string_for(aliases[0])), blueprint_obj);
-    }
-
-    find_json.insert("blueprints", blueprints);
-
-    for (const auto& image : reply.images_info())
-    {
-        QJsonObject image_obj;
-        image_obj.insert("os", QString::fromStdString(image.os()));
-        image_obj.insert("release", QString::fromStdString(image.release()));
-        image_obj.insert("version", QString::fromStdString(image.version()));
-
-        QJsonArray aliases_arr;
-        auto aliases = image.aliases_info();
-        mp::format::filter_aliases(aliases);
-
-        for (auto alias = aliases.cbegin() + 1; alias != aliases.cend(); alias++)
-        {
-            aliases_arr.append(QString::fromStdString(alias->alias()));
-        }
-        image_obj.insert("aliases", aliases_arr);
-
-        image_obj.insert("remote", QString::fromStdString(aliases[0].remote_name()));
-
-        images.insert(QString::fromStdString(mp::format::image_string_for(aliases[0])), image_obj);
-    }
-
-    find_json.insert("images", images);
+    find_json.insert("blueprints", format_images(reply.blueprints_info()));
+    find_json.insert("images", format_images(reply.images_info()));
 
     return QString(QJsonDocument(find_json).toJson()).toStdString();
 }

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -203,7 +203,8 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
 
     if (reply.show_blueprints())
     {
-        fmt::format_to(buf, "{:<28}{:<18}{:<17}{:<}\n", "Blueprint", "Aliases", "Version", "Description");
+        fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Blueprint", "Aliases", "Version",
+                       "Description");
 
         for (const auto& blueprint : reply.blueprints_info())
         {

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -220,9 +220,7 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
 
         if (reply.blueprints_info().empty())
             fmt::format_to(std::back_inserter(buf), "No blueprints found.\n");
-
-        if (reply.show_images())
-            fmt::format_to(std::back_inserter(buf), "\n");
+        fmt::format_to(std::back_inserter(buf), "\n");
     }
 
     if (reply.show_images())
@@ -244,6 +242,7 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
 
         if (reply.images_info().empty())
             fmt::format_to(std::back_inserter(buf), "No images found.\n");
+        fmt::format_to(std::back_inserter(buf), "\n");
     }
 
     return fmt::to_string(buf);

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -201,28 +201,6 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
 {
     fmt::memory_buffer buf;
 
-    if (reply.show_blueprints())
-    {
-        fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Blueprint", "Aliases", "Version",
-                       "Description");
-
-        for (const auto& blueprint : reply.blueprints_info())
-        {
-            auto aliases = blueprint.aliases_info();
-
-            mp::format::filter_aliases(aliases);
-
-            fmt::format_to(
-                std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", mp::format::image_string_for(aliases[0]),
-                fmt::format("{}", fmt::join(aliases.cbegin() + 1, aliases.cend(), ",")), blueprint.version(),
-                fmt::format("{}{}", blueprint.os().empty() ? "" : blueprint.os() + " ", blueprint.release()));
-        }
-
-        if (reply.blueprints_info().empty())
-            fmt::format_to(std::back_inserter(buf), "No blueprints found.\n");
-        fmt::format_to(std::back_inserter(buf), "\n");
-    }
-
     if (reply.show_images())
     {
         fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Image", "Aliases", "Version",
@@ -242,6 +220,28 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
 
         if (reply.images_info().empty())
             fmt::format_to(std::back_inserter(buf), "No images found.\n");
+        fmt::format_to(std::back_inserter(buf), "\n");
+    }
+
+    if (reply.show_blueprints())
+    {
+        fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Blueprint", "Aliases", "Version",
+                       "Description");
+
+        for (const auto& blueprint : reply.blueprints_info())
+        {
+            auto aliases = blueprint.aliases_info();
+
+            mp::format::filter_aliases(aliases);
+
+            fmt::format_to(
+                std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", mp::format::image_string_for(aliases[0]),
+                fmt::format("{}", fmt::join(aliases.cbegin() + 1, aliases.cend(), ",")), blueprint.version(),
+                fmt::format("{}{}", blueprint.os().empty() ? "" : blueprint.os() + " ", blueprint.release()));
+        }
+
+        if (reply.blueprints_info().empty())
+            fmt::format_to(std::back_inserter(buf), "No blueprints found.\n");
         fmt::format_to(std::back_inserter(buf), "\n");
     }
 

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -26,10 +26,12 @@ namespace mp = multipass;
 
 namespace
 {
-std::string format_images(const google::protobuf::RepeatedPtrField<mp::FindReply_ImageInfo>& images_info)
+std::string format_images(const google::protobuf::RepeatedPtrField<mp::FindReply_ImageInfo>& images_info,
+                          std::string type)
 {
     fmt::memory_buffer buf;
 
+    fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", type, "Aliases", "Version", "Description");
     for (const auto& image : images_info)
     {
         auto aliases = image.aliases_info();
@@ -216,28 +218,37 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
 {
     fmt::memory_buffer buf;
 
-    if (reply.show_images())
+    if (reply.show_images() && reply.show_blueprints())
     {
-        fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Image", "Aliases", "Version",
-                       "Description");
+        if (reply.images_info().empty() && reply.blueprints_info().empty())
+        {
+            fmt::format_to(std::back_inserter(buf), "No images or blueprints found.\n");
+        }
+        else
+        {
+            if (!reply.images_info().empty())
+                fmt::format_to(std::back_inserter(buf), format_images(reply.images_info(), "Image"));
 
-        fmt::format_to(std::back_inserter(buf), format_images(reply.images_info()));
+            if (!reply.images_info().empty() && !reply.blueprints_info().empty())
+                fmt::format_to(std::back_inserter(buf), "\n");
 
+            if (!reply.blueprints_info().empty())
+                fmt::format_to(std::back_inserter(buf), format_images(reply.blueprints_info(), "Blueprint"));
+        }
+    }
+    else if (reply.show_images() && !reply.show_blueprints())
+    {
         if (reply.images_info().empty())
             fmt::format_to(std::back_inserter(buf), "No images found.\n");
-        fmt::format_to(std::back_inserter(buf), "\n");
+        else
+            fmt::format_to(std::back_inserter(buf), format_images(reply.images_info(), "Image"));
     }
-
-    if (reply.show_blueprints())
+    else if (!reply.show_images() && reply.show_blueprints())
     {
-        fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Blueprint", "Aliases", "Version",
-                       "Description");
-
-        fmt::format_to(std::back_inserter(buf), format_images(reply.blueprints_info()));
-
         if (reply.blueprints_info().empty())
             fmt::format_to(std::back_inserter(buf), "No blueprints found.\n");
-        fmt::format_to(std::back_inserter(buf), "\n");
+        else
+            fmt::format_to(std::back_inserter(buf), format_images(reply.blueprints_info(), "Blueprint"));
     }
 
     return fmt::to_string(buf);

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -201,20 +201,48 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
 {
     fmt::memory_buffer buf;
 
-    if (reply.images_info().empty())
-        return "No images or Blueprints found.\n";
-
-    fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Image", "Aliases", "Version", "Description");
-
-    for (const auto& image : reply.images_info())
+    if (reply.show_blueprints())
     {
-        auto aliases = image.aliases_info();
+        fmt::format_to(buf, "{:<28}{:<18}{:<17}{:<}\n", "Blueprint", "Aliases", "Version", "Description");
 
-        mp::format::filter_aliases(aliases);
+        for (const auto& blueprint : reply.blueprints_info())
+        {
+            auto aliases = blueprint.aliases_info();
 
-        fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", mp::format::image_string_for(aliases[0]),
-                       fmt::format("{}", fmt::join(aliases.cbegin() + 1, aliases.cend(), ",")), image.version(),
-                       fmt::format("{}{}", image.os().empty() ? "" : image.os() + " ", image.release()));
+            mp::format::filter_aliases(aliases);
+
+            fmt::format_to(
+                std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", mp::format::image_string_for(aliases[0]),
+                fmt::format("{}", fmt::join(aliases.cbegin() + 1, aliases.cend(), ",")), blueprint.version(),
+                fmt::format("{}{}", blueprint.os().empty() ? "" : blueprint.os() + " ", blueprint.release()));
+        }
+
+        if (reply.blueprints_info().empty())
+            fmt::format_to(std::back_inserter(buf), "No blueprints found.\n");
+
+        if (reply.show_images())
+            fmt::format_to(std::back_inserter(buf), "\n");
+    }
+
+    if (reply.show_images())
+    {
+        fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Image", "Aliases", "Version",
+                       "Description");
+
+        for (const auto& image : reply.images_info())
+        {
+            auto aliases = image.aliases_info();
+
+            mp::format::filter_aliases(aliases);
+
+            fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n",
+                           mp::format::image_string_for(aliases[0]),
+                           fmt::format("{}", fmt::join(aliases.cbegin() + 1, aliases.cend(), ",")), image.version(),
+                           fmt::format("{}{}", image.os().empty() ? "" : image.os() + " ", image.release()));
+        }
+
+        if (reply.images_info().empty())
+            fmt::format_to(std::back_inserter(buf), "No images found.\n");
     }
 
     return fmt::to_string(buf);

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -41,6 +41,7 @@ std::string format_images(const google::protobuf::RepeatedPtrField<mp::FindReply
                        fmt::format("{}", fmt::join(aliases.cbegin() + 1, aliases.cend(), ",")), image.version(),
                        fmt::format("{}{}", image.os().empty() ? "" : image.os() + " ", image.release()));
     }
+    fmt::format_to(std::back_inserter(buf), "\n");
 
     return fmt::to_string(buf);
 }
@@ -228,9 +229,6 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
         {
             if (!reply.images_info().empty())
                 fmt::format_to(std::back_inserter(buf), format_images(reply.images_info(), "Image"));
-
-            if (!reply.images_info().empty() && !reply.blueprints_info().empty())
-                fmt::format_to(std::back_inserter(buf), "\n");
 
             if (!reply.blueprints_info().empty())
                 fmt::format_to(std::back_inserter(buf), format_images(reply.blueprints_info(), "Blueprint"));

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -202,7 +202,7 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
     fmt::memory_buffer buf;
 
     if (reply.images_info().empty())
-        return "No images found.\n";
+        return "No images or Blueprints found.\n";
 
     fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Image", "Aliases", "Version", "Description");
 

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -167,7 +167,30 @@ std::string mp::YamlFormatter::format(const FindReply& reply) const
 {
     YAML::Node find;
     find["errors"] = std::vector<YAML::Node>{};
+    find["blueprints"] = std::map<std::string, YAML::Node>{};
     find["images"] = std::map<std::string, YAML::Node>{};
+
+    for (const auto& blueprint : reply.blueprints_info())
+    {
+        YAML::Node blueprint_node;
+        blueprint_node["aliases"] = std::vector<std::string>{};
+
+        auto aliases = blueprint.aliases_info();
+        mp::format::filter_aliases(aliases);
+
+        for (auto alias = aliases.cbegin() + 1; alias != aliases.cend(); alias++)
+        {
+            blueprint_node["aliases"].push_back(alias->alias());
+        }
+
+        blueprint_node["os"] = blueprint.os();
+        blueprint_node["release"] = blueprint.release();
+        blueprint_node["version"] = blueprint.version();
+
+        blueprint_node["remote"] = aliases[0].remote_name();
+
+        find["blueprints"][mp::format::image_string_for(aliases[0])] = blueprint_node;
+    }
 
     for (const auto& image : reply.images_info())
     {

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -15,14 +15,12 @@
  *
  */
 
-#include <multipass/cli/yaml_formatter.h>
-
 #include <multipass/cli/alias_dict.h>
 #include <multipass/cli/client_common.h>
 #include <multipass/cli/format_utils.h>
-#include <multipass/utils.h>
-
+#include <multipass/cli/yaml_formatter.h>
 #include <multipass/format.h>
+#include <multipass/utils.h>
 
 #include <yaml-cpp/yaml.h>
 
@@ -30,6 +28,36 @@
 
 namespace mp = multipass;
 namespace mpu = multipass::utils;
+
+namespace
+{
+std::map<std::string, YAML::Node>
+format_images(const google::protobuf::RepeatedPtrField<mp::FindReply_ImageInfo>& images_info)
+{
+    std::map<std::string, YAML::Node> images_node;
+
+    for (const auto& image : images_info)
+    {
+        YAML::Node image_node;
+        image_node["aliases"] = std::vector<std::string>{};
+
+        auto aliases = image.aliases_info();
+        mp::format::filter_aliases(aliases);
+
+        for (auto alias = aliases.cbegin() + 1; alias != aliases.cend(); alias++)
+            image_node["aliases"].push_back(alias->alias());
+
+        image_node["os"] = image.os();
+        image_node["release"] = image.release();
+        image_node["version"] = image.version();
+        image_node["remote"] = aliases[0].remote_name();
+
+        images_node[mp::format::image_string_for(aliases[0])] = image_node;
+    }
+
+    return images_node;
+}
+} // namespace
 
 std::string mp::YamlFormatter::format(const InfoReply& reply) const
 {
@@ -167,52 +195,8 @@ std::string mp::YamlFormatter::format(const FindReply& reply) const
 {
     YAML::Node find;
     find["errors"] = std::vector<YAML::Node>{};
-    find["blueprints"] = std::map<std::string, YAML::Node>{};
-    find["images"] = std::map<std::string, YAML::Node>{};
-
-    for (const auto& blueprint : reply.blueprints_info())
-    {
-        YAML::Node blueprint_node;
-        blueprint_node["aliases"] = std::vector<std::string>{};
-
-        auto aliases = blueprint.aliases_info();
-        mp::format::filter_aliases(aliases);
-
-        for (auto alias = aliases.cbegin() + 1; alias != aliases.cend(); alias++)
-        {
-            blueprint_node["aliases"].push_back(alias->alias());
-        }
-
-        blueprint_node["os"] = blueprint.os();
-        blueprint_node["release"] = blueprint.release();
-        blueprint_node["version"] = blueprint.version();
-
-        blueprint_node["remote"] = aliases[0].remote_name();
-
-        find["blueprints"][mp::format::image_string_for(aliases[0])] = blueprint_node;
-    }
-
-    for (const auto& image : reply.images_info())
-    {
-        YAML::Node image_node;
-        image_node["aliases"] = std::vector<std::string>{};
-
-        auto aliases = image.aliases_info();
-        mp::format::filter_aliases(aliases);
-
-        for (auto alias = aliases.cbegin() + 1; alias != aliases.cend(); alias++)
-        {
-            image_node["aliases"].push_back(alias->alias());
-        }
-
-        image_node["os"] = image.os();
-        image_node["release"] = image.release();
-        image_node["version"] = image.version();
-
-        image_node["remote"] = aliases[0].remote_name();
-
-        find["images"][mp::format::image_string_for(aliases[0])] = image_node;
-    }
+    find["blueprints"] = format_images(reply.blueprints_info());
+    find["images"] = format_images(reply.images_info());
 
     return mpu::emit_yaml(find);
 }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -25,6 +25,7 @@
 #include <multipass/exceptions/blueprint_exceptions.h>
 #include <multipass/exceptions/create_image_exception.h>
 #include <multipass/exceptions/exitless_sshprocess_exception.h>
+#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/invalid_memory_size_exception.h>
 #include <multipass/exceptions/not_implemented_on_this_backend_exception.h>
 #include <multipass/exceptions/sshfs_missing_error.h>
@@ -1147,14 +1148,8 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
                     }
                     return true;
                 };
-                try
-                {
-                    config->vault->update_images(config->factory->fetch_type(), prepare_action, download_monitor);
-                }
-                catch (const std::exception& e)
-                {
-                    mpl::log(mpl::Level::error, category, fmt::format("Error updating images: {}", e.what()));
-                }
+
+                config->vault->update_images(config->factory->fetch_type(), prepare_action, download_monitor);
             });
         }
     });

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -917,7 +917,7 @@ bool is_ipv4_valid(const std::string& ipv4)
 }
 
 template <typename T>
-void add_aliases(T entry, const std::string& remote_name, const mp::VMImageInfo& info,
+void add_aliases(const T& entry, const std::string& remote_name, const mp::VMImageInfo& info,
                  const std::string& default_remote)
 {
     if (!info.aliases.empty())

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1250,7 +1250,8 @@ try // clang-format on
         catch (const std::exception& e)
         {
             mpl::log(mpl::Level::warning, category,
-                     fmt::format("An unexpected error occurred while fetching images: {}", e.what()));
+                     fmt::format("An unexpected error occurred while fetching images matching \"{}\": {}",
+                                 request->search_string(), e.what()));
         }
 
         try
@@ -1261,7 +1262,8 @@ try // clang-format on
         catch (const std::exception& e)
         {
             mpl::log(mpl::Level::warning, category,
-                     fmt::format("An unexpected error occurred while fetching blueprints: {}", e.what()));
+                     fmt::format("An unexpected error occurred while fetching blueprints matching \"{}\": {}",
+                                 request->search_string(), e.what()));
         }
 
         for (const auto& [remote, info] : vm_images_info)

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -19,6 +19,7 @@
 
 #include <multipass/exceptions/aborted_download_exception.h>
 #include <multipass/exceptions/create_image_exception.h>
+#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/unsupported_image_exception.h>
 #include <multipass/json_writer.h>
 #include <multipass/logging/log.h>
@@ -374,8 +375,10 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
         else
         {
             const auto info = info_for(query);
+            if (!info)
+                throw mp::ImageNotFoundException(query.release, query.remote_name);
 
-            id = info.id.toStdString();
+            id = info->id.toStdString();
 
             std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
             if (!query.name.empty())
@@ -414,12 +417,12 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
             else
             {
                 const auto image_dir =
-                    MP_UTILS.make_dir(images_dir, QString("%1-%2").arg(info.release).arg(info.version));
+                    MP_UTILS.make_dir(images_dir, QString("%1-%2").arg(info->release).arg(info->version));
 
                 // Had to use std::bind here to workaround the 5 allowable function arguments constraint of
                 // QtConcurrent::run()
                 future = QtConcurrent::run(std::bind(&DefaultVMImageVault::download_and_prepare_source_image, this,
-                                                     info, source_image, image_dir, fetch_type, prepare, monitor));
+                                                     *info, source_image, image_dir, fetch_type, prepare, monitor));
 
                 in_progress_image_fetches[id] = future;
             }
@@ -514,12 +517,12 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
             try
             {
                 auto info = info_for(record.second.query);
-                if (info.id.toStdString() != record.first)
+                if (info->id.toStdString() != record.first)
                 {
                     keys_to_update.push_back(record.first);
                 }
             }
-            catch (const mp::UnsupportedImageException& e)
+            catch (const std::exception& e)
             {
                 mpl::log(mpl::Level::warning, category, fmt::format("Skipping update: {}", e.what()));
             }
@@ -713,7 +716,10 @@ mp::VMImage mp::DefaultVMImageVault::finalize_image_records(const Query& query, 
 mp::VMImageInfo mp::DefaultVMImageVault::get_kernel_query_info(const std::string& name)
 {
     Query kernel_query{name, "default", false, "", Query::Type::Alias};
-    return info_for(kernel_query);
+    auto info = info_for(kernel_query);
+    if (!info)
+        throw mp::ImageNotFoundException("default", "");
+    return *info;
 }
 
 namespace

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -517,12 +517,19 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
             try
             {
                 auto info = info_for(record.second.query);
+                if (!info)
+                    throw mp::ImageNotFoundException(record.second.query.release, record.second.query.remote_name);
+
                 if (info->id.toStdString() != record.first)
                 {
                     keys_to_update.push_back(record.first);
                 }
             }
-            catch (const std::exception& e)
+            catch (const mp::UnsupportedImageException& e)
+            {
+                mpl::log(mpl::Level::warning, category, fmt::format("Skipping update: {}", e.what()));
+            }
+            catch (const mp::ImageNotFoundException& e)
             {
                 mpl::log(mpl::Level::warning, category, fmt::format("Skipping update: {}", e.what()));
             }

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -19,6 +19,7 @@
 #include "lxd_request.h"
 
 #include <multipass/exceptions/aborted_download_exception.h>
+#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/local_socket_connection_exception.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
@@ -195,7 +196,7 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type, const 
             {
                 const auto info = info_for(image_query);
 
-                source_image.original_release = info.release_title.toStdString();
+                source_image.original_release = info->release_title.toStdString();
             }
             catch (const std::exception&)
             {
@@ -225,7 +226,11 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type, const 
 
     if (query.query_type == Query::Type::Alias)
     {
-        info = info_for(query);
+        if (auto image_info = info_for(query); image_info.has_value())
+            info = *image_info;
+        else
+            throw mp::ImageNotFoundException(query.release, query.remote_name);
+
         id = info.id;
 
         source_image.id = id.toStdString();
@@ -410,13 +415,15 @@ void mp::LXDVMImageVault::update_images(const FetchType& fetch_type, const Prepa
             try
             {
                 auto info = info_for(query);
+                if (!info)
+                    throw mp::ImageNotFoundException(query.release, query.remote_name);
 
-                if (info.id != id)
+                if (info->id != id)
                 {
                     mpl::log(mpl::Level::info, category,
                              fmt::format("Updating {} source image to latest", query.release));
 
-                    lxd_download_image(info, query, monitor, image_info["last_used_at"].toString());
+                    lxd_download_image(*info, query, monitor, image_info["last_used_at"].toString());
 
                     lxd_request(manager, "DELETE", QUrl(QString("%1/images/%2").arg(base_url.toString()).arg(id)));
                 }

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -226,7 +226,7 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type, const 
 
     if (query.query_type == Query::Type::Alias)
     {
-        if (auto image_info = info_for(query); image_info.has_value())
+        if (auto image_info = info_for(query); image_info)
             info = *image_info;
         else
             throw mp::ImageNotFoundException(query.release, query.remote_name);

--- a/src/platform/backends/shared/base_vm_image_vault.h
+++ b/src/platform/backends/shared/base_vm_image_vault.h
@@ -79,7 +79,7 @@ protected:
         {
             for (const auto& image_host : image_hosts)
             {
-                auto info = image_host->info_for(query);
+                info = image_host->info_for(query);
 
                 if (info)
                     break;

--- a/src/platform/backends/shared/base_vm_image_vault.h
+++ b/src/platform/backends/shared/base_vm_image_vault.h
@@ -18,7 +18,6 @@
 #ifndef MULTIPASS_BASE_VM_IMAGE_VAULT_H
 #define MULTIPASS_BASE_VM_IMAGE_VAULT_H
 
-#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/format.h>
 #include <multipass/query.h>
 #include <multipass/vm_image.h>
@@ -63,22 +62,18 @@ public:
         else
             static_cast<void>(std::any_of(image_hosts.begin(), image_hosts.end(), grab_imgs)); // intentional discard
 
-        if (images_info.empty())
-            throw ImageNotFoundException(query.release);
-
         return images_info;
     };
 
 protected:
-    virtual VMImageInfo info_for(const Query& query) const
+    virtual std::optional<VMImageInfo> info_for(const Query& query) const
     {
+        std::optional<VMImageInfo> info;
+
         if (!query.remote_name.empty())
         {
             auto image_host = image_host_for(query.remote_name);
-            auto info = image_host->info_for(query);
-
-            if (info != std::nullopt)
-                return *info;
+            info = image_host->info_for(query);
         }
         else
         {
@@ -87,13 +82,11 @@ protected:
                 auto info = image_host->info_for(query);
 
                 if (info)
-                {
-                    return *info;
-                }
+                    break;
             }
         }
 
-        throw ImageNotFoundException(query.release);
+        return info;
     };
 
 private:

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -136,6 +136,8 @@ message FindRequest {
     string remote_name = 2;
     int32 verbosity_level = 3;
     bool allow_unsupported = 4;
+    bool show_images = 5;
+    bool show_blueprints = 6;
 }
 
 message FindReply {
@@ -149,8 +151,17 @@ message FindReply {
         string version = 3;
         repeated AliasInfo aliases_info = 4;
     }
-    repeated ImageInfo images_info = 1;
-    string log_line = 2;
+    message BlueprintInfo {
+        string os = 1;
+        string release = 2;
+        string version = 3;
+        repeated AliasInfo aliases_info = 4;
+    }
+    bool show_images = 1;
+    bool show_blueprints = 2;
+    repeated ImageInfo images_info = 3;
+    repeated BlueprintInfo blueprints_info = 4;
+    string log_line = 5;
 }
 
 message InstanceNames {

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -151,16 +151,10 @@ message FindReply {
         string version = 3;
         repeated AliasInfo aliases_info = 4;
     }
-    message BlueprintInfo {
-        string os = 1;
-        string release = 2;
-        string version = 3;
-        repeated AliasInfo aliases_info = 4;
-    }
     bool show_images = 1;
     bool show_blueprints = 2;
     repeated ImageInfo images_info = 3;
-    repeated BlueprintInfo blueprints_info = 4;
+    repeated ImageInfo blueprints_info = 4;
     string log_line = 5;
 }
 

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -30,6 +30,7 @@
 #include <src/platform/backends/lxd/lxd_vm_image_vault.h>
 
 #include <multipass/exceptions/aborted_download_exception.h>
+#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/local_socket_connection_exception.h>
 #include <multipass/format.h>
 #include <multipass/vm_image.h>
@@ -1133,4 +1134,27 @@ TEST_F(LXDImageVault, invalid_local_file_image_throws)
     MP_EXPECT_THROW_THAT(
         image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor, false, std::nullopt),
         std::runtime_error, mpt::match_what(StrEq(fmt::format("Custom image `{}` does not exist.", missing_file))));
+}
+
+TEST_F(LXDImageVault, updateImagesThrowsOnMissingImage)
+{
+    ON_CALL(*mock_network_access_manager.get(), createRequest(_, _, _)).WillByDefault([](auto, auto request, auto) {
+        auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
+        auto url = request.url().toString();
+
+        if (op == "GET" && url.contains("1.0/images"))
+        {
+            return new mpt::MockLocalSocketReply(mpt::image_info_update_source_info);
+        }
+
+        return new mpt::MockLocalSocketReply(mpt::not_found_data, QNetworkReply::ContentNotFoundError);
+    });
+
+    mp::LXDVMImageVault image_vault{hosts,    &stub_url_downloader, mock_network_access_manager.get(),
+                                    base_url, cache_dir.path(),     mp::days{0}};
+
+    EXPECT_CALL(host, info_for(_)).WillOnce(Return(std::nullopt));
+
+    EXPECT_THROW(image_vault.update_images(mp::FetchType::ImageOnly, stub_prepare, stub_monitor),
+                 mp::ImageNotFoundException);
 }

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -242,9 +242,8 @@ TEST_F(LXDImageVault, throws_with_invalid_alias)
     MP_EXPECT_THROW_THAT(
         image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor, false, std::nullopt),
         std::runtime_error,
-        mpt::match_what(StrEq(fmt::format("Unable to find an image matching \"{}\"."
-                                          " Please use `multipass find` for supported remotes and images.",
-                                          alias))));
+        mpt::match_what(
+            StrEq(fmt::format("Unable to find an image matching \"{}\" in remote \"{}\".", alias, "release"))));
 }
 
 TEST_F(LXDImageVault, throws_with_invalid_remote)

--- a/tests/mock_vm_blueprint_provider.h
+++ b/tests/mock_vm_blueprint_provider.h
@@ -21,13 +21,27 @@
 #include "common.h"
 
 #include <multipass/vm_blueprint_provider.h>
+#include <multipass/vm_image_info.h>
 
 namespace multipass
 {
 namespace test
 {
-struct MockVMBlueprintProvider : public VMBlueprintProvider
+class MockVMBlueprintProvider : public VMBlueprintProvider
 {
+public:
+    MockVMBlueprintProvider()
+    {
+        ON_CALL(*this, info_for(_)).WillByDefault([this](const auto& blueprint_name) {
+            mp::VMImageInfo info;
+
+            info.aliases.append(QString::fromStdString(blueprint_name));
+            info.release_title = QString::fromStdString(fmt::format("This is the {} blueprint", blueprint_name));
+
+            return info;
+        });
+    };
+
     MOCK_METHOD3(fetch_blueprint_for, Query(const std::string&, VirtualMachineDescription&, ClientLaunchData&));
     MOCK_METHOD4(blueprint_from_file,
                  Query(const std::string&, const std::string&, VirtualMachineDescription&, ClientLaunchData&));

--- a/tests/mock_vm_blueprint_provider.h
+++ b/tests/mock_vm_blueprint_provider.h
@@ -32,7 +32,7 @@ class MockVMBlueprintProvider : public VMBlueprintProvider
 public:
     MockVMBlueprintProvider()
     {
-        ON_CALL(*this, info_for(_)).WillByDefault([this](const auto& blueprint_name) {
+        ON_CALL(*this, info_for(_)).WillByDefault([](const auto& blueprint_name) {
             mp::VMImageInfo info;
 
             info.aliases.append(QString::fromStdString(blueprint_name));

--- a/tests/mock_vm_blueprint_provider.h
+++ b/tests/mock_vm_blueprint_provider.h
@@ -31,7 +31,7 @@ struct MockVMBlueprintProvider : public VMBlueprintProvider
     MOCK_METHOD3(fetch_blueprint_for, Query(const std::string&, VirtualMachineDescription&, ClientLaunchData&));
     MOCK_METHOD4(blueprint_from_file,
                  Query(const std::string&, const std::string&, VirtualMachineDescription&, ClientLaunchData&));
-    MOCK_METHOD1(info_for, VMImageInfo(const std::string&));
+    MOCK_METHOD1(info_for, std::optional<VMImageInfo>(const std::string&));
     MOCK_METHOD0(all_blueprints, std::vector<VMImageInfo>());
     MOCK_METHOD1(name_from_blueprint, std::string(const std::string&));
     MOCK_METHOD1(blueprint_timeout, int(const std::string&));

--- a/tests/stub_vm_blueprint_provider.h
+++ b/tests/stub_vm_blueprint_provider.h
@@ -38,7 +38,7 @@ struct StubVMBlueprintProvider final : public VMBlueprintProvider
         throw InvalidBlueprintException("");
     }
 
-    VMImageInfo info_for(const std::string& blueprint_name) override
+    std::optional<VMImageInfo> info_for(const std::string& blueprint_name) override
     {
         return VMImageInfo();
     }

--- a/tests/test_blueprint_provider.cpp
+++ b/tests/test_blueprint_provider.cpp
@@ -355,10 +355,11 @@ TEST_F(VMBlueprintProvider, infoForReturnsExpectedInfo)
 
     auto blueprint = blueprint_provider.info_for("test-blueprint2");
 
-    ASSERT_EQ(blueprint.aliases.size(), 1);
-    EXPECT_EQ(blueprint.aliases[0], "test-blueprint2");
-    EXPECT_EQ(blueprint.release_title, "Another test blueprint");
-    EXPECT_EQ(blueprint.version, "0.1");
+    ASSERT_TRUE(blueprint);
+    ASSERT_EQ(blueprint->aliases.size(), 1);
+    EXPECT_EQ(blueprint->aliases[0], "test-blueprint2");
+    EXPECT_EQ(blueprint->release_title, "Another test blueprint");
+    EXPECT_EQ(blueprint->version, "0.1");
 }
 
 TEST_F(VMBlueprintProvider, allBlueprintsReturnsExpectedInfo)
@@ -644,9 +645,10 @@ TEST_F(VMBlueprintProvider, infoForCompatibleReturnsExpectedInfo)
 
     auto blueprint = blueprint_provider.info_for("arch-only");
 
-    ASSERT_EQ(blueprint.aliases.size(), 1);
-    EXPECT_EQ(blueprint.aliases[0], "arch-only");
-    EXPECT_EQ(blueprint.release_title, "An arch-only blueprint");
+    ASSERT_TRUE(blueprint);
+    ASSERT_EQ(blueprint->aliases.size(), 1);
+    EXPECT_EQ(blueprint->aliases[0], "arch-only");
+    EXPECT_EQ(blueprint->release_title, "An arch-only blueprint");
 }
 
 TEST_F(VMBlueprintProvider, allBlueprintsReturnsExpectedInfoForArch)

--- a/tests/test_blueprint_provider.cpp
+++ b/tests/test_blueprint_provider.cpp
@@ -83,12 +83,12 @@ TEST_F(VMBlueprintProvider, fetchBlueprintForUnknownBlueprintThrows)
     EXPECT_THROW(blueprint_provider.fetch_blueprint_for("phony", vm_desc, dummy_data), std::out_of_range);
 }
 
-TEST_F(VMBlueprintProvider, infoForUnknownBlueprintThrows)
+TEST_F(VMBlueprintProvider, infoForUnknownBlueprintReturnsEmpty)
 {
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
-    EXPECT_THROW(blueprint_provider.info_for("phony"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("phony"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, invalidImageSchemeThrows)
@@ -616,26 +616,26 @@ TEST_F(VMBlueprintProvider, invalidRunsOnThrows)
         mpt::match_what(StrEq(fmt::format("Cannot convert \'description\' key for the {} Blueprint", blueprint))));
 }
 
-TEST_F(VMBlueprintProvider, fetchInvalidRunsOnThrows)
+TEST_F(VMBlueprintProvider, fetchForInvalidReturnsEmpty)
 {
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
     const std::string blueprint{"invalid-arch"};
-    // This call fails with an std::out_of_range exception because the Blueprint is invalid and was filtered out by
+    // This call fails with an std::nullopt exception because the Blueprint is invalid and was filtered out by
     // blueprints_map_for() at provider construction.
-    EXPECT_THROW(blueprint_provider.info_for(blueprint), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for(blueprint), std::nullopt);
 }
 
-TEST_F(VMBlueprintProvider, infoForIncompatibleThrows)
+TEST_F(VMBlueprintProvider, infoForIncompatibleReturnsEmpty)
 {
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
     const std::string blueprint{"arch-only"};
-    // This call fails with an std::out_of_range exception because the Blueprint is invalid and was filtered out by
+    // This call fails with an std::nullopt exception because the Blueprint is invalid and was filtered out by
     // blueprints_map_for() at provider construction.
-    EXPECT_THROW(blueprint_provider.info_for(blueprint), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for(blueprint), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, infoForCompatibleReturnsExpectedInfo)
@@ -675,7 +675,7 @@ TEST_F(VMBlueprintProvider, v2WithNoInstancesKeyNotAdded)
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
-    EXPECT_THROW(blueprint_provider.info_for("no-instances"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("no-instances"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, v2WithNoBlueprintKeyNotAdded)
@@ -683,7 +683,7 @@ TEST_F(VMBlueprintProvider, v2WithNoBlueprintKeyNotAdded)
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
-    EXPECT_THROW(blueprint_provider.info_for("no-blueprint"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("no-blueprint"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, v2WithNoImagesKeyNotAdded)
@@ -691,7 +691,7 @@ TEST_F(VMBlueprintProvider, v2WithNoImagesKeyNotAdded)
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
-    EXPECT_THROW(blueprint_provider.info_for("no-images"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("no-images"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, v2WithNoUrlKeyNotAdded)
@@ -699,7 +699,7 @@ TEST_F(VMBlueprintProvider, v2WithNoUrlKeyNotAdded)
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl, "multivacs"};
 
-    EXPECT_THROW(blueprint_provider.info_for("no-url"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("no-url"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, v2MininalDefinitionAdded)

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -2790,10 +2790,33 @@ TEST_F(Client, delete_cmd_accepts_purge_option)
 }
 
 // find cli tests
-TEST_F(Client, find_cmd_unsupported_option_ok)
+TEST_F(Client, findCmdUnsupportedOptionOk)
 {
     EXPECT_CALL(mock_daemon, find(_, _));
     EXPECT_THAT(send_command({"find", "--show-unsupported"}), Eq(mp::ReturnCode::Ok));
+}
+
+TEST_F(Client, findCmdFailsOnMultipleConditions)
+{
+    EXPECT_THAT(send_command({"find"
+                              "--only-blueprints",
+                              "--only-images"}),
+                Eq(mp::ReturnCode::CommandLineError));
+}
+
+TEST_F(Client, findCmdTooManyArgsFails)
+{
+    EXPECT_THAT(send_command({"find", "foo", "bar"}), Eq(mp::ReturnCode::CommandLineError));
+}
+
+TEST_F(Client, findCmdMultipleColonsFails)
+{
+    EXPECT_THAT(send_command({"find", "foo::bar"}), Eq(mp::ReturnCode::CommandLineError));
+}
+
+TEST_F(Client, findCmdHelpOk)
+{
+    EXPECT_THAT(send_command({"find", "-h"}), Eq(mp::ReturnCode::Ok));
 }
 
 // get/set cli tests

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1524,7 +1524,7 @@ TEST_F(Daemon, fails_with_image_not_found_also_if_image_is_also_non_bridgeable)
     });
 
     auto mock_blueprint_provider = std::make_unique<NiceMock<mpt::MockVMBlueprintProvider>>();
-    EXPECT_CALL(*mock_blueprint_provider, info_for(_)).WillOnce(Throw(std::out_of_range("")));
+    EXPECT_CALL(*mock_blueprint_provider, info_for(_)).WillOnce(Return(std::nullopt));
 
     config_builder.vault = std::move(mock_image_vault);
     config_builder.blueprint_provider = std::move(mock_blueprint_provider);

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -97,7 +97,7 @@ TEST_F(DaemonFind, blankQueryReturnsAllData)
                                     HasSubstr(blueprint_description_for(blueprint1_name)), HasSubstr(blueprint2_name),
                                     HasSubstr(blueprint_description_for(blueprint2_name))));
 
-    EXPECT_EQ(total_lines_of_output(stream), 7);
+    EXPECT_EQ(total_lines_of_output(stream), 9);
 }
 
 TEST_F(DaemonFind, queryForDefaultReturnsExpectedData)
@@ -118,9 +118,10 @@ TEST_F(DaemonFind, queryForDefaultReturnsExpectedData)
     mp::Daemon daemon{config_builder.build()};
 
     std::stringstream stream;
-    send_command({"find", "default"}, stream);
+    send_command({"find", "default", "--images"}, stream);
 
     EXPECT_THAT(stream.str(), AllOf(HasSubstr(mpt::default_alias), HasSubstr(mpt::default_release_info)));
+    EXPECT_THAT(stream.str(), Not(HasSubstr("No blueprints found.")));
 
     EXPECT_EQ(total_lines_of_output(stream), 3);
 }
@@ -139,9 +140,10 @@ TEST_F(DaemonFind, queryForBlueprintReturnsExpectedData)
     mp::Daemon daemon{config_builder.build()};
 
     std::stringstream stream;
-    send_command({"find", blueprint_name}, stream);
+    send_command({"find", blueprint_name, "--blueprints"}, stream);
 
     EXPECT_THAT(stream.str(), AllOf(HasSubstr(blueprint_name), HasSubstr(blueprint_description_for(blueprint_name))));
+    EXPECT_THAT(stream.str(), Not(HasSubstr("No images found.")));
 
     EXPECT_EQ(total_lines_of_output(stream), 2);
 }
@@ -161,9 +163,10 @@ TEST_F(DaemonFind, unknownQueryReturnsEmpty)
 
     constexpr auto phony_name = "phony";
     std::stringstream stream;
-    send_command({"find", phony_name}, stream, trash_stream);
+    send_command({"find", phony_name}, stream);
 
-    EXPECT_THAT(stream.str(), HasSubstr("No images or Blueprints found."));
+    EXPECT_THAT(stream.str(), HasSubstr("No images found."));
+    EXPECT_THAT(stream.str(), HasSubstr("No blueprints found."));
 }
 
 TEST_F(DaemonFind, forByRemoteReturnsExpectedData)

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -199,5 +199,5 @@ TEST_F(DaemonFind, forByRemoteReturnsExpectedData)
                                     HasSubstr(fmt::format("{}{}", remote_name, mpt::another_alias)),
                                     HasSubstr(mpt::another_release_info)));
 
-    EXPECT_EQ(total_lines_of_output(stream), 3);
+    EXPECT_EQ(total_lines_of_output(stream), 6);
 }

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -97,7 +97,7 @@ TEST_F(DaemonFind, blankQueryReturnsAllData)
                                     HasSubstr(blueprint_description_for(blueprint1_name)), HasSubstr(blueprint2_name),
                                     HasSubstr(blueprint_description_for(blueprint2_name))));
 
-    EXPECT_EQ(total_lines_of_output(stream), 9);
+    EXPECT_EQ(total_lines_of_output(stream), 10);
 }
 
 TEST_F(DaemonFind, queryForDefaultReturnsExpectedData)
@@ -145,7 +145,7 @@ TEST_F(DaemonFind, queryForBlueprintReturnsExpectedData)
     EXPECT_THAT(stream.str(), AllOf(HasSubstr(blueprint_name), HasSubstr(blueprint_description_for(blueprint_name))));
     EXPECT_THAT(stream.str(), Not(HasSubstr("No images found.")));
 
-    EXPECT_EQ(total_lines_of_output(stream), 2);
+    EXPECT_EQ(total_lines_of_output(stream), 3);
 }
 
 TEST_F(DaemonFind, unknownQueryReturnsEmpty)
@@ -199,5 +199,5 @@ TEST_F(DaemonFind, forByRemoteReturnsExpectedData)
                                     HasSubstr(fmt::format("{}{}", remote_name, mpt::another_alias)),
                                     HasSubstr(mpt::another_release_info)));
 
-    EXPECT_EQ(total_lines_of_output(stream), 6);
+    EXPECT_EQ(total_lines_of_output(stream), 7);
 }

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -97,7 +97,7 @@ TEST_F(DaemonFind, blankQueryReturnsAllData)
                                     HasSubstr(blueprint_description_for(blueprint1_name)), HasSubstr(blueprint2_name),
                                     HasSubstr(blueprint_description_for(blueprint2_name))));
 
-    EXPECT_EQ(total_lines_of_output(stream), 9);
+    EXPECT_EQ(total_lines_of_output(stream), 10);
 }
 
 TEST_F(DaemonFind, queryForDefaultReturnsExpectedData)
@@ -123,7 +123,7 @@ TEST_F(DaemonFind, queryForDefaultReturnsExpectedData)
     EXPECT_THAT(stream.str(), AllOf(HasSubstr(mpt::default_alias), HasSubstr(mpt::default_release_info)));
     EXPECT_THAT(stream.str(), Not(HasSubstr("No blueprints found.")));
 
-    EXPECT_EQ(total_lines_of_output(stream), 2);
+    EXPECT_EQ(total_lines_of_output(stream), 3);
 }
 
 TEST_F(DaemonFind, queryForBlueprintReturnsExpectedData)
@@ -145,7 +145,7 @@ TEST_F(DaemonFind, queryForBlueprintReturnsExpectedData)
     EXPECT_THAT(stream.str(), AllOf(HasSubstr(blueprint_name), HasSubstr(blueprint_description_for(blueprint_name))));
     EXPECT_THAT(stream.str(), Not(HasSubstr("No images found.")));
 
-    EXPECT_EQ(total_lines_of_output(stream), 2);
+    EXPECT_EQ(total_lines_of_output(stream), 3);
 }
 
 TEST_F(DaemonFind, unknownQueryReturnsEmpty)
@@ -198,5 +198,5 @@ TEST_F(DaemonFind, forByRemoteReturnsExpectedData)
                                     HasSubstr(fmt::format("{}{}", remote_name, mpt::another_alias)),
                                     HasSubstr(mpt::another_release_info)));
 
-    EXPECT_EQ(total_lines_of_output(stream), 3);
+    EXPECT_EQ(total_lines_of_output(stream), 4);
 }

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -97,7 +97,7 @@ TEST_F(DaemonFind, blankQueryReturnsAllData)
                                     HasSubstr(blueprint_description_for(blueprint1_name)), HasSubstr(blueprint2_name),
                                     HasSubstr(blueprint_description_for(blueprint2_name))));
 
-    EXPECT_EQ(total_lines_of_output(stream), 10);
+    EXPECT_EQ(total_lines_of_output(stream), 9);
 }
 
 TEST_F(DaemonFind, queryForDefaultReturnsExpectedData)
@@ -118,12 +118,12 @@ TEST_F(DaemonFind, queryForDefaultReturnsExpectedData)
     mp::Daemon daemon{config_builder.build()};
 
     std::stringstream stream;
-    send_command({"find", "default", "--images"}, stream);
+    send_command({"find", "default", "--only-images"}, stream);
 
     EXPECT_THAT(stream.str(), AllOf(HasSubstr(mpt::default_alias), HasSubstr(mpt::default_release_info)));
     EXPECT_THAT(stream.str(), Not(HasSubstr("No blueprints found.")));
 
-    EXPECT_EQ(total_lines_of_output(stream), 3);
+    EXPECT_EQ(total_lines_of_output(stream), 2);
 }
 
 TEST_F(DaemonFind, queryForBlueprintReturnsExpectedData)
@@ -140,12 +140,12 @@ TEST_F(DaemonFind, queryForBlueprintReturnsExpectedData)
     mp::Daemon daemon{config_builder.build()};
 
     std::stringstream stream;
-    send_command({"find", blueprint_name, "--blueprints"}, stream);
+    send_command({"find", blueprint_name, "--only-blueprints"}, stream);
 
     EXPECT_THAT(stream.str(), AllOf(HasSubstr(blueprint_name), HasSubstr(blueprint_description_for(blueprint_name))));
     EXPECT_THAT(stream.str(), Not(HasSubstr("No images found.")));
 
-    EXPECT_EQ(total_lines_of_output(stream), 3);
+    EXPECT_EQ(total_lines_of_output(stream), 2);
 }
 
 TEST_F(DaemonFind, unknownQueryReturnsEmpty)
@@ -165,8 +165,7 @@ TEST_F(DaemonFind, unknownQueryReturnsEmpty)
     std::stringstream stream;
     send_command({"find", phony_name}, stream);
 
-    EXPECT_THAT(stream.str(), HasSubstr("No images found."));
-    EXPECT_THAT(stream.str(), HasSubstr("No blueprints found."));
+    EXPECT_THAT(stream.str(), HasSubstr("No images or blueprints found."));
 }
 
 TEST_F(DaemonFind, forByRemoteReturnsExpectedData)
@@ -199,5 +198,5 @@ TEST_F(DaemonFind, forByRemoteReturnsExpectedData)
                                     HasSubstr(fmt::format("{}{}", remote_name, mpt::another_alias)),
                                     HasSubstr(mpt::another_release_info)));
 
-    EXPECT_EQ(total_lines_of_output(stream), 7);
+    EXPECT_EQ(total_lines_of_output(stream), 3);
 }

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -18,7 +18,6 @@
 #include "common.h"
 #include "daemon_test_fixture.h"
 #include "mock_image_host.h"
-#include "mock_logger.h"
 #include "mock_platform.h"
 #include "mock_settings.h"
 #include "mock_vm_blueprint_provider.h"
@@ -31,7 +30,6 @@
 
 namespace mp = multipass;
 namespace mpt = multipass::test;
-namespace mpl = multipass::logging;
 using namespace testing;
 
 namespace

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -133,8 +133,6 @@ TEST_F(DaemonFind, queryForBlueprintReturnsExpectedData)
 
     static constexpr auto blueprint_name = "foo";
 
-    EXPECT_CALL(*mock_image_vault, all_info_for(_)).WillOnce(Throw(std::runtime_error("")));
-
     config_builder.vault = std::move(mock_image_vault);
     config_builder.blueprint_provider = std::move(mock_blueprint_provider);
     mp::Daemon daemon{config_builder.build()};

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -678,7 +678,7 @@ TEST_F(ImageVault, all_info_for_remote_given_returns_expected_data)
     EXPECT_EQ(second_image_info.version.toStdString(), mpt::another_image_version);
 }
 
-TEST_F(ImageVault, all_info_for_no_images_returned_throws)
+TEST_F(ImageVault, allInfoForNoImagesReturnsEmpty)
 {
     mpt::StubURLDownloader stub_url_downloader;
     mp::DefaultVMImageVault vault{hosts, &stub_url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
@@ -686,6 +686,5 @@ TEST_F(ImageVault, all_info_for_no_images_returned_throws)
     const std::string name{"foo"};
     EXPECT_CALL(host, all_info_for(_)).WillOnce(Return(std::vector<std::pair<std::string, mp::VMImageInfo>>{}));
 
-    MP_EXPECT_THROW_THAT(vault.all_info_for({"", name, false, "", mp::Query::Type::Alias, true}), std::runtime_error,
-                         mpt::match_what(HasSubstr(fmt::format("Unable to find an image matching \"{}\"", name))));
+    EXPECT_TRUE(vault.all_info_for({"", name, false, "", mp::Query::Type::Alias, true}).empty());
 }

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -19,6 +19,7 @@
 #include "disabling_macros.h"
 #include "file_operations.h"
 #include "mock_image_host.h"
+#include "mock_logger.h"
 #include "mock_process_factory.h"
 #include "path.h"
 #include "stub_url_downloader.h"
@@ -30,6 +31,8 @@
 
 #include <multipass/exceptions/aborted_download_exception.h>
 #include <multipass/exceptions/create_image_exception.h>
+#include <multipass/exceptions/image_vault_exceptions.h>
+#include <multipass/exceptions/unsupported_image_exception.h>
 #include <multipass/format.h>
 #include <multipass/query.h>
 #include <multipass/url_downloader.h>
@@ -40,6 +43,7 @@
 #include <QUrl>
 
 namespace mp = multipass;
+namespace mpl = multipass::logging;
 namespace mpt = multipass::test;
 
 using namespace testing;
@@ -687,4 +691,61 @@ TEST_F(ImageVault, allInfoForNoImagesReturnsEmpty)
     EXPECT_CALL(host, all_info_for(_)).WillOnce(Return(std::vector<std::pair<std::string, mp::VMImageInfo>>{}));
 
     EXPECT_TRUE(vault.all_info_for({"", name, false, "", mp::Query::Type::Alias, true}).empty());
+}
+
+TEST_F(ImageVault, updateImagesLogsWarningOnUnsupportedImage)
+{
+    mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject(mpl::Level::warning);
+    mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{1}};
+    vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor, false, std::nullopt);
+
+    EXPECT_CALL(host, info_for(_)).WillOnce(Throw(mp::UnsupportedImageException(default_query.release)));
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(mpl::Level::warning, mpt::MockLogger::make_cstring_matcher(StrEq("image vault")),
+                    mpt::MockLogger::make_cstring_matcher(StrEq(fmt::format(
+                        "Skipping update: The {} release is no longer supported.", default_query.release)))));
+
+    EXPECT_NO_THROW(vault.update_images(mp::FetchType::ImageOnly, stub_prepare, stub_monitor));
+}
+
+TEST_F(ImageVault, updateImagesLogsWarningOnEmptyVault)
+{
+    mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject(mpl::Level::warning);
+    mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{1}};
+    vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor, false, std::nullopt);
+
+    EXPECT_CALL(host, info_for(_)).WillOnce(Return(std::nullopt));
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(mpl::Level::warning, mpt::MockLogger::make_cstring_matcher(StrEq("image vault")),
+                    mpt::MockLogger::make_cstring_matcher(
+                        StrEq(fmt::format("Skipping update: Unable to find an image matching \"{}\" in remote \"{}\".",
+                                          default_query.release, default_query.remote_name)))));
+
+    EXPECT_NO_THROW(vault.update_images(mp::FetchType::ImageOnly, stub_prepare, stub_monitor));
+}
+
+TEST_F(ImageVault, fetchLocalImageThrowsOnEmptyVault)
+{
+    mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{1}};
+
+    EXPECT_CALL(host, info_for(_)).WillOnce(Return(std::nullopt));
+
+    EXPECT_THROW(
+        vault.fetch_image(mp::FetchType::ImageOnly, default_query, stub_prepare, stub_monitor, false, std::nullopt),
+        mp::ImageNotFoundException);
+}
+
+TEST_F(ImageVault, fetchRemoteImageThrowsOnMissingKernel)
+{
+    mp::Query query{instance_name, "xenial", false, "", mp::Query::Type::Alias};
+    mp::DefaultVMImageVault vault{hosts, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{1}};
+
+    EXPECT_CALL(host, info_for(_)).WillOnce(Return(std::nullopt));
+
+    EXPECT_THROW(vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor, false, std::nullopt),
+                 mp::ImageNotFoundException);
 }

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -1086,31 +1086,21 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "    }\n"
      "}\n",
      "json_find_multiple_duplicate_image"},
-    {&csv_formatter, &empty_find_reply,
-     "Blueprint,Remote,Aliases,OS,Release,Version\n"
-     "\n"
-     "Image,Remote,Aliases,OS,Release,Version\n",
-     "csv_find_empty"},
+    {&csv_formatter, &empty_find_reply, "Image,Remote,Aliases,OS,Release,Version,Type\n", "csv_find_empty"},
     {&csv_formatter, &find_one_reply,
-     "Blueprint,Remote,Aliases,OS,Release,Version\n"
-     "\n"
-     "Image,Remote,Aliases,OS,Release,Version\n"
-     "ubuntu,,,Ubuntu,18.04 LTS,20190516\n",
+     "Image,Remote,Aliases,OS,Release,Version,Type\n"
+     "ubuntu,,,Ubuntu,18.04 LTS,20190516,Cloud Image\n",
      "csv_find_one"},
     {&csv_formatter, &find_multiple_reply,
-     "Blueprint,Remote,Aliases,OS,Release,Version\n"
-     "anbox-cloud-appliance,,,,Anbox Cloud Appliance,latest\n"
-     "\n"
-     "Image,Remote,Aliases,OS,Release,Version\n"
-     "lts,,,Ubuntu,18.04 LTS,20190516\n"
-     "daily:19.10,daily,eoan;devel,Ubuntu,19.10,20190516\n",
+     "Image,Remote,Aliases,OS,Release,Version,Type\n"
+     "anbox-cloud-appliance,,,,Anbox Cloud Appliance,latest,Blueprint\n"
+     "lts,,,Ubuntu,18.04 LTS,20190516,Cloud Image\n"
+     "daily:19.10,daily,eoan;devel,Ubuntu,19.10,20190516,Cloud Image\n",
      "csv_find_multiple"},
     {&csv_formatter, &find_multiple_reply_duplicate_image,
-     "Blueprint,Remote,Aliases,OS,Release,Version\n"
-     "\n"
-     "Image,Remote,Aliases,OS,Release,Version\n"
-     "core18,,,Ubuntu,Core 18,20190520\n"
-     "snapcraft:core18,snapcraft,,,Snapcraft builder for core18,20190520\n",
+     "Image,Remote,Aliases,OS,Release,Version,Type\n"
+     "core18,,,Ubuntu,Core 18,20190520,Cloud Image\n"
+     "snapcraft:core18,snapcraft,,,Snapcraft builder for core18,20190520,Cloud Image\n",
      "csv_find_multiple_duplicate_image"},
     {&yaml_formatter, &empty_find_reply,
      "errors:\n"

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -967,11 +967,13 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "No blueprints found.\n"
      "\n"
      "Image                       Aliases           Version          Description\n"
-     "No images found.\n",
+     "No images found.\n"
+     "\n",
      "table_find_empty"},
     {&table_formatter, &find_one_reply,
      "Image                       Aliases           Version          Description\n"
-     "ubuntu                                        20190516         Ubuntu 18.04 LTS\n",
+     "ubuntu                                        20190516         Ubuntu 18.04 LTS\n"
+     "\n",
      "table_find_one"},
     {&table_formatter, &find_multiple_reply,
      "Blueprint                   Aliases           Version          Description\n"
@@ -979,14 +981,16 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "\n"
      "Image                       Aliases           Version          Description\n"
      "lts                                           20190516         Ubuntu 18.04 LTS\n"
-     "daily:19.10                 eoan,devel        20190516         Ubuntu 19.10\n",
+     "daily:19.10                 eoan,devel        20190516         Ubuntu 19.10\n"
+     "\n",
      "table_find_multiple"},
     {&table_formatter, &find_one_reply_no_os,
      "Blueprint                   Aliases           Version          Description\n"
      "No blueprints found.\n"
      "\n"
      "Image                       Aliases           Version          Description\n"
-     "snapcraft:core18                              20190520         Snapcraft builder for core18\n",
+     "snapcraft:core18                              20190520         Snapcraft builder for core18\n"
+     "\n",
      "table_find_no_os"},
     {&table_formatter, &find_multiple_reply_duplicate_image,
      "Blueprint                   Aliases           Version          Description\n"
@@ -994,7 +998,8 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "\n"
      "Image                       Aliases           Version          Description\n"
      "core18                                        20190520         Ubuntu Core 18\n"
-     "snapcraft:core18                              20190520         Snapcraft builder for core18\n",
+     "snapcraft:core18                              20190520         Snapcraft builder for core18\n"
+     "\n",
      "table_find_multiple_duplicate_image"},
     {&json_formatter, &empty_find_reply,
      "{\n"

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -1141,13 +1141,6 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "    version: latest\n"
      "    remote: \"\"\n"
      "images:\n"
-     "  lts:\n"
-     "    aliases:\n"
-     "      []\n"
-     "    os: Ubuntu\n"
-     "    release: 18.04 LTS\n"
-     "    version: 20190516\n"
-     "    remote: \"\"\n"
      "  \"daily:19.10\":\n"
      "    aliases:\n"
      "      - eoan\n"
@@ -1155,7 +1148,14 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "    os: Ubuntu\n"
      "    release: 19.10\n"
      "    version: 20190516\n"
-     "    remote: daily\n",
+     "    remote: daily\n"
+     "  lts:\n"
+     "    aliases:\n"
+     "      []\n"
+     "    os: Ubuntu\n"
+     "    release: 18.04 LTS\n"
+     "    version: 20190516\n"
+     "    remote: \"\"\n",
      "yaml_find_multiple"},
     {&yaml_formatter, &find_multiple_reply_duplicate_image,
      "errors:\n"

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -252,9 +252,21 @@ auto add_petenv_to_reply(mp::InfoReply& reply)
     entry->set_id("1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd");
 }
 
+auto construct_empty_reply()
+{
+    auto reply = mp::FindReply();
+
+    reply.set_show_blueprints(true);
+    reply.set_show_images(true);
+
+    return reply;
+}
+
 auto construct_find_one_reply()
 {
     auto reply = mp::FindReply();
+
+    reply.set_show_images(true);
 
     auto image_entry = reply.add_images_info();
     image_entry->set_os("Ubuntu");
@@ -271,6 +283,9 @@ auto construct_find_one_reply_no_os()
 {
     auto reply = mp::FindReply();
 
+    reply.set_show_blueprints(true);
+    reply.set_show_images(true);
+
     auto image_entry = reply.add_images_info();
     image_entry->set_release("Snapcraft builder for core18");
     image_entry->set_version("20190520");
@@ -286,12 +301,22 @@ auto construct_find_multiple_reply()
 {
     auto reply = mp::FindReply();
 
+    reply.set_show_blueprints(true);
+    reply.set_show_images(true);
+
+    auto blueprint_entry = reply.add_blueprints_info();
+    blueprint_entry->set_release("Anbox Cloud Appliance");
+    blueprint_entry->set_version("latest");
+
+    auto alias_entry = blueprint_entry->add_aliases_info();
+    alias_entry->set_alias("anbox-cloud-appliance");
+
     auto image_entry = reply.add_images_info();
     image_entry->set_os("Ubuntu");
     image_entry->set_release("18.04 LTS");
     image_entry->set_version("20190516");
 
-    auto alias_entry = image_entry->add_aliases_info();
+    alias_entry = image_entry->add_aliases_info();
     alias_entry->set_alias("ubuntu");
     alias_entry = image_entry->add_aliases_info();
     alias_entry->set_alias("lts");
@@ -317,6 +342,9 @@ auto construct_find_multiple_reply()
 auto construct_find_multiple_reply_duplicate_image()
 {
     auto reply = mp::FindReply();
+
+    reply.set_show_blueprints(true);
+    reply.set_show_images(true);
 
     auto image_entry = reply.add_images_info();
     image_entry->set_os("Ubuntu");
@@ -927,34 +955,51 @@ const std::vector<FormatterParamType> non_orderable_networks_formatter_outputs{
      "}\n",
      "json_networks_multiple_lines"}};
 
-const auto empty_find_reply = mp::FindReply();
+const auto empty_find_reply = construct_empty_reply();
 const auto find_one_reply = construct_find_one_reply();
 const auto find_multiple_reply = construct_find_multiple_reply();
 const auto find_one_reply_no_os = construct_find_one_reply_no_os();
 const auto find_multiple_reply_duplicate_image = construct_find_multiple_reply_duplicate_image();
 
 const std::vector<FormatterParamType> find_formatter_outputs{
-    {&table_formatter, &empty_find_reply, "No images or Blueprints found.\n", "table_find_empty"},
+    {&table_formatter, &empty_find_reply,
+     "Blueprint                   Aliases           Version          Description\n"
+     "No blueprints found.\n"
+     "\n"
+     "Image                       Aliases           Version          Description\n"
+     "No images found.\n",
+     "table_find_empty"},
     {&table_formatter, &find_one_reply,
      "Image                       Aliases           Version          Description\n"
      "ubuntu                                        20190516         Ubuntu 18.04 LTS\n",
      "table_find_one"},
     {&table_formatter, &find_multiple_reply,
+     "Blueprint                   Aliases           Version          Description\n"
+     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n"
+     "\n"
      "Image                       Aliases           Version          Description\n"
      "lts                                           20190516         Ubuntu 18.04 LTS\n"
      "daily:19.10                 eoan,devel        20190516         Ubuntu 19.10\n",
      "table_find_multiple"},
     {&table_formatter, &find_one_reply_no_os,
+     "Blueprint                   Aliases           Version          Description\n"
+     "No blueprints found.\n"
+     "\n"
      "Image                       Aliases           Version          Description\n"
      "snapcraft:core18                              20190520         Snapcraft builder for core18\n",
      "table_find_no_os"},
     {&table_formatter, &find_multiple_reply_duplicate_image,
+     "Blueprint                   Aliases           Version          Description\n"
+     "No blueprints found.\n"
+     "\n"
      "Image                       Aliases           Version          Description\n"
      "core18                                        20190520         Ubuntu Core 18\n"
      "snapcraft:core18                              20190520         Snapcraft builder for core18\n",
      "table_find_multiple_duplicate_image"},
     {&json_formatter, &empty_find_reply,
      "{\n"
+     "    \"blueprints\": {\n"
+     "    },\n"
      "    \"errors\": [\n"
      "    ],\n"
      "    \"images\": {\n"
@@ -963,6 +1008,8 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "json_find_empty"},
     {&json_formatter, &find_one_reply,
      "{\n"
+     "    \"blueprints\": {\n"
+     "    },\n"
      "    \"errors\": [\n"
      "    ],\n"
      "    \"images\": {\n"
@@ -979,6 +1026,16 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "json_find_one"},
     {&json_formatter, &find_multiple_reply,
      "{\n"
+     "    \"blueprints\": {\n"
+     "        \"anbox-cloud-appliance\": {\n"
+     "            \"aliases\": [\n"
+     "            ],\n"
+     "            \"os\": \"\",\n"
+     "            \"release\": \"Anbox Cloud Appliance\",\n"
+     "            \"remote\": \"\",\n"
+     "            \"version\": \"latest\"\n"
+     "        }\n"
+     "    },\n"
      "    \"errors\": [\n"
      "    ],\n"
      "    \"images\": {\n"
@@ -1005,6 +1062,8 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "json_find_multiple"},
     {&json_formatter, &find_multiple_reply_duplicate_image,
      "{\n"
+     "    \"blueprints\": {\n"
+     "    },\n"
      "    \"errors\": [\n"
      "    ],\n"
      "    \"images\": {\n"
@@ -1027,17 +1086,28 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "    }\n"
      "}\n",
      "json_find_multiple_duplicate_image"},
-    {&csv_formatter, &empty_find_reply, "Image,Remote,Aliases,OS,Release,Version\n", "csv_find_empty"},
+    {&csv_formatter, &empty_find_reply,
+     "Blueprint,Remote,Aliases,OS,Release,Version\n"
+     "\n"
+     "Image,Remote,Aliases,OS,Release,Version\n",
+     "csv_find_empty"},
     {&csv_formatter, &find_one_reply,
+     "Blueprint,Remote,Aliases,OS,Release,Version\n"
+     "\n"
      "Image,Remote,Aliases,OS,Release,Version\n"
      "ubuntu,,,Ubuntu,18.04 LTS,20190516\n",
      "csv_find_one"},
     {&csv_formatter, &find_multiple_reply,
+     "Blueprint,Remote,Aliases,OS,Release,Version\n"
+     "anbox-cloud-appliance,,,,Anbox Cloud Appliance,latest\n"
+     "\n"
      "Image,Remote,Aliases,OS,Release,Version\n"
      "lts,,,Ubuntu,18.04 LTS,20190516\n"
      "daily:19.10,daily,eoan;devel,Ubuntu,19.10,20190516\n",
      "csv_find_multiple"},
     {&csv_formatter, &find_multiple_reply_duplicate_image,
+     "Blueprint,Remote,Aliases,OS,Release,Version\n"
+     "\n"
      "Image,Remote,Aliases,OS,Release,Version\n"
      "core18,,,Ubuntu,Core 18,20190520\n"
      "snapcraft:core18,snapcraft,,,Snapcraft builder for core18,20190520\n",
@@ -1045,12 +1115,16 @@ const std::vector<FormatterParamType> find_formatter_outputs{
     {&yaml_formatter, &empty_find_reply,
      "errors:\n"
      "  []\n"
+     "blueprints:\n"
+     "  {}\n"
      "images:\n"
      "  {}\n",
      "yaml_find_empty"},
     {&yaml_formatter, &find_one_reply,
      "errors:\n"
      "  []\n"
+     "blueprints:\n"
+     "  {}\n"
      "images:\n"
      "  ubuntu:\n"
      "    aliases:\n"
@@ -1063,6 +1137,14 @@ const std::vector<FormatterParamType> find_formatter_outputs{
     {&yaml_formatter, &find_multiple_reply,
      "errors:\n"
      "  []\n"
+     "blueprints:\n"
+     "  anbox-cloud-appliance:\n"
+     "    aliases:\n"
+     "      []\n"
+     "    os: \"\"\n"
+     "    release: Anbox Cloud Appliance\n"
+     "    version: latest\n"
+     "    remote: \"\"\n"
      "images:\n"
      "  lts:\n"
      "    aliases:\n"
@@ -1083,6 +1165,8 @@ const std::vector<FormatterParamType> find_formatter_outputs{
     {&yaml_formatter, &find_multiple_reply_duplicate_image,
      "errors:\n"
      "  []\n"
+     "blueprints:\n"
+     "  {}\n"
      "images:\n"
      "  core18:\n"
      "    aliases:\n"

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -255,10 +255,22 @@ auto add_petenv_to_reply(mp::InfoReply& reply)
 auto construct_empty_reply()
 {
     auto reply = mp::FindReply();
-
     reply.set_show_blueprints(true);
     reply.set_show_images(true);
+    return reply;
+}
 
+auto construct_empty_reply_only_images()
+{
+    auto reply = mp::FindReply();
+    reply.set_show_images(true);
+    return reply;
+}
+
+auto construct_empty_reply_only_blueprints()
+{
+    auto reply = mp::FindReply();
+    reply.set_show_blueprints(true);
     return reply;
 }
 
@@ -275,6 +287,23 @@ auto construct_find_one_reply()
 
     auto alias_entry = image_entry->add_aliases_info();
     alias_entry->set_alias("ubuntu");
+
+    return reply;
+}
+
+auto construct_find_one_blueprint_reply()
+{
+    auto reply = mp::FindReply();
+
+    reply.set_show_blueprints(true);
+    reply.set_show_images(true);
+
+    auto blueprint_entry = reply.add_blueprints_info();
+    blueprint_entry->set_release("Anbox Cloud Appliance");
+    blueprint_entry->set_version("latest");
+
+    auto alias_entry = blueprint_entry->add_aliases_info();
+    alias_entry->set_alias("anbox-cloud-appliance");
 
     return reply;
 }
@@ -956,61 +985,62 @@ const std::vector<FormatterParamType> non_orderable_networks_formatter_outputs{
      "json_networks_multiple_lines"}};
 
 const auto empty_find_reply = construct_empty_reply();
+const auto empty_find_reply_only_images = construct_empty_reply_only_images();
+const auto empty_find_reply_only_blueprints = construct_empty_reply_only_blueprints();
 const auto find_one_reply = construct_find_one_reply();
+const auto find_one_blueprint_reply = construct_find_one_blueprint_reply();
 const auto find_multiple_reply = construct_find_multiple_reply();
 const auto find_one_reply_no_os = construct_find_one_reply_no_os();
 const auto find_multiple_reply_duplicate_image = construct_find_multiple_reply_duplicate_image();
 
+const auto json_empty_find_reply = "{\n"
+                                   "    \"blueprints\": {\n"
+                                   "    },\n"
+                                   "    \"errors\": [\n"
+                                   "    ],\n"
+                                   "    \"images\": {\n"
+                                   "    }\n"
+                                   "}\n";
+const auto csv_empty_find_reply = "Image,Remote,Aliases,OS,Release,Version,Type\n";
+const auto yaml_empty_find_reply = "errors:\n"
+                                   "  []\n"
+                                   "blueprints:\n"
+                                   "  {}\n"
+                                   "images:\n"
+                                   "  {}\n";
+
 const std::vector<FormatterParamType> find_formatter_outputs{
-    {&table_formatter, &empty_find_reply,
-     "Image                       Aliases           Version          Description\n"
-     "No images found.\n"
-     "\n"
-     "Blueprint                   Aliases           Version          Description\n"
-     "No blueprints found.\n"
-     "\n",
-     "table_find_empty"},
+    {&table_formatter, &empty_find_reply, "No images or blueprints found.\n", "table_find_empty"},
+    {&table_formatter, &empty_find_reply_only_images, "No images found.\n", "table_find_empty_only_images"},
+    {&table_formatter, &empty_find_reply_only_blueprints, "No blueprints found.\n", "table_find_empty_only_blueprints"},
     {&table_formatter, &find_one_reply,
      "Image                       Aliases           Version          Description\n"
-     "ubuntu                                        20190516         Ubuntu 18.04 LTS\n"
-     "\n",
-     "table_find_one"},
+     "ubuntu                                        20190516         Ubuntu 18.04 LTS\n",
+     "table_find_one_image"},
+    {&table_formatter, &find_one_blueprint_reply,
+     "Blueprint                   Aliases           Version          Description\n"
+     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n",
+     "table_find_one_blueprint"},
     {&table_formatter, &find_multiple_reply,
      "Image                       Aliases           Version          Description\n"
      "lts                                           20190516         Ubuntu 18.04 LTS\n"
      "daily:19.10                 eoan,devel        20190516         Ubuntu 19.10\n"
      "\n"
      "Blueprint                   Aliases           Version          Description\n"
-     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n"
-     "\n",
+     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n",
      "table_find_multiple"},
     {&table_formatter, &find_one_reply_no_os,
      "Image                       Aliases           Version          Description\n"
-     "snapcraft:core18                              20190520         Snapcraft builder for core18\n"
-     "\n"
-     "Blueprint                   Aliases           Version          Description\n"
-     "No blueprints found.\n"
-     "\n",
+     "snapcraft:core18                              20190520         Snapcraft builder for core18\n",
      "table_find_no_os"},
     {&table_formatter, &find_multiple_reply_duplicate_image,
      "Image                       Aliases           Version          Description\n"
      "core18                                        20190520         Ubuntu Core 18\n"
-     "snapcraft:core18                              20190520         Snapcraft builder for core18\n"
-     "\n"
-     "Blueprint                   Aliases           Version          Description\n"
-     "No blueprints found.\n"
-     "\n",
+     "snapcraft:core18                              20190520         Snapcraft builder for core18\n",
      "table_find_multiple_duplicate_image"},
-    {&json_formatter, &empty_find_reply,
-     "{\n"
-     "    \"blueprints\": {\n"
-     "    },\n"
-     "    \"errors\": [\n"
-     "    ],\n"
-     "    \"images\": {\n"
-     "    }\n"
-     "}\n",
-     "json_find_empty"},
+    {&json_formatter, &empty_find_reply, json_empty_find_reply, "json_find_empty"},
+    {&json_formatter, &empty_find_reply_only_images, json_empty_find_reply, "json_find_empty_only_images"},
+    {&json_formatter, &empty_find_reply_only_blueprints, json_empty_find_reply, "json_find_empty_only_blueprints"},
     {&json_formatter, &find_one_reply,
      "{\n"
      "    \"blueprints\": {\n"
@@ -1029,6 +1059,24 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "    }\n"
      "}\n",
      "json_find_one"},
+    {&json_formatter, &find_one_blueprint_reply,
+     "{\n"
+     "    \"blueprints\": {\n"
+     "        \"anbox-cloud-appliance\": {\n"
+     "            \"aliases\": [\n"
+     "            ],\n"
+     "            \"os\": \"\",\n"
+     "            \"release\": \"Anbox Cloud Appliance\",\n"
+     "            \"remote\": \"\",\n"
+     "            \"version\": \"latest\"\n"
+     "        }\n"
+     "    },\n"
+     "    \"errors\": [\n"
+     "    ],\n"
+     "    \"images\": {\n"
+     "    }\n"
+     "}\n",
+     "json_find_one_blueprint"},
     {&json_formatter, &find_multiple_reply,
      "{\n"
      "    \"blueprints\": {\n"
@@ -1091,30 +1139,31 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "    }\n"
      "}\n",
      "json_find_multiple_duplicate_image"},
-    {&csv_formatter, &empty_find_reply, "Image,Remote,Aliases,OS,Release,Version,Type\n", "csv_find_empty"},
+    {&csv_formatter, &empty_find_reply, csv_empty_find_reply, "csv_find_empty"},
+    {&csv_formatter, &empty_find_reply_only_images, csv_empty_find_reply, "csv_find_empty_only_images"},
+    {&csv_formatter, &empty_find_reply_only_blueprints, csv_empty_find_reply, "csv_find_empty_only_blueprints"},
     {&csv_formatter, &find_one_reply,
      "Image,Remote,Aliases,OS,Release,Version,Type\n"
      "ubuntu,,,Ubuntu,18.04 LTS,20190516,Cloud Image\n",
      "csv_find_one"},
+    {&csv_formatter, &find_one_blueprint_reply,
+     "Image,Remote,Aliases,OS,Release,Version,Type\n"
+     "anbox-cloud-appliance,,,,Anbox Cloud Appliance,latest,Blueprint\n",
+     "csv_find_one_blueprint"},
     {&csv_formatter, &find_multiple_reply,
      "Image,Remote,Aliases,OS,Release,Version,Type\n"
-     "anbox-cloud-appliance,,,,Anbox Cloud Appliance,latest,Blueprint\n"
      "lts,,,Ubuntu,18.04 LTS,20190516,Cloud Image\n"
-     "daily:19.10,daily,eoan;devel,Ubuntu,19.10,20190516,Cloud Image\n",
+     "daily:19.10,daily,eoan;devel,Ubuntu,19.10,20190516,Cloud Image\n"
+     "anbox-cloud-appliance,,,,Anbox Cloud Appliance,latest,Blueprint\n",
      "csv_find_multiple"},
     {&csv_formatter, &find_multiple_reply_duplicate_image,
      "Image,Remote,Aliases,OS,Release,Version,Type\n"
      "core18,,,Ubuntu,Core 18,20190520,Cloud Image\n"
      "snapcraft:core18,snapcraft,,,Snapcraft builder for core18,20190520,Cloud Image\n",
      "csv_find_multiple_duplicate_image"},
-    {&yaml_formatter, &empty_find_reply,
-     "errors:\n"
-     "  []\n"
-     "blueprints:\n"
-     "  {}\n"
-     "images:\n"
-     "  {}\n",
-     "yaml_find_empty"},
+    {&yaml_formatter, &empty_find_reply, yaml_empty_find_reply, "yaml_find_empty"},
+    {&yaml_formatter, &empty_find_reply_only_images, yaml_empty_find_reply, "yaml_find_empty_only_images"},
+    {&yaml_formatter, &empty_find_reply_only_blueprints, yaml_empty_find_reply, "yaml_find_empty_only_blueprints"},
     {&yaml_formatter, &find_one_reply,
      "errors:\n"
      "  []\n"
@@ -1129,6 +1178,20 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "    version: 20190516\n"
      "    remote: \"\"\n",
      "yaml_find_one"},
+    {&yaml_formatter, &find_one_blueprint_reply,
+     "errors:\n"
+     "  []\n"
+     "blueprints:\n"
+     "  anbox-cloud-appliance:\n"
+     "    aliases:\n"
+     "      []\n"
+     "    os: \"\"\n"
+     "    release: Anbox Cloud Appliance\n"
+     "    version: latest\n"
+     "    remote: \"\"\n"
+     "images:\n"
+     "  {}\n",
+     "yaml_find_one_blueprint"},
     {&yaml_formatter, &find_multiple_reply,
      "errors:\n"
      "  []\n"

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -963,11 +963,11 @@ const auto find_multiple_reply_duplicate_image = construct_find_multiple_reply_d
 
 const std::vector<FormatterParamType> find_formatter_outputs{
     {&table_formatter, &empty_find_reply,
-     "Blueprint                   Aliases           Version          Description\n"
-     "No blueprints found.\n"
-     "\n"
      "Image                       Aliases           Version          Description\n"
      "No images found.\n"
+     "\n"
+     "Blueprint                   Aliases           Version          Description\n"
+     "No blueprints found.\n"
      "\n",
      "table_find_empty"},
     {&table_formatter, &find_one_reply,
@@ -976,29 +976,29 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "\n",
      "table_find_one"},
     {&table_formatter, &find_multiple_reply,
-     "Blueprint                   Aliases           Version          Description\n"
-     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n"
-     "\n"
      "Image                       Aliases           Version          Description\n"
      "lts                                           20190516         Ubuntu 18.04 LTS\n"
      "daily:19.10                 eoan,devel        20190516         Ubuntu 19.10\n"
+     "\n"
+     "Blueprint                   Aliases           Version          Description\n"
+     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n"
      "\n",
      "table_find_multiple"},
     {&table_formatter, &find_one_reply_no_os,
-     "Blueprint                   Aliases           Version          Description\n"
-     "No blueprints found.\n"
-     "\n"
      "Image                       Aliases           Version          Description\n"
      "snapcraft:core18                              20190520         Snapcraft builder for core18\n"
+     "\n"
+     "Blueprint                   Aliases           Version          Description\n"
+     "No blueprints found.\n"
      "\n",
      "table_find_no_os"},
     {&table_formatter, &find_multiple_reply_duplicate_image,
-     "Blueprint                   Aliases           Version          Description\n"
-     "No blueprints found.\n"
-     "\n"
      "Image                       Aliases           Version          Description\n"
      "core18                                        20190520         Ubuntu Core 18\n"
      "snapcraft:core18                              20190520         Snapcraft builder for core18\n"
+     "\n"
+     "Blueprint                   Aliases           Version          Description\n"
+     "No blueprints found.\n"
      "\n",
      "table_find_multiple_duplicate_image"},
     {&json_formatter, &empty_find_reply,

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -934,7 +934,7 @@ const auto find_one_reply_no_os = construct_find_one_reply_no_os();
 const auto find_multiple_reply_duplicate_image = construct_find_multiple_reply_duplicate_image();
 
 const std::vector<FormatterParamType> find_formatter_outputs{
-    {&table_formatter, &empty_find_reply, "No images found.\n", "table_find_empty"},
+    {&table_formatter, &empty_find_reply, "No images or Blueprints found.\n", "table_find_empty"},
     {&table_formatter, &find_one_reply,
      "Image                       Aliases           Version          Description\n"
      "ubuntu                                        20190516         Ubuntu 18.04 LTS\n",

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -1015,11 +1015,13 @@ const std::vector<FormatterParamType> find_formatter_outputs{
     {&table_formatter, &empty_find_reply_only_blueprints, "No blueprints found.\n", "table_find_empty_only_blueprints"},
     {&table_formatter, &find_one_reply,
      "Image                       Aliases           Version          Description\n"
-     "ubuntu                                        20190516         Ubuntu 18.04 LTS\n",
+     "ubuntu                                        20190516         Ubuntu 18.04 LTS\n"
+     "\n",
      "table_find_one_image"},
     {&table_formatter, &find_one_blueprint_reply,
      "Blueprint                   Aliases           Version          Description\n"
-     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n",
+     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n"
+     "\n",
      "table_find_one_blueprint"},
     {&table_formatter, &find_multiple_reply,
      "Image                       Aliases           Version          Description\n"
@@ -1027,16 +1029,19 @@ const std::vector<FormatterParamType> find_formatter_outputs{
      "daily:19.10                 eoan,devel        20190516         Ubuntu 19.10\n"
      "\n"
      "Blueprint                   Aliases           Version          Description\n"
-     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n",
+     "anbox-cloud-appliance                         latest           Anbox Cloud Appliance\n"
+     "\n",
      "table_find_multiple"},
     {&table_formatter, &find_one_reply_no_os,
      "Image                       Aliases           Version          Description\n"
-     "snapcraft:core18                              20190520         Snapcraft builder for core18\n",
+     "snapcraft:core18                              20190520         Snapcraft builder for core18\n"
+     "\n",
      "table_find_no_os"},
     {&table_formatter, &find_multiple_reply_duplicate_image,
      "Image                       Aliases           Version          Description\n"
      "core18                                        20190520         Ubuntu Core 18\n"
-     "snapcraft:core18                              20190520         Snapcraft builder for core18\n",
+     "snapcraft:core18                              20190520         Snapcraft builder for core18\n"
+     "\n",
      "table_find_multiple_duplicate_image"},
     {&json_formatter, &empty_find_reply, json_empty_find_reply, "json_find_empty"},
     {&json_formatter, &empty_find_reply_only_images, json_empty_find_reply, "json_find_empty_only_images"},


### PR DESCRIPTION
This PR adds the flags `--only-images` and `--only-blueprints` which modifies the behavior of `multipass find` causing it to display only images or blueprints respectively. Additionally, when no flag is specified, `multipass` will make the distinction between images and blueprints by separating them. Sample output is as follows:

```
scott:build-debug$ bin/multipass find
Image                       Aliases           Version          Description
snapcraft:core18            18.04             20201111         Snapcraft builder for Core 18
snapcraft:core20            20.04             20210921         Snapcraft builder for Core 20
snapcraft:core22            22.04             20220426         Snapcraft builder for Core 22
snapcraft:devel                               20220808         Snapcraft builder for the devel series
core                        core16            20200818         Ubuntu Core 16
core18                                        20211124         Ubuntu Core 18
18.04                       bionic            20220712         Ubuntu 18.04 LTS
20.04                       focal,lts         20220810         Ubuntu 20.04 LTS
22.04                       jammy             20220810         Ubuntu 22.04 LTS
daily:22.10                 devel,kinetic     20220808         Ubuntu 22.10
appliance:adguard-home                        20200812         Ubuntu AdGuard Home Appliance
appliance:mosquitto                           20200812         Ubuntu Mosquitto Appliance
appliance:nextcloud                           20200812         Ubuntu Nextcloud Appliance
appliance:openhab                             20200812         Ubuntu openHAB Home Appliance
appliance:plexmediaserver                     20200812         Ubuntu Plex Media Server Appliance

Blueprint                   Aliases           Version          Description
anbox-cloud-appliance                         latest           Anbox Cloud Appliance
charm-dev                                     latest           A development and testing environment for charmers
docker                                        latest           A Docker environment with Portainer and related tools
jellyfin                                      latest           Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media.
minikube                                      latest           minikube is local Kubernetes

scott:build-debug$ bin/multipass find --only-images
Image                       Aliases           Version          Description
snapcraft:core18            18.04             20201111         Snapcraft builder for Core 18
snapcraft:core20            20.04             20210921         Snapcraft builder for Core 20
snapcraft:core22            22.04             20220426         Snapcraft builder for Core 22
snapcraft:devel                               20220808         Snapcraft builder for the devel series
core                        core16            20200818         Ubuntu Core 16
core18                                        20211124         Ubuntu Core 18
18.04                       bionic            20220712         Ubuntu 18.04 LTS
20.04                       focal,lts         20220810         Ubuntu 20.04 LTS
22.04                       jammy             20220810         Ubuntu 22.04 LTS
daily:22.10                 devel,kinetic     20220808         Ubuntu 22.10
appliance:adguard-home                        20200812         Ubuntu AdGuard Home Appliance
appliance:mosquitto                           20200812         Ubuntu Mosquitto Appliance
appliance:nextcloud                           20200812         Ubuntu Nextcloud Appliance
appliance:openhab                             20200812         Ubuntu openHAB Home Appliance
appliance:plexmediaserver                     20200812         Ubuntu Plex Media Server Appliance

scott:build-debug$ bin/multipass find --only-blueprints
Blueprint                   Aliases           Version          Description
anbox-cloud-appliance                         latest           Anbox Cloud Appliance
charm-dev                                     latest           A development and testing environment for charmers
docker                                        latest           A Docker environment with Portainer and related tools
jellyfin                                      latest           Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media.
minikube                                      latest           minikube is local Kubernetes

scott:build-debug$ bin/multipass find daily:
Image                       Aliases           Version          Description
daily:18.04                 bionic            20220810         Ubuntu 18.04 LTS
daily:20.04                 focal,lts         20220810         Ubuntu 20.04 LTS
daily:22.04                 jammy             20220810         Ubuntu 22.04 LTS
daily:22.10                 devel,kinetic     20220808         Ubuntu 22.10

scott:build-debug$ bin/multipass find docker
Blueprint                   Aliases           Version          Description
docker                                        latest           A Docker environment with Portainer and related tools
```

Note: this output is an initial first draft of what this new form of output will look like and suggestions on how to make it better are welcome!

Fixes #2678 