### PR TITLE
sshfs infinitely looping on missing mount directory

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -39,6 +39,7 @@ public:
     FileOps(const Singleton<FileOps>::PrivatePass&) noexcept;
 
     // QDir operations
+    virtual bool exists(const QDir& dir) const;
     virtual bool isReadable(const QDir& dir) const;
     virtual bool mkpath(const QDir& dir, const QString& dirName) const;
     virtual bool rmdir(QDir& dir, const QString& dirName) const;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2667,11 +2667,15 @@ error_string mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::stri
                 }
                 catch (const std::exception& e)
                 {
-                    fmt::format_to(errors, "Removing \"{}\": {}\n", target_path, e.what());
+                    mpl::log(mpl::Level::error, category, fmt::format("Removing \"{}\": {}\n", target_path, e.what()));
                     invalid_mounts.push_back(target_path);
                 }
-                persist_instances();
             }
+
+            for (const auto& mount : invalid_mounts)
+                vm_instance_specs[name].mounts.erase(mount);
+
+            persist_instances();
         }
     }
     catch (const std::exception& e)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2667,7 +2667,8 @@ error_string mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::stri
                 }
                 catch (const std::exception& e)
                 {
-                    mpl::log(mpl::Level::error, category, fmt::format("Removing \"{}\": {}\n", target_path, e.what()));
+                    mpl::log(mpl::Level::warning, category,
+                             fmt::format("Removing \"{}\": {}\n", target_path, e.what()));
                     invalid_mounts.push_back(target_path);
                 }
             }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2670,9 +2670,9 @@ error_string mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::stri
                 {
                     // TODO: Combine these into one warning level log once they are displayed in the cli by
                     // default
-                    mpl::log(mpl::Level::info, category, fmt::format("Removing \'{}\': {}\n", target_path, e.what()));
+                    mpl::log(mpl::Level::info, category, fmt::format("Removing \"{}\": {}\n", target_path, e.what()));
                     fmt::format_to(warnings,
-                                   fmt::format("Removing mount \'{}\' from {}: {}\n", target_path, name, e.what()));
+                                   fmt::format("Removing mount \"{}\" from {}: {}\n", target_path, name, e.what()));
                     invalid_mounts.push_back(target_path);
                 }
             }
@@ -2680,7 +2680,7 @@ error_string mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::stri
             for (const auto& mount : invalid_mounts)
                 vm_instance_specs[name].mounts.erase(mount);
 
