### PR TITLE
Handle bad settings read from disk

### DIFF
--- a/src/settings/persistent_settings_handler.cpp
+++ b/src/settings/persistent_settings_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Canonical, Ltd.
+ * Copyright (C) 2021-2023 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,11 +19,13 @@
 
 #include <multipass/exceptions/settings_exceptions.h>
 #include <multipass/file_ops.h>
+#include <multipass/logging/log.h>
 #include <multipass/settings/persistent_settings_handler.h>
 
 #include <cassert>
 
 namespace mp = multipass;
+namespace mpl = mp::logging;
 
 namespace
 {
@@ -56,14 +58,28 @@ void check_status(const mp::WrappedQSettings& qsettings, const QString& attempte
                                      : QStringLiteral("access error (consider running with an administrative role)")};
 }
 
-QString checked_get(const mp::WrappedQSettings& qsettings, const QString& key, const QString& fallback,
-                    std::mutex& mutex)
+QString checked_get(mp::WrappedQSettings& qsettings, const QString& key, const mp::SettingSpec& spec, std::mutex& mutex)
 {
     std::lock_guard<std::mutex> lock{mutex};
 
+    const auto& fallback = spec.get_default();
     auto ret = qsettings.value(key, fallback).toString();
 
     check_status(qsettings, QStringLiteral("read"));
+
+    try
+    {
+        spec.interpret(ret); // check validity of what we read from disk
+    }
+    catch (const mp::InvalidSettingException& e)
+    {
+        mpl::log(mpl::Level::warning, "settings", fmt::format("{}. Resetting '{}'.", e.what(), key));
+        qsettings.remove(key);
+        qsettings.sync();
+        check_status(qsettings, "reset");
+        ret = fallback;
+    }
+
     return ret;
 }
 
@@ -86,9 +102,9 @@ mp::PersistentSettingsHandler::PersistentSettingsHandler(QString filename, Setti
 // TODO try installing yaml backend
 QString mp::PersistentSettingsHandler::get(const QString& key) const
 {
-    const auto& default_ret = get_setting(key).get_default(); // make sure the key is valid before reading from disk
+    const auto& setting_spec = get_setting(key); // make sure the key is valid before reading from disk
     auto settings_file = persistent_settings(filename);
-    return checked_get(*settings_file, key, default_ret, mutex);
+    return checked_get(*settings_file, key, setting_spec, mutex);
 }
 
 auto mp::PersistentSettingsHandler::get_setting(const QString& key) const -> const SettingSpec&

--- a/src/settings/wrapped_qsettings.h
+++ b/src/settings/wrapped_qsettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Canonical, Ltd.
+ * Copyright (C) 2021-2023 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -61,6 +61,12 @@ public:
     {
         assert(qsettings);
         qsettings->setValue(key, value);
+    }
+
+    virtual void remove(const QString& key)
+    {
+        assert(qsettings);
+        qsettings->remove(key);
     }
 
     QVariant value(const QString& key, const QVariant& default_value = QVariant()) const

--- a/tests/mock_qsettings.h
+++ b/tests/mock_qsettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Canonical, Ltd.
+ * Copyright (C) 2019-2023 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,6 +35,7 @@ public:
     MOCK_METHOD1(setIniCodec, void(const char* codec_name));
     MOCK_METHOD0(sync, void());
     MOCK_METHOD2(setValue, void(const QString& key, const QVariant& value));
+    MOCK_METHOD1(remove, void(const QString&));
 };
 
 class MockQSettingsProvider : public WrappedQSettingsFactory

--- a/tests/test_persistent_settings_handler.cpp
+++ b/tests/test_persistent_settings_handler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Canonical, Ltd.
+ * Copyright (C) 2019-2023 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -219,6 +219,28 @@ TEST_F(TestPersistentSettingsHandler, getReturnsRecordedSetting)
 
     ASSERT_NE(val, default_);
     EXPECT_EQ(handler.get(key), QString{val});
+}
+
+TEST_F(TestPersistentSettingsHandler, getResetsInvalidValueAndReturnsDefault)
+{
+    const auto key = "tampered.setting", val = "xyz", default_ = "abc", error = "nonsense";
+    const auto handler = make_handler(key, default_, [&key, &val, &error](QString v) -> QString {
+        if (v == val)
+            throw mp::InvalidSettingException{key, val, error};
+
+        return v;
+    });
+
+    {
+        InSequence seq;
+        EXPECT_CALL(*mock_qsettings, value_impl(Eq(key), _)).WillOnce(Return(val));
+        EXPECT_CALL(*mock_qsettings, remove(Eq(key)));
+    }
+
+    inject_mock_qsettings();
+
+    ASSERT_NE(val, default_);
+    EXPECT_EQ(handler.get(key), QString{default_});
 }
 
 TEST_F(TestPersistentSettingsHandler, getReturnsDefaultByDefault)


### PR DESCRIPTION
Be robust to bad setting values read from disk, by logging the occurrence, resetting, and returning the default.

The lazy approach taken here reuses `SettingSpec::interpret`, but it imposes a new constraint on it: it needs to be able to validate already "interpreted" (marshalled) settings. I want to see how this goes on different platforms and integration tests. 

If this works, we can rely on it to reset `hyperkit` to `qemu` once the former is gone (because the latter will be the default by then). Otherwise, we could try to finally move to a marshall/unmarshall scheme, or just tackle the hyperkit case with dedicated code.