### PR TITLE
Introduce alias contexts

### DIFF
--- a/include/multipass/alias_definition.h
+++ b/include/multipass/alias_definition.h
@@ -35,7 +35,7 @@ inline bool operator==(const AliasDefinition& a, const AliasDefinition& b)
     return (a.instance == b.instance && a.command == b.command);
 }
 
-typedef typename std::unordered_map<std::string, AliasDefinition> AliasMap;
+typedef typename std::unordered_map<std::string, AliasDefinition> AliasContext;
 
 } // namespace multipass
 #endif // MULTIPASS_ALIAS_DEFINITION_H

--- a/include/multipass/cli/alias_dict.h
+++ b/include/multipass/cli/alias_dict.h
@@ -32,6 +32,8 @@ namespace multipass
 {
 static constexpr auto default_context_name = "default";
 
+typedef std::pair<std::string, std::string> ContextAliasPair;
+
 // The alias dictionary is basically a mapping between strings and contexts. The string represents the context name
 // and the associated context is itself a map relating alias names to alias definitions.
 class AliasDict
@@ -52,8 +54,8 @@ public:
     bool is_alias_unique(const std::string& alias) const;
     bool remove_alias(const std::string& alias);
     bool remove_context(const std::string& context);
-    std::vector<std::pair<std::string, std::string>> remove_aliases_for_instance(const std::string& instance);
-    std::optional<std::pair<std::string, std::string>> get_context_and_alias(const std::string& alias) const;
+    std::vector<ContextAliasPair> remove_aliases_for_instance(const std::string& instance);
+    std::optional<ContextAliasPair> get_context_and_alias(const std::string& alias) const;
     std::optional<AliasDefinition> get_alias_from_current_context(const std::string& alias) const;
     std::optional<AliasDefinition> get_alias(const std::string& alias) const;
     DictType::iterator begin()

--- a/include/multipass/cli/alias_dict.h
+++ b/include/multipass/cli/alias_dict.h
@@ -51,7 +51,8 @@ public:
     bool exists_alias(const std::string& alias) const;
     bool remove_alias(const std::string& alias);
     bool remove_context(const std::string& context);
-    std::vector<std::string> remove_aliases_for_instance(const std::string& instance);
+    std::vector<std::pair<std::string, std::string>> remove_aliases_for_instance(const std::string& instance);
+    std::optional<std::pair<std::string, std::string>> get_context_and_alias(const std::string& alias) const;
     std::optional<AliasDefinition> get_alias(const std::string& alias) const;
     DictType::iterator begin()
     {

--- a/include/multipass/cli/alias_dict.h
+++ b/include/multipass/cli/alias_dict.h
@@ -54,6 +54,7 @@ public:
     bool remove_context(const std::string& context);
     std::vector<std::pair<std::string, std::string>> remove_aliases_for_instance(const std::string& instance);
     std::optional<std::pair<std::string, std::string>> get_context_and_alias(const std::string& alias) const;
+    std::optional<AliasDefinition> get_alias_from_current_context(const std::string& alias) const;
     std::optional<AliasDefinition> get_alias(const std::string& alias) const;
     DictType::iterator begin()
     {

--- a/include/multipass/cli/alias_dict.h
+++ b/include/multipass/cli/alias_dict.h
@@ -49,6 +49,7 @@ public:
     const AliasContext& get_active_context() const;
     bool add_alias(const std::string& alias, const AliasDefinition& command);
     bool exists_alias(const std::string& alias) const;
+    bool is_alias_unique(const std::string& alias) const;
     bool remove_alias(const std::string& alias);
     bool remove_context(const std::string& context);
     std::vector<std::pair<std::string, std::string>> remove_aliases_for_instance(const std::string& instance);

--- a/include/multipass/cli/alias_dict.h
+++ b/include/multipass/cli/alias_dict.h
@@ -30,6 +30,7 @@ class QJsonObject;
 
 namespace multipass
 {
+static constexpr auto default_context_name = "default";
 
 // The alias dictionary is basically a mapping between strings and contexts. The string represents the context name
 // and the associated context is itself a map relating alias names to alias definitions.
@@ -78,11 +79,13 @@ public:
     }
     void clear()
     {
-        if (!aliases.empty())
+        if (!empty())
         {
             modified = true;
 
             aliases.clear();
+            active_context = default_context_name;
+            aliases[default_context_name] = AliasContext();
         }
     }
     QJsonObject to_json() const;

--- a/include/multipass/cli/alias_dict.h
+++ b/include/multipass/cli/alias_dict.h
@@ -95,6 +95,7 @@ private:
     void load_dict();
     void save_dict();
     void sanitize_contexts();
+    std::optional<AliasDefinition> get_alias_from_all_contexts(const std::string& alias) const;
 
     std::string active_context;
     DictType aliases;

--- a/include/multipass/cli/format_utils.h
+++ b/include/multipass/cli/format_utils.h
@@ -46,6 +46,9 @@ void filter_aliases(google::protobuf::RepeatedPtrField<multipass::FindReply_Alia
 // which takes as input the element in the range and returns its width in columns.
 static constexpr auto column_width = [](const auto begin, const auto end, const auto get_width, int minimum_width,
                                         int space = 2) {
+    if (0 == std::distance(begin, end))
+        return minimum_width;
+
     auto max_width =
         std::max_element(begin, end, [&get_width](auto& lhs, auto& rhs) { return get_width(lhs) < get_width(rhs); });
     return std::max(get_width(*max_width) + space, minimum_width);

--- a/include/multipass/cli/format_utils.h
+++ b/include/multipass/cli/format_utils.h
@@ -44,10 +44,11 @@ void filter_aliases(google::protobuf::RepeatedPtrField<multipass::FindReply_Alia
 
 // Computes the column width needed to display all the elements of a range [begin, end). get_width is a function
 // which takes as input the element in the range and returns its width in columns.
-static constexpr auto column_width = [](const auto begin, const auto end, const auto get_width, int minimum_width = 0) {
+static constexpr auto column_width = [](const auto begin, const auto end, const auto get_width, int minimum_width,
+                                        int space = 2) {
     auto max_width =
         std::max_element(begin, end, [&get_width](auto& lhs, auto& rhs) { return get_width(lhs) < get_width(rhs); });
-    return std::max(get_width(*max_width) + 2, minimum_width);
+    return std::max(get_width(*max_width) + space, minimum_width);
 };
 } // namespace format
 } // namespace multipass

--- a/include/multipass/client_launch_data.h
+++ b/include/multipass/client_launch_data.h
@@ -27,7 +27,7 @@ namespace multipass
 {
 struct ClientLaunchData
 {
-    AliasMap aliases_to_be_created;
+    AliasContext aliases_to_be_created;
     std::vector<std::string> workspaces_to_be_created;
 };
 } // namespace multipass

--- a/include/multipass/json_utils.h
+++ b/include/multipass/json_utils.h
@@ -20,11 +20,14 @@
 #ifndef MULTIPASS_JSON_UTILS_H
 #define MULTIPASS_JSON_UTILS_H
 
+#include <string>
+
 #include <QJsonObject>
 #include <QString>
 
 namespace multipass
 {
 void write_json(const QJsonObject& root, QString file_name);
+std::string json_to_string(const QJsonObject& root);
 }
 #endif // MULTIPASS_JSON_UTILS_H

--- a/include/multipass/json_utils.h
+++ b/include/multipass/json_utils.h
@@ -17,19 +17,14 @@
  *
  */
 
-#include <multipass/file_ops.h>
-#include <multipass/json_writer.h>
+#ifndef MULTIPASS_JSON_UTILS_H
+#define MULTIPASS_JSON_UTILS_H
 
-#include <QFile>
-#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
 
-namespace mp = multipass;
-
-void mp::write_json(const QJsonObject& root, QString file_name)
+namespace multipass
 {
-    QJsonDocument doc{root};
-    auto raw_json = doc.toJson();
-    QFile db_file{file_name};
-    MP_FILEOPS.open(db_file, QIODevice::ReadWrite | QIODevice::Truncate);
-    MP_FILEOPS.write(db_file, raw_json);
+void write_json(const QJsonObject& root, QString file_name);
 }
+#endif // MULTIPASS_JSON_UTILS_H

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -29,6 +29,7 @@
 #include "cmd/list.h"
 #include "cmd/mount.h"
 #include "cmd/networks.h"
+#include "cmd/prefer.h"
 #include "cmd/purge.h"
 #include "cmd/recover.h"
 #include "cmd/remote_settings_handler.h"
@@ -90,6 +91,7 @@ mp::Client::Client(ClientConfig& config)
     add_command<cmd::List>();
     add_command<cmd::Networks>();
     add_command<cmd::Mount>();
+    add_command<cmd::Prefer>(aliases);
     add_command<cmd::Recover>();
     add_command<cmd::Set>();
     add_command<cmd::Shell>();

--- a/src/client/cli/cmd/CMakeLists.txt
+++ b/src/client/cli/cmd/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(commands STATIC
   list.cpp
   mount.cpp
   networks.cpp
+  prefer.cpp
   purge.cpp
   recover.cpp
   remote_settings_handler.cpp

--- a/src/client/cli/cmd/alias.cpp
+++ b/src/client/cli/cmd/alias.cpp
@@ -141,9 +141,9 @@ mp::ParseCode cmd::Alias::parse_args(mp::ArgParser* parser)
         return ParseCode::CommandLineError;
     }
 
-    if (aliases.get_alias(alias_name))
+    if (aliases.get_alias_from_current_context(alias_name))
     {
-        cerr << fmt::format("Alias '{}' already exists\n", alias_name);
+        cerr << fmt::format("Alias '{}' already exists in current context\n", alias_name);
         return ParseCode::CommandLineError;
     }
 

--- a/src/client/cli/cmd/create_alias.cpp
+++ b/src/client/cli/cmd/create_alias.cpp
@@ -51,6 +51,24 @@ multipass::ReturnCode multipass::cmd::create_alias(AliasDict& aliases, const std
         return ReturnCode::CommandLineError;
     }
 
+    try
+    {
+        if (aliases.is_alias_unique(alias_name))
+        {
+            MP_PLATFORM.create_alias_script(alias_name, alias_definition);
+        }
+    }
+    catch (std::runtime_error& e)
+    {
+        aliases.remove_alias(alias_name);
+        aliases.set_active_context(old_context_name);
+        MP_PLATFORM.remove_alias_script(aliases.active_context_name() + "." + alias_name);
+
+        cerr << fmt::format("Error when creating script for alias: {}\n", e.what());
+
+        return ReturnCode::CommandLineError;
+    }
+
     aliases.set_active_context(old_context_name);
 
 #ifdef MULTIPASS_PLATFORM_WINDOWS

--- a/src/client/cli/cmd/create_alias.cpp
+++ b/src/client/cli/cmd/create_alias.cpp
@@ -22,9 +22,12 @@
 
 multipass::ReturnCode multipass::cmd::create_alias(AliasDict& aliases, const std::string& alias_name,
                                                    const AliasDefinition& alias_definition, std::ostream& cout,
-                                                   std::ostream& cerr)
+                                                   std::ostream& cerr, std::optional<const std::string> context)
 {
     bool empty_before_add = aliases.empty();
+
+    if (context)
+        aliases.set_active_context(*context);
 
     if (!aliases.add_alias(alias_name, alias_definition))
         return ReturnCode::CommandLineError;

--- a/src/client/cli/cmd/create_alias.cpp
+++ b/src/client/cli/cmd/create_alias.cpp
@@ -22,7 +22,7 @@
 
 multipass::ReturnCode multipass::cmd::create_alias(AliasDict& aliases, const std::string& alias_name,
                                                    const AliasDefinition& alias_definition, std::ostream& cout,
-                                                   std::ostream& cerr, std::optional<const std::string> context)
+                                                   std::ostream& cerr, const std::optional<std::string>& context)
 {
     bool empty_before_add = aliases.empty();
 

--- a/src/client/cli/cmd/create_alias.h
+++ b/src/client/cli/cmd/create_alias.h
@@ -21,12 +21,15 @@
 #include <multipass/cli/alias_dict.h>
 #include <multipass/cli/return_codes.h>
 
+#include <optional>
+
 namespace multipass
 {
 namespace cmd
 {
 ReturnCode create_alias(AliasDict& aliases, const std::string& alias_name, const AliasDefinition& alias_definition,
-                        std::ostream& cout, std::ostream& cerr);
+                        std::ostream& cout, std::ostream& cerr,
+                        std::optional<const std::string> context = std::nullopt);
 } // namespace cmd
 } // namespace multipass
 

--- a/src/client/cli/cmd/create_alias.h
+++ b/src/client/cli/cmd/create_alias.h
@@ -29,7 +29,7 @@ namespace cmd
 {
 ReturnCode create_alias(AliasDict& aliases, const std::string& alias_name, const AliasDefinition& alias_definition,
                         std::ostream& cout, std::ostream& cerr,
-                        std::optional<const std::string> context = std::nullopt);
+                        const std::optional<std::string>& context = std::nullopt);
 } // namespace cmd
 } // namespace multipass
 

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -36,7 +36,8 @@ mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
         auto size = reply.purged_instances_size();
         for (auto i = 0; i < size; ++i)
         {
-            const auto removed_aliases = aliases.remove_aliases_for_instance(reply.purged_instances(i));
+            const auto purged_instance = reply.purged_instances(i);
+            const auto removed_aliases = aliases.remove_aliases_for_instance(purged_instance);
 
             for (const auto& removed_alias : removed_aliases)
             {
@@ -49,6 +50,8 @@ mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
                     cerr << fmt::format("Warning: '{}' when removing alias script for {}\n", e.what(), removed_alias);
                 }
             }
+
+            aliases.remove_context(purged_instance);
         }
 
         return mp::ReturnCode::Ok;

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -41,17 +41,17 @@ mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
 
             for (const auto& removed_alias : removed_aliases)
             {
+                const auto& [removal_context, removed_alias_name] = removed_alias;
                 try
                 {
-                    MP_PLATFORM.remove_alias_script(removed_alias);
+                    MP_PLATFORM.remove_alias_script(removal_context + "." + removed_alias_name);
                 }
                 catch (const std::runtime_error& e)
                 {
-                    cerr << fmt::format("Warning: '{}' when removing alias script for {}\n", e.what(), removed_alias);
+                    cerr << fmt::format("Warning: '{}' when removing alias script for {}.{}\n", e.what(),
+                                        removal_context, removed_alias_name);
                 }
             }
-
-            aliases.remove_context(purged_instance);
         }
 
         return mp::ReturnCode::Ok;

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -45,6 +45,11 @@ mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
                 try
                 {
                     MP_PLATFORM.remove_alias_script(removal_context + "." + removed_alias_name);
+
+                    if (!aliases.exists_alias(removed_alias_name))
+                    {
+                        MP_PLATFORM.remove_alias_script(removed_alias_name);
+                    }
                 }
                 catch (const std::runtime_error& e)
                 {

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -465,21 +465,22 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
         if (timer)
             timer->pause();
 
+        instance_name = QString::fromStdString(request.instance_name().empty() ? reply.vm_instance_name()
+                                                                               : request.instance_name());
+
         std::vector<std::string> warning_aliases;
         for (const auto& alias_to_be_created : reply.aliases_to_be_created())
         {
             AliasDefinition alias_definition{alias_to_be_created.instance(), alias_to_be_created.command(),
                                              alias_to_be_created.working_directory()};
-            if (create_alias(aliases, alias_to_be_created.name(), alias_definition, cout, cerr) != ReturnCode::Ok)
+            if (create_alias(aliases, alias_to_be_created.name(), alias_definition, cout, cerr,
+                             instance_name.toStdString()) != ReturnCode::Ok)
                 warning_aliases.push_back(alias_to_be_created.name());
         }
 
         if (warning_aliases.size())
             cout << fmt::format("Warning: unable to create {} {}.\n", warning_aliases.size() == 1 ? "alias" : "aliases",
                                 fmt::join(warning_aliases, ", "));
-
-        instance_name = QString::fromStdString(request.instance_name().empty() ? reply.vm_instance_name()
-                                                                               : request.instance_name());
 
         for (const auto& workspace_to_be_created : reply.workspaces_to_be_created())
         {

--- a/src/client/cli/cmd/prefer.cpp
+++ b/src/client/cli/cmd/prefer.cpp
@@ -49,7 +49,7 @@ QString cmd::Prefer::short_help() const
 
 QString cmd::Prefer::description() const
 {
-    return QStringLiteral("Switch the current alias context");
+    return QStringLiteral("Switch the current alias context. If it does not exist, create it before switching.");
 }
 
 mp::ParseCode cmd::Prefer::parse_args(mp::ArgParser* parser)

--- a/src/client/cli/cmd/prefer.cpp
+++ b/src/client/cli/cmd/prefer.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/cli/alias_dict.h>
+#include <multipass/cli/argparser.h>
+
+#include "common_cli.h"
+#include "prefer.h"
+
+namespace mp = multipass;
+namespace cmd = multipass::cmd;
+
+mp::ReturnCode cmd::Prefer::run(mp::ArgParser* parser)
+{
+    auto ret = parse_args(parser);
+    if (ret != ParseCode::Ok)
+    {
+        return parser->returnCodeFrom(ret);
+    }
+
+    aliases.set_active_context(parser->positionalArguments()[0].toStdString());
+
+    return ReturnCode::Ok;
+}
+
+std::string cmd::Prefer::name() const
+{
+    return "prefer";
+}
+
+QString cmd::Prefer::short_help() const
+{
+    return QStringLiteral("Switch the current alias context");
+}
+
+QString cmd::Prefer::description() const
+{
+    return QStringLiteral("Switch the current alias context");
+}
+
+mp::ParseCode cmd::Prefer::parse_args(mp::ArgParser* parser)
+{
+    parser->addPositionalArgument("name", "Name of the context to switch to", "<name>");
+
+    auto status = parser->commandParse(this);
+
+    if (status != ParseCode::Ok)
+    {
+        return status;
+    }
+
+    if (parser->positionalArguments().count() == 0)
+    {
+        cerr << "The prefer command needs an argument\n";
+        return ParseCode::CommandLineError;
+    }
+
+    if (parser->positionalArguments().count() > 1)
+    {
+        cerr << "Wrong number of arguments given\n";
+        return ParseCode::CommandLineError;
+    }
+
+    return status;
+}

--- a/src/client/cli/cmd/prefer.h
+++ b/src/client/cli/cmd/prefer.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_PREFER_H
+#define MULTIPASS_PREFER_H
+
+#include <multipass/cli/command.h>
+
+#include <QString>
+
+namespace multipass
+{
+class AliasDict;
+
+namespace cmd
+{
+class Prefer final : public Command
+{
+public:
+    using Command::Command;
+
+    Prefer(Rpc::StubInterface& stub, Terminal* term, AliasDict& dict) : Command(stub, term), aliases(dict)
+    {
+    }
+
+    ReturnCode run(ArgParser* parser) override;
+    std::string name() const override;
+    QString short_help() const override;
+    QString description() const override;
+
+private:
+    ParseCode parse_args(ArgParser* parser);
+
+    AliasDict aliases;
+};
+} // namespace cmd
+} // namespace multipass
+#endif // MULTIPASS_PREFER_H

--- a/src/client/cli/cmd/purge.cpp
+++ b/src/client/cli/cmd/purge.cpp
@@ -36,7 +36,8 @@ mp::ReturnCode cmd::Purge::run(mp::ArgParser* parser)
         auto size = reply.purged_instances_size();
         for (auto i = 0; i < size; ++i)
         {
-            const auto removed_aliases = aliases.remove_aliases_for_instance(reply.purged_instances(i));
+            const auto purged_instance = reply.purged_instances(i);
+            const auto removed_aliases = aliases.remove_aliases_for_instance(purged_instance);
 
             for (const auto& removed_alias : removed_aliases)
             {
@@ -49,6 +50,8 @@ mp::ReturnCode cmd::Purge::run(mp::ArgParser* parser)
                     cerr << fmt::format("Warning: '{}' when removing alias script for {}\n", e.what(), removed_alias);
                 }
             }
+
+            aliases.remove_context(purged_instance);
         }
 
         return mp::ReturnCode::Ok;

--- a/src/client/cli/cmd/purge.cpp
+++ b/src/client/cli/cmd/purge.cpp
@@ -39,19 +39,18 @@ mp::ReturnCode cmd::Purge::run(mp::ArgParser* parser)
             const auto purged_instance = reply.purged_instances(i);
             const auto removed_aliases = aliases.remove_aliases_for_instance(purged_instance);
 
-            for (const auto& removed_alias : removed_aliases)
+            for (const auto& [removal_context, removed_alias_name] : removed_aliases)
             {
                 try
                 {
-                    MP_PLATFORM.remove_alias_script(removed_alias);
+                    MP_PLATFORM.remove_alias_script(removal_context + "." + removed_alias_name);
                 }
                 catch (const std::runtime_error& e)
                 {
-                    cerr << fmt::format("Warning: '{}' when removing alias script for {}\n", e.what(), removed_alias);
+                    cerr << fmt::format("Warning: '{}' when removing alias script for {}.{}\n", e.what(),
+                                        removal_context, removed_alias_name);
                 }
             }
-
-            aliases.remove_context(purged_instance);
         }
 
         return mp::ReturnCode::Ok;

