### PR TITLE
Print client warnings by default

### DIFF
--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -85,10 +85,8 @@ auto verbosity_level_in(const QStringList& arguments)
             return 1;
         if (arg == QStringLiteral("-vv"))
             return 2;
-        if (arg == QStringLiteral("-vvv"))
+        if (QRegExp{"-vvv+"}.exactMatch(arg))
             return 3;
-        if (QRegExp{"-vvvv+"}.exactMatch(arg))
-            return 4;
     }
     return 0;
 }
@@ -117,7 +115,7 @@ mp::ParseCode mp::ArgParser::parse(const std::optional<mp::AliasDict>& aliases)
     QCommandLineOption help_option(help_option_names, "Displays help on commandline options");
     QCommandLineOption verbose_option({"v", "verbose"},
                                       "Increase logging verbosity. Repeat the 'v' in the short option for more detail. "
-                                      "Maximum verbosity is obtained with 4 (or more) v's, i.e. -vvvv.");
+                                      "Maximum verbosity is obtained with 3 (or more) v's, i.e. -vvv.");
     QCommandLineOption version_option({"V", "version"}, "Show version details");
     version_option.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(help_option);
@@ -374,9 +372,9 @@ QStringList mp::ArgParser::unknownOptionNames() const
 
 void mp::ArgParser::setVerbosityLevel(int verbosity)
 {
-    if (verbosity > 4 || verbosity < 0)
+    if (verbosity > 3 || verbosity < 0)
     {
-        cerr << "Verbosity level is incorrect. Must be between 0 and 4.\n";
+        cerr << "Verbosity level is incorrect. Must be between 0 and 3.\n";
     }
     else if (verbosity_level != verbosity)
     {

--- a/tests/test_argparser.cpp
+++ b/tests/test_argparser.cpp
@@ -57,7 +57,7 @@ TEST_P(TestVerbosity, test_various_vs)
     auto parser = mp::ArgParser{args, cmds, oss, oss};
     parser.parse();
 
-    const auto expect = v > 4 ? 4 : v;
+    const auto expect = v > 3 ? 3 : v;
     EXPECT_EQ(parser.verbosityLevel(), expect);
 }
 

--- a/tests/test_argparser.cpp
+++ b/tests/test_argparser.cpp
@@ -40,6 +40,18 @@ struct TestVerbosity : public TestWithParam<int>
 {
 };
 
+TEST_F(TestVerbosity, verbosity_is_zero_with_no_arguments)
+{
+    std::ostringstream oss;
+    const auto cmds = std::vector<mp::cmd::Command::UPtr>{};
+    auto args = QStringList{"multipass_tests"};
+
+    auto parser = mp::ArgParser{args, cmds, oss, oss};
+    parser.parse();
+
+    EXPECT_EQ(parser.verbosityLevel(), 0);
+}
+
 TEST_P(TestVerbosity, test_various_vs)
 {
     std::ostringstream oss;
@@ -62,6 +74,18 @@ TEST_P(TestVerbosity, test_various_vs)
 }
 
 INSTANTIATE_TEST_SUITE_P(ArgParser, TestVerbosity, Range(0, 10));
+
+TEST_F(TestVerbosity, cannot_be_more_verbose)
+{
+    std::ostringstream oss, ess;
+    const auto cmds = std::vector<mp::cmd::Command::UPtr>{};
+    auto args = QStringList{"multipass_tests"};
+
+    auto parser = mp::ArgParser{args, cmds, oss, ess};
+    parser.setVerbosityLevel(4);
+
+    EXPECT_EQ(ess.str(), "Verbosity level is incorrect. Must be between 0 and 3.\n");
+}
 
 struct TestAliasArguments : public TestWithParam<std::tuple<QStringList /* pre */, QStringList /* post */>>,
                             public FakeAliasConfig

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -451,7 +451,7 @@ TEST_P(RemoteHandlerVerbosity, honors_verbosity_in_remote_settings_handler)
     send_command({vs, cmd});
 }
 
-INSTANTIATE_TEST_SUITE_P(Client, RemoteHandlerVerbosity, Combine(Range(0, 5), RemoteHandlerTest::cmds));
+INSTANTIATE_TEST_SUITE_P(Client, RemoteHandlerVerbosity, Combine(Range(0, 4), RemoteHandlerTest::cmds));
 
 TEST_F(Client, handles_remote_handler_exception)
 {
@@ -1130,7 +1130,7 @@ TEST_F(Client, launch_cmd_fails_when_automounting_in_petenv_fails)
 
 TEST_F(Client, launch_cmd_forwards_verbosity_to_subcommands)
 {
-    const auto verbosity = 4;
+    const auto verbosity = 3;
     const auto launch_verbosity_matcher = make_request_verbosity_matcher<mp::LaunchRequest>(verbosity);
     const auto mount_verbosity_matcher = make_request_verbosity_matcher<mp::MountRequest>(verbosity);
 
@@ -1140,7 +1140,7 @@ TEST_F(Client, launch_cmd_forwards_verbosity_to_subcommands)
             WithArg<1>(check_request_and_return<mp::LaunchReply, mp::LaunchRequest>(launch_verbosity_matcher, ok)));
     EXPECT_CALL(mock_daemon, mount)
         .WillOnce(WithArg<1>(check_request_and_return<mp::MountReply, mp::MountRequest>(mount_verbosity_matcher, ok)));
-    EXPECT_THAT(send_command({"launch", "--name", petenv_name, "-vvvv"}), Eq(mp::ReturnCode::Ok));
+    EXPECT_THAT(send_command({"launch", "--name", petenv_name, "-vvv"}), Eq(mp::ReturnCode::Ok));
 }
 
 TEST_F(Client, launch_cmd_does_not_automount_in_normal_instances)


### PR DESCRIPTION
In order to show the user messages related to Hyperkit deprecation, the client must print warnings. We also need to decide which warnings are worth printing and which are not.

Implements https://github.com/canonical/multipass/projects/15#card-85698674