### PR TITLE
Hyperkit migration barebones

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2975,8 +2975,8 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                 std::make_unique<CustomQemuImgProcessSpec>(std::move(qemuimg_args), new_image));
 
             if (auto qemuimg_state = qemuimg_proc->execute(); !qemuimg_state.completed_successfully())
-                throw std::runtime_error{fmt::format("Failed to fix image metadata: {}",
-                                                     qemuimg_state.failure_message())}; // TODO@no-merge get stderr
+                throw std::runtime_error{
+                    fmt::format("Failed to fix image metadata: {}", qemuimg_state.failure_message())};
 
             // Add JSON for QEMU instance
             qemu_instances_json.insert(key, vm_spec_to_json(vm_specs));

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2918,7 +2918,6 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
 
     // Read QEMU instance DB
     bool instances_migrated = false;
-    QJsonObject qemu_instances_json{};
     QFile qemu_instances_db{QString::fromStdString(qemu_instances_db_path)};
     if (MP_FILEOPS.exists(qemu_instances_db))
         mpl::log(mpl::Level::debug, category, "Found QEMU instance database");
@@ -2941,8 +2940,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     if (parse_error.error)
         throw std::runtime_error{fmt::format("Could not parse QEMU instance DB: {}", parse_error.errorString())};
 
-    if (!qemu_instances_doc.isNull())
-        qemu_instances_json = qemu_instances_doc.object(); // TODO@nomerge do this RAII-like
+    auto qemu_instances_json = qemu_instances_doc.isNull() ? QJsonObject{} : qemu_instances_doc.object();
 
     // Migrate instances
     for (const auto& [vm_name, vm_specs] : vm_instance_specs)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2917,7 +2917,6 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     auto qemu_instances_db_path = fmt::format("{}/{}", qemu_data_dir, instance_db_name);
 
     // Read QEMU instance DB
-    bool instances_migrated = false;
     QFile qemu_instances_db{QString::fromStdString(qemu_instances_db_path)};
     if (MP_FILEOPS.exists(qemu_instances_db))
         mpl::log(mpl::Level::debug, category, "Found QEMU instance database");
@@ -2943,6 +2942,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     auto qemu_instances_json = qemu_instances_doc.isNull() ? QJsonObject{} : qemu_instances_doc.object();
 
     // Migrate instances
+    bool instances_migrated = false;
     for (const auto& [vm_name, vm_specs] : vm_instance_specs)
     {
         auto key = QString::fromStdString(vm_name);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2993,6 +2993,22 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             // Add JSON for QEMU instance
             qemu_instances_json.insert(key, vm_spec_to_json(vm_specs));
             instances_migrated = true;
+
+            // Migrate JSON for instance image
+            auto record = hyperkit_instance_images_json[key].toObject();
+            if (record.isEmpty())
+                throw std::runtime_error{fmt::format("Failed to migrate instance image: corrupted image records")};
+
+            auto image = record["image"].toObject();
+            if (image.isEmpty())
+                throw std::runtime_error{fmt::format(
+                    "Failed to migrate instance image: corrupted image records")}; // TODO@nomerge avoid repeating
+
+            image.insert("path", new_image);
+            image.insert("kernel_path", "");
+            image.insert("initrd_path", "");
+            record.insert("image", image);
+            qemu_instance_images_json.insert(key, record);
         }
     }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2990,10 +2990,6 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                 throw std::runtime_error{
                     fmt::format("Failed to fix image metadata: {}", qemuimg_state.failure_message())};
 
-            // Add JSON for QEMU instance
-            qemu_instances_json.insert(key, vm_spec_to_json(vm_specs));
-            instances_migrated = true;
-
             // Migrate JSON for instance image
             auto instance_image_record = hyperkit_instance_images_json[key].toObject();
             auto image_record = instance_image_record["image"].toObject();
@@ -3005,6 +3001,10 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             image_record.insert("initrd_path", "");
             instance_image_record.insert("image", image_record);
             qemu_instance_images_json.insert(key, instance_image_record);
+
+            // Add JSON for QEMU instance
+            qemu_instances_json.insert(key, vm_spec_to_json(vm_specs));
+            instances_migrated = true;
         }
     }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2998,7 +2998,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             auto instance_image_record = hyperkit_instance_images_json[key].toObject();
             auto image_record = instance_image_record["image"].toObject();
             if (image_record.isEmpty()) // true if either the image or instance objects were empty/absent
