### PR TITLE
Name mounts consistently

### DIFF
--- a/include/multipass/vm_mount.h
+++ b/include/multipass/vm_mount.h
@@ -28,8 +28,8 @@ struct VMMount
 {
     enum class MountType : int
     {
-        SSHFS = 0,
-        Performance = 1
+        Classic = 0,
+        Native = 1
     };
 
     std::string source_path;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1455,11 +1455,11 @@ try // clang-format on
 {
     mpl::ClientLogger<MountReply, MountRequest> logger{mpl::level_from(request->verbosity_level()), *config->logger,
                                                        server};
-    auto mount_type = request->mount_type() == mp::MountRequest_MountType_CLASSIC ? mp::VMMount::MountType::SSHFS
-                                                                                  : mp::VMMount::MountType::Performance;
+    auto mount_type = request->mount_type() == mp::MountRequest_MountType_CLASSIC ? mp::VMMount::MountType::Classic
+                                                                                  : mp::VMMount::MountType::Native;
 
-    if (mount_type == mp::VMMount::MountType::Performance &&
-        (config->mount_handlers.find(mp::VMMount::MountType::Performance) == config->mount_handlers.end()))
+    if (mount_type == mp::VMMount::MountType::Native &&
+        (config->mount_handlers.find(mp::VMMount::MountType::Native) == config->mount_handlers.end()))
         throw mp::NotImplementedOnThisBackendException("native mounts");
 
     if (!MP_SETTINGS.get_as<bool>(mp::mounts_key))

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1460,7 +1460,7 @@ try // clang-format on
 
     if (mount_type == mp::VMMount::MountType::Performance &&
         (config->mount_handlers.find(mp::VMMount::MountType::Performance) == config->mount_handlers.end()))
-        throw mp::NotImplementedOnThisBackendException("experimental mounts");
+        throw mp::NotImplementedOnThisBackendException("native mounts");
 
     if (!MP_SETTINGS.get_as<bool>(mp::mounts_key))
     {

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -188,11 +188,11 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
 
     if (mount_handlers.empty())
     {
-        mount_handlers[mp::VMMount::MountType::SSHFS] = std::make_unique<SSHFSMountHandler>(*ssh_key_provider);
+        mount_handlers[mp::VMMount::MountType::Classic] = std::make_unique<SSHFSMountHandler>(*ssh_key_provider);
 
         try
         {
-            mount_handlers[mp::VMMount::MountType::Performance] =
+            mount_handlers[mp::VMMount::MountType::Native] =
                 factory->create_performance_mount_handler(*ssh_key_provider);
         }
         catch (const NotImplementedOnThisBackendException& e)

--- a/tests/daemon_test_fixture.cpp
+++ b/tests/daemon_test_fixture.cpp
@@ -315,7 +315,7 @@ mpt::DaemonTestFixture::DaemonTestFixture()
     config_builder.logger = std::make_unique<StubLogger>();
     config_builder.update_prompt = std::make_unique<DisabledUpdatePrompt>();
     config_builder.blueprint_provider = std::make_unique<StubVMBlueprintProvider>();
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::make_unique<StubMountHandler>();
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::make_unique<StubMountHandler>();
 }
 
 void mpt::DaemonTestFixture::SetUp()

--- a/tests/qemu/test_qemu_mount_handler.cpp
+++ b/tests/qemu/test_qemu_mount_handler.cpp
@@ -306,7 +306,7 @@ TEST_F(QemuMountHandlerTest, mountFailsOnNotStoppedState)
 
     mp::QemuMountHandler qemu_mount_handler(key_provider);
 
-    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Performance};
+    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Native};
 
     EXPECT_THROW(
         try { qemu_mount_handler.init_mount(&vm, default_target, mount); } catch (const std::runtime_error& e) {
@@ -323,7 +323,7 @@ TEST_F(QemuMountHandlerTest, mountFailsOnNonExistentPath)
 
     mp::QemuMountHandler qemu_mount_handler(key_provider);
 
-    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Performance};
+    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Native};
 
     EXPECT_THROW(
         try { qemu_mount_handler.init_mount(&vm, default_target, mount); } catch (const std::runtime_error& e) {
@@ -340,7 +340,7 @@ TEST_F(QemuMountHandlerTest, mountFailsOnMultipleUIDs)
 
     mp::QemuMountHandler qemu_mount_handler(key_provider);
 
-    const mp::VMMount mount{default_source, {{1, 2}, {3, 4}}, {{5, -1}, {6, 10}}, mp::VMMount::MountType::Performance};
+    const mp::VMMount mount{default_source, {{1, 2}, {3, 4}}, {{5, -1}, {6, 10}}, mp::VMMount::MountType::Native};
 
     EXPECT_THROW(
         try { qemu_mount_handler.init_mount(&vm, default_target, mount); } catch (const std::runtime_error& e) {
@@ -357,7 +357,7 @@ TEST_F(QemuMountHandlerTest, hasInstanceAlreadyMountedReturnsTrueWhenFound)
 
     mp::QemuMountHandler qemu_mount_handler(key_provider);
 
-    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Performance};
+    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Native};
     EXPECT_CALL(vm, add_vm_mount(default_target, mount)).WillOnce(Return());
 
     qemu_mount_handler.init_mount(&vm, default_target, mount);
@@ -372,7 +372,7 @@ TEST_F(QemuMountHandlerTest, hasInstanceAlreadyMountedReturnsFalseWhenFound)
 
     mp::QemuMountHandler qemu_mount_handler(key_provider);
 
-    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Performance};
+    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Native};
     EXPECT_CALL(vm, add_vm_mount(default_target, mount)).WillOnce(Return());
 
     qemu_mount_handler.init_mount(&vm, default_target, mount);
@@ -426,7 +426,7 @@ TEST_F(QemuMountHandlerTest, stopAllMountsDeletesAllMounts)
     EXPECT_CALL(vm, add_vm_mount(_, _)).WillOnce(Return());
     EXPECT_CALL(vm, delete_vm_mount(_)).WillOnce(Return());
 
-    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Performance};
+    const mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Native};
     mp::QemuMountHandler qemu_mount_handler(key_provider);
 
     qemu_mount_handler.init_mount(&vm, default_target, mount);

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1343,11 +1343,11 @@ TEST_F(Daemon, writesAndReadsMountsInJson)
     std::unordered_map<std::string, mp::VMMount> mounts;
 
     mounts.emplace("target_1",
-                   mp::VMMount{temp_mount_1, uid_mappings_1, gid_mappings_1, mp::VMMount::MountType::SSHFS});
+                   mp::VMMount{temp_mount_1, uid_mappings_1, gid_mappings_1, mp::VMMount::MountType::Classic});
     mounts.emplace("target_2",
-                   mp::VMMount{temp_mount_2, uid_mappings_2, gid_mappings_2, mp::VMMount::MountType::SSHFS});
+                   mp::VMMount{temp_mount_2, uid_mappings_2, gid_mappings_2, mp::VMMount::MountType::Classic});
     mounts.emplace("target_3",
-                   mp::VMMount{temp_mount_3, uid_mappings_3, gid_mappings_3, mp::VMMount::MountType::SSHFS});
+                   mp::VMMount{temp_mount_3, uid_mappings_3, gid_mappings_3, mp::VMMount::MountType::Classic});
 
     const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, extra_interfaces, mounts));
 
