### PR TITLE
Ignore LXDNotFoundException on purge

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -196,22 +196,29 @@ mp::LXDVirtualMachine::~LXDVirtualMachine()
 {
     update_shutdown_status = false;
 
-    current_state();
-    if (state == State::running)
+    try
     {
-        try
+        current_state();
+
+        if (state == State::running)
         {
-            if (!QFileInfo::exists(mp::utils::snap_common_dir() + "/snap_refresh"))
+            try
+            {
+                if (!QFileInfo::exists(mp::utils::snap_common_dir() + "/snap_refresh"))
+                    stop();
+            }
+            catch (const mp::SnapEnvironmentException&)
+            {
                 stop();
+            }
         }
-        catch (const mp::SnapEnvironmentException&)
+        else
         {
-            stop();
+            update_state();
         }
     }
-    else
+    catch (const LXDNotFoundException& e)
     {
-        update_state();
     }
 }
 

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -26,6 +26,7 @@
 #include "tests/mock_platform.h"
 #include "tests/mock_status_monitor.h"
 #include "tests/stub_status_monitor.h"
+#include "tests/stub_terminal.h"
 #include "tests/stub_url_downloader.h"
 #include "tests/temp_dir.h"
 
@@ -647,6 +648,65 @@ TEST_F(LXDBackend, machine_does_not_update_state_in_dtor)
         mp::LXDVirtualMachine machine{
             default_description, mock_monitor,        mock_network_access_manager.get(), base_url,
             bridge_name,         default_storage_pool};
+    }
+
+    EXPECT_TRUE(vm_shutdown);
+    EXPECT_TRUE(stop_requested);
+}
+
+TEST_F(LXDBackend, machine_logs_not_found_exception_in_dtor)
+{
+    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+
+    bool vm_shutdown{false}, stop_requested{false};
+
+    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
+        .WillRepeatedly([&vm_shutdown, &stop_requested](auto, auto request, auto outgoingData) {
+            outgoingData->open(QIODevice::ReadOnly);
+            auto data = outgoingData->readAll();
+            auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
+            auto url = request.url().toString();
+
+            if (op == "GET")
+            {
+                if (url.contains("1.0/operations/b043d632-5c48-44b3-983c-a25660d61164"))
+                {
+                    vm_shutdown = true;
+                    return new mpt::MockLocalSocketReply(mpt::vm_stop_wait_task_data);
+                }
+                else if (url.contains("1.0/virtual-machines/pied-piper-valley/state"))
+                {
+                    if (vm_shutdown)
+                    {
+                        throw mp::LXDNotFoundException();
+                    }
+                    else
+                    {
+                        return new mpt::MockLocalSocketReply(mpt::vm_state_fully_running_data);
+                    }
+                }
+            }
+            else if (op == "PUT" && url.contains("1.0/virtual-machines/pied-piper-valley/state") &&
+                     data.contains("stop"))
+            {
+                stop_requested = true;
+                return new mpt::MockLocalSocketReply(mpt::stop_vm_data);
+            }
+
+            return new mpt::MockLocalSocketReply(mpt::not_found_data, QNetworkReply::ContentNotFoundError);
+        });
+
+    EXPECT_CALL(*logger_scope.mock_logger,
+                log(Eq(mpl::Level::debug), mpt::MockLogger::make_cstring_matcher(StrEq("pied-piper-valley")),
+                    mpt::MockLogger::make_cstring_matcher(StrEq("LXD object not found"))));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _));
+
+    // create in its own scope so the dtor is called
+    {
+        mp::LXDVirtualMachine machine{
+            default_description, mock_monitor,        mock_network_access_manager.get(), base_url,
+            bridge_name,         default_storage_pool};
+        machine.shutdown();
     }
 
     EXPECT_TRUE(vm_shutdown);

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -26,7 +26,6 @@
 #include "tests/mock_platform.h"
 #include "tests/mock_status_monitor.h"
 #include "tests/stub_status_monitor.h"
-#include "tests/stub_terminal.h"
 #include "tests/stub_url_downloader.h"
 #include "tests/temp_dir.h"
 
@@ -654,7 +653,7 @@ TEST_F(LXDBackend, machine_does_not_update_state_in_dtor)
     EXPECT_TRUE(stop_requested);
 }
 
-TEST_F(LXDBackend, machine_logs_not_found_exception_in_dtor)
+TEST_F(LXDBackend, machineLogsNotFoundExceptionInDtor)
 {
     NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
 


### PR DESCRIPTION
Ignore `LXDNotFoundException` which is thrown when an instance has been purged. This isn't a particularly nice fix, but seems to be the simplest without a complete refactor of the LXD backend. Another potential way of accounting for this situation could be through the use of the `update_shutdown_status` boolean, but I felt like that would just add unnecessary complexity to an already complex state machine.

Fixes #2714 