### PR TITLE
ci: allow cancellation of BuildAndTest

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,10 +59,13 @@ jobs:
     # Let Lint fail on pull requests
     if: |
       ${{
-        success()
-        || needs.Lint.result == 'skipped'
-        || ( needs.Lint.result == 'failure'
-             && github.event_name == 'pull_request' )
+        !cancelled()
+        && ( success()
+             || needs.Lint.result == 'skipped'
+             || ( needs.Lint.result == 'failure'
+                  && github.event_name == 'pull_request'
+                )
+           )
       }}
 
     outputs:


### PR DESCRIPTION
Jobs/steps need explicit `!cancelled()` if they use any of the status
check functions:

https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions