### PR TITLE
Launch Blueprints from file

### DIFF
--- a/include/multipass/default_vm_blueprint_provider.h
+++ b/include/multipass/default_vm_blueprint_provider.h
@@ -49,6 +49,8 @@ public:
 
     Query fetch_blueprint_for(const std::string& blueprint_name, VirtualMachineDescription& vm_desc,
                               ClientLaunchData& client_launch_data) override;
+    Query blueprint_from_file(const std::string& path, const std::string& blueprint_name,
+                              VirtualMachineDescription& vm_desc, ClientLaunchData& client_launch_data) override;
     VMImageInfo info_for(const std::string& blueprint_name) override;
     std::vector<VMImageInfo> all_blueprints() override;
     std::string name_from_blueprint(const std::string& blueprint_name) override;

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -74,6 +74,7 @@ public:
     virtual SettingSpec::Set extra_client_settings() const;
     virtual QString default_driver() const;
     virtual QString default_privileged_mounts() const;
+    virtual bool is_image_url_supported() const;
 };
 
 QString interpret_setting(const QString& key, const QString& val);
@@ -90,7 +91,6 @@ UpdatePrompt::UPtr make_update_prompt();
 std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& config);
 std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spec);
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
-bool is_image_url_supported();
 
 std::function<int()> make_quit_watchdog(); // call while single-threaded; call result later, in dedicated thread
 

--- a/include/multipass/vm_blueprint_provider.h
+++ b/include/multipass/vm_blueprint_provider.h
@@ -36,6 +36,8 @@ public:
 
     virtual Query fetch_blueprint_for(const std::string& blueprint_name, VirtualMachineDescription& vm_desc,
                                       ClientLaunchData& client_launch_data) = 0;
+    virtual Query blueprint_from_file(const std::string& path, const std::string& blueprint_name,
+                                      VirtualMachineDescription& vm_desc, ClientLaunchData& client_launch_data) = 0;
     virtual VMImageInfo info_for(const std::string& blueprint_name) = 0;
     virtual std::vector<VMImageInfo> all_blueprints() = 0;
     virtual std::string name_from_blueprint(const std::string& blueprint_name) = 0;