--- a/src/client/cli/cmd/purge.cpp
+++ b/src/client/cli/cmd/purge.cpp
@@ -44,6 +44,11 @@ mp::ReturnCode cmd::Purge::run(mp::ArgParser* parser)
                 try
                 {
                     MP_PLATFORM.remove_alias_script(removal_context + "." + removed_alias_name);
+
+                    if (!aliases.exists_alias(removed_alias_name))
+                    {
+                        MP_PLATFORM.remove_alias_script(removed_alias_name);
+                    }
                 }
                 catch (const std::runtime_error& e)
                 {

--- a/src/client/cli/cmd/unalias.cpp
+++ b/src/client/cli/cmd/unalias.cpp
@@ -21,6 +21,9 @@
 #include <multipass/cli/argparser.h>
 #include <multipass/platform.h>
 
+#include <QJsonDocument>
+#include <QJsonObject>
+
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
 
@@ -32,35 +35,24 @@ mp::ReturnCode cmd::Unalias::run(mp::ArgParser* parser)
         return parser->returnCodeFrom(ret);
     }
 
-    if (!parser->isSet(all_option_name))
+    auto old_active_context = aliases.active_context_name();
+
+    for (const auto& [context_from, alias_only] : aliases_to_remove)
     {
-        std::vector<std::string> bad_aliases;
-
-        for (const auto& alias_to_remove : aliases_to_remove)
-            if (!aliases.exists_alias(alias_to_remove))
-                bad_aliases.push_back(alias_to_remove);
-
-        if (!bad_aliases.empty())
-        {
-            cerr << fmt::format("Nonexistent {}: {}.\n", bad_aliases.size() == 1 ? "alias" : "aliases",
-                                fmt::join(bad_aliases, ", "));
-
-            return ReturnCode::CommandLineError;
-        }
-    }
-
-    for (const auto& alias_to_remove : aliases_to_remove)
-    {
-        aliases.remove_alias(alias_to_remove); // We know removal won't fail because the alias exists.
+        aliases.set_active_context(context_from);
+        aliases.remove_alias(alias_only); // We know removal won't fail because the alias exists.
         try
         {
-            MP_PLATFORM.remove_alias_script(alias_to_remove);
+            MP_PLATFORM.remove_alias_script(context_from + "." + alias_only);
         }
         catch (std::runtime_error& e)
         {
-            cerr << fmt::format("Warning: '{}' when removing alias script for {}\n", e.what(), alias_to_remove);
+            cerr << fmt::format("Warning: '{}' when removing alias script for {}.{}\n", e.what(), context_from,
+                                alias_only);
         }
     }
+
+    aliases.set_active_context(old_active_context);
 
     return ReturnCode::Ok;
 }
@@ -95,17 +87,37 @@ mp::ParseCode cmd::Unalias::parse_args(mp::ArgParser* parser)
     if (parse_code != ParseCode::Ok)
         return parse_code;
 