@@ -1379,7 +1379,7 @@ TEST_F(Daemon, writes_and_reads_ordered_maps_in_json)
     mp::id_mappings gid_mappings{{1002, 0}, {1000, 2}};
     std::unordered_map<std::string, mp::VMMount> mounts;
     mounts.emplace("Home", mp::VMMount{mpt::TempDir().path().toStdString(), uid_mappings, gid_mappings,
-                                       mp::VMMount::MountType::SSHFS});
+                                       mp::VMMount::MountType::Classic});
 
     const auto [temp_dir, filename] =
         plant_instance_json(fake_json_contents("52:54:00:73:76:29", std::vector<mp::NetworkInterface>{}, mounts));

--- a/tests/test_daemon_mount.cpp
+++ b/tests/test_daemon_mount.cpp
@@ -429,5 +429,5 @@ TEST_F(TestDaemonMount, performanceMountsNotImplementedHasErrorFails)
                                    StrictMock<mpt::MockServerReaderWriter<mp::MountReply, mp::MountRequest>>{});
 
     EXPECT_EQ(status.error_code(), grpc::StatusCode::FAILED_PRECONDITION);
-    EXPECT_THAT(status.error_message(), StrEq("The experimental mounts feature is not implemented on this backend."));
+    EXPECT_THAT(status.error_message(), StrEq("The native mounts feature is not implemented on this backend."));
 }