--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -216,7 +216,11 @@ mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config, const std::stri
     {
         auto arch_node = blueprint_instance["images"][arch.toStdString()];
 
-        query.release = arch_node["url"].as<std::string>();
+        if (arch_node["url"])
+            query.release = arch_node["url"].as<std::string>();
+        else
+            throw mp::InvalidBlueprintException(fmt::format("No image URL for architecture {} in Blueprint", arch));
+
         query.query_type = mp::Query::Type::HttpDownload;
 
         if (arch_node["sha256"])

--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -404,6 +404,8 @@ mp::Query mp::DefaultVMBlueprintProvider::blueprint_from_file(const std::string&
     if (!mp::platform::is_image_url_supported())
         throw std::runtime_error(fmt::format("Launching a Blueprint from a file is not supported"));
 
+    mpl::log(mpl::Level::debug, category, fmt::format("Reading Blueprint '{}' from file {}", blueprint_name, path));
+
     QFileInfo file_info{QString::fromStdString(path)};
 
     if (!mp::utils::valid_hostname(blueprint_name))
@@ -507,6 +509,16 @@ std::string mp::DefaultVMBlueprintProvider::name_from_blueprint(const std::strin
 {
     if (blueprint_map.count(blueprint_name) == 1)
         return blueprint_name;
+
+    auto name_qstr = QString::fromStdString(blueprint_name);
+
+    if (name_qstr.startsWith("file://") &&
+        (name_qstr.toLower().endsWith(".yaml") || name_qstr.toLower().endsWith(".yml")))
+    {
+        auto file_path = name_qstr.remove(0, 7);
+        auto chop = file_path.at(file_path.size() - 4) == '.' ? 4 : 5;
+        return QFileInfo(file_path).fileName().chopped(chop).toStdString();
+    }
 
     return {};
 }

--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -401,7 +401,7 @@ mp::Query mp::DefaultVMBlueprintProvider::blueprint_from_file(const std::string&
                                                               VirtualMachineDescription& vm_desc,
                                                               ClientLaunchData& client_launch_data)
 {
-    if (!mp::platform::is_image_url_supported())
+    if (!MP_PLATFORM.is_image_url_supported())
         throw std::runtime_error(fmt::format("Launching a Blueprint from a file is not supported"));
 
     mpl::log(mpl::Level::debug, category, fmt::format("Reading Blueprint '{}' from file {}", blueprint_name, path));

--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -418,7 +418,16 @@ mp::Query mp::DefaultVMBlueprintProvider::blueprint_from_file(const std::string&
         throw InvalidBlueprintException(error_message);
     }
 
-    auto blueprint_config = YAML::LoadFile(path);
+    YAML::Node blueprint_config;
+
+    try
+    {
+        blueprint_config = YAML::LoadFile(path);
+    }
+    catch (const YAML::BadFile&)
+    {
+        throw InvalidBlueprintException(fmt::format("Wrong file \'{}\'", path));
+    }
 
     return blueprint_from_yaml_node(blueprint_config, blueprint_name, vm_desc, client_launch_data, arch, url_downloader,
                                     &needs_update);

--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -170,7 +170,7 @@ std::string get_blueprint_version(const YAML::Node& blueprint_instance)
 
 mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config, const std::string& blueprint_name,
                                    mp::VirtualMachineDescription& vm_desc, mp::ClientLaunchData& client_launch_data,
-                                   const QString& arch, mp::URLDownloader* url_downloader, bool* needs_update)
+                                   const QString& arch, mp::URLDownloader* url_downloader, bool& needs_update)
 {
     mp::Query query{"", "default", false, "", mp::Query::Type::Alias};
 
@@ -259,7 +259,7 @@ mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config, const std::stri
         }
         else
         {
-            *needs_update = true;
+            needs_update = true;
             throw mp::InvalidBlueprintException("Unsupported image scheme in Blueprint");
         }
     }
@@ -281,7 +281,7 @@ mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config, const std::stri
         }
         catch (const YAML::BadConversion&)
         {
-            *needs_update = true;
+            needs_update = true;
             throw mp::InvalidBlueprintException(fmt::format("Minimum CPU value in Blueprint is invalid"));
         }
     }
@@ -305,7 +305,7 @@ mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config, const std::stri
         }
         catch (const mp::InvalidMemorySizeException&)
         {
-            *needs_update = true;
+            needs_update = true;
             throw mp::InvalidBlueprintException(fmt::format("Minimum memory size value in Blueprint is invalid"));
         }
     }
@@ -329,7 +329,7 @@ mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config, const std::stri
         }
         catch (const mp::InvalidMemorySizeException&)
         {
-            *needs_update = true;
+            needs_update = true;
             throw mp::InvalidBlueprintException(fmt::format("Minimum disk space value in Blueprint is invalid"));
         }
     }
@@ -350,7 +350,7 @@ mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config, const std::stri
         }
         catch (const YAML::BadConversion&)
         {
-            *needs_update = true;
+            needs_update = true;
             throw mp::InvalidBlueprintException(
                 fmt::format("Cannot convert cloud-init data for the {} Blueprint", blueprint_name));
         }