-                throw std::runtime_error{fmt::format("Failed to migrate instance image: corrupted image records")};
+                throw std::runtime_error{"Failed to migrate instance image: corrupted image records"};
 
             image_record.insert("path", new_image);
             image_record.insert("kernel_path", "");

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2949,7 +2949,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         auto key = QString::fromStdString(vm_name);
         if (qemu_instances_json.contains(key)) // TODO@nomerge test
         {
-            reply.set_log_line(fmt::format("Cannot migrate {}: name already taken by a qemu instance", vm_name));
+            reply.set_log_line(fmt::format("Cannot migrate {}: name already taken by a qemu instance\n", vm_name));
             server->Write(reply);
         }
         else

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2913,7 +2913,8 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
 
     auto data_dir = MP_STDPATHS.writableLocation(mp::StandardPaths::AppDataLocation);
     auto qemu_data_dir = fmt::format("{}/qemu", data_dir);
-    auto qemu_instances_dir = fmt::format("{}/vault/instances", qemu_data_dir);
+    auto qemu_vault_dir = fmt::format("{}/vault", qemu_data_dir);
+    auto qemu_instances_dir = fmt::format("{}/instances", qemu_vault_dir);
     auto qemu_instances_db_path = fmt::format("{}/{}", qemu_data_dir, instance_db_name);
 
     // Read QEMU instance DB
@@ -2924,8 +2925,8 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     {
         mpl::log(mpl::Level::debug, category, "No existing QEMU instance database found");
 
-        if (std::error_code err; !MP_FILEOPS.create_directories(qemu_data_dir, err) && err)
-            throw std::runtime_error{fmt::format("Could not create directory for QEMU data: {} ", err.message())};
+        if (std::error_code err; !MP_FILEOPS.create_directories(qemu_vault_dir, err) && err)
+            throw std::runtime_error{fmt::format("Could not create directory for QEMU vault: {} ", err.message())};
     }
 
     if (!MP_FILEOPS.open(qemu_instances_db, QFile::ReadWrite))

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2924,7 +2924,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         if (!MP_FILEOPS.open(*file, QFile::ReadWrite))
             throw std::runtime_error{fmt::format("Could not open file for reading and writing: {}", file->fileName())};
 
-        QJsonParseError parse_error;
+        QJsonParseError parse_error{};
         const auto& data = file->readAll();
         auto doc = data.isEmpty() ? QJsonDocument{} : QJsonDocument::fromJson(data, &parse_error);
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2910,8 +2910,6 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         return grpc::Status::OK;
 
     mp::SetReply reply{};
-    reply.set_log_line("Migration placeholder\n");
-    server->Write(reply);
 
     auto data_dir = MP_STDPATHS.writableLocation(mp::StandardPaths::AppDataLocation);
     auto qemu_data_dir = fmt::format("{}/qemu", data_dir);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2996,13 +2996,9 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
 
             // Migrate JSON for instance image
             auto instance_image_record = hyperkit_instance_images_json[key].toObject();
-            if (instance_image_record.isEmpty())
-                throw std::runtime_error{fmt::format("Failed to migrate instance image: corrupted image records")};
-
             auto image_record = instance_image_record["image"].toObject();
