### PR TITLE
Hyperkit migration fix networking

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(daemon
   petname
   platform
   rpc
+  scope_guard # TODO hk migration, remove
   settings
   simplestreams
   ssh

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2954,6 +2954,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         MP_FILEOPS.write(file, doc.toJson()); /* overwrites with more content, so no need to erase first */
     };
 
+    const auto cloud_init_iso_name = "cloud-init-config.iso";
     auto cloud_init_mount_point = "/Volumes/cidata"; // TODO@no-merge can I really assume this?
     auto instance_image_db_filename = "multipassd-instance-image-records.json";
     auto data_dir = MP_STDPATHS.writableLocation(mp::StandardPaths::AppDataLocation);
@@ -3035,7 +3036,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
 
             // Mount the cloud-init ISO for the instance
             const auto hyperkit_instances_dir = mp::utils::base_dir(vm_image.image_path);
-            const auto hyperkit_iso_path = hyperkit_instances_dir.filePath("cloud-init-config.iso");
+            const auto hyperkit_iso_path = hyperkit_instances_dir.filePath(cloud_init_iso_name);
             auto mount_proc =
                 mp::platform::make_process(mp::simple_process_spec("hdiutil", {"mount", hyperkit_iso_path}));
             if (auto mount_state = mount_proc->execute(); !mount_state.completed_successfully())
@@ -3045,7 +3046,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             // TODO@no-merge Update MAC address via cloud-init (copy files, edit, create new ISO)
             mp::CloudInitIso qemu_iso{};
             qemu_iso.add_file("network-config", mpu::emit_cloud_config(YAML::Node{}));
-            qemu_iso.write_to(QString::fromStdString(fmt::format("{}/{}", target_directory, "cloud-init-config.iso")));
+            qemu_iso.write_to(QString::fromStdString(fmt::format("{}/{}", target_directory, cloud_init_iso_name)));
 
             // Migrate JSON for instance image
             auto instance_image_record = hyperkit_instance_images_json[key].toObject();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3034,9 +3034,9 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
 
             // Mount the cloud-init ISO for the instance
             const auto hyperkit_instances_dir = mp::utils::base_dir(vm_image.image_path);
-            const auto cloud_init_iso_path = hyperkit_instances_dir.filePath("cloud-init-config.iso");
+            const auto hyperkit_iso_path = hyperkit_instances_dir.filePath("cloud-init-config.iso");
             auto mount_proc =
-                mp::platform::make_process(mp::simple_process_spec("hdiutil", {"mount", cloud_init_iso_path}));
+                mp::platform::make_process(mp::simple_process_spec("hdiutil", {"mount", hyperkit_iso_path}));
             if (auto mount_state = mount_proc->execute(); !mount_state.completed_successfully())
                 throw std::runtime_error{fmt::format("Failed to mount the cloud-init ISO for {}: {}", vm_name,
                                                      mount_state.failure_message())};

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -20,6 +20,7 @@
 #include "instance_settings_handler.h"
 
 #include <multipass/alias_definition.h>
+#include <multipass/cloud_init_iso.h> // TODO hk migration, remove
 #include <multipass/constants.h>
 #include <multipass/exceptions/blueprint_exceptions.h>
 #include <multipass/exceptions/create_image_exception.h>
@@ -3042,6 +3043,9 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                                                      mount_state.failure_message())};
 
             // TODO@no-merge Update MAC address via cloud-init (copy files, edit, create new ISO)
+            mp::CloudInitIso qemu_iso{};
+            qemu_iso.add_file("network-config", mpu::emit_cloud_config(YAML::Node{}));
+            qemu_iso.write_to(QString::fromStdString(fmt::format("{}/{}", target_directory, "cloud-init-config.iso")));
 
             // Migrate JSON for instance image
             auto instance_image_record = hyperkit_instance_images_json[key].toObject();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -29,6 +29,7 @@
 #include <multipass/exceptions/sshfs_missing_error.h>
 #include <multipass/exceptions/start_exception.h>
 #include <multipass/file_ops.h> // TODO hk migration, remove
+#include <multipass/format.h>
 #include <multipass/ip_address.h>
 #include <multipass/json_writer.h>
 #include <multipass/logging/client_logger.h>
@@ -52,7 +53,8 @@
 #include <multipass/vm_image_host.h>
 #include <multipass/vm_image_vault.h>
 
-#include <multipass/format.h>
+#include <scope_guard.hpp> // TODO hk migration, remove
+
 #include <yaml-cpp/yaml.h>
 
 #include <QDir>
@@ -3014,7 +3016,21 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                 default mount point to be available (which will virtually always be the case), we avoid having to parse
                 the output of the mounting tool. */
 
