### PR TITLE
Transfer p flag

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -75,6 +75,7 @@ public:
     virtual bool exists(const fs::path& path, std::error_code& err) const;
     virtual bool is_directory(const fs::path& path, std::error_code& err) const;
     virtual bool create_directory(const fs::path& path, std::error_code& err) const;
+    virtual bool create_directories(const fs::path& path, std::error_code& err) const;
     virtual bool remove(const fs::path& path, std::error_code& err) const;
     virtual void create_symlink(const fs::path& to, const fs::path& path, std::error_code& err) const;
     virtual fs::path read_symlink(const fs::path& path, std::error_code& err) const;

--- a/include/multipass/ssh/sftp_client.h
+++ b/include/multipass/ssh/sftp_client.h
@@ -54,7 +54,7 @@ public:
     virtual bool is_remote_dir(const fs::path& path);
     virtual bool push(const fs::path& source_path, const fs::path& target_path, Flags flags = {});
     virtual bool pull(const fs::path& source_path, const fs::path& target_path, Flags flags = {});
-    virtual void from_cin(std::istream& cin, const fs::path& target_path);
+    virtual void from_cin(std::istream& cin, const fs::path& target_path, bool make_parent);
     virtual void to_cout(const fs::path& source_path, std::ostream& cout);
 
     virtual ~SFTPClient() = default;

--- a/include/multipass/ssh/sftp_client.h
+++ b/include/multipass/ssh/sftp_client.h
@@ -43,6 +43,7 @@ public:
     enum class Flag
     {
         Recursive = 1,
+        MakeParent = 2,
     };
     Q_DECLARE_FLAGS(Flags, Flag)
 

--- a/include/multipass/ssh/sftp_utils.h
+++ b/include/multipass/ssh/sftp_utils.h
@@ -61,6 +61,7 @@ struct SFTPUtils : public Singleton<SFTPUtils>
                                             const fs::path& target_path);
     virtual fs::path get_local_dir_target(const fs::path& source_path, const fs::path& target_path);
     virtual fs::path get_remote_dir_target(sftp_session sftp, const fs::path& source_path, const fs::path& target_path);
+    virtual void mkdir_recursive(sftp_session sftp, const fs::path& path);
     virtual std::unique_ptr<SFTPDirIterator> make_SFTPDirIterator(sftp_session sftp, const fs::path& path);
     virtual std::unique_ptr<SFTPClient> make_SFTPClient(const std::string& host, int port, const std::string& username,
                                                         const std::string& priv_key_blob);

--- a/include/multipass/ssh/sftp_utils.h
+++ b/include/multipass/ssh/sftp_utils.h
@@ -56,11 +56,12 @@ struct SFTPUtils : public Singleton<SFTPUtils>
 {
     SFTPUtils(const Singleton<SFTPUtils>::PrivatePass&) noexcept;
 
-    virtual fs::path get_local_file_target(const fs::path& source_path, const fs::path& target_path);
-    virtual fs::path get_remote_file_target(sftp_session sftp, const fs::path& source_path,
-                                            const fs::path& target_path);
-    virtual fs::path get_local_dir_target(const fs::path& source_path, const fs::path& target_path);
-    virtual fs::path get_remote_dir_target(sftp_session sftp, const fs::path& source_path, const fs::path& target_path);
+    virtual fs::path get_local_file_target(const fs::path& source_path, const fs::path& target_path, bool make_parent);
+    virtual fs::path get_remote_file_target(sftp_session sftp, const fs::path& source_path, const fs::path& target_path,
+                                            bool make_parent);
+    virtual fs::path get_local_dir_target(const fs::path& source_path, const fs::path& target_path, bool make_parent);
+    virtual fs::path get_remote_dir_target(sftp_session sftp, const fs::path& source_path, const fs::path& target_path,
+                                           bool make_parent);
     virtual void mkdir_recursive(sftp_session sftp, const fs::path& path);
     virtual std::unique_ptr<SFTPDirIterator> make_SFTPDirIterator(sftp_session sftp, const fs::path& path);
     virtual std::unique_ptr<SFTPClient> make_SFTPClient(const std::string& host, int port, const std::string& username,

--- a/src/client/cli/cmd/transfer.cpp
+++ b/src/client/cli/cmd/transfer.cpp
@@ -126,11 +126,13 @@ mp::ParseCode cmd::Transfer::parse_args(mp::ArgParser* parser)
                                   "a path inside the instance, or '-' for stdout",
                                   "<destination>");
     parser->addOption({{"r", "recursive"}, "Recursively copy entire directories"});
+    parser->addOption({{"p", "parents"}, "Make parent directories as needed"});
 
     if (auto status = parser->commandParse(this); status != ParseCode::Ok)
         return status;
 
     flags.setFlag(SFTPClient::Flag::Recursive, parser->isSet("r"));
+    flags.setFlag(SFTPClient::Flag::MakeParent, parser->isSet("p"));
 
     auto positionalArgs = parser->positionalArguments();
     if (positionalArgs.size() < 2)

--- a/src/client/cli/cmd/transfer.cpp
+++ b/src/client/cli/cmd/transfer.cpp
@@ -72,7 +72,7 @@ mp::ReturnCode cmd::Transfer::run(mp::ArgParser* parser)
                 }
 
                 if (const auto args = std::get_if<FromCin>(&arguments); args)