-            if (image_record.isEmpty())
-                throw std::runtime_error{fmt::format(
-                    "Failed to migrate instance image: corrupted image records")}; // TODO@nomerge avoid repeating
+            if (image_record.isEmpty()) // true if either the image or instance objects were empty/absent
+                throw std::runtime_error{fmt::format("Failed to migrate instance image: corrupted image records")};
 
             image_record.insert("path", new_image);
             image_record.insert("kernel_path", "");

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2954,7 +2954,8 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         }
         else
         {
-            reply.set_log_line(fmt::format("Migrating {} from hyperkit to qemu\n", vm_name)); // TODO@nomerge spin it
+            reply.set_log_line(
+                fmt::format("Migrating instance from hyperkit to qemu: {}\n", vm_name)); // TODO@nomerge spin it
             server->Write(reply);
 
             // Copy instance image to qemu vault

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2906,7 +2906,8 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     assert(config->factory->get_backend_version_string() == "hyperkit" &&
            "can only migrate when hyperkit is in effect");
 
-    // TODO@nomerge return early if there are no hyperkit instances to migrate
+    if (vm_instance_specs.empty())
+        return grpc::Status::OK;
 
     mp::SetReply reply{};
     reply.set_log_line("Migration placeholder\n");

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2964,7 +2964,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     for (const auto& [vm_name, vm_specs] : vm_instance_specs)
     {
         auto key = QString::fromStdString(vm_name);
-        if (qemu_instances_json.contains(key))
+        if (qemu_instances_json.contains(key) || qemu_instance_images_json.contains(key))
             reply_msg(fmt::format("Cannot migrate {}: name already taken by a qemu instance\n", vm_name));
         else
         {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2903,9 +2903,8 @@ void mp::Daemon::finish_async_operation(QFuture<AsyncOperationStatus> async_futu
 
 grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface<SetReply, SetRequest>* server)
 { // TODO hk migration, remove
-#ifndef MULTIPASS_PLATFORM_APPLE
-    assert(false && "no hyperkit otherwise");
-#endif
+    assert(config->factory->get_backend_version_string() == "hyperkit" &&
+           "can only migrate when hyperkit is in effect");
 
     mp::SetReply reply{};
     reply.set_log_line("Migration placeholder\n");

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2934,9 +2934,13 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         throw std::runtime_error{"Could not open QEMU instance database"};
 
     QJsonParseError parse_error;
+    const auto& qemu_instances_data = qemu_instance_db.readAll();
     auto qemu_instances_doc =
-        QJsonDocument::fromJson(qemu_instance_db.readAll(),
-                                &parse_error); // TODO@nomerge check error, but avoid empty file causing trouble
+        qemu_instances_data.isEmpty() ? QJsonDocument{} : QJsonDocument::fromJson(qemu_instances_data, &parse_error);
+
+    if (parse_error.error)
+        throw std::runtime_error{fmt::format("Could not parse QEMU instance DB: {}", parse_error.errorString())};
+
     if (!qemu_instances_doc.isNull())
         qemu_instances_json = qemu_instances_doc.object(); // TODO@nomerge do this RAII-like
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2947,7 +2947,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     for (const auto& [vm_name, vm_specs] : vm_instance_specs)
     {
         auto key = QString::fromStdString(vm_name);
-        if (qemu_instances_json.contains(key)) // TODO@nomerge test
+        if (qemu_instances_json.contains(key))
         {
             reply.set_log_line(fmt::format("Cannot migrate {}: name already taken by a qemu instance\n", vm_name));
             server->Write(reply);
@@ -2978,7 +2978,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                                                      qemuimg_state.failure_message())}; // TODO@no-merge get stderr
 
             // Add JSON for QEMU instance
-            qemu_instances_json.insert(key, vm_spec_to_json(vm_specs)); // TODO@nomerge test
+            qemu_instances_json.insert(key, vm_spec_to_json(vm_specs));
             instance_migrated = true;
         }
     }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2929,8 +2929,12 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             qemu_instances_json = doc.object(); // TODO@nomerge do this RAII-like
     }
     else
+    {
         mpl::log(mpl::Level::debug, category, "No existing QEMU instance database found");
 
+        if (std::error_code err; !MP_FILEOPS.create_directories(qemu_data_dir, err) && err)
+            throw std::runtime_error{fmt::format("Could not create directory for QEMU data: {} ", err.message())};
+    }
     // Migrate instances
     for (const auto& [vm_name, vm_ptr] : vm_instances)
     {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2916,11 +2916,17 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     auto qemu_instance_db_path = fmt::format("{}/{}", qemu_data_dir, instance_db_name);
 
     // Read QEMU instance DB
+    QJsonObject qemu_instances_json{};
     QFile qemu_instance_db{QString::fromStdString(qemu_instance_db_path)};
     if (qemu_instance_db.exists())
     {
         qemu_instance_db.open(QIODevice::ReadOnly); // TODO@nomerge handle errors
         mpl::log(mpl::Level::debug, category, "Found QEMU instance database");
+
+        QJsonParseError parse_error;
+        auto doc = QJsonDocument::fromJson(qemu_instance_db.readAll(), &parse_error);
+        if (!doc.isNull())
+            qemu_instances_json = doc.object(); // TODO@nomerge do this RAII-like
     }
     else
         mpl::log(mpl::Level::debug, category, "No existing QEMU instance database found");

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2909,7 +2909,12 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     if (vm_instance_specs.empty())
         return grpc::Status::OK;
 
+    // Utility to write a msg back to the client
     mp::SetReply reply{};
+    auto reply_msg = [server, &reply](auto&& msg) {
+        reply.template set_log_line(std::forward<decltype(msg)>(msg));
+        server->Write(reply);
+    };
 
     auto data_dir = MP_STDPATHS.writableLocation(mp::StandardPaths::AppDataLocation);
     auto qemu_data_dir = fmt::format("{}/qemu", data_dir);
@@ -2948,15 +2953,10 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     {
         auto key = QString::fromStdString(vm_name);
         if (qemu_instances_json.contains(key))
-        {
-            reply.set_log_line(fmt::format("Cannot migrate {}: name already taken by a qemu instance\n", vm_name));
-            server->Write(reply);
-        }
+            reply_msg(fmt::format("Cannot migrate {}: name already taken by a qemu instance\n", vm_name));
         else
         {
-            reply.set_log_line(
-                fmt::format("Migrating instance from hyperkit to qemu: {}\n", vm_name)); // TODO@nomerge spin it
-            server->Write(reply);
+            reply_msg(fmt::format("Migrating instance from hyperkit to qemu: {}\n", vm_name)); // TODO@nomerge spin it
 
             // Copy instance image to qemu vault
             auto vm_image = fetch_image_for(vm_name, config->factory->fetch_type(), *config->vault);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2936,19 +2936,28 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         return std::tuple(std::move(file), std::move(doc), std::move(json));
     };
 
+    auto instance_image_db_filename = "multipassd-instance-image-records.json";
     auto data_dir = MP_STDPATHS.writableLocation(mp::StandardPaths::AppDataLocation);
     auto qemu_data_dir = fmt::format("{}/qemu", data_dir);
     auto qemu_vault_dir = fmt::format("{}/vault", qemu_data_dir);
     auto qemu_instances_dir = fmt::format("{}/instances", qemu_vault_dir);
     auto qemu_instances_db_path = fmt::format("{}/{}", qemu_data_dir, instance_db_name);
+    auto qemu_instance_images_db_path = fmt::format("{}/{}", qemu_vault_dir, instance_image_db_filename);
+    auto hyperkit_instance_image_db_path = fmt::format("{}/vault/{}", data_dir, instance_image_db_filename);
 
     // Create QEMU vault (if not there yet)
     if (std::error_code err; !MP_FILEOPS.create_directories(qemu_vault_dir, err) && err)
         throw std::runtime_error{fmt::format("Could not create directory for QEMU vault: {} ", err.message())};
 
-    // Read QEMU instance DB
+    // Read JSON DBs
     auto [qemu_instances_db, qemu_instances_doc, qemu_instances_json] =
         read_json(QString::fromStdString(qemu_instances_db_path));
+
+    auto [qemu_instance_images_db, qemu_instance_images_doc, qemu_instance_images_json] =
+        read_json(QString::fromStdString(qemu_instance_images_db_path));
+
+    const auto hyperkit_instance_images_json =
+        std::get<2>(read_json(QString::fromStdString(hyperkit_instance_image_db_path)));
 
     // Migrate instances
     bool instances_migrated = false;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2916,36 +2916,39 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         server->Write(reply);
     };
 
+    // Utility to read a json file
+    auto read_json = [](auto&& file_path) {
+        auto file = std::make_unique<QFile>(std::forward<decltype(file_path)>(file_path)); /* QFile is noncopyable,
+                                                                  but we need to return it, so we use an owning ptr */
+
+        if (!MP_FILEOPS.open(*file, QFile::ReadWrite))
+            throw std::runtime_error{fmt::format("Could not open file for reading and writing: {}", file->fileName())};
+
+        QJsonParseError parse_error;
+        const auto& data = file->readAll();
+        auto doc = data.isEmpty() ? QJsonDocument{} : QJsonDocument::fromJson(data, &parse_error);
+
+        if (parse_error.error)
+            throw std::runtime_error{fmt::format("Could not parse file as JSON; error: {}; file: {}", file->fileName(),
+                                                 parse_error.errorString())};
+
+        auto json = doc.isNull() ? QJsonObject{} : doc.object();
+        return std::tuple(std::move(file), std::move(doc), std::move(json));
+    };
+
     auto data_dir = MP_STDPATHS.writableLocation(mp::StandardPaths::AppDataLocation);
     auto qemu_data_dir = fmt::format("{}/qemu", data_dir);
     auto qemu_vault_dir = fmt::format("{}/vault", qemu_data_dir);
     auto qemu_instances_dir = fmt::format("{}/instances", qemu_vault_dir);
     auto qemu_instances_db_path = fmt::format("{}/{}", qemu_data_dir, instance_db_name);
 
+    // Create QEMU vault (if not there yet)
+    if (std::error_code err; !MP_FILEOPS.create_directories(qemu_vault_dir, err) && err)
+        throw std::runtime_error{fmt::format("Could not create directory for QEMU vault: {} ", err.message())};
+
     // Read QEMU instance DB
-    QFile qemu_instances_db{QString::fromStdString(qemu_instances_db_path)};
-    if (MP_FILEOPS.exists(qemu_instances_db))
-        mpl::log(mpl::Level::debug, category, "Found QEMU instance database");
-    else
-    {
-        mpl::log(mpl::Level::debug, category, "No existing QEMU instance database found");
-
-        if (std::error_code err; !MP_FILEOPS.create_directories(qemu_vault_dir, err) && err)
-            throw std::runtime_error{fmt::format("Could not create directory for QEMU vault: {} ", err.message())};
-    }
-
-    if (!MP_FILEOPS.open(qemu_instances_db, QFile::ReadWrite))
-        throw std::runtime_error{"Could not open QEMU instance database"};
-
-    QJsonParseError parse_error;
-    const auto& qemu_instances_data = qemu_instances_db.readAll();
-    auto qemu_instances_doc =
-        qemu_instances_data.isEmpty() ? QJsonDocument{} : QJsonDocument::fromJson(qemu_instances_data, &parse_error);
-
-    if (parse_error.error)
-        throw std::runtime_error{fmt::format("Could not parse QEMU instance DB: {}", parse_error.errorString())};
-
-    auto qemu_instances_json = qemu_instances_doc.isNull() ? QJsonObject{} : qemu_instances_doc.object();
+    auto [qemu_instances_db, qemu_instances_doc, qemu_instances_json] =
+        read_json(QString::fromStdString(qemu_instances_db_path));
 
     // Migrate instances
     bool instances_migrated = false;
@@ -2988,12 +2991,12 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     if (instances_migrated)
     {
         qemu_instances_doc.setObject(qemu_instances_json);
-        [[maybe_unused]] auto reset_success = qemu_instances_db.reset(); /* seek back to the beginning of the file, to
-                                                                           overwrite its current contents */
+        [[maybe_unused]] auto reset_success = qemu_instances_db->reset(); /* seek back to the beginning of the file, to
+                                                                             overwrite its current contents */
         assert(reset_success);
 
-        MP_FILEOPS.write(qemu_instances_db, qemu_instances_doc.toJson()); /* overwrites with more content, so no need to
-                                                                            erase first */
+        MP_FILEOPS.write(*qemu_instances_db, qemu_instances_doc.toJson()); /* overwrites with more content, so no need
+                                                                              to erase first */
     }
 
     return grpc::Status::OK;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2995,20 +2995,20 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             instances_migrated = true;
 
             // Migrate JSON for instance image
-            auto record = hyperkit_instance_images_json[key].toObject();
-            if (record.isEmpty())
+            auto instance_image_record = hyperkit_instance_images_json[key].toObject();
+            if (instance_image_record.isEmpty())
                 throw std::runtime_error{fmt::format("Failed to migrate instance image: corrupted image records")};
 
-            auto image = record["image"].toObject();
-            if (image.isEmpty())
+            auto image_record = instance_image_record["image"].toObject();
+            if (image_record.isEmpty())
                 throw std::runtime_error{fmt::format(
                     "Failed to migrate instance image: corrupted image records")}; // TODO@nomerge avoid repeating
 
-            image.insert("path", new_image);
-            image.insert("kernel_path", "");
-            image.insert("initrd_path", "");
-            record.insert("image", image);
-            qemu_instance_images_json.insert(key, record);
+            image_record.insert("path", new_image);
+            image_record.insert("kernel_path", "");
+            image_record.insert("initrd_path", "");
+            instance_image_record.insert("image", image_record);
+            qemu_instance_images_json.insert(key, instance_image_record);
         }
     }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3012,9 +3012,9 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         }
     }
 
