### PR TITLE
Make core 20/22 not change IP address over reboot

### DIFF
--- a/src/platform/backends/qemu/linux/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/linux/dnsmasq_server.cpp
@@ -82,7 +82,8 @@ mp::DNSMasqServer::~DNSMasqServer()
     }
 }
 
-std::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const std::string& hw_addr)
+// FIXME: after moving to core22, go to the old way of just returning the ip address
+std::optional<std::pair<mp::IPAddress, std::string>> mp::DNSMasqServer::get_ip_and_host_for(const std::string& hw_addr)
 {
     // DNSMasq leases entries consist of:
     // <lease expiration> <mac addr> <ipv4> <name> * * *
@@ -90,30 +91,32 @@ std::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const std::string& hw
     const std::string delimiter{" "};
     const int hw_addr_idx{1};
     const int ipv4_idx{2};
+    const int host_name_idx{3};
     std::ifstream leases_file{path};
     std::string line;
     while (getline(leases_file, line))
     {
         const auto fields = mp::utils::split(line, delimiter);
-        if (fields.size() > 2 && fields[hw_addr_idx] == hw_addr)
-            return std::optional<mp::IPAddress>{fields[ipv4_idx]};
+        if (fields.size() > 3 && fields[hw_addr_idx] == hw_addr)
+            return {{fields[ipv4_idx], fields[host_name_idx]}};
     }
     return std::nullopt;
 }
 
 void mp::DNSMasqServer::release_mac(const std::string& hw_addr)
 {
-    auto ip = get_ip_for(hw_addr);
-    if (!ip)
+    auto ip_and_host = get_ip_and_host_for(hw_addr);
+    if (!ip_and_host)
     {
         mpl::log(mpl::Level::warning, "dnsmasq", fmt::format("attempting to release non-existant addr: {}", hw_addr));
         return;
     }
 
+    auto ip = ip_and_host.value().first;
     QProcess dhcp_release;
     QObject::connect(&dhcp_release, &QProcess::errorOccurred, [&ip, &hw_addr](QProcess::ProcessError error) {
         mpl::log(mpl::Level::warning, "dnsmasq",
-                 fmt::format("failed to release ip addr {} with mac {}: {}", ip.value().as_string(), hw_addr,
+                 fmt::format("failed to release ip addr {} with mac {}: {}", ip.as_string(), hw_addr,
                              utils::qenum_to_string(error)));
     });
 
@@ -121,14 +124,14 @@ void mp::DNSMasqServer::release_mac(const std::string& hw_addr)
         if (exit_code == 0 && exit_status == QProcess::NormalExit)
             return;
 
-        auto msg = fmt::format("failed to release ip addr {} with mac {}, exit_code: {}", ip.value().as_string(),
-                               hw_addr, exit_code);
+        auto msg =
+            fmt::format("failed to release ip addr {} with mac {}, exit_code: {}", ip.as_string(), hw_addr, exit_code);
         mpl::log(mpl::Level::warning, "dnsmasq", msg);
     };
     QObject::connect(&dhcp_release, static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
                      log_exit_status);
 
-    dhcp_release.start("dhcp_release", QStringList() << bridge_name << QString::fromStdString(ip.value().as_string())
+    dhcp_release.start("dhcp_release", QStringList() << bridge_name << QString::fromStdString(ip.as_string())
                                                      << QString::fromStdString(hw_addr));
 
     dhcp_release.waitForFinished();

--- a/src/platform/backends/qemu/linux/dnsmasq_server.h
+++ b/src/platform/backends/qemu/linux/dnsmasq_server.h
@@ -41,7 +41,7 @@ public:
     DNSMasqServer(const Path& data_dir, const QString& bridge_name, const std::string& subnet);
     virtual ~DNSMasqServer(); // inherited by mock for testing
 
-    virtual std::optional<IPAddress> get_ip_for(const std::string& hw_addr);
+    virtual std::optional<std::pair<IPAddress, std::string>> get_ip_and_host_for(const std::string& hw_addr);
     virtual void release_mac(const std::string& hw_addr);
     virtual void check_dnsmasq_running();
 

--- a/src/platform/backends/qemu/linux/qemu_platform_detail.h
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail.h
@@ -40,6 +40,7 @@ public:
     std::optional<IPAddress> get_ip_for(const std::string& hw_addr) override;
     void remove_resources_for(const std::string& name) override;
     void platform_health_check() override;
+    void release_mac_with_different_hostname(const std::string& hw_addr, const std::string& name) override;
     QStringList vm_platform_args(const VirtualMachineDescription& vm_desc) override;
 
 private:

--- a/src/platform/backends/qemu/qemu_platform.h
+++ b/src/platform/backends/qemu/qemu_platform.h
@@ -45,6 +45,7 @@ public:
     virtual std::optional<IPAddress> get_ip_for(const std::string& hw_addr) = 0;
     virtual void remove_resources_for(const std::string&) = 0;
     virtual void platform_health_check() = 0;
+    virtual void release_mac_with_different_hostname(const std::string& hw_addr, const std::string& name){};
     virtual QStringList vmstate_platform_args()
     {
         return {};

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -391,6 +391,8 @@ void mp::QemuVirtualMachine::on_suspend()
 
 void mp::QemuVirtualMachine::on_restart()
 {
+    qemu_platform->release_mac_with_different_hostname(mac_addr, vm_name);
+
     state = State::restarting;
     update_state();
 

--- a/tests/qemu/linux/mock_dnsmasq_server.h
+++ b/tests/qemu/linux/mock_dnsmasq_server.h
@@ -31,7 +31,7 @@ struct MockDNSMasqServer : public DNSMasqServer
 {
     using DNSMasqServer::DNSMasqServer; // ctor
 
-    MOCK_METHOD1(get_ip_for, std::optional<IPAddress>(const std::string&));
+    MOCK_METHOD1(get_ip_and_host_for, std::optional<std::pair<IPAddress, std::string>>(const std::string&));
     MOCK_METHOD1(release_mac, void(const std::string&));
     MOCK_METHOD0(check_dnsmasq_running, void());
 };

--- a/tests/qemu/linux/test_dnsmasq_server.cpp
+++ b/tests/qemu/linux/test_dnsmasq_server.cpp
@@ -110,7 +110,10 @@ TEST_F(DNSMasqServer, finds_ip)
     auto ip_and_host = dns.get_ip_and_host_for(hw_addr);
 
     ASSERT_TRUE(ip_and_host);
-    EXPECT_THAT(ip_and_host.value().first, Eq(mp::IPAddress(expected_ip)));
+
+    auto [ip, host] = ip_and_host.value();
+    EXPECT_EQ(ip, mp::IPAddress(expected_ip));
+    EXPECT_EQ(host, "dummy_name");
 }
 
 TEST_F(DNSMasqServer, returns_null_ip_when_leases_file_does_not_exist)

--- a/tests/qemu/linux/test_dnsmasq_server.cpp
+++ b/tests/qemu/linux/test_dnsmasq_server.cpp
@@ -107,10 +107,10 @@ TEST_F(DNSMasqServer, finds_ip)
     auto dns = make_default_dnsmasq_server();
     make_lease_entry();
 
-    auto ip = dns.get_ip_for(hw_addr);
+    auto ip_and_host = dns.get_ip_and_host_for(hw_addr);
 
-    ASSERT_TRUE(ip);
-    EXPECT_THAT(ip.value(), Eq(mp::IPAddress(expected_ip)));
+    ASSERT_TRUE(ip_and_host);
+    EXPECT_THAT(ip_and_host.value().first, Eq(mp::IPAddress(expected_ip)));
 }
 
 TEST_F(DNSMasqServer, returns_null_ip_when_leases_file_does_not_exist)
@@ -118,9 +118,9 @@ TEST_F(DNSMasqServer, returns_null_ip_when_leases_file_does_not_exist)
     auto dns = make_default_dnsmasq_server();
 
     const std::string hw_addr{"00:01:02:03:04:05"};
-    auto ip = dns.get_ip_for(hw_addr);
+    auto ip_and_host = dns.get_ip_and_host_for(hw_addr);
 
-    EXPECT_FALSE(ip);
+    EXPECT_FALSE(ip_and_host);
 }
 
 TEST_F(DNSMasqServer, release_mac_releases_ip)

--- a/tests/qemu/linux/test_qemu_platform_detail.cpp
+++ b/tests/qemu/linux/test_qemu_platform_detail.cpp
@@ -211,3 +211,19 @@ TEST_F(QemuPlatformDetail, writing_ipforward_file_failure_logs_expected_message)
 
     mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
 }