-                    sftp_client->from_cin(term->cin(), args->target);
+                    sftp_client->from_cin(term->cin(), args->target, flags.testFlag(SFTPClient::Flag::MakeParent));
 
                 if (const auto args = std::get_if<ToCout>(&arguments); args)
                     sftp_client->to_cout(args->source, term->cout());

--- a/src/ssh/sftp_client.cpp
+++ b/src/ssh/sftp_client.cpp
@@ -75,13 +75,15 @@ try
         if (!flags.testFlag(Flag::Recursive))
             throw SFTPError{"omitting local directory {}: recursive mode not specified", source_path};
 
-        auto full_target_path = MP_SFTPUTILS.get_remote_dir_target(sftp.get(), source, target_path);
+        auto full_target_path = MP_SFTPUTILS.get_remote_dir_target(sftp.get(), source, target_path,
+                                                                   flags.testFlag(SFTPClient::Flag::MakeParent));
         return push_dir(source, full_target_path);
     }
     else if (err)
         throw SFTPError{"cannot access {}: {}", source_path, err.message()};
 
-    auto full_target_path = MP_SFTPUTILS.get_remote_file_target(sftp.get(), source, target_path);
+    auto full_target_path = MP_SFTPUTILS.get_remote_file_target(sftp.get(), source, target_path,
+                                                                flags.testFlag(SFTPClient::Flag::MakeParent));
     push_file(source, full_target_path);
     return true;
 }
@@ -102,11 +104,13 @@ try
         if (!flags.testFlag(Flag::Recursive))
             throw SFTPError{"omitting remote directory {}: recursive mode not specified", source_path};
 
-        auto full_target_path = MP_SFTPUTILS.get_local_dir_target(source, target_path);
+        auto full_target_path =
+            MP_SFTPUTILS.get_local_dir_target(source, target_path, flags.testFlag(SFTPClient::Flag::MakeParent));
         return pull_dir(source, full_target_path);
     }
 
-    auto full_target_path = MP_SFTPUTILS.get_local_file_target(source, target_path);
+    auto full_target_path =
+        MP_SFTPUTILS.get_local_file_target(source, target_path, flags.testFlag(SFTPClient::Flag::MakeParent));
     pull_file(source, full_target_path);
     return true;
 }
@@ -273,9 +277,9 @@ bool SFTPClient::pull_dir(const fs::path& source_path, const fs::path& target_pa
     return success;
 }
 
-void SFTPClient::from_cin(std::istream& cin, const fs::path& target_path)
+void SFTPClient::from_cin(std::istream& cin, const fs::path& target_path, bool make_parent)
 {
-    auto full_target_path = MP_SFTPUTILS.get_remote_file_target(sftp.get(), stream_file_name, target_path);
+    auto full_target_path = MP_SFTPUTILS.get_remote_file_target(sftp.get(), stream_file_name, target_path, make_parent);
     do_push_file(cin, full_target_path);
 }
 