+    std::vector<std::string> bad_aliases;
+
     if (parser->isSet(all_option_name))
     {
+        const auto& active_context_name = aliases.active_context_name();
         const auto& active_context = aliases.get_active_context();
 
         for (auto definition_it = active_context.cbegin(); definition_it != active_context.cend(); ++definition_it)
-            aliases_to_remove.emplace(definition_it->first);
+            aliases_to_remove.emplace_back(active_context_name, definition_it->first);
     }
     else
     {
         for (const auto& arg : parser->positionalArguments())
-            aliases_to_remove.emplace(arg.toStdString());
+        {
+            auto arg_str = arg.toStdString();
+
+            auto context_and_alias = aliases.get_context_and_alias(arg_str);
+
+            if (context_and_alias)
+                aliases_to_remove.emplace_back(context_and_alias->first, context_and_alias->second);
+            else
+                bad_aliases.push_back(arg_str);
+        }
+    }
+
+    if (!bad_aliases.empty())
+    {
+        cerr << fmt::format("Nonexistent {}: {}.\n", bad_aliases.size() == 1 ? "alias" : "aliases",
+                            fmt::join(bad_aliases, ", "));
+
+        return ParseCode::CommandLineError;
     }
 
     return ParseCode::Ok;

--- a/src/client/cli/cmd/unalias.cpp
+++ b/src/client/cli/cmd/unalias.cpp
@@ -84,7 +84,7 @@ mp::ParseCode cmd::Unalias::parse_args(mp::ArgParser* parser)
 {
     parser->addPositionalArgument("name", "Names of aliases to remove", "<name> [<name> ...]");
 
-    QCommandLineOption all_option(all_option_name, "Remove all aliases");
+    QCommandLineOption all_option(all_option_name, "Remove all aliases from current context");
     parser->addOption(all_option);
 
     auto status = parser->commandParse(this);
@@ -97,7 +97,9 @@ mp::ParseCode cmd::Unalias::parse_args(mp::ArgParser* parser)
 
     if (parser->isSet(all_option_name))
     {
-        for (auto definition_it = aliases.cbegin(); definition_it != aliases.cend(); ++definition_it)
+        const auto& active_context = aliases.get_active_context();
+
+        for (auto definition_it = active_context.cbegin(); definition_it != active_context.cend(); ++definition_it)
             aliases_to_remove.emplace(definition_it->first);
     }
     else

--- a/src/client/cli/cmd/unalias.cpp
+++ b/src/client/cli/cmd/unalias.cpp
@@ -44,6 +44,11 @@ mp::ReturnCode cmd::Unalias::run(mp::ArgParser* parser)
         try
         {
             MP_PLATFORM.remove_alias_script(context_from + "." + alias_only);
+
+            if (!aliases.exists_alias(alias_only))
+            {
+                MP_PLATFORM.remove_alias_script(alias_only);
+            }
         }
         catch (std::runtime_error& e)
         {

--- a/src/client/cli/cmd/unalias.h
+++ b/src/client/cli/cmd/unalias.h
@@ -47,7 +47,16 @@ private:
     ParseCode parse_args(ArgParser* parser);
 
     AliasDict aliases;
-    std::unordered_set<std::string> aliases_to_remove;
+
+    struct str_pair_hash
+    {
+        inline std::size_t operator()(const std::pair<std::string, std::string> p) const
+        {
+            return std::hash<std::string>()(p.first) + std::hash<std::string>()(p.second);
+        }
+    };
+
+    std::vector<std::pair<std::string, std::string>> aliases_to_remove;
 };
 } // namespace cmd
 } // namespace multipass

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -133,20 +133,23 @@ std::string mp::CSVFormatter::format(const VersionReply& reply, const std::strin
 
 std::string mp::CSVFormatter::format(const mp::AliasDict& aliases) const
 {
-    /*
     fmt::memory_buffer buf;
-    fmt::format_to(std::back_inserter(buf), "Alias,Instance,Command,Working directory\n");
+    fmt::format_to(std::back_inserter(buf), "Alias,Instance,Command,Context,Working directory\n");
 
-    for (const auto& elt : sort_dict(aliases))
+    for (const auto& context : sort_dict(aliases))
     {
-        const auto& name = elt.first;
-        const auto& def = elt.second;
+        const auto& context_name = context.first;
+        const auto& context_contents = context.second;
 
-        fmt::format_to(std::back_inserter(buf), "{},{},{},{}\n", name, def.instance, def.command,
-                       def.working_directory);
+        for (const auto& elt : sort_dict(context_contents))
+        {
+            const auto& name = elt.first;
+            const auto& def = elt.second;
+
+            fmt::format_to(std::back_inserter(buf), "{},{},{},{},{}\n", name, def.instance, def.command, context_name,
+                           def.working_directory);
+        }
     }
 
     return fmt::to_string(buf);
-    */
-    return std::string{"TODO"};
 }

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -134,7 +134,7 @@ std::string mp::CSVFormatter::format(const VersionReply& reply, const std::strin
 std::string mp::CSVFormatter::format(const mp::AliasDict& aliases) const
 {
     fmt::memory_buffer buf;
-    fmt::format_to(std::back_inserter(buf), "Alias,Instance,Command,Context,Working directory\n");
+    fmt::format_to(std::back_inserter(buf), "Alias,Instance,Command,Working directory,Context\n");
 
     for (const auto& context : sort_dict(aliases))
     {
@@ -143,8 +143,8 @@ std::string mp::CSVFormatter::format(const mp::AliasDict& aliases) const
 
         for (const auto& [name, def] : sort_dict(context_contents))
         {
-            fmt::format_to(std::back_inserter(buf), "{},{},{},{},{}\n", name, def.instance, def.command, context_name,
-                           def.working_directory);
+            fmt::format_to(std::back_inserter(buf), "{},{},{},{},{}\n", name, def.instance, def.command,
+                           def.working_directory, context_name);
         }
     }
 

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -136,15 +136,14 @@ std::string mp::CSVFormatter::format(const mp::AliasDict& aliases) const
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "Alias,Instance,Command,Working directory,Context\n");
 
-    for (const auto& context : sort_dict(aliases))
+    for (const auto& [context_name, context_contents] : sort_dict(aliases))
     {
-        const auto& context_name = context.first;
-        const auto& context_contents = context.second;
+        std::string shown_context = context_name == aliases.active_context_name() ? context_name + "*" : context_name;
 
         for (const auto& [name, def] : sort_dict(context_contents))
         {
             fmt::format_to(std::back_inserter(buf), "{},{},{},{},{}\n", name, def.instance, def.command,
-                           def.working_directory, context_name);
+                           def.working_directory, shown_context);
         }
     }
 

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -133,6 +133,7 @@ std::string mp::CSVFormatter::format(const VersionReply& reply, const std::strin
 
 std::string mp::CSVFormatter::format(const mp::AliasDict& aliases) const
 {
+    /*
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "Alias,Instance,Command,Working directory\n");
 
@@ -146,4 +147,6 @@ std::string mp::CSVFormatter::format(const mp::AliasDict& aliases) const
     }
 
     return fmt::to_string(buf);
+    */
+    return std::string{"TODO"};
 }

--- a/src/client/cli/formatter/csv_formatter.cpp
+++ b/src/client/cli/formatter/csv_formatter.cpp
@@ -141,11 +141,8 @@ std::string mp::CSVFormatter::format(const mp::AliasDict& aliases) const
         const auto& context_name = context.first;
         const auto& context_contents = context.second;
 
-        for (const auto& elt : sort_dict(context_contents))
+        for (const auto& [name, def] : sort_dict(context_contents))
         {
-            const auto& name = elt.first;
-            const auto& def = elt.second;
-
             fmt::format_to(std::back_inserter(buf), "{},{},{},{},{}\n", name, def.instance, def.command, context_name,
                            def.working_directory);
         }

--- a/src/client/cli/formatter/json_formatter.cpp
+++ b/src/client/cli/formatter/json_formatter.cpp
@@ -235,24 +235,5 @@ std::string mp::JsonFormatter::format(const VersionReply& reply, const std::stri
 
 std::string mp::JsonFormatter::format(const mp::AliasDict& aliases) const
 {
-    QJsonObject aliases_json;
-    QJsonArray aliases_array;
-
-    for (const auto& elt : sort_dict(aliases))
-    {
-        const auto& alias = elt.first;
-        const auto& def = elt.second;
-
-        QJsonObject alias_obj;
-        alias_obj.insert("alias", QString::fromStdString(alias));
-        alias_obj.insert("instance", QString::fromStdString(def.instance));
-        alias_obj.insert("command", QString::fromStdString(def.command));
-        alias_obj.insert("working-directory", QString::fromStdString(def.working_directory));
-
-        aliases_array.append(alias_obj);
-    }
-
-    aliases_json.insert("aliases", aliases_array);
-
-    return QString(QJsonDocument(aliases_json).toJson()).toStdString();
+    return QString(QJsonDocument(aliases.to_json()).toJson()).toStdString();
 }

--- a/src/client/cli/formatter/json_formatter.cpp
+++ b/src/client/cli/formatter/json_formatter.cpp
@@ -18,6 +18,7 @@
 #include <multipass/cli/client_common.h>
 #include <multipass/cli/format_utils.h>
 #include <multipass/cli/json_formatter.h>
+#include <multipass/json_utils.h>
 #include <multipass/utils.h>
 
 #include <QJsonArray>
@@ -147,7 +148,7 @@ std::string mp::JsonFormatter::format(const InfoReply& reply) const
     }
     info_json.insert("info", info_obj);
 
-    return QString(QJsonDocument(info_json).toJson()).toStdString();
+    return mp::json_to_string(info_json);
 }
 
 std::string mp::JsonFormatter::format(const ListReply& reply) const
@@ -176,7 +177,7 @@ std::string mp::JsonFormatter::format(const ListReply& reply) const
 
     list_json.insert("list", instances);
 
-    return QString(QJsonDocument(list_json).toJson()).toStdString();
+    return mp::json_to_string(list_json);
 }
 
 std::string mp::JsonFormatter::format(const NetworksReply& reply) const
@@ -196,7 +197,7 @@ std::string mp::JsonFormatter::format(const NetworksReply& reply) const
 
     list_json.insert("list", interfaces);
 
-    return QString(QJsonDocument(list_json).toJson()).toStdString();
+    return mp::json_to_string(list_json);
 }
 
 std::string mp::JsonFormatter::format(const FindReply& reply) const
@@ -207,7 +208,7 @@ std::string mp::JsonFormatter::format(const FindReply& reply) const
     find_json.insert("blueprints", format_images(reply.blueprints_info()));
     find_json.insert("images", format_images(reply.images_info()));
 
-    return QString(QJsonDocument(find_json).toJson()).toStdString();
+    return mp::json_to_string(find_json);
 }
 
 std::string mp::JsonFormatter::format(const VersionReply& reply, const std::string& client_version) const
@@ -230,10 +231,10 @@ std::string mp::JsonFormatter::format(const VersionReply& reply, const std::stri
             version_json.insert("update", update);
         }
     }
-    return QString(QJsonDocument(version_json).toJson()).toStdString();
+    return mp::json_to_string(version_json);
 }
 
 std::string mp::JsonFormatter::format(const mp::AliasDict& aliases) const
 {
-    return QString(QJsonDocument(aliases.to_json()).toJson()).toStdString();
+    return mp::json_to_string(aliases.to_json());
 }

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -288,38 +288,8 @@ std::string mp::TableFormatter::format(const mp::AliasDict& aliases) const
     };
 
     const auto alias_width = width([](const auto& alias) -> int { return alias.first.length(); }, 7);
-    /*mp::format::column_width(aliases.cbegin(),
-                             aliases.cend(),
-                             [](const auto& ctx) -> int {
-                                return mp::format::column_width(
-                                    ctx.second.cbegin(),
-                                    ctx.second.cend(),
-                                    [](const auto& alias) -> int { return alias.first.length(); },
-                                    7); },
-                             7);*/
-
     const auto instance_width = width([](const auto& alias) -> int { return alias.second.instance.length(); }, 10);