--- a/tests/test_daemon_mount.cpp
+++ b/tests/test_daemon_mount.cpp
@@ -146,7 +146,7 @@ TEST_F(TestDaemonMount, invalidTargetPathFails)
     });
 
     EXPECT_CALL(*mock_mount_handler, stop_all_mounts_for_instance(_)).Times(1);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -174,7 +174,7 @@ TEST_F(TestDaemonMount, mountExistsDoesNotTryMount)
     });
 
     EXPECT_CALL(*mock_mount_handler, has_instance_already_mounted(_, _)).WillOnce(Return(true));
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -207,7 +207,7 @@ TEST_F(TestDaemonMount, skipStartMountIfInstanceIsNotRunning)
     EXPECT_CALL(*mock_mount_handler, has_instance_already_mounted(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_mount_handler, init_mount(_, _, _)).Times(1);
     EXPECT_CALL(*mock_mount_handler, start_mount(_, _, _, _)).Times(0);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -227,7 +227,7 @@ TEST_F(TestDaemonMount, mountAlreadyDefinedLogsAndContinues)
 {
     std::unordered_map<std::string, mp::VMMount> mounts;
     mounts.emplace(fake_target_path,
-                   mp::VMMount{mount_dir.path().toStdString(), {}, {}, mp::VMMount::MountType::SSHFS});
+                   mp::VMMount{mount_dir.path().toStdString(), {}, {}, mp::VMMount::MountType::Classic});
 
     const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, extra_interfaces, mounts));
     config_builder.data_directory = temp_dir->path();