--- a/src/ssh/sftp_utils.cpp
+++ b/src/ssh/sftp_utils.cpp
@@ -47,9 +47,9 @@ fs::path SFTPUtils::get_local_file_target(const fs::path& source_path, const fs:
         return target_path;
 
     auto target_full_path = target_path / source_path.filename();
-    if (MP_FILEOPS.is_directory(target_full_path, err) && !err)
+    if (MP_FILEOPS.is_directory(target_full_path, err))
         throw SFTPError{"cannot overwrite local directory {} with non-directory", target_full_path};
-    else if (err)
+    else if (err && err != std::errc::no_such_file_or_directory)
         throw SFTPError{"cannot access {}: {}", target_full_path, err.message()};
 
     return target_full_path;

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -154,6 +154,11 @@ bool mp::FileOps::create_directory(const fs::path& path, std::error_code& err) c
     return fs::create_directory(path, err);
 }
 
+bool mp::FileOps::create_directories(const fs::path& path, std::error_code& err) const
+{
+    return fs::create_directories(path, err);
+}
+
 bool mp::FileOps::remove(const fs::path& path, std::error_code& err) const
 {
     return fs::remove(path, err);

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -58,6 +58,7 @@ public:
     MOCK_METHOD(bool, exists, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(bool, is_directory, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(bool, create_directory, (const fs::path& path, std::error_code& err), (override, const));
+    MOCK_METHOD(bool, create_directories, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(bool, remove, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(void, create_symlink, (const fs::path& to, const fs::path& path, std::error_code& err),
                 (override, const));

--- a/tests/mock_sftp_client.h
+++ b/tests/mock_sftp_client.h
@@ -28,7 +28,7 @@ struct MockSFTPClient : public SFTPClient
     MOCK_METHOD(bool, is_remote_dir, (const fs::path& path), (override));
     MOCK_METHOD(bool, push, (const fs::path& source_path, const fs::path& target_path, Flags flags), (override));
     MOCK_METHOD(bool, pull, (const fs::path& source_path, const fs::path& target_path, Flags flags), (override));
-    MOCK_METHOD(void, from_cin, (std::istream & cin, const fs::path& target_path), (override));
+    MOCK_METHOD(void, from_cin, (std::istream & cin, const fs::path& target_path, bool make_parent), (override));
     MOCK_METHOD(void, to_cout, (const fs::path& source_path, std::ostream& cout), (override));
 };
 } // namespace multipass::test

--- a/tests/mock_sftp_utils.h
+++ b/tests/mock_sftp_utils.h
@@ -11,13 +11,16 @@ struct MockSFTPUtils : public SFTPUtils
 {
     using SFTPUtils::SFTPUtils;
 
-    MOCK_METHOD(fs::path, get_local_file_target, (const fs::path& source_path, const fs::path& target_path),
-                (override));
+    MOCK_METHOD(fs::path, get_local_file_target,
+                (const fs::path& source_path, const fs::path& target_path, bool make_parent), (override));
     MOCK_METHOD(fs::path, get_remote_file_target,
-                (sftp_session sftp, const fs::path& source_path, const fs::path& target_path), (override));
-    MOCK_METHOD(fs::path, get_local_dir_target, (const fs::path& source_path, const fs::path& target_path), (override));
+                (sftp_session sftp, const fs::path& source_path, const fs::path& target_path, bool make_parent),
+                (override));
+    MOCK_METHOD(fs::path, get_local_dir_target,
+                (const fs::path& source_path, const fs::path& target_path, bool make_parent), (override));
     MOCK_METHOD(fs::path, get_remote_dir_target,
-                (sftp_session sftp, const fs::path& source_path, const fs::path& target_path), (override));
+                (sftp_session sftp, const fs::path& source_path, const fs::path& target_path, bool make_parent),
+                (override));
     MOCK_METHOD(void, mkdir_recursive, (sftp_session sftp, const fs::path& path), (override));
     MOCK_METHOD(std::unique_ptr<SFTPDirIterator>, make_SFTPDirIterator, (sftp_session sftp, const fs::path& path),
                 (override));

--- a/tests/mock_sftp_utils.h
+++ b/tests/mock_sftp_utils.h
@@ -18,6 +18,7 @@ struct MockSFTPUtils : public SFTPUtils
     MOCK_METHOD(fs::path, get_local_dir_target, (const fs::path& source_path, const fs::path& target_path), (override));
     MOCK_METHOD(fs::path, get_remote_dir_target,
                 (sftp_session sftp, const fs::path& source_path, const fs::path& target_path), (override));
+    MOCK_METHOD(void, mkdir_recursive, (sftp_session sftp, const fs::path& path), (override));
     MOCK_METHOD(std::unique_ptr<SFTPDirIterator>, make_SFTPDirIterator, (sftp_session sftp, const fs::path& path),
                 (override));
     MOCK_METHOD(std::unique_ptr<SFTPClient>, make_SFTPClient,

--- a/tests/test_file_ops.cpp
+++ b/tests/test_file_ops.cpp
@@ -117,3 +117,11 @@ TEST_F(FileOps, dir_iter)
     MP_FILEOPS.recursive_dir_iterator(temp_file, err);
     EXPECT_TRUE(err);
 }
+
+TEST_F(FileOps, create_directories)
+{
+    EXPECT_TRUE(MP_FILEOPS.create_directories(temp_dir / "subdir/nested", err));
+    EXPECT_FALSE(err);
+    EXPECT_FALSE(MP_FILEOPS.create_directories(temp_dir / "subdir/nested", err));
+    EXPECT_FALSE(err);
+}

--- a/tests/test_sftp_client.cpp
+++ b/tests/test_sftp_client.cpp
@@ -128,7 +128,7 @@ TEST_F(SFTPClient, push_file_success)
 
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_read(source_path))
         .WillOnce(Return(std::make_unique<std::stringstream>(test_data)));
     REPLACE(sftp_open, [](auto sftp, auto...) { return get_dummy_sftp_file(sftp); });
@@ -156,7 +156,7 @@ TEST_F(SFTPClient, push_file_cannot_open_source)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     auto err = EACCES;
     EXPECT_CALL(*mock_file_ops, open_read(source_path)).WillOnce([&](auto...) {
         auto file = std::make_unique<std::stringstream>();
@@ -176,7 +176,7 @@ TEST_F(SFTPClient, push_file_cannot_open_target)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_read(source_path)).WillOnce(Return(std::make_unique<std::stringstream>()));
     REPLACE(sftp_open, [](auto...) { return nullptr; });
     auto err = "SFTP server: Permission denied";
@@ -194,7 +194,7 @@ TEST_F(SFTPClient, push_file_cannot_write_target)
 
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_read(source_path))
         .WillOnce(Return(std::make_unique<std::stringstream>(test_data)));
     REPLACE(sftp_open, [](auto sftp, auto...) { return get_dummy_sftp_file(sftp); });
@@ -215,7 +215,7 @@ TEST_F(SFTPClient, push_file_cannot_read_source)
 
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto test_file = std::make_unique<std::stringstream>(test_data);
     auto test_file_p = test_file.get();
@@ -247,7 +247,7 @@ TEST_F(SFTPClient, push_file_cannot_set_perms)
 
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_read(source_path))
         .WillOnce(Return(std::make_unique<std::stringstream>(test_data)));
     REPLACE(sftp_open, [](auto sftp, auto...) { return get_dummy_sftp_file(sftp); });
