### PR TITLE
ci: rework job-queues for new format

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,19 +74,20 @@ jobs:
         path: ${{ env.TESTFLINGER_FILE }}
         write-mode: overwrite
         contents: |
-          job_queue: ${{ matrix.os == 'macOS' && matrix.arch == 'arm64' && 'macos-arm' || 'vmware-fusion' }}
+          job_queue: ${{ matrix.os == 'macOS' && matrix.arch == 'arm64' && 'macos-arm' || matrix.vm }}
           output_timeout: 2400
           provision_data:
-            ${{ matrix.vm && format('vmx: /Users/michal/Virtual Machines.localized/{0}.vmwarevm/{0}.vmx', matrix.vm) || '' }}
+            ${{ matrix.vm && format('vmx: /Users/cibot/Virtual Machines.localized/{0}.vmwarevm/{0}.vmx', matrix.vm) || '' }}
             snapshot: Testflinger
-            ${{ matrix.os == 'Linux' && 'image_url: http://cloud-images.ubuntu.com/releases/impish/release/ubuntu-21.10-server-cloudimg-amd64.img' || '' }}
+            ${{ matrix.os == 'Linux' && 'image_url: https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.img' || '' }}
+            ${{ matrix.vm == 'windows-10' && 'username: ieuser' || '' }}
+            ${{ matrix.vm == 'windows-11' && 'username: user' || '' }}
             vmx_config:
               memsize: 2048
               vhv.enable: true
               vpmc.enable: true
 
           test_data:
-            ${{ matrix.os == 'Windows' && 'test_username: user' || '' }}
             test_cmds: |
               set -xeuo pipefail
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -182,7 +182,7 @@ jobs:
                 if [ '${{ matrix.driver }}' == 'hyperv' ]; then
                   _ps "Set-Variable ProgressPreference SilentlyContinue; Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart"
                   _ps "Restart-Computer -Force"
-                  sleep 60
+                  sleep 120
                 fi
               fi
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -180,7 +180,7 @@ jobs:
                 _install ${{ github.event.inputs.win-package }}
 
                 if [ '${{ matrix.driver }}' == 'hyperv' ]; then
-                  _ps "Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart"
+                  _ps "Set-Variable ProgressPreference SilentlyContinue; Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart"
                   _ps "Restart-Computer -Force"
                   sleep 60
                 fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -215,7 +215,7 @@ jobs:
           echo "${JOB_ID}" > testflinger_job
 
           testflinger-cli poll "${JOB_ID}"
-          [ "$( testflinger-cli results ${JOB_ID} | jq -r .test_status )" -eq 0 ]
+          [ "$( testflinger-cli results ${JOB_ID} | jq -r .test_status )" == "0" ]
 
         on_retry_command: |
           testflinger-cli cancel "$( cat testflinger_job )"


### PR DESCRIPTION
With the new Mini, we need more context than just `vmware-fusion` in the
job queue. For now Windows is left alone.