+
+TEST_F(QemuPlatformDetail, release_mac_with_different_hostname)
+{
+    const mp::IPAddress ip_address{fmt::format("{}.5", subnet)};
+
+    EXPECT_CALL(*mock_dnsmasq_server, get_ip_and_host_for)
+        .WillOnce(Return(std::make_optional(std::make_pair(ip_address, name))))
+        .WillOnce(Return(std::make_optional(std::make_pair(ip_address, name + "not"))))
+        .WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*mock_dnsmasq_server, release_mac(hw_addr));
+
+    mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
+    qemu_platform_detail.release_mac_with_different_hostname(hw_addr, name);
+    qemu_platform_detail.release_mac_with_different_hostname(hw_addr, name);
+    qemu_platform_detail.release_mac_with_different_hostname(hw_addr + "not", name);
+}

--- a/tests/qemu/linux/test_qemu_platform_detail.cpp
+++ b/tests/qemu/linux/test_qemu_platform_detail.cpp
@@ -120,7 +120,9 @@ TEST_F(QemuPlatformDetail, get_ip_for_returns_expected_info)
 {
     const mp::IPAddress ip_address{fmt::format("{}.5", subnet)};
 
-    EXPECT_CALL(*mock_dnsmasq_server, get_ip_for(hw_addr)).WillOnce([&ip_address](auto...) { return ip_address; });
+    EXPECT_CALL(*mock_dnsmasq_server, get_ip_and_host_for(hw_addr)).WillOnce([&ip_address](auto...) {
+        return std::make_optional(std::make_pair(ip_address, ""));
+    });
 
     mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
 

--- a/tests/qemu/mock_qemu_platform.h
+++ b/tests/qemu/mock_qemu_platform.h
@@ -39,6 +39,7 @@ struct MockQemuPlatform : public QemuPlatform
     MOCK_METHOD1(get_ip_for, std::optional<IPAddress>(const std::string&));
     MOCK_METHOD1(remove_resources_for, void(const std::string&));
     MOCK_METHOD0(platform_health_check, void());
+    MOCK_METHOD2(release_mac_with_different_hostname, void(const std::string&, const std::string&));
     MOCK_METHOD0(vmstate_platform_args, QStringList());
     MOCK_METHOD1(vm_platform_args, QStringList(const VirtualMachineDescription&));
     MOCK_METHOD0(get_directory_name, QString());


### PR DESCRIPTION
This PR makes it so that when a Linux QEMU instance reboots, it checks the `dnsmasq.leases` file for leases that have the same MAC address as the instance but under a different host name and releases them. This is needed for core20 and core22, which change host names during launching and get the daemon confused about which IP is the correct one.

It also makes sure that when an instance is done rebooting, it has a `Running` state, since those instances were getting stuck in a `Restarting` state.

fix #2690 