@@ -242,7 +242,7 @@ TEST_F(TestDaemonMount, mountAlreadyDefinedLogsAndContinues)
     EXPECT_CALL(*mock_mount_handler, has_instance_already_mounted(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_mount_handler, init_mount(_, _, _)).Times(1);
     EXPECT_CALL(*mock_mount_handler, start_mount(_, _, _, _)).Times(0);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -278,7 +278,7 @@ TEST_F(TestDaemonMount, startsMountIfInstanceRunning)
     EXPECT_CALL(*mock_mount_handler, has_instance_already_mounted(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_mount_handler, init_mount(_, _, _)).Times(1);
     EXPECT_CALL(*mock_mount_handler, start_mount(_, _, _, _)).Times(1);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -309,7 +309,7 @@ TEST_F(TestDaemonMount, mountFailsSshfsMissing)
     EXPECT_CALL(*mock_mount_handler, has_instance_already_mounted(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_mount_handler, init_mount(_, _, _)).Times(1);
     EXPECT_CALL(*mock_mount_handler, start_mount(_, _, _, _)).WillOnce(Throw(mp::SSHFSMissingError{}));
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -343,7 +343,7 @@ TEST_F(TestDaemonMount, mountFailsErrorMounting)
     EXPECT_CALL(*mock_mount_handler, has_instance_already_mounted(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_mount_handler, init_mount(_, _, _)).Times(1);
     EXPECT_CALL(*mock_mount_handler, start_mount(_, _, _, _)).WillOnce(Throw(std::runtime_error(error_msg)));
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -365,7 +365,7 @@ TEST_F(TestDaemonMount, expectedUidsGidsPassedToInitMount)
 {
     const auto host_uid{1000}, instance_uid{1001}, host_gid{1002}, instance_gid{1003};
     const mp::VMMount mount{mount_dir.path().toStdString(), mp::id_mappings{{host_gid, instance_gid}},
-                            mp::id_mappings{{host_uid, instance_uid}}, mp::VMMount::MountType::SSHFS};
+                            mp::id_mappings{{host_uid, instance_uid}}, mp::VMMount::MountType::Classic};
 
     const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, extra_interfaces));
     config_builder.data_directory = temp_dir->path();
@@ -379,7 +379,7 @@ TEST_F(TestDaemonMount, expectedUidsGidsPassedToInitMount)
 
     EXPECT_CALL(*mock_mount_handler, has_instance_already_mounted(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_mount_handler, init_mount(_, _, mount)).Times(1);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 

--- a/tests/test_daemon_start.cpp
+++ b/tests/test_daemon_start.cpp
@@ -143,7 +143,7 @@ TEST_F(TestDaemonStart, definedMountsInitializedDuringStart)
     const std::string fake_target_path{"/home/luke/skywalker"}, fake_source_path{"/home/han/solo"};
     const mp::id_mappings uid_mappings{{1000, 1001}}, gid_mappings{{1002, 1003}};
     std::unordered_map<std::string, mp::VMMount> mounts;
-    const mp::VMMount mount{fake_source_path, uid_mappings, gid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{fake_source_path, uid_mappings, gid_mappings, mp::VMMount::MountType::Classic};
 
     mounts.emplace(fake_target_path, mount);
 
@@ -164,7 +164,7 @@ TEST_F(TestDaemonStart, definedMountsInitializedDuringStart)
     EXPECT_CALL(*mock_mount_handler, start_mount(_, _, _, _)).Times(1);
 
     config_builder.mount_handlers.clear();
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
     config_builder.data_directory = temp_dir->path();
     config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
 

--- a/tests/test_daemon_umount.cpp
+++ b/tests/test_daemon_umount.cpp
@@ -90,7 +90,7 @@ TEST_F(TestDaemonUmount, noTargetsUnmountsAll)
     });
 
     EXPECT_CALL(*mock_mount_handler, stop_all_mounts_for_instance(mock_instance_name)).Times(2);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -107,7 +107,7 @@ TEST_F(TestDaemonUmount, noTargetsUnmountsAll)
 TEST_F(TestDaemonUmount, unmountsMountedTargetWhenInstanceRunning)
 {
     std::unordered_map<std::string, mp::VMMount> mounts;
-    mounts.emplace(fake_target_path, mp::VMMount{"foo", {}, {}, mp::VMMount::MountType::SSHFS});
+    mounts.emplace(fake_target_path, mp::VMMount{"foo", {}, {}, mp::VMMount::MountType::Classic});
 
     const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, extra_interfaces, mounts));
     config_builder.data_directory = temp_dir->path();
@@ -118,7 +118,7 @@ TEST_F(TestDaemonUmount, unmountsMountedTargetWhenInstanceRunning)
     });
 
     EXPECT_CALL(*mock_mount_handler, stop_mount(mock_instance_name, fake_target_path)).Times(1);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -144,7 +144,7 @@ TEST_F(TestDaemonUmount, mountNotFoundInDatabaseHasError)
     });
 
     EXPECT_CALL(*mock_mount_handler, stop_mount(mock_instance_name, fake_target_path)).Times(0);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 
@@ -174,7 +174,7 @@ TEST_F(TestDaemonUmount, invalidMountTypeHasError)
     });
 
     EXPECT_CALL(*mock_mount_handler, stop_mount(mock_instance_name, fake_target_path)).Times(0);
-    config_builder.mount_handlers[mp::VMMount::MountType::SSHFS] = std::move(mock_mount_handler);
+    config_builder.mount_handlers[mp::VMMount::MountType::Classic] = std::move(mock_mount_handler);
 
     mp::Daemon daemon{config_builder.build()};
 

--- a/tests/test_sshfs_mount_handler.cpp
+++ b/tests/test_sshfs_mount_handler.cpp
@@ -119,7 +119,7 @@ TEST_F(SSHFSMountHandlerTest, mount_creates_sshfs_process)
     EXPECT_CALL(mock_vm, ssh_hostname()).Times(2);
     EXPECT_CALL(mock_vm, ssh_username()).Times(2);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&mock_vm, target_path, mount);
     sshfs_mount_handler.start_mount(&mock_vm, &server, target_path);
 
