### PR TITLE
Verify launch mount source path before launching

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -48,6 +48,11 @@ public:
     virtual bool mkpath(const QDir& dir, const QString& dirName) const;
     virtual bool rmdir(QDir& dir, const QString& dirName) const;
 
+    // QFileInfo operations
+    virtual bool exists(const QFileInfo& file) const;
+    virtual bool isDir(const QFileInfo& file) const;
+    virtual bool isReadable(const QFileInfo& file) const;
+
     // QFile operations
     virtual bool exists(const QFile& file) const;
     virtual bool is_open(const QFile& file) const;

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -353,6 +353,27 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
             auto mount_source = value.section(':', 0, colon_split);
             auto mount_target = value.section(':', colon_split + 1);
             mount_target = mount_target.isEmpty() ? mount_source : mount_target;
+
+            // Validate source directory of client side mounts
+            QFileInfo source_dir(mount_source);
+            if (!source_dir.exists())
+            {
+                cerr << "Mount source path \"" << mount_source.toStdString() << "\" does not exist\n";
+                return ParseCode::CommandLineError;
+            }
+
+            if (!source_dir.isDir())
+            {
+                cerr << "Mount source path \"" << mount_source.toStdString() << "\" is not a directory\n";
+                return ParseCode::CommandLineError;
+            }
+
+            if (!source_dir.isReadable())
+            {
+                cerr << "Mount source path \"" << mount_source.toStdString() << "\" is not readable\n";
+                return ParseCode::CommandLineError;
+            }
+
             mount_routes.emplace_back(mount_source, mount_target);
         }
     }

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -356,19 +356,19 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
 
             // Validate source directory of client side mounts
             QFileInfo source_dir(mount_source);
-            if (!source_dir.exists())
+            if (!MP_FILEOPS.exists(source_dir))
             {
                 cerr << "Mount source path \"" << mount_source.toStdString() << "\" does not exist\n";
                 return ParseCode::CommandLineError;
             }
 
-            if (!source_dir.isDir())
+            if (!MP_FILEOPS.isDir(source_dir))
             {
                 cerr << "Mount source path \"" << mount_source.toStdString() << "\" is not a directory\n";
                 return ParseCode::CommandLineError;
             }
 
-            if (!source_dir.isReadable())
+            if (!MP_FILEOPS.isReadable(source_dir))
             {
                 cerr << "Mount source path \"" << mount_source.toStdString() << "\" is not readable\n";
                 return ParseCode::CommandLineError;

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -49,6 +49,21 @@ bool mp::FileOps::exists(const QFile& file) const
     return file.exists();
 }
 
+bool mp::FileOps::isDir(const QFileInfo& file) const
+{
+    return file.isDir();
+}
+
+bool mp::FileOps::exists(const QFileInfo& file) const
+{
+    return file.exists();
+}
+
+bool mp::FileOps::isReadable(const QFileInfo& file) const
+{
+    return file.isReadable();
+}
+
 bool mp::FileOps::is_open(const QFile& file) const
 {
     return file.isOpen();

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -30,11 +30,19 @@ class MockFileOps : public FileOps
 public:
     using FileOps::FileOps;
 
+    // QDir mock methods
     MOCK_CONST_METHOD0(current, QDir());
     MOCK_CONST_METHOD1(exists, bool(const QDir&));
     MOCK_CONST_METHOD1(isReadable, bool(const QDir&));
     MOCK_CONST_METHOD2(mkpath, bool(const QDir&, const QString& dirName));
     MOCK_CONST_METHOD2(rmdir, bool(QDir&, const QString& dirName));
+
+    // QFileInfo mock methods
+    MOCK_CONST_METHOD1(exists, bool(const QFileInfo&));
+    MOCK_CONST_METHOD1(isDir, bool(const QFileInfo&));
+    MOCK_CONST_METHOD1(isReadable, bool(const QFileInfo&));
+
+    // QFile mock methods
     MOCK_CONST_METHOD1(exists, bool(const QFile&));
     MOCK_CONST_METHOD1(is_open, bool(const QFile&));
     MOCK_CONST_METHOD2(open, bool(QFileDevice&, QIODevice::OpenMode));
@@ -50,9 +58,12 @@ public:
     MOCK_CONST_METHOD1(size, qint64(QFile&));
     MOCK_CONST_METHOD3(write, qint64(QFile&, const char*, qint64));
     MOCK_CONST_METHOD2(write, qint64(QFileDevice&, const QByteArray&));
-    MOCK_CONST_METHOD3(open, void(std::fstream&, const char*, std::ios_base::openmode));
+
+    // QSaveFile mock methods
     MOCK_CONST_METHOD1(commit, bool(QSaveFile&));
 
+    // Mock std methods
+    MOCK_CONST_METHOD3(open, void(std::fstream&, const char*, std::ios_base::openmode));
     MOCK_METHOD(std::unique_ptr<std::ostream>, open_write, (const fs::path& path), (override, const));
     MOCK_METHOD(std::unique_ptr<std::istream>, open_read, (const fs::path& path), (override, const));
     MOCK_METHOD(bool, exists, (const fs::path& path, std::error_code& err), (override, const));

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1239,18 +1239,20 @@ TEST_F(Client, launchCmdMountOptionFailsOnInvalidDir)
                      trash_stream, err),
         mp::ReturnCode::CommandLineError);
     EXPECT_THAT(err.str(), HasSubstr(fmt::format("Mount source path \"{}\" does not exist", fake_source)));