-    // Write QEMU instance DB
     if (instances_migrated)
     {
+        // Write QEMU instances DB
         qemu_instances_doc.setObject(qemu_instances_json);
         [[maybe_unused]] auto reset_success = qemu_instances_db->reset(); /* seek back to the beginning of the file, to
                                                                              overwrite its current contents */
@@ -3022,6 +3022,16 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
 
         MP_FILEOPS.write(*qemu_instances_db, qemu_instances_doc.toJson()); /* overwrites with more content, so no need
                                                                               to erase first */
+
+        // Write QEMU instance images DB
+        // TODO@nomerge extract this common code
+        qemu_instance_images_doc.setObject(qemu_instance_images_json);
+        reset_success = qemu_instance_images_db->reset(); /* seek back to the beginning of the file, to overwrite its
+                                                             current contents */
+        assert(reset_success);
+
+        MP_FILEOPS.write(*qemu_instance_images_db, qemu_instance_images_doc.toJson()); /* overwrites with more content,
+                                                                                          so no need to erase first */
     }
 
     return grpc::Status::OK;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2088,11 +2088,17 @@ try
     auto key = request->key();
     auto val = request->val();
 
+    bool need_migration = false; // TODO hk migration, remove
+#ifdef MULTIPASS_PLATFORM_APPLE  // TODO hk migration, remove
+    need_migration = val == "qemu" && MP_SETTINGS.get(QString::fromStdString(key)) == "hyperkit";
+#endif
+
     mpl::log(mpl::Level::trace, category, fmt::format("Trying to set {}={}", key, val));
     MP_SETTINGS.set(QString::fromStdString(key), QString::fromStdString(val));
     mpl::log(mpl::Level::debug, category, fmt::format("Succeeded setting {}={}", key, val));
 
