### PR TITLE
Ignore leading and trailing whitespace in strings for memory sizes

### DIFF
--- a/src/utils/memory_size.cpp
+++ b/src/utils/memory_size.cpp
@@ -31,7 +31,7 @@ constexpr auto gibi = mebi * kibi;
 
 long long in_bytes(const std::string& mem_value)
 {
-    QRegExp matcher("(\\d+)(?:([KMG])(?:i?B)?|B)?", Qt::CaseInsensitive); // TODO accept decimals
+    QRegExp matcher("\\s*(\\d+)(?:([KMG])(?:i?B)?|B)?\\s*", Qt::CaseInsensitive); // TODO accept decimals
 
     if (matcher.exactMatch(QString::fromStdString(mem_value)))
     {


### PR DESCRIPTION
Ignore leading and trailing whitespace in a string passed to the memory sizer.