+    err.clear();
 
     EXPECT_EQ(
         send_command({"launch", "--name", instance_name, "--mount", fmt::format("{}:{}", fake_source, fake_target)},
                      trash_stream, err),
         mp::ReturnCode::CommandLineError);
-    EXPECT_THAT(err.str(), HasSubstr(fmt::format("Mount source path \"{}\" does not exist", fake_source)));
+    EXPECT_THAT(err.str(), HasSubstr(fmt::format("Mount source path \"{}\" is not a directory", fake_source)));
+    err.clear();
 
     EXPECT_EQ(
         send_command({"launch", "--name", instance_name, "--mount", fmt::format("{}:{}", fake_source, fake_target)},
                      trash_stream, err),
         mp::ReturnCode::CommandLineError);
-    EXPECT_THAT(err.str(), HasSubstr(fmt::format("Mount source path \"{}\" does not exist", fake_source)));
+    EXPECT_THAT(err.str(), HasSubstr(fmt::format("Mount source path \"{}\" is not readable", fake_source)));
 }
 
 TEST_F(Client, launch_cmd_petenv_mount_option_override_home)

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1220,6 +1220,39 @@ TEST_F(Client, launch_cmd_mount_option)
     EXPECT_EQ(send_command({"launch", "--name", instance_name, "--mount", fake_source}), mp::ReturnCode::Ok);
 }
 
+TEST_F(Client, launchCmdMountOptionFailsOnInvalidDir)
+{
+    auto [mocked_file_ops, mocked_file_ops_guard] = mpt::MockFileOps::inject();
+    EXPECT_CALL(*mocked_file_ops, exists(A<const QFileInfo&>())).WillOnce(Return(false)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*mocked_file_ops, isDir(A<const QFileInfo&>())).WillOnce(Return(false)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*mocked_file_ops, isReadable(A<const QFileInfo&>()))
+        .WillOnce(Return(false))
+        .WillRepeatedly(Return(true));
+
+    const auto fake_source = "invalid/dir";
+    const auto fake_target = fake_source;
+    const auto instance_name = "some_instance";
+
+    std::stringstream err;
+    EXPECT_EQ(
+        send_command({"launch", "--name", instance_name, "--mount", fmt::format("{}:{}", fake_source, fake_target)},
+                     trash_stream, err),
+        mp::ReturnCode::CommandLineError);
+    EXPECT_THAT(err.str(), HasSubstr(fmt::format("Mount source path \"{}\" does not exist", fake_source)));
+
+    EXPECT_EQ(
+        send_command({"launch", "--name", instance_name, "--mount", fmt::format("{}:{}", fake_source, fake_target)},
+                     trash_stream, err),
+        mp::ReturnCode::CommandLineError);
+    EXPECT_THAT(err.str(), HasSubstr(fmt::format("Mount source path \"{}\" does not exist", fake_source)));
+
+    EXPECT_EQ(
+        send_command({"launch", "--name", instance_name, "--mount", fmt::format("{}:{}", fake_source, fake_target)},
+                     trash_stream, err),
+        mp::ReturnCode::CommandLineError);
+    EXPECT_THAT(err.str(), HasSubstr(fmt::format("Mount source path \"{}\" does not exist", fake_source)));
+}
+
 TEST_F(Client, launch_cmd_petenv_mount_option_override_home)
 {
     const QTemporaryDir fake_directory{};

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -390,7 +390,7 @@ TEST_F(SftpServer, opendir_not_readable_fails)
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
 
-    EXPECT_CALL(*mock_file_ops, isReadable(_)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, isReadable(A<const QDir&>())).WillOnce(Return(false));
 
     auto sftp = make_sftpserver(mpt::test_data_path().toStdString());
     auto msg = make_msg(SFTP_OPENDIR);


### PR DESCRIPTION
Verify client source directories before launching an instance and fail the launch if they are invalid.

Fixes #2817 