### PR TITLE
[cli] Remove padded chars in cli output

### DIFF
--- a/include/multipass/cli/client_platform.h
+++ b/include/multipass/cli/client_platform.h
@@ -44,6 +44,7 @@ public:
     Platform(const Singleton::PrivatePass&) noexcept;
 
     virtual std::pair<std::string, std::string> get_user_password(Terminal* term) const;
+    virtual void enable_ansi_escape_chars() const;
 };
 
 void parse_transfer_entry(const QString& entry, QString& path, QString& instance_name);

--- a/src/client/cli/CMakeLists.txt
+++ b/src/client/cli/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(client STATIC
   client.cpp)
 
 target_link_libraries(client
+  client_platform
   commands
   fmt
   formatter

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -45,6 +45,7 @@
 
 #include <multipass/cli/argparser.h>
 #include <multipass/cli/client_common.h>
+#include <multipass/cli/client_platform.h>
 #include <multipass/constants.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
@@ -103,6 +104,8 @@ mp::Client::Client(ClientConfig& config)
     add_command<cmd::Version>();
 
     sort_commands();
+
+    MP_CLIENT_PLATFORM.enable_ansi_escape_chars();
 }
 
 void mp::Client::sort_commands()

--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -19,14 +19,22 @@
 #include <iomanip>
 #include <iostream>
 
+#ifdef MULTIPASS_PLATFORM_WINDOWS
+#include <windows.h>
+#endif
+
 namespace mp = multipass;
 
 namespace
 {
 void clear_line(std::ostream& out)
 {
+#ifdef MULTIPASS_PLATFORM_WINDOWS
+    out << "\x1B[1M"
+#else
     out << "\x1B[2K";               // Delete current line
     out << "\x1B[0E" << std::flush; // Move cursor to leftmost position of current line
+#endif
 }
 }
 

--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -26,7 +26,8 @@ namespace
 void clear_line(std::ostream& out)
 {
 #ifdef MULTIPASS_PLATFORM_WINDOWS
-    out << "\x1B[1M"
+    out << "\r" << std::setw(80) << " ";
+    out << "\r" << std::flush;
 #else
     out << "\x1B[2K";               // Delete current line
     out << "\x1B[0E" << std::flush; // Move cursor to leftmost position of current line

--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -19,10 +19,6 @@
 #include <iomanip>
 #include <iostream>
 
-#ifdef MULTIPASS_PLATFORM_WINDOWS
-#include <windows.h>
-#endif
-
 namespace mp = multipass;
 
 namespace

--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -25,8 +25,8 @@ namespace
 {
 void clear_line(std::ostream& out)
 {
-    out << "\r" << std::setw(80) << " ";
-    out << "\r" << std::flush;
+    out << "\x1B[2K";               // Delete current line
+    out << "\x1B[0E" << std::flush; // Move cursor to leftmost position of current line
 }
 }
 

--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -25,13 +25,8 @@ namespace
 {
 void clear_line(std::ostream& out)
 {
-#ifdef MULTIPASS_PLATFORM_WINDOWS
-    out << "\r" << std::setw(80) << " ";
-    out << "\r" << std::flush;
-#else
     out << "\x1B[2K";               // Delete current line
     out << "\x1B[0E" << std::flush; // Move cursor to leftmost position of current line
-#endif
 }
 }
 

--- a/src/platform/client/client_platform.cpp
+++ b/src/platform/client/client_platform.cpp
@@ -61,3 +61,8 @@ std::pair<std::string, std::string> mcp::Platform::get_user_password(mp::Termina
 {
     return {};
 }
+
+void mcp::Platform::enable_ansi_escape_chars() const
+{
+    return;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ set(FETCHCONTENT_QUIET FALSE)
 
 FetchContent_Declare(googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG main
+  GIT_TAG release-1.12.1
   GIT_SHALLOW TRUE
   GIT_PROGRESS TRUE
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ set(FETCHCONTENT_QUIET FALSE)
 
 FetchContent_Declare(googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.12.1
+  GIT_TAG main
   GIT_SHALLOW TRUE
   GIT_PROGRESS TRUE
 )

--- a/tests/test_common_callbacks.cpp
+++ b/tests/test_common_callbacks.cpp
@@ -33,8 +33,9 @@ struct TestSpinnerCallbacks : public Test
 {
     auto clearStreamMatcher()
     {
-        static const std::regex clear_regex{R"(\s*)"}; /* A "clear" stream can either be empty or made up of whitespaces
-                                                          (including carriage returns) */
+        static const std::regex clear_regex{
+            R"(\u001B\[2K\u001B\[0E|^$)"}; /* A "clear" stream should have nothing on the current
+                                     line and the cursor in the leftmost position */
         return Truly([](const auto& str) {
             return std::regex_match(str, clear_regex); // (gtest regex not cutting it on macOS)
         });
@@ -70,7 +71,7 @@ TEST_P(TestLoggingSpinnerCallbacks, loggingSpinnerCallbackLogs)
 
     EXPECT_THAT(err.str(), StrEq(log));
     EXPECT_THAT(out.str(), clearStreamMatcher()); /* this is not empty because print stops, stop clears, and clear
-                                                     prints carriage returns and spaces */
+                                                     prints ANSI escape characters to clear the line */
 }
 
 TEST_P(TestLoggingSpinnerCallbacks, loggingSpinnerCallbackIgnoresEmptyLog)


### PR DESCRIPTION
Use [ANSI escape characters](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797) to manipulate cursor and overwrite test in the cli. 

---

public side of [pr512](https://github.com/canonical/multipass-private/pull/512)

Fixes #958 