-    status_promise->set_value(grpc::Status::OK);
+    status_promise->set_value(need_migration ? migrate_from_hyperkit(server)
+                                             : grpc::Status::OK); // TODO hk migration, revert
 }
 catch (const mp::UnrecognizedSettingException& e)
 {
@@ -2879,4 +2885,17 @@ void mp::Daemon::finish_async_operation(QFuture<AsyncOperationStatus> async_futu
 
     if (async_op_result.status_promise)
         async_op_result.status_promise->set_value(async_op_result.status);
+}
+
+grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface<SetReply, SetRequest>* server)
+{ // TODO hk migration, remove
+#ifndef MULTIPASS_PLATFORM_APPLE
+    assert(false && "no hyperkit otherwise");
+#endif
+
+    mp::SetReply reply{};
+    reply.set_log_line("Migration placeholder\n");
+    server->Write(reply);
+
+    return grpc::Status::OK;
 }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -36,6 +36,7 @@
 #include <multipass/name_generator.h>
 #include <multipass/network_interface.h>
 #include <multipass/platform.h>
+#include <multipass/process/qemuimg_process_spec.h> // TODO hk migration, remove
 #include <multipass/query.h>
 #include <multipass/settings/settings.h>
 #include <multipass/ssh/ssh_session.h>