-    /*mp::format::column_width(aliases.cbegin(),
-                             aliases.cend(),
-                             [](const auto& ctx) -> int {
-                                return mp::format::column_width(
-                                    ctx.second.cbegin(),
-                                    ctx.second.cend(),
-                                    [](const auto& alias) -> int { return alias.second.instance.length(); },
-                                    10); },
-                             10);*/
-
     const auto command_width = width([](const auto& alias) -> int { return alias.second.command.length(); }, 9);
-    /*mp::format::column_width(aliases.cbegin(),
-                             aliases.cend(),
-                             [](const auto& ctx) -> int {
-                                return mp::format::column_width(
-                                    ctx.second.cbegin(),
-                                    ctx.second.cend(),
-                                    [](const auto& alias) -> int { return alias.second.command.length(); },
-                                    9); },
-                             9);*/
-
     const auto context_width = mp::format::column_width(
         aliases.cbegin(), aliases.cend(), [](const auto& alias) -> int { return alias.first.length(); }, 10);
 

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -282,9 +282,9 @@ std::string mp::TableFormatter::format(const mp::AliasDict& aliases) const
             [&, get_width, minimum_width](const auto& ctx) -> int {
                 return mp::format::column_width(
                     ctx.second.cbegin(), ctx.second.cend(),
-                    [&get_width](const auto& alias) -> int { return get_width(alias); }, minimum_width);
+                    [&get_width](const auto& alias) -> int { return get_width(alias); }, minimum_width, 2);
             },
-            minimum_width);
+            minimum_width, 0);
     };
 
     const auto alias_width = width([](const auto& alias) -> int { return alias.first.length(); }, 7);

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -298,18 +298,12 @@ std::string mp::TableFormatter::format(const mp::AliasDict& aliases) const
     fmt::format_to(std::back_inserter(buf), row_format, "Alias", alias_width, "Instance", instance_width, "Command",
                    command_width, "Context", context_width, "Working directory");
 
