### PR TITLE
Recursive transfer dir perms

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -257,6 +257,9 @@ _multipass_complete()
             _unused_aliases
             opts="${opts} ${unused_aliases}"
         ;;
+        "transfer"|"copy-files")
+            opts="${opts} --parents --recursive"
+        ;;
     esac
 
     if [[ ${prev} == -* ]]; then

--- a/tests/c_mock_defines.cmake
+++ b/tests/c_mock_defines.cmake
@@ -81,5 +81,6 @@ add_c_mocks(
   sftp_unlink
   sftp_setstat
   sftp_dir_eof
+  sftp_chmod
   ssh_get_error
 )

--- a/tests/mock_sftp.cpp
+++ b/tests/mock_sftp.cpp
@@ -36,4 +36,5 @@ extern "C"
     IMPL_MOCK_DEFAULT(2, sftp_unlink);
     IMPL_MOCK_DEFAULT(3, sftp_setstat);
     IMPL_MOCK_DEFAULT(1, sftp_dir_eof);
+    IMPL_MOCK_DEFAULT(3, sftp_chmod);
 }

--- a/tests/mock_sftp.h
+++ b/tests/mock_sftp.h
@@ -40,5 +40,6 @@ DECL_MOCK(sftp_symlink);
 DECL_MOCK(sftp_unlink);
 DECL_MOCK(sftp_setstat);
 DECL_MOCK(sftp_dir_eof);
+DECL_MOCK(sftp_chmod);
 
 #endif // MULTIPASS_MOCK_SFTP_H


### PR DESCRIPTION
This PR fixes a bug in the `transfer -r` command that did not set the copied directories permissions accordingly