### PR TITLE
integration: fix getting driver

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -195,7 +195,7 @@ jobs:
               _run $MP set local.driver=${{ matrix.driver }}
 
               # Wait for the daemon to restart
-              _retry_grep 12 5 '^${{ matrix.driver }}$' _run $MP get local.driver
+              _retry_grep 12 5 '^${{ matrix.driver }}' _run $MP get local.driver
 
               # and for the streams to flow down
               _retry_grep 12 5 "\w,lts\W" _run $MP find


### PR DESCRIPTION
Windows stucks a \0a\0d at the end. Because why not.

Signed-off-by: Michał Sawicz <michal.sawicz@canonical.com>