@@ -396,7 +396,7 @@ mp::Query mp::DefaultVMBlueprintProvider::fetch_blueprint_for(const std::string&
     auto& blueprint_config = blueprint_map.at(blueprint_name);
 
     return blueprint_from_yaml_node(blueprint_config, blueprint_name, vm_desc, client_launch_data, arch, url_downloader,
-                                    &needs_update);
+                                    needs_update);
 }
 
 mp::Query mp::DefaultVMBlueprintProvider::blueprint_from_file(const std::string& path,
@@ -433,7 +433,7 @@ mp::Query mp::DefaultVMBlueprintProvider::blueprint_from_file(const std::string&
     }
 
     return blueprint_from_yaml_node(blueprint_config, blueprint_name, vm_desc, client_launch_data, arch, url_downloader,
-                                    &needs_update);
+                                    needs_update);
 }
 
 mp::VMImageInfo mp::DefaultVMBlueprintProvider::info_for(const std::string& blueprint_name)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2523,16 +2523,20 @@ void mp::Daemon::create_vm(const CreateRequest* request,
                 if (image_qstr.startsWith("file://") &&
                     (image_qstr.toLower().endsWith(".yaml") || image_qstr.toLower().endsWith(".yml")))
                 {
-                    auto file_path = image_qstr.remove(0, 7);
-                    auto blueprint_name = QFile(file_path).fileName().chopped(5).toStdString();
+                    auto file_info = QFileInfo(image_qstr.remove(0, 7));
+                    auto file_path = file_info.absoluteFilePath();
 
-                    query = config->blueprint_provider->blueprint_from_file(file_path.toStdString(), blueprint_name,
-                                                                            vm_desc, client_launch_data);
+                    auto chop = image_qstr.at(image_qstr.size() - 4) == '.' ? 4 : 5;
+                    image = file_info.fileName().chopped(chop).toStdString();
+
+                    query = config->blueprint_provider->blueprint_from_file(file_path.toStdString(), image, vm_desc,
+                                                                            client_launch_data);
                 }
                 else
                 {
                     query = config->blueprint_provider->fetch_blueprint_for(image, vm_desc, client_launch_data);
                 }
+
                 query.name = name;
 
                 // Aliases and default workspace are named in function of the instance name in the Blueprint. If the

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -261,7 +261,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
         }
     }
 
-    if (!unlock && query.query_type != Query::Type::Alias && !mp::platform::is_image_url_supported())
+    if (!unlock && query.query_type != Query::Type::Alias && !MP_PLATFORM.is_image_url_supported())
         throw std::runtime_error(fmt::format("http and file based images are not supported"));
 
     if (query.query_type == Query::Type::LocalFile)

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -347,6 +347,11 @@ QString mp::platform::Platform::default_privileged_mounts() const
     return QStringLiteral("true");
 }
 
+bool mp::platform::Platform::is_image_url_supported() const
+{
+    return true;
+}
+
 auto mp::platform::detail::get_network_interfaces_from(const QDir& sys_dir)
     -> std::map<std::string, NetworkInterfaceInfo>
 {
@@ -442,11 +447,6 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
 mp::logging::Logger::UPtr mp::platform::make_logger(mp::logging::Level level)
 {
     return std::make_unique<logging::JournaldLogger>(level);
-}
-
-bool mp::platform::is_image_url_supported()
-{
-    return true;
 }
 
 std::string mp::platform::reinterpret_interface_id(const std::string& ux_id)

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -54,6 +54,7 @@ public:
     MOCK_CONST_METHOD0(daemon_config_home, QString());
     MOCK_CONST_METHOD0(default_driver, QString());
     MOCK_CONST_METHOD0(default_privileged_mounts, QString());
+    MOCK_CONST_METHOD0(is_image_url_supported, bool());
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockPlatform, Platform);
 };

--- a/tests/mock_vm_blueprint_provider.h
+++ b/tests/mock_vm_blueprint_provider.h
@@ -29,6 +29,8 @@ namespace test
 struct MockVMBlueprintProvider : public VMBlueprintProvider
 {
     MOCK_METHOD3(fetch_blueprint_for, Query(const std::string&, VirtualMachineDescription&, ClientLaunchData&));
+    MOCK_METHOD4(blueprint_from_file,
+                 Query(const std::string&, const std::string&, VirtualMachineDescription&, ClientLaunchData&));
     MOCK_METHOD1(info_for, VMImageInfo(const std::string&));
     MOCK_METHOD0(all_blueprints, std::vector<VMImageInfo>());
     MOCK_METHOD1(name_from_blueprint, std::string(const std::string&));

--- a/tests/stub_vm_blueprint_provider.h
+++ b/tests/stub_vm_blueprint_provider.h
@@ -17,6 +17,7 @@
 #ifndef MULTIPASS_STUB_WORKFLOW_PROVIDER
 #define MULTIPASS_STUB_WORKFLOW_PROVIDER
 
+#include <multipass/exceptions/blueprint_exceptions.h>
 #include <multipass/vm_blueprint_provider.h>
 
 namespace multipass
@@ -29,6 +30,12 @@ struct StubVMBlueprintProvider final : public VMBlueprintProvider
                               ClientLaunchData& client_launch_data) override
     {
         throw std::out_of_range("");
+    }
+
+    Query blueprint_from_file(const std::string& path, const std::string& blueprint_name,
+                              VirtualMachineDescription& vm_desc, ClientLaunchData& client_launch_data) override
+    {
+        throw InvalidBlueprintException("");
     }
 
     VMImageInfo info_for(const std::string& blueprint_name) override