-    for (const auto& context : sort_dict(aliases))
+    for (const auto& [context_name, context_contents] : sort_dict(aliases))
     {
-        const auto& context_name = context.first;
-        const auto& context_contents = context.second;
-
         std::string shown_context = context_name == aliases.active_context_name() ? context_name + "*" : context_name;
 
-        for (const auto& elt : sort_dict(context_contents))
+        for (const auto& [name, def] : sort_dict(context_contents))
         {
-            const auto& name = elt.first;
-            const auto& def = elt.second;
-
             fmt::format_to(std::back_inserter(buf), row_format, name, alias_width, def.instance, instance_width,
                            def.command, command_width, shown_context, context_width, def.working_directory);
         }

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -303,13 +303,15 @@ std::string mp::TableFormatter::format(const mp::AliasDict& aliases) const
         const auto& context_name = context.first;
         const auto& context_contents = context.second;
 
+        std::string shown_context = context_name == aliases.active_context_name() ? context_name + "*" : context_name;
+
         for (const auto& elt : sort_dict(context_contents))
         {
             const auto& name = elt.first;
             const auto& def = elt.second;
 
             fmt::format_to(std::back_inserter(buf), row_format, name, alias_width, def.instance, instance_width,
-                           def.command, command_width, context_name, context_width, def.working_directory);
+                           def.command, command_width, shown_context, context_width, def.working_directory);
         }
     }
 

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -226,6 +226,7 @@ std::string mp::YamlFormatter::format(const VersionReply& reply, const std::stri
 
 std::string mp::YamlFormatter::format(const mp::AliasDict& aliases) const
 {
+    /*
     YAML::Node aliases_list, aliases_node;
 
     for (const auto& elt : sort_dict(aliases))
@@ -245,4 +246,6 @@ std::string mp::YamlFormatter::format(const mp::AliasDict& aliases) const
     aliases_list["aliases"] = aliases_node;
 
     return mpu::emit_yaml(aliases_list);
+    */
+    return std::string{"TODO"};
 }

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -228,18 +228,12 @@ std::string mp::YamlFormatter::format(const mp::AliasDict& aliases) const
 {
     YAML::Node aliases_list, aliases_node;
 
-    for (const auto& context : sort_dict(aliases))
+    for (const auto& [context_name, context_contents] : sort_dict(aliases))
     {
         YAML::Node context_node;
 
-        const auto& context_name = context.first;
-        const auto& context_contents = context.second;
-
-        for (const auto& elt : sort_dict(context_contents))
+        for (const auto& [name, def] : sort_dict(context_contents))
         {
-            const auto& name = elt.first;
-            const auto& def = elt.second;
-
             YAML::Node alias_node;
             alias_node["alias"] = name;
             alias_node["command"] = def.command;

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -226,26 +226,34 @@ std::string mp::YamlFormatter::format(const VersionReply& reply, const std::stri
 
 std::string mp::YamlFormatter::format(const mp::AliasDict& aliases) const
 {
-    /*
     YAML::Node aliases_list, aliases_node;
 
-    for (const auto& elt : sort_dict(aliases))
+    for (const auto& context : sort_dict(aliases))
     {
-        const auto& alias = elt.first;
-        const auto& def = elt.second;
+        YAML::Node context_node;
 
-        YAML::Node alias_node;
-        alias_node["alias"] = alias;
-        alias_node["command"] = def.command;
-        alias_node["instance"] = def.instance;
-        alias_node["working-directory"] = def.working_directory;
+        const auto& context_name = context.first;
+        const auto& context_contents = context.second;
 
-        aliases_node.push_back(alias_node);
+        for (const auto& elt : sort_dict(context_contents))
+        {
+            const auto& name = elt.first;
+            const auto& def = elt.second;
+
+            YAML::Node alias_node;
+            alias_node["alias"] = name;
+            alias_node["command"] = def.command;
+            alias_node["instance"] = def.instance;
+            alias_node["working-directory"] = def.working_directory;
+
+            context_node.push_back(alias_node);
+        }
+
+        aliases_node[context_name] = context_node;
     }
 
+    aliases_list["active_context"] = aliases.active_context_name();
     aliases_list["aliases"] = aliases_node;
 
     return mpu::emit_yaml(aliases_list);
-    */
-    return std::string{"TODO"};
 }

--- a/src/client/common/alias_dict.cpp
+++ b/src/client/common/alias_dict.cpp
@@ -176,10 +176,8 @@ std::vector<std::pair<std::string, std::string>> mp::AliasDict::remove_aliases_f
         }
     }
 
-    for (auto pair_to_remove : removed_aliases)
+    for (auto [context_from, removed_alias] : removed_aliases)
     {
-        auto [context_from, removed_alias] = pair_to_remove;
-
         set_active_context(context_from);
         remove_alias(removed_alias);
     }

--- a/src/client/common/alias_dict.cpp
+++ b/src/client/common/alias_dict.cpp
@@ -165,9 +165,24 @@ std::vector<std::string> mp::AliasDict::remove_aliases_for_instance(const std::s
 
 std::optional<mp::AliasDefinition> mp::AliasDict::get_alias(const std::string& alias) const
 {
+    std::string::size_type dot_pos;
+
     try
     {
         return aliases.at(active_context).at(alias);
+    }
+    catch (const std::out_of_range&)
+    {
+        if ((dot_pos = alias.find('.')) == std::string::npos)
+            return std::nullopt;
+    }
+
+    std::string context = alias.substr(0, dot_pos);
+    std::string alias_only = alias.substr(dot_pos + 1);
+
+    try
+    {
+        return aliases.at(context).at(alias_only);
     }
     catch (const std::out_of_range&)
     {

--- a/src/client/common/alias_dict.cpp
+++ b/src/client/common/alias_dict.cpp
@@ -71,10 +71,15 @@ mp::AliasDict::~AliasDict()
 
 void mp::AliasDict::set_active_context(const std::string& new_active_context)
 {
-    active_context = new_active_context;
+    if (new_active_context != active_context)
+    {
+        modified = true;
+        active_context = new_active_context;
+    }
 
     // When switching active context, make sure that a context associated with the new active context exists.
-    aliases.try_emplace(active_context, mp::AliasContext{});
+    if (aliases.try_emplace(active_context, mp::AliasContext{}).second)
+        modified = true;
 }
 
 std::string mp::AliasDict::active_context_name() const
@@ -127,6 +132,10 @@ bool mp::AliasDict::remove_context(const std::string& context)
     if (aliases.erase(context) > 0)
     {
         modified = true;
+
+        if (active_context == context)
+            set_active_context(default_context_name);
+
         return true;
     }
 

--- a/src/client/common/alias_dict.cpp
+++ b/src/client/common/alias_dict.cpp
@@ -187,16 +187,14 @@ std::vector<std::pair<std::string, std::string>> mp::AliasDict::remove_aliases_f
     return removed_aliases;
 }
 
+// The argument is an alias name, which can have the forms (i) "alias" or (ii) "context.alias".
+// (i): returns <active context name, alias name> if the alias exists in the current context; std::nullopt otherwise.
+// (ii): returns <context name, alias name> if the alias exists in the given context; std::nullopt otherwise.
 std::optional<std::pair<std::string, std::string>> mp::AliasDict::get_context_and_alias(const std::string& alias) const
 {
-    try
-    {
-        if (aliases.at(active_context).count(alias) > 0)
-            return std::make_pair(active_context, alias);
-    }
-    catch (const std::out_of_range&)
-    {
-    }
+    // This will never throw because we already checked that the active context exists.
+    if (aliases.at(active_context).count(alias) > 0)
+        return std::make_pair(active_context, alias);
 
     std::string::size_type dot_pos = alias.rfind('.');
 

--- a/src/client/common/alias_dict.cpp
+++ b/src/client/common/alias_dict.cpp
@@ -157,9 +157,9 @@ bool mp::AliasDict::remove_context(const std::string& context)
 
 // This function removes the context called as the instance, and then it iterates through all the remaining contexts
 // to see if there are aliases defined for the instance.
-std::vector<std::pair<std::string, std::string>> mp::AliasDict::remove_aliases_for_instance(const std::string& instance)
+std::vector<mp::ContextAliasPair> mp::AliasDict::remove_aliases_for_instance(const std::string& instance)
 {
-    std::vector<std::pair<std::string, std::string>> removed_aliases;
+    std::vector<mp::ContextAliasPair> removed_aliases;
 
     remove_context(instance);
 
@@ -190,7 +190,7 @@ std::vector<std::pair<std::string, std::string>> mp::AliasDict::remove_aliases_f
 // The argument is an alias name, which can have the forms (i) "alias" or (ii) "context.alias".
 // (i): returns <active context name, alias name> if the alias exists in the current context; std::nullopt otherwise.
 // (ii): returns <context name, alias name> if the alias exists in the given context; std::nullopt otherwise.
-std::optional<std::pair<std::string, std::string>> mp::AliasDict::get_context_and_alias(const std::string& alias) const
+std::optional<mp::ContextAliasPair> mp::AliasDict::get_context_and_alias(const std::string& alias) const
 {
     // This will never throw because we already checked that the active context exists.
     if (aliases.at(active_context).count(alias) > 0)

--- a/src/client/common/alias_dict.cpp
+++ b/src/client/common/alias_dict.cpp
@@ -36,8 +36,6 @@ namespace mpu = multipass::utils;
 
 namespace
 {
-static constexpr auto default_context_name = "default";
-
 void check_working_directory_string(const std::string& dir)
 {
     if (dir != "map" && dir != "default")

--- a/src/client/common/alias_dict.cpp
+++ b/src/client/common/alias_dict.cpp
@@ -19,7 +19,7 @@
 #include <multipass/constants.h>
 #include <multipass/file_ops.h>
 #include <multipass/format.h>
-#include <multipass/json_writer.h>
+#include <multipass/json_utils.h>
 #include <multipass/standard_paths.h>
 #include <multipass/utils.h>
 

--- a/src/client/common/alias_dict.cpp
+++ b/src/client/common/alias_dict.cpp
@@ -36,6 +36,8 @@ namespace mpu = multipass::utils;
 
 namespace
 {
+static constexpr auto default_context_name = "default";
+
 void check_working_directory_string(const std::string& dir)
 {
     if (dir != "map" && dir != "default")
@@ -69,9 +71,34 @@ mp::AliasDict::~AliasDict()
     }
 }
 
+void mp::AliasDict::set_active_context(const std::string& new_active_context)
+{
+    active_context = new_active_context;
+
+    // When switching active context, make sure that a context associated with the new active context exists.
+    aliases.try_emplace(active_context, mp::AliasContext{});
+}
+
+std::string mp::AliasDict::active_context_name() const
+{
+    return active_context;
+}
+
+const mp::AliasContext& mp::AliasDict::get_active_context() const
+{
+    try
+    {
+        return aliases.at(active_context);
+    }
+    catch (const std::out_of_range&)
+    {
+        throw std::runtime_error(fmt::format("active context \"{}\" does not exist in dictionary", active_context));
+    }
+}
+
 bool mp::AliasDict::add_alias(const std::string& alias, const mp::AliasDefinition& command)
 {
-    if (aliases.try_emplace(alias, command).second)
+    if (aliases[active_context].try_emplace(alias, command).second)
     {
         modified = true;
 
@@ -81,14 +108,25 @@ bool mp::AliasDict::add_alias(const std::string& alias, const mp::AliasDefinitio
     return false;
 }
 
-bool mp::AliasDict::exists_alias(const std::string& alias)
+bool mp::AliasDict::exists_alias(const std::string& alias) const
 {
-    return aliases.count(alias);
+    return (aliases.count(active_context) && aliases.at(active_context).count(alias));
 }
 
 bool mp::AliasDict::remove_alias(const std::string& alias)
 {
-    if (aliases.erase(alias) > 0)
+    if (aliases[active_context].erase(alias) > 0)
+    {
+        modified = true;
+        return true;
+    }
+
+    return false;
+}
+
+bool mp::AliasDict::remove_context(const std::string& context)
+{
+    if (aliases.erase(context) > 0)
     {
         modified = true;
         return true;
@@ -101,13 +139,15 @@ std::vector<std::string> mp::AliasDict::remove_aliases_for_instance(const std::s
 {
     std::vector<std::string> removed_aliases;
 
-    for (auto it = aliases.begin(); it != aliases.end();)
+    auto& context = aliases[active_context];
+
+    for (auto it = context.begin(); it != context.end();)
     {
         if (it->second.instance == instance)
         {
             modified = true;
             removed_aliases.push_back(it->first);
-            it = aliases.erase(it);
+            it = context.erase(it);
         }
         else
             ++it;
@@ -120,12 +160,46 @@ std::optional<mp::AliasDefinition> mp::AliasDict::get_alias(const std::string& a
 {
     try
     {
-        return aliases.at(alias);
+        return aliases.at(active_context).at(alias);
     }
     catch (const std::out_of_range&)
     {
         return std::nullopt;
     }
+}
+
+QJsonObject mp::AliasDict::to_json() const
+{
+    auto alias_to_json = [](const mp::AliasDefinition& alias) -> QJsonObject {
+        QJsonObject json;
+
+        check_working_directory_string(alias.working_directory);
+
+        json.insert("instance", QString::fromStdString(alias.instance));
+        json.insert("command", QString::fromStdString(alias.command));
+        json.insert("working-directory", QString::fromStdString(alias.working_directory));
+
+        return json;
+    };
+
+    QJsonObject dict_json, all_contexts_json;
+    dict_json.insert("active-context", QString::fromStdString(active_context));
+
+    for (const auto& [context_name, context_contents] : aliases)
+    {
+        QJsonObject context_json;
+
+        for (const auto& [alias_name, alias_definition] : context_contents)
+        {
+            context_json.insert(QString::fromStdString(alias_name), alias_to_json(alias_definition));
+        }
+
+        all_contexts_json.insert(QString::fromStdString(context_name), context_json);
+    }
+
+    dict_json.insert(QString("contexts"), all_contexts_json);
+
+    return dict_json;
 }
 
 void mp::AliasDict::load_dict()
@@ -140,38 +214,82 @@ void mp::AliasDict::load_dict()
             throw std::runtime_error(fmt::format("Error opening file '{}'", db_file.fileName()));
     }
     else
+    {
+        active_context = default_context_name;
+        aliases[default_context_name] = AliasContext();
+
         return;
+    }
 
     QJsonParseError parse_error;
     QJsonDocument doc = QJsonDocument::fromJson(db_file.readAll(), &parse_error);
     if (doc.isNull())
+    {
+        active_context = default_context_name;
+        aliases[default_context_name] = AliasContext();
+
         return;
+    }
 
     QJsonObject records = doc.object();
     if (records.isEmpty())
-        return;
-
-    for (auto it = records.constBegin(); it != records.constEnd(); ++it)
     {
-        auto alias = it.key().toStdString();
-        auto record = it.value().toObject();
-        if (record.isEmpty())
-            break;
+        active_context = default_context_name;
+        aliases[default_context_name] = AliasContext();
 
-        auto instance = record["instance"].toString().toStdString();
-        auto command = record["command"].toString().toStdString();
+        return;
+    }
 
-        auto read_working_directory = record["working-directory"];
-        std::string working_directory;
+    auto records_to_context = [](const QJsonObject& records, AliasContext& context) -> void {
+        for (auto it = records.constBegin(); it != records.constEnd(); ++it)
+        {
+            auto alias = it.key().toStdString();
+            auto record = it.value().toObject();
+            if (record.isEmpty())
+                break;
 
-        if (read_working_directory.isString() && !read_working_directory.toString().isEmpty())
-            working_directory = read_working_directory.toString().toStdString();
-        else
-            working_directory = "default";
+            auto instance = record["instance"].toString().toStdString();
+            auto command = record["command"].toString().toStdString();
 
-        check_working_directory_string(working_directory);
+            auto read_working_directory = record["working-directory"];
+            std::string working_directory;
 
-        aliases.emplace(alias, mp::AliasDefinition{instance, command, working_directory});
+            if (read_working_directory.isString() && !read_working_directory.toString().isEmpty())
+                working_directory = read_working_directory.toString().toStdString();
+            else
+                working_directory = "default";
+
+            check_working_directory_string(working_directory);
+
+            context.emplace(alias, mp::AliasDefinition{instance, command, working_directory});
+        }
+    };
+
+    // If the JSON does not contain the active-context field, then the file was written by a version of Multipass
+    // previous than the introduction of alias contexts.
+    if (records.contains("active-context"))
+    {
+        active_context = records["active-context"].toString().toStdString();
+
+        auto context_array = records["contexts"].toObject();
+
+        for (auto it = context_array.constBegin(); it != context_array.constEnd(); ++it)
+        {
+            AliasContext context;
+            std::string context_name = it.key().toStdString();
+            records_to_context(it.value().toObject(), context);
+            aliases.emplace(std::make_pair(context_name, context));
+        }
+    }
+    else
+    {
+        // The file with the old format does not contain information about contexts. For that reason, everything
+        // defined goes into the default context.
+        active_context = default_context_name;
+
+        AliasContext default_context;
+        records_to_context(records, default_context);
+        aliases.emplace(std::make_pair(active_context, default_context));
     }
 
     db_file.close();
@@ -179,26 +297,9 @@ void mp::AliasDict::load_dict()
 
 void mp::AliasDict::save_dict()
 {
-    auto alias_to_json = [](const mp::AliasDefinition& alias) -> QJsonObject {
-        QJsonObject json;
+    sanitize_contexts();
 
-        check_working_directory_string(alias.working_directory);
-
-        json.insert("instance", QString::fromStdString(alias.instance));
-        json.insert("command", QString::fromStdString(alias.command));
-        json.insert("working-directory", QString::fromStdString(alias.working_directory));
-
-        return json;
-    };
-
-    QJsonObject aliases_json;
-    for (const auto& record : aliases)
-    {
-        auto name = QString::fromStdString(record.first);
-        auto definition = alias_to_json(record.second);
-
-        aliases_json.insert(name, definition);
-    }
+    QJsonObject dict_json = to_json();
 
     auto config_file_name = QString::fromStdString(aliases_file);
 
@@ -208,7 +309,7 @@ void mp::AliasDict::save_dict()
     {
         temp_file.setAutoRemove(false);
 
-        mp::write_json(aliases_json, temp_file.fileName());
+        mp::write_json(dict_json, temp_file.fileName());
 
         temp_file.close();
 
@@ -227,5 +328,24 @@ void mp::AliasDict::save_dict()
 
         if (!MP_FILEOPS.rename(temp_file, config_file_name))
             throw std::runtime_error(fmt::format("cannot create aliases config file {}", config_file_name));
+    }
+}
+
+// This function removes the contexts which do not contain aliases, except the active context.
+void mp::AliasDict::sanitize_contexts()
+{
+    // To avoid invalidating iterators, the function works in two stages. First, the aliases which need to be
+    // removed are determined and, second, they are effectively removed.
+    std::vector<std::string> empty_contexts;
+
+    for (auto& context : aliases)
+        if (context.first != active_context && context.second.empty())
+            empty_contexts.push_back(context.first);
+
+    if (!empty_contexts.empty())
+    {
+        modified = true;
+        for (const auto& context : empty_contexts)
+            aliases.erase(context);
     }
 }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -33,7 +33,7 @@
 #include <multipass/file_ops.h> // TODO hk migration, remove
 #include <multipass/format.h>
 #include <multipass/ip_address.h>
-#include <multipass/json_writer.h>
+#include <multipass/json_utils.h>
 #include <multipass/logging/client_logger.h>
 #include <multipass/logging/log.h>
 #include <multipass/name_generator.h>

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -21,7 +21,7 @@
 #include <multipass/exceptions/create_image_exception.h>
 #include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/unsupported_image_exception.h>
-#include <multipass/json_writer.h>
+#include <multipass/json_utils.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
 #include <multipass/process/qemuimg_process_spec.h>

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -16,7 +16,7 @@ function(add_target TARGET_NAME)
   add_library(${TARGET_NAME} STATIC
     file_ops.cpp
     memory_size.cpp
-    json_writer.cpp
+    json_utils.cpp
     snap_utils.cpp
     standard_paths.cpp
     timer.cpp

--- a/src/utils/json_utils.cpp
+++ b/src/utils/json_utils.cpp
@@ -33,3 +33,9 @@ void mp::write_json(const QJsonObject& root, QString file_name)
     MP_FILEOPS.open(db_file, QIODevice::ReadWrite | QIODevice::Truncate);
     MP_FILEOPS.write(db_file, raw_json);
 }
+
+std::string mp::json_to_string(const QJsonObject& root)
+{
+    // The function name toJson() is shockingly wrong, for it converts an actual JsonDocument to a QByteArray.
+    return QJsonDocument(root).toJson().toStdString();
+}

--- a/src/utils/json_utils.cpp
+++ b/src/utils/json_utils.cpp
@@ -17,14 +17,19 @@
  *
  */
 
-#ifndef MULTIPASS_JSON_WRITER_H
-#define MULTIPASS_JSON_WRITER_H
+#include <multipass/file_ops.h>
+#include <multipass/json_utils.h>
 
-#include <QJsonObject>
-#include <QString>
+#include <QFile>
+#include <QJsonDocument>
 
-namespace multipass
+namespace mp = multipass;
+
+void mp::write_json(const QJsonObject& root, QString file_name)
 {
-void write_json(const QJsonObject& root, QString file_name);
+    QJsonDocument doc{root};
+    auto raw_json = doc.toJson();
+    QFile db_file{file_name};
+    MP_FILEOPS.open(db_file, QIODevice::ReadWrite | QIODevice::Truncate);
+    MP_FILEOPS.write(db_file, raw_json);
 }
-#endif // MULTIPASS_JSON_WRITER_H

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -556,11 +556,18 @@ TEST_P(DaemonAliasTestsuite, purge_removes_purged_instance_aliases_and_scripts)
     mpt::MockPlatform* mock_platform = attr.first;
 
     ON_CALL(*mock_platform, create_alias_script(_, _)).WillByDefault(Return());
+
     for (const auto& removed_alias : expected_removed_aliases)
-        EXPECT_CALL(*mock_platform, remove_alias_script("default." + removed_alias));
+    {
+        EXPECT_CALL(*mock_platform, remove_alias_script("default." + removed_alias)).Times(1);
+        EXPECT_CALL(*mock_platform, remove_alias_script(removed_alias)).Times(1);
+    }
+
     for (const auto& removed_alias : expected_failed_removal)
+    {
         EXPECT_CALL(*mock_platform, remove_alias_script("default." + removed_alias))
             .WillOnce(Throw(std::runtime_error("foo")));
+    }
 
     mpt::TempDir temp_dir;
     QString filename(temp_dir.path() + "/multipassd-vm-instances.json");

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -475,7 +475,7 @@ INSTANTIATE_TEST_SUITE_P(
                "                \"working-directory\": \"map\"\n"
                "            }\n        }\n    }\n}\n",
                "Alias  Instance  Command  Context   Working directory\n"
-               "llp    primary   ls       default   map\nlsp    primary   ls       default   map\n",
+               "llp    primary   ls       default*  map\nlsp    primary   ls       default*  map\n",
                "active_context: default\naliases:\n  default:\n"
                "    - alias: llp\n      command: ls\n      instance: primary\n      working-directory: map\n"
                "    - alias: lsp\n      command: ls\n      instance: primary\n      working-directory: map\n")));

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -375,19 +375,36 @@ TEST_F(AliasDictionary, correctlyGetsAliasInDefaultContext)
     ASSERT_FALSE(dict.empty());
 }
 
-TEST_F(AliasDictionary, correctlyGetsAliasInNonDefaultContext)
+TEST_F(AliasDictionary, correctlyGetsUniqueAliasInAnotherContext)
 {
     std::stringstream trash_stream;
     mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
     mp::AliasDict dict(&trash_term);
 
     std::string alias_name{"alias"};
+    mp::AliasDefinition alias_def{"instance", "command", "map"};
+
+    dict.add_alias(alias_name, alias_def);
+
+    dict.set_active_context("new_context");
+
+    auto result = dict.get_alias(alias_name);
+    ASSERT_EQ(result, alias_def);
+    ASSERT_FALSE(dict.empty());
+}
+
+TEST_F(AliasDictionary, correctlyGetsAliasInNonDefaultContext)
+{
+    std::stringstream trash_stream;
+    mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
+    mp::AliasDict dict(&trash_term);
+
     std::string context{"non-default"};
+    std::string alias_name{"alias"};
     mp::AliasDefinition alias_def{"instance", "command", "map"};
 
     dict.set_active_context(context);
     dict.add_alias(alias_name, alias_def);
-    ASSERT_FALSE(dict.empty());
     dict.set_active_context("default");
 
     auto result = dict.get_alias(context + '.' + alias_name);

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -478,7 +478,7 @@ INSTANTIATE_TEST_SUITE_P(
                            "No aliases defined.\n", "active_context: default\naliases:\n  default: ~\n"),
            std::make_tuple(
                AliasesVector{{"lsp", {"primary", "ls", "map"}}, {"llp", {"primary", "ls", "map"}}},
-               csv_head + "llp,primary,ls,map,default\nlsp,primary,ls,map,default\n",
+               csv_head + "llp,primary,ls,map,default*\nlsp,primary,ls,map,default*\n",
                "{\n    \"active-context\": \"default\",\n    \"contexts\": {\n"
                "        \"default\": {\n"
                "            \"llp\": {\n"
@@ -609,20 +609,21 @@ TEST_P(DaemonAliasTestsuite, purge_removes_purged_instance_aliases_and_scripts)
 
 INSTANTIATE_TEST_SUITE_P(
     AliasDictionary, DaemonAliasTestsuite,
-    Values(std::make_tuple(CmdList{{"delete", "real-zebraphant"}, {"purge"}}, csv_head + "lsp,primary,ls,map,default\n",
-                           std::vector<std::string>{"lsz"}, std::vector<std::string>{}),
-           std::make_tuple(CmdList{{"delete", "--purge", "real-zebraphant"}}, csv_head + "lsp,primary,ls,map,default\n",
-                           std::vector<std::string>{"lsz"}, std::vector<std::string>{}),
-           std::make_tuple(CmdList{{"delete", "primary"}, {"delete", "primary", "real-zebraphant", "--purge"}},
-                           csv_head, std::vector<std::string>{"lsp", "lsz"}, std::vector<std::string>{}),
-           std::make_tuple(CmdList{{"delete", "primary"}, {"delete", "primary", "real-zebraphant", "--purge"}},
-                           csv_head, std::vector<std::string>{}, std::vector<std::string>{"lsp", "lsz"}),
-           std::make_tuple(CmdList{{"delete", "primary"}, {"delete", "primary", "real-zebraphant", "--purge"}},
-                           csv_head, std::vector<std::string>{"lsp"}, std::vector<std::string>{"lsz"}),
-           std::make_tuple(CmdList{{"delete", "real-zebraphant"}, {"purge"}}, csv_head + "lsp,primary,ls,map,default\n",
-                           std::vector<std::string>{}, std::vector<std::string>{"lsz"}),
-           std::make_tuple(CmdList{{"delete", "real-zebraphant", "primary"}, {"purge"}}, csv_head,
-                           std::vector<std::string>{}, std::vector<std::string>{"lsz", "lsp"})));
+    Values(
+        std::make_tuple(CmdList{{"delete", "real-zebraphant"}, {"purge"}}, csv_head + "lsp,primary,ls,map,default*\n",
+                        std::vector<std::string>{"lsz"}, std::vector<std::string>{}),
+        std::make_tuple(CmdList{{"delete", "--purge", "real-zebraphant"}}, csv_head + "lsp,primary,ls,map,default*\n",
+                        std::vector<std::string>{"lsz"}, std::vector<std::string>{}),
+        std::make_tuple(CmdList{{"delete", "primary"}, {"delete", "primary", "real-zebraphant", "--purge"}}, csv_head,
+                        std::vector<std::string>{"lsp", "lsz"}, std::vector<std::string>{}),
+        std::make_tuple(CmdList{{"delete", "primary"}, {"delete", "primary", "real-zebraphant", "--purge"}}, csv_head,
+                        std::vector<std::string>{}, std::vector<std::string>{"lsp", "lsz"}),
+        std::make_tuple(CmdList{{"delete", "primary"}, {"delete", "primary", "real-zebraphant", "--purge"}}, csv_head,
+                        std::vector<std::string>{"lsp"}, std::vector<std::string>{"lsz"}),
+        std::make_tuple(CmdList{{"delete", "real-zebraphant"}, {"purge"}}, csv_head + "lsp,primary,ls,map,default*\n",
+                        std::vector<std::string>{}, std::vector<std::string>{"lsz"}),
+        std::make_tuple(CmdList{{"delete", "real-zebraphant", "primary"}, {"purge"}}, csv_head,
+                        std::vector<std::string>{}, std::vector<std::string>{"lsz", "lsp"})));
 
 TEST_F(AliasDictionary, unexistingActiveContextThrows)
 {

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -758,4 +758,80 @@ TEST_F(AliasDictionary, removingUnexistingContextDoesNothing)
     ASSERT_EQ(dict.active_context_name(), "default");
     ASSERT_EQ(dict.get_active_context().size(), 1u);
 }
+
+TEST_F(AliasDictionary, unqualifiedGetContextAndAliasWorksIfInDifferentContext)
+{
+    std::stringstream trash_stream;
+    mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
+    mp::AliasDict dict(&trash_term);
+
+    dict.add_alias("first_alias", mp::AliasDefinition{"instance-1", "command-1", "map"});
+    dict.set_active_context("new_context");
+
+    ASSERT_EQ(dict.get_context_and_alias("first_alias"), std::nullopt);
+}
+
+TEST_F(AliasDictionary, unqualifiedGetContextAndAliasWorksIfInCurrentContext)
+{
+    std::stringstream trash_stream;
+    mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
+    mp::AliasDict dict(&trash_term);
+
+    dict.add_alias("first_alias", mp::AliasDefinition{"instance-1", "command-1", "map"});
+    auto context_and_alias = dict.get_context_and_alias("first_alias");
+
+    ASSERT_EQ(context_and_alias->first, "default");
+    ASSERT_EQ(context_and_alias->second, "first_alias");
+}
+
+TEST_F(AliasDictionary, unqualifiedGetContextAndAliasWorksWithEquallyNamesAliasesInDifferentContext)
+{
+    std::stringstream trash_stream;
+    mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
+    mp::AliasDict dict(&trash_term);
+
+    dict.add_alias("first_alias", mp::AliasDefinition{"instance-1", "command-1", "map"});
+    dict.set_active_context("new_context");
+    dict.add_alias("first_alias", mp::AliasDefinition{"instance-2", "command-2", "map"});
+    auto context_and_alias = dict.get_context_and_alias("first_alias");
+
+    ASSERT_EQ(context_and_alias->first, "new_context");
+    ASSERT_EQ(context_and_alias->second, "first_alias");
+}
+
+TEST_F(AliasDictionary, qualifiedGetContextAndAliasWorksIfAliasAndContextExist)
+{
+    std::stringstream trash_stream;
+    mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
+    mp::AliasDict dict(&trash_term);
+
+    dict.add_alias("first_alias", mp::AliasDefinition{"instance-1", "command-1", "map"});
+    dict.set_active_context("new_context");
+    dict.add_alias("second_alias", mp::AliasDefinition{"instance-2", "command-2", "map"});
+    auto context_and_alias = dict.get_context_and_alias("default.first_alias");
+
+    ASSERT_EQ(context_and_alias->first, "default");
+    ASSERT_EQ(context_and_alias->second, "first_alias");
+}
+
+TEST_F(AliasDictionary, qualifiedGetContextAndAliasWorksIfContextDoesNotExist)
+{
+    std::stringstream trash_stream;
+    mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
+    mp::AliasDict dict(&trash_term);
+
+    dict.add_alias("first_alias", mp::AliasDefinition{"instance-1", "command-1", "map"});
+    ASSERT_EQ(dict.get_context_and_alias("nonexistant_context.first_alias"), std::nullopt);
+}
+
+TEST_F(AliasDictionary, qualifiedGetContextAndAliasWorksIfAliasDoesNotExist)
+{
+    std::stringstream trash_stream;
+    mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
+    mp::AliasDict dict(&trash_term);
+
+    dict.add_alias("first_alias", mp::AliasDefinition{"instance-1", "command-1", "map"});
+    ASSERT_EQ(dict.get_context_and_alias("default.nonexistant_alias"), std::nullopt);
+}
+
 } // namespace

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -557,9 +557,10 @@ TEST_P(DaemonAliasTestsuite, purge_removes_purged_instance_aliases_and_scripts)
 
     ON_CALL(*mock_platform, create_alias_script(_, _)).WillByDefault(Return());
     for (const auto& removed_alias : expected_removed_aliases)
-        EXPECT_CALL(*mock_platform, remove_alias_script(removed_alias));
+        EXPECT_CALL(*mock_platform, remove_alias_script("default." + removed_alias));
     for (const auto& removed_alias : expected_failed_removal)
-        EXPECT_CALL(*mock_platform, remove_alias_script(removed_alias)).WillOnce(Throw(std::runtime_error("foo")));
+        EXPECT_CALL(*mock_platform, remove_alias_script("default." + removed_alias))
+            .WillOnce(Throw(std::runtime_error("foo")));
 
     mpt::TempDir temp_dir;
     QString filename(temp_dir.path() + "/multipassd-vm-instances.json");
@@ -575,8 +576,8 @@ TEST_P(DaemonAliasTestsuite, purge_removes_purged_instance_aliases_and_scripts)
         send_command(command, cout, cerr);
 
     for (const auto& removed_alias : expected_failed_removal)
-        EXPECT_THAT(cerr.str(),
-                    HasSubstr(fmt::format("Warning: 'foo' when removing alias script for {}\n", removed_alias)));
+        EXPECT_THAT(cerr.str(), HasSubstr(fmt::format("Warning: 'foo' when removing alias script for default.{}\n",
+                                                      removed_alias)));
 
     send_command({"aliases", "--format", "csv"}, cout);
     EXPECT_EQ(cout.str(), expected_output);

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -358,7 +358,7 @@ TEST_F(AliasDictionary, clearWorks)
     ASSERT_TRUE(dict.empty());
 }
 
-TEST_F(AliasDictionary, correctly_gets_alias)
+TEST_F(AliasDictionary, correctlyGetsAliasInDefaultContext)
 {
     std::stringstream trash_stream;
     mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
@@ -371,6 +371,26 @@ TEST_F(AliasDictionary, correctly_gets_alias)
     ASSERT_FALSE(dict.empty());
 
     auto result = dict.get_alias(alias_name);
+    ASSERT_EQ(result, alias_def);
+    ASSERT_FALSE(dict.empty());
+}
+
+TEST_F(AliasDictionary, correctlyGetsAliasInNonDefaultContext)
+{
+    std::stringstream trash_stream;
+    mpt::StubTerminal trash_term(trash_stream, trash_stream, trash_stream);
+    mp::AliasDict dict(&trash_term);
+
+    std::string alias_name{"alias"};
+    std::string context{"non-default"};
+    mp::AliasDefinition alias_def{"instance", "command", "map"};
+
+    dict.set_active_context(context);
+    dict.add_alias(alias_name, alias_def);
+    ASSERT_FALSE(dict.empty());
+    dict.set_active_context("default");
+
+    auto result = dict.get_alias(context + '.' + alias_name);
     ASSERT_EQ(result, alias_def);
     ASSERT_FALSE(dict.empty());
 }

--- a/tests/test_alias_dict.cpp
+++ b/tests/test_alias_dict.cpp
@@ -468,7 +468,7 @@ TEST_P(FormatterTestsuite, table)
     ASSERT_EQ(mp::YamlFormatter().format(dict), yaml_output);
 }
 
-const std::string csv_head{"Alias,Instance,Command,Context,Working directory\n"};
+const std::string csv_head{"Alias,Instance,Command,Working directory,Context\n"};
 
 INSTANTIATE_TEST_SUITE_P(
     AliasDictionary, FormatterTestsuite,
@@ -478,7 +478,7 @@ INSTANTIATE_TEST_SUITE_P(
                            "No aliases defined.\n", "active_context: default\naliases:\n  default: ~\n"),
            std::make_tuple(
                AliasesVector{{"lsp", {"primary", "ls", "map"}}, {"llp", {"primary", "ls", "map"}}},
-               csv_head + "llp,primary,ls,default,map\nlsp,primary,ls,default,map\n",
+               csv_head + "llp,primary,ls,map,default\nlsp,primary,ls,map,default\n",
                "{\n    \"active-context\": \"default\",\n    \"contexts\": {\n"
                "        \"default\": {\n"
                "            \"llp\": {\n"
@@ -609,9 +609,9 @@ TEST_P(DaemonAliasTestsuite, purge_removes_purged_instance_aliases_and_scripts)
 
 INSTANTIATE_TEST_SUITE_P(
     AliasDictionary, DaemonAliasTestsuite,
-    Values(std::make_tuple(CmdList{{"delete", "real-zebraphant"}, {"purge"}}, csv_head + "lsp,primary,ls,default,map\n",
+    Values(std::make_tuple(CmdList{{"delete", "real-zebraphant"}, {"purge"}}, csv_head + "lsp,primary,ls,map,default\n",
                            std::vector<std::string>{"lsz"}, std::vector<std::string>{}),
-           std::make_tuple(CmdList{{"delete", "--purge", "real-zebraphant"}}, csv_head + "lsp,primary,ls,default,map\n",
+           std::make_tuple(CmdList{{"delete", "--purge", "real-zebraphant"}}, csv_head + "lsp,primary,ls,map,default\n",
                            std::vector<std::string>{"lsz"}, std::vector<std::string>{}),
            std::make_tuple(CmdList{{"delete", "primary"}, {"delete", "primary", "real-zebraphant", "--purge"}},
                            csv_head, std::vector<std::string>{"lsp", "lsz"}, std::vector<std::string>{}),
@@ -619,7 +619,7 @@ INSTANTIATE_TEST_SUITE_P(
                            csv_head, std::vector<std::string>{}, std::vector<std::string>{"lsp", "lsz"}),
            std::make_tuple(CmdList{{"delete", "primary"}, {"delete", "primary", "real-zebraphant", "--purge"}},
                            csv_head, std::vector<std::string>{"lsp"}, std::vector<std::string>{"lsz"}),
-           std::make_tuple(CmdList{{"delete", "real-zebraphant"}, {"purge"}}, csv_head + "lsp,primary,ls,default,map\n",
+           std::make_tuple(CmdList{{"delete", "real-zebraphant"}, {"purge"}}, csv_head + "lsp,primary,ls,map,default\n",
                            std::vector<std::string>{}, std::vector<std::string>{"lsz"}),
            std::make_tuple(CmdList{{"delete", "real-zebraphant", "primary"}, {"purge"}}, csv_head,
                            std::vector<std::string>{}, std::vector<std::string>{"lsz", "lsp"})));

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -429,7 +429,7 @@ auto make_info_function(const std::string& source_path = "", const std::string& 
 
 typedef std::vector<std::pair<std::string, mp::AliasDefinition>> AliasesVector;
 
-const std::string csv_header{"Alias,Instance,Command,Context,Working directory\n"};
+const std::string csv_header{"Alias,Instance,Command,Working directory,Context\n"};
 
 // Tests for no postional args given
 TEST_F(Client, no_command_is_error)
@@ -3337,7 +3337,7 @@ TEST_F(ClientAlias, alias_creates_alias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n"
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n"
                                                 "another_alias,primary,another_command,default,default\n");
 }
 
@@ -3418,7 +3418,7 @@ TEST_F(ClientAlias, alias_does_not_overwrite_alias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n");
 }
 
 struct ArgumentCheckTestsuite
@@ -3549,7 +3549,7 @@ TEST_F(ClientAlias, alias_refuses_creation_nonexistent_instance)
 
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n");
 }
 
 TEST_F(ClientAlias, alias_refuses_creation_rpc_error)
@@ -3566,7 +3566,7 @@ TEST_F(ClientAlias, alias_refuses_creation_rpc_error)
 
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n");
 }
 
 TEST_F(ClientAlias, aliasRefusesCreateDuplicateAlias)
@@ -3583,7 +3583,7 @@ TEST_F(ClientAlias, aliasRefusesCreateDuplicateAlias)
 
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,primary,a_command,default,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,primary,a_command,map,default\n");
 }
 
 TEST_F(ClientAlias, aliasCreatesAliasThatExistsInAnotherContext)
@@ -3605,7 +3605,7 @@ TEST_F(ClientAlias, aliasCreatesAliasThatExistsInAnotherContext)
 
     EXPECT_THAT(cout_stream.str(),
                 csv_header +
-                    "an_alias,primary,a_command,default,map\nan_alias,primary,another_command,new_context,map\n");
+                    "an_alias,primary,a_command,map,default\nan_alias,primary,another_command,map,new_context\n");
 }
 
 TEST_F(ClientAlias, unalias_removes_existing_alias)
@@ -3635,7 +3635,7 @@ TEST_F(ClientAlias, unalias_succeeds_even_if_script_cannot_be_removed)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n");
 }
 
 TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAlias)
@@ -3651,7 +3651,7 @@ TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAlias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n"
+    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n"
                                               "another_alias,another_instance,another_command,default,default\n");
 }
 
@@ -3674,7 +3674,7 @@ TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAliases)
     send_command({"aliases", "--format=csv"}, cout_stream);
 
     EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,default\n"
-                                              "another_alias,another_instance,another_command,default,map\n");
+                                              "another_alias,another_instance,another_command,map,default\n");
 }
 
 TEST_F(ClientAlias, unaliasDashDashAllWorks)
@@ -3704,7 +3704,7 @@ TEST_F(ClientAlias, unaliasDashDashAllClashesWithOtherArguments)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n"
+    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n"
                                               "another_alias,another_instance,another_command,default,default\n");
 }
 

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -3571,7 +3571,7 @@ TEST_F(ClientAlias, unalias_succeeds_even_if_script_cannot_be_removed)
 
     std::stringstream cerr_stream;
     EXPECT_EQ(send_command({"unalias", "another_alias"}, trash_stream, cerr_stream), mp::ReturnCode::Ok);
-    EXPECT_THAT(cerr_stream.str(), Eq("Warning: 'bbb' when removing alias script for another_alias\n"));
+    EXPECT_THAT(cerr_stream.str(), Eq("Warning: 'bbb' when removing alias script for default.another_alias\n"));
 
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -3338,8 +3338,8 @@ TEST_F(ClientAlias, alias_creates_alias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n"
-                                                "another_alias,primary,another_command,default,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default*\n"
+                                                "another_alias,primary,another_command,default,default*\n");
 }
 
 struct ClientAliasNameSuite : public ClientAlias,
@@ -3363,7 +3363,7 @@ TEST_P(ClientAliasNameSuite, creates_correct_default_alias_name)
     send_command({"aliases", "--format=csv"}, cout_stream);
 
     EXPECT_THAT(cout_stream.str(),
-                fmt::format(csv_header + "{},primary,{}{},default,default\n", command, path, command));
+                fmt::format(csv_header + "{},primary,{}{},default,default*\n", command, path, command));
 }
 
 INSTANTIATE_TEST_SUITE_P(ClientAlias, ClientAliasNameSuite,
@@ -3419,7 +3419,7 @@ TEST_F(ClientAlias, alias_does_not_overwrite_alias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default*\n");
 }
 
 struct ArgumentCheckTestsuite
@@ -3550,7 +3550,7 @@ TEST_F(ClientAlias, alias_refuses_creation_nonexistent_instance)
 
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default*\n");
 }
 
 TEST_F(ClientAlias, alias_refuses_creation_rpc_error)