@@ -273,7 +273,7 @@ TEST_F(SFTPClient, pull_file_success)
     std::string test_data = "test_data";
 
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
-    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     std::stringstream test_file;
     auto tee_stream = std::make_unique<Poco::TeeOutputStream>();
@@ -304,7 +304,7 @@ TEST_F(SFTPClient, pull_file_cannot_open_source)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_write(target_path)).WillOnce(Return(std::make_unique<std::stringstream>()));
     REPLACE(sftp_open, [](auto...) { return nullptr; });
     auto err = "SFTP server: Permission denied";
@@ -320,7 +320,7 @@ TEST_F(SFTPClient, pull_file_cannot_open_target)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
     auto err = EACCES;
     EXPECT_CALL(*mock_file_ops, open_write(target_path)).WillOnce([&](auto...) {
         auto file = std::make_unique<std::stringstream>();
@@ -339,7 +339,7 @@ TEST_F(SFTPClient, pull_file_cannot_open_target)
 TEST_F(SFTPClient, pull_file_cannot_write_target)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
-    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto test_file = std::make_unique<std::stringstream>();
     auto test_file_p = test_file.get();
@@ -369,7 +369,7 @@ TEST_F(SFTPClient, pull_file_cannot_read_source)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_write(target_path)).WillOnce(Return(std::make_unique<std::stringstream>()));
     REPLACE(sftp_open, [](auto sftp, auto...) { return get_dummy_sftp_file(sftp); });
 
@@ -386,7 +386,7 @@ TEST_F(SFTPClient, pull_file_cannot_read_source)
 TEST_F(SFTPClient, pull_file_cannot_set_perms)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
-    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_write(target_path)).WillOnce(Return(std::make_unique<std::stringstream>()));
     REPLACE(sftp_open, [](auto sftp, auto...) { return get_dummy_sftp_file(sftp); });
     REPLACE(sftp_read, [read = false](auto...) mutable { return (read = !read) ? 10 : 0; });
