### PR TITLE
ci: drop `**` from ccache `path:`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,12 +118,12 @@ jobs:
         echo "::set-output name=key::$( git merge-base origin/main ${{ github.sha }} )"
 
     - name: CCache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: ccache-${{ runner.os }}-${{ matrix.build-type }}-${{ steps.setup-ccache.outputs.key }}
         restore-keys: |
           ccache-${{ runner.os }}-${{ matrix.build-type }}-
-        path: ~/.ccache/**
+        path: ~/.ccache
 
     - name: Set up coverage
       id: coverage-setup


### PR DESCRIPTION
Having this resulted in 4 copies of the same file in my work with Mir…

While here, upgrade the action.

Signed-off-by: Michał Sawicz <michal.sawicz@canonical.com>