-            if (server && !fmt::to_string(warnings).empty())
+            if (server && warnings.size() > 0)
             {
                 Reply reply;
                 reply.set_log_line(fmt::to_string(warnings));

--- a/src/sshfs_mount/sshfs_mounts.cpp
+++ b/src/sshfs_mount/sshfs_mounts.cpp
@@ -70,7 +70,7 @@ void mp::SSHFSMounts::start_mount(VirtualMachine* vm, const std::string& source_
     if (!MP_FILEOPS.exists(QDir{QString::fromStdString(source_path)}))
     {
         mount_processes[vm->vm_name].erase(target_path);
-        throw std::runtime_error(fmt::format("Mount path `{}` does not exist.", source_path));
+        throw std::runtime_error(fmt::format("Mount path \"{}\" does not exist.", source_path));
     }
 
     mp::SSHFSServerConfig config;

--- a/src/sshfs_mount/sshfs_mounts.cpp
+++ b/src/sshfs_mount/sshfs_mounts.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <multipass/exceptions/sshfs_missing_error.h>
+#include <multipass/file_ops.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
@@ -25,6 +26,7 @@
 #include <multipass/utils.h>
 #include <multipass/virtual_machine.h>
 
+#include <QDir>
 #include <QEventLoop>
 
 namespace mp = multipass;
@@ -65,6 +67,12 @@ mp::SSHFSMounts::SSHFSMounts(const SSHKeyProvider& key_provider) : key(key_provi
 void mp::SSHFSMounts::start_mount(VirtualMachine* vm, const std::string& source_path, const std::string& target_path,
                                   const mp::id_mappings& gid_mappings, const mp::id_mappings& uid_mappings)
 {
+    if (!MP_FILEOPS.exists(QDir{QString::fromStdString(source_path)}))
+    {
+        mount_processes[vm->vm_name].erase(target_path);
+        throw std::runtime_error(fmt::format("Mount path `{}` does not exist.", source_path));
+    }
+
     mp::SSHFSServerConfig config;
     config.host = vm->ssh_hostname();
     config.port = vm->ssh_port();

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -23,6 +23,11 @@ mp::FileOps::FileOps(const Singleton<FileOps>::PrivatePass& pass) noexcept : Sin
 {
 }
 
+bool mp::FileOps::exists(const QDir& dir) const
+{
+    return dir.exists();
+}
+
 bool mp::FileOps::isReadable(const QDir& dir) const
 {
     return dir.isReadable();

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -386,7 +386,7 @@ INSTANTIATE_TEST_SUITE_P(CreateBridgeTest, CreateBridgeExceptionTest, Values(tru
 TEST(LinuxBackendUtils, check_for_kvm_support_no_error_does_not_throw)
 {
     auto [mock_file_ops, file_ops_guard] = mpt::MockFileOps::inject();
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, open(_, _)).WillOnce(Return(true));
 
     EXPECT_NO_THROW(MP_BACKEND.check_for_kvm_support());
@@ -395,7 +395,7 @@ TEST(LinuxBackendUtils, check_for_kvm_support_no_error_does_not_throw)
 TEST(LinuxBackendUtils, check_for_kvm_support_does_not_exist_throws_expected_error)
 {
     auto [mock_file_ops, file_ops_guard] = mpt::MockFileOps::inject();
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(MP_BACKEND.check_for_kvm_support(), std::runtime_error,
                          mpt::match_what(AllOf(HasSubstr("KVM support is not enabled on this machine."),
@@ -405,7 +405,7 @@ TEST(LinuxBackendUtils, check_for_kvm_support_does_not_exist_throws_expected_err
 TEST(LinuxBackendUtils, check_for_kvm_support_no_read_write_throws_expected_error)
 {
     auto [mock_file_ops, file_ops_guard] = mpt::MockFileOps::inject();
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, open(_, _)).WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -31,6 +31,7 @@ public:
     using FileOps::FileOps;
 
     MOCK_CONST_METHOD0(current, QDir());
+    MOCK_CONST_METHOD1(exists, bool(const QDir&));
     MOCK_CONST_METHOD1(isReadable, bool(const QDir&));
     MOCK_CONST_METHOD2(mkpath, bool(const QDir&, const QString& dirName));
     MOCK_CONST_METHOD2(rmdir, bool(QDir&, const QString& dirName));

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -342,7 +342,7 @@ TEST_F(AliasDictionary, throws_when_open_alias_file_fails)
 {
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, open(_, _)).WillOnce(Return(false));
 
     std::stringstream trash_stream;

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -3203,7 +3203,10 @@ TEST_F(ClientAlias, fails_when_remove_backup_alias_file_fails)
 {
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(false)).WillOnce(Return(true)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>()))
+        .WillOnce(Return(false))
+        .WillOnce(Return(true))
+        .WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, mkpath(_, _)).WillOnce(Return(true)); // mpu::create_temp_file_with_path()
     EXPECT_CALL(*mock_file_ops, open(_, _)).Times(2).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_file_ops, write(_, _)).WillOnce(Return(true));
@@ -3221,7 +3224,10 @@ TEST_F(ClientAlias, fails_renaming_alias_file_fails)
 {
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(false)).WillOnce(Return(true)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>()))
+        .WillOnce(Return(false))
+        .WillOnce(Return(true))
+        .WillOnce(Return(false));
     EXPECT_CALL(*mock_file_ops, mkpath(_, _)).WillOnce(Return(true)); // mpu::create_temp_file_with_path()
     EXPECT_CALL(*mock_file_ops, open(_, _)).Times(2).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_file_ops, write(_, _)).WillOnce(Return(true));
@@ -3239,7 +3245,7 @@ TEST_F(ClientAlias, fails_creating_alias_file_fails)
 {
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(false)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(false)).WillOnce(Return(false));
     EXPECT_CALL(*mock_file_ops, mkpath(_, _)).WillOnce(Return(true)); // mpu::create_temp_file_with_path()
     EXPECT_CALL(*mock_file_ops, open(_, _)).Times(2).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_file_ops, write(_, _)).WillOnce(Return(true));

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -21,6 +21,7 @@
 #include "mock_process_factory.h"
 #include "mock_virtual_machine.h"
 #include "stub_ssh_key_provider.h"
+#include "tests/mock_file_ops.h"
 
 #include <multipass/exceptions/sshfs_missing_error.h>
 #include <multipass/sshfs_mount/sshfs_mounts.h>
@@ -46,6 +47,8 @@ struct SSHFSMountsTest : public ::Test
 
     mpt::StubSSHKeyProvider key_provider;
     std::string source_path{"/my/source/path"}, target_path{"/the/target/path"};
+    mpt::MockFileOps::GuardedMock mock_file_ops_injection = mpt::MockFileOps::inject();
+    mpt::MockFileOps& mock_file_ops = *mock_file_ops_injection.first;
     mp::id_mappings gid_mappings{{1, 2}, {3, 4}}, uid_mappings{{5, -1}, {6, 10}};
     mpt::SetEnvScope env_scope{"DISABLE_APPARMOR", "1"};
     mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject(default_log_level);
@@ -66,6 +69,8 @@ struct SSHFSMountsTest : public ::Test
 
 TEST_F(SSHFSMountsTest, mount_creates_sshfs_process)
 {
+    EXPECT_CALL(mock_file_ops, exists(A<const QDir&>())).WillOnce(Return(true));
+
     auto factory = mpt::MockProcessFactory::Inject();
     factory->register_callback(sshfs_prints_connected);
 
@@ -98,6 +103,8 @@ TEST_F(SSHFSMountsTest, mount_creates_sshfs_process)
 
 TEST_F(SSHFSMountsTest, sshfs_process_failing_with_return_code_9_causes_exception)
 {
+    EXPECT_CALL(mock_file_ops, exists(A<const QDir&>())).WillOnce(Return(true));
+
     auto factory = mpt::MockProcessFactory::Inject();
 
     mpt::MockProcessFactory::Callback sshfs_fails_with_exit_code_nine = [](mpt::MockProcess* process) {
@@ -127,6 +134,8 @@ TEST_F(SSHFSMountsTest, sshfs_process_failing_with_return_code_9_causes_exceptio
 
 TEST_F(SSHFSMountsTest, sshfs_process_failing_causes_runtime_exception)
 {
+    EXPECT_CALL(mock_file_ops, exists(A<const QDir&>())).WillOnce(Return(true));
+
     auto factory = mpt::MockProcessFactory::Inject();
 
     mpt::MockProcessFactory::Callback sshfs_fails = [](mpt::MockProcess* process) {
@@ -159,6 +168,8 @@ TEST_F(SSHFSMountsTest, sshfs_process_failing_causes_runtime_exception)
 
 TEST_F(SSHFSMountsTest, stop_terminates_sshfs_process)
 {
+    EXPECT_CALL(mock_file_ops, exists(A<const QDir&>())).WillOnce(Return(true));
+
     auto factory = mpt::MockProcessFactory::Inject();
     mpt::MockProcessFactory::Callback sshfs_fails = [this](mpt::MockProcess* process) {
         sshfs_prints_connected(process);
@@ -181,6 +192,8 @@ TEST_F(SSHFSMountsTest, stop_terminates_sshfs_process)
 
 TEST_F(SSHFSMountsTest, stop_all_mounts_terminates_all_sshfs_processes)
 {
+    EXPECT_CALL(mock_file_ops, exists(A<const QDir&>())).Times(3).WillRepeatedly(Return(true));
+
     auto factory = mpt::MockProcessFactory::Inject();
     mpt::MockProcessFactory::Callback sshfs_fails = [this](mpt::MockProcess* process) {
         sshfs_prints_connected(process);
@@ -205,6 +218,8 @@ TEST_F(SSHFSMountsTest, stop_all_mounts_terminates_all_sshfs_processes)
 
 TEST_F(SSHFSMountsTest, has_instance_already_mounted_returns_true_when_found)
 {
+    EXPECT_CALL(mock_file_ops, exists(A<const QDir&>())).WillOnce(Return(true));
+
     auto factory = mpt::MockProcessFactory::Inject();
     factory->register_callback(sshfs_prints_connected);
 
@@ -219,6 +234,8 @@ TEST_F(SSHFSMountsTest, has_instance_already_mounted_returns_true_when_found)
 
 TEST_F(SSHFSMountsTest, has_instance_already_mounted_returns_false_when_no_such_mount)
 {
+    EXPECT_CALL(mock_file_ops, exists(A<const QDir&>())).WillOnce(Return(true));
+
     auto factory = mpt::MockProcessFactory::Inject();
     factory->register_callback(sshfs_prints_connected);
 
@@ -233,6 +250,8 @@ TEST_F(SSHFSMountsTest, has_instance_already_mounted_returns_false_when_no_such_
 
 TEST_F(SSHFSMountsTest, has_instance_already_mounted_returns_false_when_no_such_instance)
 {
+    EXPECT_CALL(mock_file_ops, exists(A<const QDir&>())).WillOnce(Return(true));
+
     auto factory = mpt::MockProcessFactory::Inject();
     factory->register_callback(sshfs_prints_connected);
 

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -277,5 +277,5 @@ TEST_F(SSHFSMountsTest, mount_fails_on_nonexist_directory)
 
     MP_EXPECT_THROW_THAT(sshfs_mounts.start_mount(&vm, source_path, target_path, gid_mappings, uid_mappings),
                          std::runtime_error,
-                         mpt::match_what(StrEq(fmt::format("Mount path `{}` does not exist.", source_path))));
+                         mpt::match_what(StrEq(fmt::format("Mount path \"{}\" does not exist.", source_path))));
 }

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -303,7 +303,7 @@ TEST(Utils, make_file_with_content_fails_if_path_cannot_be_created)
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(false));
     EXPECT_CALL(*mock_file_ops, mkpath(_, _)).WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(MP_UTILS.make_file_with_content(file_name, file_contents), std::runtime_error,
@@ -316,7 +316,7 @@ TEST(Utils, make_file_with_content_fails_if_file_cannot_be_created)
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(false));
     EXPECT_CALL(*mock_file_ops, mkpath(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, open(_, _)).WillOnce(Return(false));
 
@@ -330,7 +330,7 @@ TEST(Utils, make_file_with_content_throws_on_write_error)
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
-    EXPECT_CALL(*mock_file_ops, exists(_)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(false));
     EXPECT_CALL(*mock_file_ops, mkpath(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, open(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, write(_, _, _)).WillOnce(Return(747));


### PR DESCRIPTION
This PR add a check to make sure that the given directory exists before attempting to mount it. If the directory is not found, the host and target directories will be removed from the database.

Fixes #1677 