### PR TITLE
Use `--dhcp-ignore-clid` option for `dnsmasq`

### DIFF
--- a/src/platform/backends/qemu/linux/dnsmasq_process_spec.cpp
+++ b/src/platform/backends/qemu/linux/dnsmasq_process_spec.cpp
@@ -48,6 +48,7 @@ QStringList mp::DNSMasqProcessSpec::arguments() const
                          << "--except-interface=lo" << QString("--interface=%1").arg(bridge_name)
                          << QString("--listen-address=%1").arg(QString::fromStdString(bridge_addr.as_string()))
                          << "--dhcp-no-override"
+                         << "--dhcp-ignore-clid"
                          << "--dhcp-authoritative" << QString("--dhcp-leasefile=%1/dnsmasq.leases").arg(data_dir)
                          << QString("--dhcp-hostsfile=%1/dnsmasq.hosts").arg(data_dir) << "--dhcp-range"
                          << QString("%1,%2,infinite")

--- a/src/platform/backends/qemu/linux/dnsmasq_server.h
+++ b/src/platform/backends/qemu/linux/dnsmasq_server.h
@@ -41,7 +41,7 @@ public:
     DNSMasqServer(const Path& data_dir, const QString& bridge_name, const std::string& subnet);
     virtual ~DNSMasqServer(); // inherited by mock for testing
 
-    virtual std::optional<std::pair<IPAddress, std::string>> get_ip_and_host_for(const std::string& hw_addr);
+    virtual std::optional<IPAddress> get_ip_for(const std::string& hw_addr);
     virtual void release_mac(const std::string& hw_addr);
     virtual void check_dnsmasq_running();
 

--- a/src/platform/backends/qemu/linux/qemu_platform_detail.h
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail.h
@@ -40,7 +40,6 @@ public:
     std::optional<IPAddress> get_ip_for(const std::string& hw_addr) override;
     void remove_resources_for(const std::string& name) override;
     void platform_health_check() override;
-    void release_mac_with_different_hostname(const std::string& hw_addr, const std::string& name) override;
     QStringList vm_platform_args(const VirtualMachineDescription& vm_desc) override;
 
 private:

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -136,8 +136,7 @@ mp::QemuPlatformDetail::~QemuPlatformDetail()
 
 std::optional<mp::IPAddress> mp::QemuPlatformDetail::get_ip_for(const std::string& hw_addr)
 {
-    auto ip_and_host = dnsmasq_server->get_ip_and_host_for(hw_addr);
-    return ip_and_host ? std::make_optional(ip_and_host.value().first) : std::nullopt;
+    return dnsmasq_server->get_ip_for(hw_addr);
 }
 
 void mp::QemuPlatformDetail::remove_resources_for(const std::string& name)
@@ -194,14 +193,6 @@ QStringList mp::QemuPlatformDetail::vm_platform_args(const VirtualMachineDescrip
                                                tap_device_name, vm_desc.default_mac_address));
 
     return opts;
-}
-
-// FIXME: after moving to core22, this will be handled by dnsmasq --dhcp-ignore-clid
-void multipass::QemuPlatformDetail::release_mac_with_different_hostname(const std::string& hw_addr,
-                                                                        const std::string& name)
-{
-    if (auto ip_and_host = dnsmasq_server->get_ip_and_host_for(hw_addr); ip_and_host && ip_and_host->second != name)
-        dnsmasq_server->release_mac(hw_addr);
 }
 
 mp::QemuPlatform::UPtr mp::QemuPlatformFactory::make_qemu_platform(const Path& data_dir) const

--- a/src/platform/backends/qemu/qemu_platform.h
+++ b/src/platform/backends/qemu/qemu_platform.h
@@ -45,7 +45,6 @@ public:
     virtual std::optional<IPAddress> get_ip_for(const std::string& hw_addr) = 0;
     virtual void remove_resources_for(const std::string&) = 0;
     virtual void platform_health_check() = 0;