-            // TODO@no-merge scope_guard to unmount cloud-init
+            // Unmount the cloud-init ISO when we're done
+            const auto unmount_guard = sg::make_scope_guard([&cloud_init_mount_point]() noexcept {
+                mp::top_catch_all(category, [&cloud_init_mount_point] {
+                    if (QFile::exists(cloud_init_mount_point))
+                    {
+                        auto unmount_proc = mp::platform::make_process(
+                            mp::simple_process_spec("hdiutil", {"unmount", cloud_init_mount_point}));
+
+                        if (auto unmount_state = unmount_proc->execute(); !unmount_state.completed_successfully())
+                            throw std::runtime_error{
+                                fmt::format("Failed to unmount the cloud-init ISO in {}", cloud_init_mount_point)}; /*
+                                                                                    TODO@no-merge stop throwing here */
+                    }
+                });
+            });
 
             const auto hyperkit_instances_dir = mp::utils::base_dir(vm_image.image_path);
             const auto cloud_init_iso_path = hyperkit_instances_dir.filePath("cloud-init-config.iso");

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3046,9 +3046,15 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                 throw std::runtime_error{fmt::format("Failed to mount the cloud-init ISO for {}: {}", vm_name,
                                                      mount_state.failure_message())};
 
-            // TODO@no-merge Update MAC address via cloud-init (copy files, edit, create new ISO)
+            // Create a network-config file to give the new interface (w/ new MAC address) DHCP and the previous name
+            YAML::Node network_data;
+            network_data["version"] = "2";
+            network_data["ethernets"]["default"]["match"]["macaddress"] = vm_specs.default_mac_address;
+            network_data["ethernets"]["default"]["set-name"] = "enp0s2";
+            network_data["ethernets"]["default"]["dhcp4"] = true;
+
             mp::CloudInitIso qemu_iso{};
-            qemu_iso.add_file("network-config", mpu::emit_cloud_config(YAML::Node{}));
+            qemu_iso.add_file("network-config", mpu::emit_cloud_config(network_data));
 
             for (auto filename : {"meta-data", "user-data", "vendor-data"})
             {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2946,7 +2946,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
         return std::tuple(std::move(file), std::move(doc), std::move(json));
     };
 
-    // Utility to write json to a file (with fewer contents than the serialized json will have)
+    // Utility to write json to a (currently shorter) file
     // Precondition: when serialized, the json object must produce more data than the current file contents.
     auto write_longer_json = [](QFile& file, QJsonDocument& doc, const QJsonObject& json) {
         doc.setObject(json);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2907,6 +2907,9 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     assert(config->factory->get_backend_version_string() == "hyperkit" &&
            "can only migrate when hyperkit is in effect");
 
+    // TODO@no-merge throw in consts in variables
+    // TODO@no-merge homogenise failure messages
+
     if (vm_instance_specs.empty())
         return grpc::Status::OK;
 
@@ -2988,6 +2991,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             auto target_directory = fmt::format("{}/{}", qemu_instances_dir, vm_name);
             mpl::log(mpl::Level::debug, category, fmt::format("Migrating instance files to '{}'", target_directory));
 
+            // TODO@no-merge for error handling, may want a scope guard to rollback things on failure (delete dir)
             if (std::error_code err; !MP_FILEOPS.create_directories(target_directory, err) && err)
                 throw std::runtime_error{
                     fmt::format("Could not create directory for QEMU instance: {} ", err.message())};
@@ -3001,7 +3005,8 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
 
             if (auto qemuimg_state = qemuimg_proc->execute(); !qemuimg_state.completed_successfully())
                 throw std::runtime_error{
-                    fmt::format("Failed to fix image metadata: {}", qemuimg_state.failure_message())};
+                    fmt::format("Failed to fix image metadata: {}", qemuimg_state.failure_message())}; /*
+                                                                          TODO@no-merge include vm name */
 
             // TODO@no-merge Update MAC address via cloud-init
             if (QFile::exists(cloud_init_mount_point))

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2958,15 +2958,15 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
     };
 
     const auto cloud_init_iso_name = "cloud-init-config.iso";
-    auto cloud_init_mount_point = "/Volumes/cidata"; // TODO@no-merge can I really assume this?
-    auto instance_image_db_filename = "multipassd-instance-image-records.json";
-    auto data_dir = MP_STDPATHS.writableLocation(mp::StandardPaths::AppDataLocation);
-    auto qemu_data_dir = fmt::format("{}/qemu", data_dir);
-    auto qemu_vault_dir = fmt::format("{}/vault", qemu_data_dir);
-    auto qemu_instances_dir = fmt::format("{}/instances", qemu_vault_dir);
-    auto qemu_instances_db_path = fmt::format("{}/{}", qemu_data_dir, instance_db_name);
-    auto qemu_instance_images_db_path = fmt::format("{}/{}", qemu_vault_dir, instance_image_db_filename);
-    auto hyperkit_instance_image_db_path = fmt::format("{}/vault/{}", data_dir, instance_image_db_filename);
+    const auto cloud_init_mount_point = "/Volumes/cidata"; // TODO@no-merge can I really assume this?
+    const auto instance_image_db_filename = "multipassd-instance-image-records.json";
+    const auto data_dir = MP_STDPATHS.writableLocation(mp::StandardPaths::AppDataLocation);
+    const auto qemu_data_dir = fmt::format("{}/qemu", data_dir);
+    const auto qemu_vault_dir = fmt::format("{}/vault", qemu_data_dir);
+    const auto qemu_instances_dir = fmt::format("{}/instances", qemu_vault_dir);
+    const auto qemu_instances_db_path = fmt::format("{}/{}", qemu_data_dir, instance_db_name);
+    const auto qemu_instance_images_db_path = fmt::format("{}/{}", qemu_vault_dir, instance_image_db_filename);
+    const auto hyperkit_instance_image_db_path = fmt::format("{}/vault/{}", data_dir, instance_image_db_filename);
 
     // Create QEMU vault (if not there yet)
     if (std::error_code err; !MP_FILEOPS.create_directories(qemu_vault_dir, err) && err)