@@ -879,6 +880,17 @@ register_instance_mod(std::unordered_map<std::string, mp::VMSpecs>& vm_instance_
     return MP_SETTINGS.register_handler(std::make_unique<mp::InstanceSettingsHandler>(
         vm_instance_specs, vm_instances, deleted_instances, preparing_instances, std::move(instance_persister)));
 }
+
+class CustomQemuImgProcessSpec : public mp::QemuImgProcessSpec // TODO hk migration, remove
+{
+public:
+    using mp::QemuImgProcessSpec::QemuImgProcessSpec;
+    virtual mpl::Level error_log_level() const
+    {
+        return mpl::Level::trace; /* qemu-img prints tens of thousands of (benign) error lines when repairing image
+                                     metadata, which our BasicProcess class logs with the error level returned here */
+    }
+};
 
 } // namespace
 
@@ -2907,6 +2919,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         reply.set_log_line(fmt::format("Migrating {} from hyperkit to qemu\n", vm_name)); // TODO@nomerge spin it
         server->Write(reply);
 
+        // Copy instance image to qemu vault
         auto vm_image = fetch_image_for(vm_name, config->factory->fetch_type(), *config->vault);
         auto target_directory = fmt::format("{}/{}", qemu_instances_dir, vm_name);
         mpl::log(mpl::Level::debug, category, fmt::format("Migrating instance files to '{}'", target_directory));
