### PR TITLE
sshfs not cleanly shutdown when stopping an instance

### DIFF
--- a/src/sshfs_mount/sshfs_mounts.cpp
+++ b/src/sshfs_mount/sshfs_mounts.cpp
@@ -154,7 +154,8 @@ bool mp::SSHFSMounts::stop_mount(const std::string& instance, const std::string&
 
         if (!sshfs_mount->wait_for_finished(1000))
         {
-            mpl::log(mpl::Level::info, category, "failed to terminate nicely, killing");
+            mpl::log(mpl::Level::info, category,
+                     fmt::format("Failed to terminate mount '{}' in instance \"{}\", killing", path, instance));
             sshfs_mount->kill();
         }
         return true;

--- a/src/sshfs_mount/sshfs_mounts.cpp
+++ b/src/sshfs_mount/sshfs_mounts.cpp
@@ -172,10 +172,11 @@ void mp::SSHFSMounts::stop_all_mounts_for_instance(const std::string& instance)
     }
     else
     {
-        for (auto it = mounts_it->second.cbegin(), next = it; it != mounts_it->second.cend(); it = next)
+        for (auto it = mounts_it->second.cbegin(); it != mounts_it->second.cend();)
         {
-            next++;
-            stop_mount(instance, it->first);
+            // Clever postfix increment with member access needed to prevent iterator invalidation since iterable is
+            // modified in sshfs connection signal handler
+            stop_mount(instance, it++->first);
         }
     }
     mount_processes[instance].clear();

--- a/tests/test_sshfsmounts.cpp
+++ b/tests/test_sshfsmounts.cpp
@@ -166,6 +166,8 @@ TEST_F(SSHFSMountsTest, stop_terminates_sshfs_process)
         if (process->program().contains("sshfs_server"))
         {
             EXPECT_CALL(*process, terminate);
+            EXPECT_CALL(*process, wait_for_finished(_)).WillOnce(Return(false));
+            EXPECT_CALL(*process, kill);
         }
     };
     factory->register_callback(sshfs_fails);
@@ -188,6 +190,7 @@ TEST_F(SSHFSMountsTest, stop_all_mounts_terminates_all_sshfs_processes)
         if (process->program().contains("sshfs_server"))
         {
             EXPECT_CALL(*process, terminate);
+            ON_CALL(*process, wait_for_finished(_)).WillByDefault(Return(true));
         }
     };
     factory->register_callback(sshfs_fails);


### PR DESCRIPTION
This PR adds logic to force a process to wait until the process has exited before continuing. If the process does not terminate within the specified amount of time, kill it.

Fixes #1132 