@@ -408,7 +408,7 @@ TEST_F(SFTPClient, push_dir_success_regular)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockRecursiveDirIterator>();
     auto iter_p = iter.get();
@@ -448,7 +448,7 @@ TEST_F(SFTPClient, push_dir_success_dir)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockRecursiveDirIterator>();
     auto iter_p = iter.get();
@@ -472,7 +472,7 @@ TEST_F(SFTPClient, push_dir_fail_dir)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockRecursiveDirIterator>();
     auto iter_p = iter.get();
@@ -501,7 +501,7 @@ TEST_F(SFTPClient, push_dir_success_symlink)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockRecursiveDirIterator>();
     auto iter_p = iter.get();
@@ -529,7 +529,7 @@ TEST_F(SFTPClient, push_dir_cannot_read_symlink)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockRecursiveDirIterator>();
     auto iter_p = iter.get();
@@ -560,7 +560,7 @@ TEST_F(SFTPClient, push_dir_cannot_create_symlink)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockRecursiveDirIterator>();
     auto iter_p = iter.get();
@@ -592,7 +592,7 @@ TEST_F(SFTPClient, push_dir_symlink_over_dir)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockRecursiveDirIterator>();
     auto iter_p = iter.get();
@@ -620,7 +620,7 @@ TEST_F(SFTPClient, push_dir_unknown_file_type)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockRecursiveDirIterator>();
     auto iter_p = iter.get();
@@ -645,7 +645,7 @@ TEST_F(SFTPClient, push_dir_open_iter_fail)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
-    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto err = std::make_error_code(std::errc::permission_denied);
     EXPECT_CALL(*mock_file_ops, recursive_dir_iterator(source_path, _)).WillOnce([&](auto, std::error_code& e) {
@@ -691,7 +691,7 @@ TEST_F(SFTPClient, push_dir_r_not_specified)
 TEST_F(SFTPClient, pull_dir_success_regular)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
-    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
     auto iter_p = iter.get();
@@ -734,7 +734,7 @@ TEST_F(SFTPClient, pull_dir_success_dir)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
     auto iter_p = iter.get();
@@ -754,7 +754,7 @@ TEST_F(SFTPClient, pull_dir_fail_dir)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
     auto iter_p = iter.get();
@@ -781,7 +781,7 @@ TEST_F(SFTPClient, pull_dir_success_symlink)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
     auto iter_p = iter.get();
@@ -805,7 +805,7 @@ TEST_F(SFTPClient, pull_dir_cannot_read_symlink)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
     auto iter_p = iter.get();
@@ -830,7 +830,7 @@ TEST_F(SFTPClient, pull_dir_cannot_create_symlink)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
     auto iter_p = iter.get();
@@ -857,7 +857,7 @@ TEST_F(SFTPClient, pull_dir_symlink_over_dir)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
     auto iter_p = iter.get();
@@ -881,7 +881,7 @@ TEST_F(SFTPClient, pull_dir_unknown_file_type)
 {
     REPLACE(sftp_init, [](auto...) { return SSH_OK; });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
-    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path)).WillOnce(Return(target_path));
+    EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
     auto iter_p = iter.get();


### PR DESCRIPTION
This PR adds the `-p|--parents` option to the `transfer` command, to create any missing parent directories

fix #1434 