@@ -163,7 +163,7 @@ TEST_F(SSHFSMountHandlerTest, sshfs_process_failing_with_return_code_9_causes_ex
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
 
     EXPECT_THROW(sshfs_mount_handler.start_mount(&vm, &server, target_path), mp::SSHFSMissingError);
@@ -196,7 +196,7 @@ TEST_F(SSHFSMountHandlerTest, sshfs_process_failing_causes_runtime_exception)
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
 
     EXPECT_THROW(
@@ -226,7 +226,7 @@ TEST_F(SSHFSMountHandlerTest, stop_terminates_sshfs_process)
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
     sshfs_mount_handler.start_mount(&vm, &server, target_path);
 
@@ -264,9 +264,9 @@ TEST_F(SSHFSMountHandlerTest, stop_all_mounts_terminates_all_sshfs_processes)
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount1{"/source/one", gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS},
-        mount2{"/source/two", gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS},
-        mount3{"/source/three", gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount1{"/source/one", gid_mappings, uid_mappings, mp::VMMount::MountType::Classic},
+        mount2{"/source/two", gid_mappings, uid_mappings, mp::VMMount::MountType::Classic},
+        mount3{"/source/three", gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, "/target/one", mount1);
     sshfs_mount_handler.init_mount(&vm, "/target/two", mount2);
     sshfs_mount_handler.init_mount(&vm, "/target/three", mount3);
@@ -287,7 +287,7 @@ TEST_F(SSHFSMountHandlerTest, has_instance_already_mounted_returns_true_when_fou
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
     sshfs_mount_handler.start_mount(&vm, &server, target_path);
 
@@ -303,7 +303,7 @@ TEST_F(SSHFSMountHandlerTest, has_instance_already_mounted_returns_false_when_no
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
     sshfs_mount_handler.start_mount(&vm, &server, target_path);
 
@@ -319,7 +319,7 @@ TEST_F(SSHFSMountHandlerTest, has_instance_already_mounted_returns_false_when_no
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
     sshfs_mount_handler.start_mount(&vm, &server, target_path);
 
@@ -337,7 +337,7 @@ TEST_F(SSHFSMountHandlerTest, mount_fails_on_nonexist_directory)
 
     NiceMock<mpt::MockVirtualMachine> vm{"my_instance"};
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     MP_EXPECT_THROW_THAT(sshfs_mount_handler.init_mount(&vm, target_path, mount), std::runtime_error,
                          mpt::match_what(StrEq(fmt::format("Mount path \"{}\" does not exist.", source_path))));
 }
@@ -352,7 +352,7 @@ TEST_F(SSHFSMountHandlerTest, throws_install_sshfs_which_snap_fails)
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
 
     EXPECT_THROW(sshfs_mount_handler.start_mount(&vm, &server, target_path), std::runtime_error);
@@ -369,7 +369,7 @@ TEST_F(SSHFSMountHandlerTest, throws_install_sshfs_no_snap_dir_fails)
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
 
     EXPECT_THROW(sshfs_mount_handler.start_mount(&vm, &server, target_path), std::runtime_error);
@@ -387,7 +387,7 @@ TEST_F(SSHFSMountHandlerTest, throws_install_sshfs_snap_install_fails)
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
 
     EXPECT_THROW(sshfs_mount_handler.start_mount(&vm, &server, target_path), mp::SSHFSMissingError);
@@ -444,7 +444,7 @@ TEST_F(SSHFSMountHandlerTest, install_sshfs_timeout_logs_info)
 
     mp::SSHFSMountHandler sshfs_mount_handler(key_provider);
 
-    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::SSHFS};
+    const mp::VMMount mount{source_path, gid_mappings, uid_mappings, mp::VMMount::MountType::Classic};
     sshfs_mount_handler.init_mount(&vm, target_path, mount);
 
     EXPECT_THROW(sshfs_mount_handler.start_mount(&vm, &server, target_path, std::chrono::milliseconds(1)),


### PR DESCRIPTION
Use "classic" and "native" throughout the code. Most significantly, refer to the feature as "native mounts" in error messages.