### PR TITLE
Catch `INSTANCE_EXISTS` error from daemon

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -511,7 +511,7 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
             {
                 error_details = fmt::format("Invalid memory size value supplied: {}.", request.mem_size());
             }
-            else if (error == LaunchError::INVALID_HOSTNAME)
+            else if (error == LaunchError::INVALID_HOSTNAME || error == LaunchError::INSTANCE_EXISTS)
             {
                 error_details = fmt::format("Invalid instance name supplied: {}", request.instance_name());
             }

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -511,7 +511,7 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
             {
                 error_details = fmt::format("Invalid memory size value supplied: {}.", request.mem_size());
             }
-            else if (error == LaunchError::INVALID_HOSTNAME || error == LaunchError::INSTANCE_EXISTS)
+            else if (error == LaunchError::INVALID_HOSTNAME)
             {
                 error_details = fmt::format("Invalid instance name supplied: {}", request.instance_name());
             }

--- a/src/client/common/client_common.cpp
+++ b/src/client/common/client_common.cpp
@@ -145,9 +145,7 @@ mp::ReturnCode mp::cmd::standard_failure_handler_for(const std::string& command,
                                                      const grpc::Status& status, const std::string& error_details)
 {
     fmt::print(cerr, "{} failed: {}\n{}", command, status.error_message(),
-               !error_details.empty()
-                   ? fmt::format("{}\n", error_details)
-                   : !status.error_details().empty() ? fmt::format("{}\n", status.error_details()) : "");
+               !error_details.empty() ? fmt::format("{}\n", error_details) : "");
 
     return return_code_for(status.error_code());
 }

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -466,7 +466,7 @@ TEST_F(Client, handles_remote_handler_exception)
     std::stringstream fake_cerr;
     auto got = send_command({cmd, key}, trash_stream, fake_cerr);
 
-    EXPECT_THAT(fake_cerr.str(), AllOf(HasSubstr(cmd), HasSubstr(msg), HasSubstr(details)));
+    EXPECT_THAT(fake_cerr.str(), AllOf(HasSubstr(cmd), HasSubstr(msg), Not(HasSubstr(details))));
     EXPECT_EQ(got, mp::CommandFail);
 }
 


### PR DESCRIPTION
When launching an instance with a duplicate name, the multipass cli will by default print out the serialized binary string of the protobuf message resulting in extra newlines appearing in the console. 

Ex:

```
scott:~$ multipass launch -n foo                                            
Launched: foo                                                                   
scott:~$ multipass launch -n foo
launch failed: instance "foo" already exists                                    


scott:~$  
```

After changes:

```
scott:~$ multipass launch -n foo
launch failed: instance "foo" already exists                                    
Invalid instance name supplied: foo
scott::~$
```