@@ -3567,7 +3567,7 @@ TEST_F(ClientAlias, alias_refuses_creation_rpc_error)
 
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default*\n");
 }
 
 TEST_F(ClientAlias, aliasRefusesCreateDuplicateAlias)
@@ -3584,7 +3584,7 @@ TEST_F(ClientAlias, aliasRefusesCreateDuplicateAlias)
 
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,primary,a_command,map,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,primary,a_command,map,default*\n");
 }
 
 TEST_F(ClientAlias, aliasCreatesAliasThatExistsInAnotherContext)
@@ -3606,7 +3606,7 @@ TEST_F(ClientAlias, aliasCreatesAliasThatExistsInAnotherContext)
 
     EXPECT_THAT(cout_stream.str(),
                 csv_header +
-                    "an_alias,primary,a_command,map,default\nan_alias,primary,another_command,map,new_context\n");
+                    "an_alias,primary,a_command,map,default\nan_alias,primary,another_command,map,new_context*\n");
 }
 
 TEST_F(ClientAlias, unalias_removes_existing_alias)
@@ -3619,7 +3619,7 @@ TEST_F(ClientAlias, unalias_removes_existing_alias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,default*\n");
 }
 
 TEST_F(ClientAlias, unalias_succeeds_even_if_script_cannot_be_removed)