--- a/tests/test_blueprint_provider.cpp
+++ b/tests/test_blueprint_provider.cpp
@@ -900,3 +900,21 @@ INSTANTIATE_TEST_SUITE_P(VMBlueprintProvider, NameFromBlueprintTestSuite,
                          Values(std::pair{"file:///blah/blueprint1.yaml", "blueprint1"},
                                 std::pair{"file:///blah/blueprint2.yml", "blueprint2"},
                                 std::pair{"nonexistent-blueprint", ""}));
+
+TEST_F(VMBlueprintFileLaunch, fileLoadfailsWithNoUrl)
+{
+    auto blueprint_path = QString(mpt::test_data_path() + "/blueprints/v2/test-blueprint1.yaml").toStdString();
+
+    ON_CALL(*mock_platform, is_image_url_supported()).WillByDefault(Return(true));
+
+    mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
+                                                      default_ttl, "microvac"};
+
+    mp::VirtualMachineDescription vm_desc{0, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}};
+
+    mp::ClientLaunchData dummy_data;
+
+    MP_EXPECT_THROW_THAT(blueprint_provider.blueprint_from_file(blueprint_path, "test-blueprint1", vm_desc, dummy_data),
+                         mp::InvalidBlueprintException,
+                         mpt::match_what(StrEq("No image URL for architecture microvac in Blueprint")));
+}

--- a/tests/test_blueprint_provider.cpp
+++ b/tests/test_blueprint_provider.cpp
@@ -880,3 +880,23 @@ TEST_F(VMBlueprintFileLaunch, failsIfFileLaunchIsUnsupported)
                          std::runtime_error,
                          mpt::match_what(StrEq("Launching a Blueprint from a file is not supported")));
 }
+
+struct NameFromBlueprintTestSuite : public VMBlueprintProvider,
+                                    public WithParamInterface<std::pair<std::string, std::string>>
+{
+};
+
+TEST_P(NameFromBlueprintTestSuite, nameFromBlueprintWorks)
+{
+    const auto& [input, output] = GetParam();
+
+    mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
+                                                      default_ttl};
+
+    EXPECT_EQ(blueprint_provider.name_from_blueprint(input), output);
+}
+
+INSTANTIATE_TEST_SUITE_P(VMBlueprintProvider, NameFromBlueprintTestSuite,
+                         Values(std::pair{"file:///blah/blueprint1.yaml", "blueprint1"},
+                                std::pair{"file:///blah/blueprint2.yml", "blueprint2"},
+                                std::pair{"nonexistent-blueprint", ""}));

--- a/tests/test_data/blueprints/v2/test-blueprint1.yaml
+++ b/tests/test_data/blueprints/v2/test-blueprint1.yaml
@@ -1,0 +1,21 @@
+description: The first test blueprint, v2 variation
+version: 0.1
+
+aliases:
+  lst: test-blueprint1:ls
+  lsp: test-blueprint1:pwd
+
+instances:
+  test-blueprint1:
+    images:
+        multivacs:
+            url: https://some-multivacs-image.img
+            sha256: https://some-multivacs-image.sha256 
+    limits:
+      min-cpu: 2
+      min-mem: 2G
+      min-disk: 25G
+    cloud-init:
+      vendor-data: |
+        runcmd:
+          echo "Have fun!"


### PR DESCRIPTION
This introduces the ability to launch (only in Linux) a Blueprint defined on a YAML file. The syntax for doing so is the same as when launching a local image:
```
multipass launch file://blueprint.yaml
```

This works on top of the interface of Blueprints v2. Private bits are in https://github.com/canonical/multipass-private/pull/485.