-    virtual void release_mac_with_different_hostname(const std::string& hw_addr, const std::string& name){};
     virtual QStringList vmstate_platform_args()
     {
         return {};

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -435,8 +435,6 @@ void mp::QemuVirtualMachine::on_suspend()
 
 void mp::QemuVirtualMachine::on_restart()
 {
-    qemu_platform->release_mac_with_different_hostname(mac_addr, vm_name);
-
     state = State::restarting;
     update_state();
 

--- a/tests/qemu/linux/mock_dnsmasq_server.h
+++ b/tests/qemu/linux/mock_dnsmasq_server.h
@@ -31,7 +31,7 @@ struct MockDNSMasqServer : public DNSMasqServer
 {
     using DNSMasqServer::DNSMasqServer; // ctor
 
-    MOCK_METHOD1(get_ip_and_host_for, std::optional<std::pair<IPAddress, std::string>>(const std::string&));
+    MOCK_METHOD1(get_ip_for, std::optional<IPAddress>(const std::string&));
     MOCK_METHOD1(release_mac, void(const std::string&));
     MOCK_METHOD0(check_dnsmasq_running, void());
 };

--- a/tests/qemu/linux/test_dnsmasq_process_spec.cpp
+++ b/tests/qemu/linux/test_dnsmasq_process_spec.cpp
@@ -44,12 +44,13 @@ TEST_F(TestDnsmasqProcessSpec, default_arguments_correct)
     mpt::SetEnvScope e1("SNAP", "/something");
     mpt::SetEnvScope e2("SNAP_NAME", snap_name);
     mp::DNSMasqProcessSpec spec(data_dir, bridge_name, subnet, conf_file_path);
-    EXPECT_EQ(spec.arguments(),
-              QStringList({"--keep-in-foreground", "--strict-order", "--bind-interfaces", "--pid-file",
-                           "--domain=multipass", "--local=/multipass/", "--except-interface=lo", "--interface=bridgey",
-                           "--listen-address=1.2.3.1", "--dhcp-no-override", "--dhcp-authoritative",
-                           "--dhcp-leasefile=/data/dnsmasq.leases", "--dhcp-hostsfile=/data/dnsmasq.hosts",
-                           "--dhcp-range", "1.2.3.2,1.2.3.254,infinite", "--conf-file=/path/to/file.conf"}));
+    EXPECT_EQ(
+        spec.arguments(),
+        QStringList({"--keep-in-foreground", "--strict-order", "--bind-interfaces", "--pid-file", "--domain=multipass",
+                     "--local=/multipass/", "--except-interface=lo", "--interface=bridgey", "--listen-address=1.2.3.1",
+                     "--dhcp-no-override", "--dhcp-ignore-clid", "--dhcp-authoritative",
+                     "--dhcp-leasefile=/data/dnsmasq.leases", "--dhcp-hostsfile=/data/dnsmasq.hosts", "--dhcp-range",
+                     "1.2.3.2,1.2.3.254,infinite", "--conf-file=/path/to/file.conf"}));
 }
 
 TEST_F(TestDnsmasqProcessSpec, apparmor_profile_has_correct_name)

--- a/tests/qemu/linux/test_dnsmasq_server.cpp
+++ b/tests/qemu/linux/test_dnsmasq_server.cpp
@@ -107,13 +107,10 @@ TEST_F(DNSMasqServer, finds_ip)
     auto dns = make_default_dnsmasq_server();
     make_lease_entry();
 
-    auto ip_and_host = dns.get_ip_and_host_for(hw_addr);
+    auto ip = dns.get_ip_for(hw_addr);
 
-    ASSERT_TRUE(ip_and_host);
-
-    auto [ip, host] = ip_and_host.value();
-    EXPECT_EQ(ip, mp::IPAddress(expected_ip));
-    EXPECT_EQ(host, "dummy_name");
+    ASSERT_TRUE(ip);
+    EXPECT_EQ(ip.value(), mp::IPAddress(expected_ip));
 }
 
 TEST_F(DNSMasqServer, returns_null_ip_when_leases_file_does_not_exist)
@@ -121,9 +118,9 @@ TEST_F(DNSMasqServer, returns_null_ip_when_leases_file_does_not_exist)
     auto dns = make_default_dnsmasq_server();
 
     const std::string hw_addr{"00:01:02:03:04:05"};
-    auto ip_and_host = dns.get_ip_and_host_for(hw_addr);
+    auto ip = dns.get_ip_for(hw_addr);
 
-    EXPECT_FALSE(ip_and_host);
+    EXPECT_FALSE(ip);
 }
 
 TEST_F(DNSMasqServer, release_mac_releases_ip)

--- a/tests/qemu/linux/test_qemu_platform_detail.cpp
+++ b/tests/qemu/linux/test_qemu_platform_detail.cpp
@@ -120,9 +120,7 @@ TEST_F(QemuPlatformDetail, get_ip_for_returns_expected_info)
 {
     const mp::IPAddress ip_address{fmt::format("{}.5", subnet)};
 
-    EXPECT_CALL(*mock_dnsmasq_server, get_ip_and_host_for(hw_addr)).WillOnce([&ip_address](auto...) {
-        return std::make_optional(std::make_pair(ip_address, ""));
-    });
+    EXPECT_CALL(*mock_dnsmasq_server, get_ip_for(hw_addr)).WillOnce([&ip_address](auto...) { return ip_address; });
 
     mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
 
@@ -209,20 +207,4 @@ TEST_F(QemuPlatformDetail, writing_ipforward_file_failure_logs_expected_message)
     EXPECT_CALL(*mock_file_ops, write(_, QByteArray("1"))).WillOnce(Return(-1));
 
     mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
-}
-
-TEST_F(QemuPlatformDetail, release_mac_with_different_hostname)
-{
-    const mp::IPAddress ip_address{fmt::format("{}.5", subnet)};
-
-    EXPECT_CALL(*mock_dnsmasq_server, get_ip_and_host_for)
-        .WillOnce(Return(std::make_optional(std::make_pair(ip_address, name))))
-        .WillOnce(Return(std::make_optional(std::make_pair(ip_address, name + "not"))))
-        .WillOnce(Return(std::nullopt));
-    EXPECT_CALL(*mock_dnsmasq_server, release_mac(hw_addr));
-
-    mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
-    qemu_platform_detail.release_mac_with_different_hostname(hw_addr, name);
-    qemu_platform_detail.release_mac_with_different_hostname(hw_addr, name);
-    qemu_platform_detail.release_mac_with_different_hostname(hw_addr + "not", name);
 }

--- a/tests/qemu/mock_qemu_platform.h
+++ b/tests/qemu/mock_qemu_platform.h
@@ -39,7 +39,6 @@ struct MockQemuPlatform : public QemuPlatform
     MOCK_METHOD1(get_ip_for, std::optional<IPAddress>(const std::string&));
     MOCK_METHOD1(remove_resources_for, void(const std::string&));
     MOCK_METHOD0(platform_health_check, void());
-    MOCK_METHOD2(release_mac_with_different_hostname, void(const std::string&, const std::string&));
     MOCK_METHOD0(vmstate_platform_args, QStringList());
     MOCK_METHOD1(vm_platform_args, QStringList(const VirtualMachineDescription&));
     MOCK_METHOD0(get_directory_name, QString());


### PR DESCRIPTION
This is a follow-up to #2717 which required a more convoluted fix to get the correct IP address based only on the MAC address of an instance. In a newer version of `dnsmasq` available in core22, there is the `--dhcp-ignore-clid` option which does just that.