@@ -3636,7 +3636,7 @@ TEST_F(ClientAlias, unalias_succeeds_even_if_script_cannot_be_removed)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default*\n");
 }
 
 TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAlias)
@@ -3652,8 +3652,8 @@ TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAlias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n"
-                                              "another_alias,another_instance,another_command,default,default\n");
+    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default*\n"
+                                              "another_alias,another_instance,another_command,default,default*\n");
 }
 
 TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAliases)
@@ -3674,8 +3674,8 @@ TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAliases)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,default\n"
-                                              "another_alias,another_instance,another_command,map,default\n");
+    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,default*\n"
+                                              "another_alias,another_instance,another_command,map,default*\n");
 }
 
 TEST_F(ClientAlias, unaliasDashDashAllWorks)
@@ -3705,8 +3705,8 @@ TEST_F(ClientAlias, unaliasDashDashAllClashesWithOtherArguments)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default\n"
-                                              "another_alias,another_instance,another_command,default,default\n");
+    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map,default*\n"
+                                              "another_alias,another_instance,another_command,default,default*\n");
 }
 
 TEST_F(ClientAlias, fails_when_remove_backup_alias_file_fails)

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -3075,12 +3075,13 @@ TEST_P(HelpTestsuite, answers_correctly)
     EXPECT_THAT(cout_stream.str(), HasSubstr(expected_text));
 }
 
