### PR TITLE
Update apparmor profile for qemu

### DIFF
--- a/src/process/qemuimg_process_spec.cpp
+++ b/src/process/qemuimg_process_spec.cpp
@@ -45,6 +45,7 @@ QString mp::QemuImgProcessSpec::apparmor_profile() const
 profile %1 flags=(attach_disconnected) {
   #include <abstractions/base>
 
+  capability dac_read_search,
   %2
 
   # binary and its libs
@@ -75,9 +76,8 @@ profile %1 flags=(attach_disconnected) {
     }
     catch (mp::SnapEnvironmentException&)
     {
-        extra_capabilities =
-            "capability dac_read_search,\n    capability dac_override,"; // FIXME - unclear why this is required when
-                                                                         // not snap confined
+        extra_capabilities = "capability dac_override,"; // FIXME - unclear why this is required when
+                                                         // not snap confined
         signal_peer = "unconfined";
     }
 


### PR DESCRIPTION
This is needed so Multipass can still create vm instances under snap confinement after changing `MULTIPASS_STORAGE`.