### PR TITLE
Format dates in image vault and custom image host in c locale

### DIFF
--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -136,7 +136,7 @@ const QMap<QString, QMap<QString, CustomImageInfo>> snapcraft_image_info{
 auto base_image_info_for(mp::URLDownloader* url_downloader, const QString& image_url, const QString& hash_url,
                          const QString& image_file)
 {
-    const auto last_modified = url_downloader->last_modified({image_url}).toString("yyyyMMdd");
+    const auto last_modified = QLocale::c().toString(url_downloader->last_modified({image_url}), "yyyyMMdd");
     const auto sha256_sums = url_downloader->download({hash_url}).split('\n');
     QString hash;
 

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -355,9 +355,8 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
                 // Attempt to make a sane directory name based on the filename of the image
 
                 const auto image_dir_name =
-                    QString("%1-%2")
-                        .arg(image_filename.section(".", 0, image_filename.endsWith(".xz") ? -3 : -2))
-                        .arg(last_modified.toString("yyyyMMdd"));
+                    QString("%1-%2").arg(image_filename.section(".", 0, image_filename.endsWith(".xz") ? -3 : -2),
+                                         QLocale::c().toString(last_modified, "yyyyMMdd"));
                 const auto image_dir = mp::utils::make_dir(images_dir, image_dir_name);
 
                 // Had to use std::bind here to workaround the 5 allowable function arguments constraint of

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -104,7 +104,7 @@ TEST_P(ExpectedDataSuite, returns_expected_data)
         EXPECT_EQ(info->release, release);
         EXPECT_EQ(info->release_title, release_title);
         EXPECT_TRUE(info->supported);
-        EXPECT_EQ(info->version, QDateTime::currentDateTime().toString("yyyyMMdd"));
+        EXPECT_EQ(info->version, QLocale::c().toString(QDateTime::currentDateTime(), "yyyyMMdd"));
     }
 }
 


### PR DESCRIPTION
The dates used by the image vault and custom image host are formatted in the system locale. This PR formats them using the C locale for consistency.

fix #2442 