-INSTANTIATE_TEST_SUITE_P(Client, HelpTestsuite,
-                         Values(std::make_pair(std::string{"alias"},
-                                               "Create an alias to be executed on a given instance.\n"),
-                                std::make_pair(std::string{"aliases"}, "List available aliases\n"),
-                                std::make_pair(std::string{"unalias"}, "Remove aliases\n"),
-                                std::make_pair(std::string{"prefer"}, "Switch the current alias context\n")));
+INSTANTIATE_TEST_SUITE_P(
+    Client, HelpTestsuite,
+    Values(std::make_pair(std::string{"alias"}, "Create an alias to be executed on a given instance.\n"),
+           std::make_pair(std::string{"aliases"}, "List available aliases\n"),
+           std::make_pair(std::string{"unalias"}, "Remove aliases\n"),
+           std::make_pair(std::string{"prefer"},
+                          "Switch the current alias context. If it does not exist, create it before switching.")));
 
 TEST_F(Client, command_help_is_different_than_general_help)
 {

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -429,7 +429,7 @@ auto make_info_function(const std::string& source_path = "", const std::string& 
 
 typedef std::vector<std::pair<std::string, mp::AliasDefinition>> AliasesVector;
 
-const std::string csv_header{"Alias,Instance,Command,Working directory\n"};
+const std::string csv_header{"Alias,Instance,Command,Context,Working directory\n"};
 
 // Tests for no postional args given
 TEST_F(Client, no_command_is_error)
@@ -3336,8 +3336,8 @@ TEST_F(ClientAlias, alias_creates_alias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map\n"
-                                                "another_alias,primary,another_command,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n"
+                                                "another_alias,primary,another_command,default,default\n");
 }
 
 struct ClientAliasNameSuite : public ClientAlias,
@@ -3360,7 +3360,8 @@ TEST_P(ClientAliasNameSuite, creates_correct_default_alias_name)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), fmt::format(csv_header + "{},primary,{}{},default\n", command, path, command));
+    EXPECT_THAT(cout_stream.str(),
+                fmt::format(csv_header + "{},primary,{}{},default,default\n", command, path, command));
 }
 
 INSTANTIATE_TEST_SUITE_P(ClientAlias, ClientAliasNameSuite,
@@ -3397,7 +3398,7 @@ TEST_F(ClientAlias, alias_does_not_overwrite_alias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n");
 }
 
 struct ArgumentCheckTestsuite
@@ -3528,7 +3529,7 @@ TEST_F(ClientAlias, alias_refuses_creation_nonexistent_instance)
 
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n");
 }
 
 TEST_F(ClientAlias, alias_refuses_creation_rpc_error)
@@ -3545,7 +3546,7 @@ TEST_F(ClientAlias, alias_refuses_creation_rpc_error)
 
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n");
 }
 
 TEST_F(ClientAlias, unalias_removes_existing_alias)
@@ -3558,7 +3559,7 @@ TEST_F(ClientAlias, unalias_removes_existing_alias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,default\n");
 }
 
 TEST_F(ClientAlias, unalias_succeeds_even_if_script_cannot_be_removed)
@@ -3575,7 +3576,7 @@ TEST_F(ClientAlias, unalias_succeeds_even_if_script_cannot_be_removed)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map\n");
+    EXPECT_THAT(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n");
 }
 
 TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAlias)
@@ -3591,9 +3592,8 @@ TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAlias)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_EQ(cout_stream.str(),
-              csv_header +
-                  "an_alias,an_instance,a_command,map\nanother_alias,another_instance,another_command,default\n");
+    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n"
+                                              "another_alias,another_instance,another_command,default,default\n");
 }
 
 TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAliases)
@@ -3614,8 +3614,8 @@ TEST_F(ClientAlias, unaliasDoesNotRemoveNonexistentAliases)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default\n"
-                                              "another_alias,another_instance,another_command,map\n");
+    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,default\n"
+                                              "another_alias,another_instance,another_command,default,map\n");
 }
 
 TEST_F(ClientAlias, unaliasDashDashAllWorks)
@@ -3645,8 +3645,8 @@ TEST_F(ClientAlias, unaliasDashDashAllClashesWithOtherArguments)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,map\n"
-                                              "another_alias,another_instance,another_command,default\n");
+    EXPECT_EQ(cout_stream.str(), csv_header + "an_alias,an_instance,a_command,default,map\n"
+                                              "another_alias,another_instance,another_command,default,default\n");
 }
 
 TEST_F(ClientAlias, fails_when_remove_backup_alias_file_fails)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -673,7 +673,7 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundPassesExpectedAliases)
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    auto expected_csv_string = alias_name + "," + name + "," + alias_command + "," + alias_wdir + "\n";
+    auto expected_csv_string = alias_name + "," + name + "," + alias_command + "," + name + "," + alias_wdir + "\n";
     EXPECT_THAT(cout_stream.str(), HasSubstr(expected_csv_string));
 }
 
@@ -918,7 +918,8 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundPassesExpectedAliasesWith
     std::stringstream cout_stream;
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    auto expected_csv_string = alias_name + "," + command_line_name + "," + alias_command + "," + alias_wdir + "\n";
+    auto expected_csv_string =
+        alias_name + "," + command_line_name + "," + alias_command + "," + command_line_name + "," + alias_wdir + "\n";
     EXPECT_THAT(cout_stream.str(), HasSubstr(expected_csv_string));
 }
 
@@ -940,6 +941,7 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundDoesNotOverwriteAliases)
     const std::string alias_command{"aliascommand"};
     const std::string alias_wdir{"map"};
 
+    // This makes the alias be defined in the default context. Launching an instance will define it in another context.
     populate_db_file(AliasesVector{{alias_name, {"original_instance", "a_command", "map"}}});
 
     EXPECT_CALL(*mock_factory, create_virtual_machine(_, _))
@@ -961,12 +963,13 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundDoesNotOverwriteAliases)
     std::stringstream cout_stream;
     send_command({"launch", name}, cout_stream);
 
-    EXPECT_THAT(cout_stream.str(), HasSubstr("Warning: unable to create alias " + alias_name));
+    // EXPECT_THAT(cout_stream.str(), HasSubstr("Warning: unable to create alias " + alias_name));
 
     cout_stream.str("");
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    auto expected_csv_string = alias_name + ",original_instance,a_command,map\n";
+    auto expected_csv_string = alias_name + ",original_instance,a_command,default,map\n" + alias_name + "," + name +
+                               "," + alias_command + "," + name + "," + alias_wdir + "\n";
     EXPECT_THAT(cout_stream.str(), HasSubstr(expected_csv_string));
 }
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -969,7 +969,7 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundDoesNotOverwriteAliases)
     cout_stream.str("");
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    auto expected_csv_string = csv_header + alias_name + ",original_instance,a_command,map,default\n" + alias_name +
+    auto expected_csv_string = csv_header + alias_name + ",original_instance,a_command,map,default*\n" + alias_name +
                                "," + name + "," + alias_command + "," + alias_wdir + "," + name + "\n";
     EXPECT_EQ(cout_stream.str(), expected_csv_string);
 }
@@ -1020,7 +1020,7 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundDoesNotOverwriteAliasesIf
     cout_stream.str("");
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    auto expected_csv_string = csv_header + alias_name + ",original_instance,a_command,map,default\n";
+    auto expected_csv_string = csv_header + alias_name + ",original_instance,a_command,map,default*\n";
     EXPECT_EQ(cout_stream.str(), expected_csv_string);
 }
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -88,7 +88,7 @@ namespace
 {
 const qint64 default_total_bytes{16'106'127'360}; // 15G
 
-const std::string csv_header{"Alias,Instance,Command,Context,Working directory\n"};
+const std::string csv_header{"Alias,Instance,Command,Working directory,Context\n"};
 
 struct StubNameGenerator : public mp::NameGenerator
 {
@@ -676,7 +676,7 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundPassesExpectedAliases)
     send_command({"aliases", "--format=csv"}, cout_stream);
 
     auto expected_csv_string =
-        csv_header + alias_name + "," + name + "," + alias_command + "," + name + "," + alias_wdir + "\n";
+        csv_header + alias_name + "," + name + "," + alias_command + "," + alias_wdir + "," + name + "\n";
     EXPECT_EQ(cout_stream.str(), expected_csv_string);
 }
 
@@ -922,7 +922,7 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundPassesExpectedAliasesWith
     send_command({"aliases", "--format=csv"}, cout_stream);
 
     auto expected_csv_string = csv_header + alias_name + "," + command_line_name + "," + alias_command + "," +
-                               command_line_name + "," + alias_wdir + "\n";
+                               alias_wdir + "," + command_line_name + "\n";
     EXPECT_EQ(cout_stream.str(), expected_csv_string);
 }
 
@@ -969,8 +969,8 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundDoesNotOverwriteAliases)
     cout_stream.str("");
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    auto expected_csv_string = csv_header + alias_name + ",original_instance,a_command,default,map\n" + alias_name +
-                               "," + name + "," + alias_command + "," + name + "," + alias_wdir + "\n";
+    auto expected_csv_string = csv_header + alias_name + ",original_instance,a_command,map,default\n" + alias_name +
+                               "," + name + "," + alias_command + "," + alias_wdir + "," + name + "\n";
     EXPECT_EQ(cout_stream.str(), expected_csv_string);
 }
 
@@ -1020,7 +1020,7 @@ TEST_F(DaemonCreateLaunchAliasTestSuite, blueprintFoundDoesNotOverwriteAliasesIf
     cout_stream.str("");
     send_command({"aliases", "--format=csv"}, cout_stream);
 
-    auto expected_csv_string = csv_header + alias_name + ",original_instance,a_command,default,map\n";
+    auto expected_csv_string = csv_header + alias_name + ",original_instance,a_command,map,default\n";
     EXPECT_EQ(cout_stream.str(), expected_csv_string);
 }
 

--- a/tests/test_format_utils.cpp
+++ b/tests/test_format_utils.cpp
@@ -203,3 +203,35 @@ TEST(AliasFilter, at_least_one_alias_left)
     EXPECT_EQ(aliases.size(), 1);
     EXPECT_EQ(aliases[0].alias(), "d");
 }
+
+TEST(StaticFormatFunctions, columnWidthOnEmptyInputWorks)
+{
+    std::vector<std::string> empty_vector;
+    const auto get_width = [](const auto& str) -> int { return str.length(); };
+    int min_w = 3;
+
+    ASSERT_EQ(mp::format::column_width(empty_vector.begin(), empty_vector.end(), get_width, min_w), min_w);
+}
+
+TEST(StaticFormatFunctions, columnWidthOnWideInputWorks)
+{
+    const std::string wider_str = "wide string example";
+
+    const auto str_vector = std::vector<std::string>{wider_str, "w2"};
+    const auto get_width = [](const auto& str) -> int { return str.length(); };
+    int min_w = 3;
+    int space = 1;
+
+    ASSERT_EQ(mp::format::column_width(str_vector.begin(), str_vector.end(), get_width, min_w, space),
+              wider_str.length() + space);
+}
+
+TEST(StaticFormatFunctions, columnWidthOnNarrowInputWorks)
+{
+    const auto str_vector = std::vector<std::string>{"n", "n2"};
+    const auto get_width = [](const auto& str) -> int { return str.length(); };
+    int min_w = 3;
+    int space = 2;
+
+    ASSERT_EQ(mp::format::column_width(str_vector.begin(), str_vector.end(), get_width, min_w, space), 4);
+}


### PR DESCRIPTION
Alias contexts avoid clash between alias names. Specification is [here](https://docs.google.com/document/d/1L8q0TdQMiwvd5iAELiAuWqU3fVii0_nPF5dKzUdYOLY/edit#heading=h.a291qhvyhsw3).