@@ -2914,7 +2927,16 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         if (std::error_code err; !MP_FILEOPS.create_directories(target_directory, err) && err)
             throw std::runtime_error{fmt::format("Could not create directory for QEMU instance: {} ", err.message())};
 
-        mp::vault::copy(vm_image.image_path, QString::fromStdString(target_directory));
+        auto new_image = mp::vault::copy(vm_image.image_path, QString::fromStdString(target_directory));
+
+        // Fix image metadata
+        QStringList qemuimg_args = QStringList{"check", "-r", "all", new_image};
+        auto qemuimg_proc =
+            mp::platform::make_process(std::make_unique<CustomQemuImgProcessSpec>(std::move(qemuimg_args), new_image));
+
+        if (auto qemuimg_state = qemuimg_proc->execute(); !qemuimg_state.completed_successfully())
+            throw std::runtime_error{fmt::format("Failed to fix image metadata: {}",
+                                                 qemuimg_state.failure_message())}; // TODO@no-merge get stderr
     }
 
     return grpc::Status::OK;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2919,15 +2919,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     QJsonObject qemu_instances_json{};
     QFile qemu_instance_db{QString::fromStdString(qemu_instance_db_path)};
     if (qemu_instance_db.exists())
-    {
-        qemu_instance_db.open(QIODevice::ReadOnly); // TODO@nomerge handle errors
         mpl::log(mpl::Level::debug, category, "Found QEMU instance database");
-
-        QJsonParseError parse_error;
-        auto doc = QJsonDocument::fromJson(qemu_instance_db.readAll(), &parse_error);
-        if (!doc.isNull())
-            qemu_instances_json = doc.object(); // TODO@nomerge do this RAII-like
-    }
     else
     {
         mpl::log(mpl::Level::debug, category, "No existing QEMU instance database found");
@@ -2935,6 +2927,17 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         if (std::error_code err; !MP_FILEOPS.create_directories(qemu_data_dir, err) && err)
             throw std::runtime_error{fmt::format("Could not create directory for QEMU data: {} ", err.message())};
     }
+
+    if (!qemu_instance_db.open(QFile::ReadWrite))
+        throw std::runtime_error{"Could not open QEMU instance database"};
+
+    QJsonParseError parse_error;
+    auto qemu_instances_doc =
+        QJsonDocument::fromJson(qemu_instance_db.readAll(),
+                                &parse_error); // TODO@nomerge check error, but avoid empty file causing trouble
+    if (!qemu_instances_doc.isNull())
+        qemu_instances_json = qemu_instances_doc.object(); // TODO@nomerge do this RAII-like
+
     // Migrate instances
     for (const auto& [vm_name, vm_ptr] : vm_instances)
     {

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -163,6 +163,9 @@ private:
     void finish_async_operation(QFuture<AsyncOperationStatus> async_future);
     QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});
 
+    grpc::Status migrate_from_hyperkit(
+        grpc::ServerReaderWriterInterface<SetReply, SetRequest>* server); // TODO temporary code, remove
+
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;
     std::unordered_map<std::string, VirtualMachine::ShPtr> vm_instances;


### PR DESCRIPTION
This PR implements a bare-bones migration of `hyperkit` instances to `qemu`:

  - Copies images
  - Fixes copied image metadata
  - Migrates image JSON (updating paths)
  - Migrates instance JSON

It skips instances whose name is already taken in QEMU. Future PRs will take care of MAC address updating, proper error handling, etc.