@@ -2994,8 +2994,8 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             reply_msg(fmt::format("Migrating instance from hyperkit to qemu: {}\n", vm_name)); // TODO@nomerge spin it
 
             // Copy instance image to qemu vault
-            auto vm_image = fetch_image_for(vm_name, config->factory->fetch_type(), *config->vault);
-            auto target_directory = fmt::format("{}/{}", qemu_instances_dir, vm_name);
+            const auto vm_image = fetch_image_for(vm_name, config->factory->fetch_type(), *config->vault);
+            const auto target_directory = fmt::format("{}/{}", qemu_instances_dir, vm_name);
             mpl::log(mpl::Level::debug, category, fmt::format("Migrating instance files to '{}'", target_directory));
 
             // TODO@no-merge for error handling, may want a scope guard to rollback things on failure (delete dir)
@@ -3003,14 +3003,14 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                 throw std::runtime_error{
                     fmt::format("Could not create directory for QEMU instance: {} ", err.message())};
 
-            auto new_image = mp::vault::copy(vm_image.image_path, QString::fromStdString(target_directory));
+            const auto new_image = mp::vault::copy(vm_image.image_path, QString::fromStdString(target_directory));
 
             // Fix image metadata
             QStringList qemuimg_args = QStringList{"check", "-r", "all", new_image};
             auto qemuimg_proc = mp::platform::make_process(
                 std::make_unique<CustomQemuImgProcessSpec>(std::move(qemuimg_args), new_image));
 
-            if (auto qemuimg_state = qemuimg_proc->execute(); !qemuimg_state.completed_successfully())
+            if (const auto qemuimg_state = qemuimg_proc->execute(); !qemuimg_state.completed_successfully())
                 throw std::runtime_error{
                     fmt::format("Failed to fix image metadata: {}", qemuimg_state.failure_message())}; /*
                                                                           TODO@no-merge include vm name */
@@ -3029,7 +3029,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                         auto unmount_proc = mp::platform::make_process(
                             mp::simple_process_spec("hdiutil", {"unmount", cloud_init_mount_point}));
 
-                        if (auto unmount_state = unmount_proc->execute(); !unmount_state.completed_successfully())
+                        if (const auto unmount_state = unmount_proc->execute(); !unmount_state.completed_successfully())
                             throw std::runtime_error{
                                 fmt::format("Failed to unmount the cloud-init ISO in {}", cloud_init_mount_point)}; /*
                                                                                     TODO@no-merge stop throwing here */
@@ -3042,7 +3042,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             const auto hyperkit_iso_path = hyperkit_instances_dir.filePath(cloud_init_iso_name);
             auto mount_proc =
                 mp::platform::make_process(mp::simple_process_spec("hdiutil", {"mount", hyperkit_iso_path}));
-            if (auto mount_state = mount_proc->execute(); !mount_state.completed_successfully())
+            if (const auto mount_state = mount_proc->execute(); !mount_state.completed_successfully())
                 throw std::runtime_error{fmt::format("Failed to mount the cloud-init ISO for {}: {}", vm_name,
                                                      mount_state.failure_message())};
 
@@ -3062,7 +3062,7 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
             qemu_iso.add_file("meta-data", mpu::emit_cloud_config(meta_data));
 
             // Copy the remaining cloud-init files
-            for (auto filename : {"user-data", "vendor-data"})
+            for (const auto filename : {"user-data", "vendor-data"})
             {
                 auto stream = MP_FILEOPS.open_read(fmt::format("{}/{}", cloud_init_mount_point, filename));
                 auto contents = std::string{std::istreambuf_iterator{*stream}, {}};


### PR DESCRIPTION
This adapts the original cloud-init ISO when migrating instances from Hyperkit to Qemu. It causes cloud-init to re-render the network inside the migrated instance, with DHCP enabled on the new default network interface, which has a new MAC address (the one that Multipass always intended for it). That interface is also renamed to match the original default interface on Hyperkit.