### PR TITLE
[gui] allow only one tray icon app to run

### DIFF
--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -28,6 +28,7 @@
 
 #include <QApplication>
 #include <QDesktopServices>
+#include <QLockFile>
 #include <QStyle>
 #include <QtConcurrent/QtConcurrent>
 
@@ -97,6 +98,13 @@ void set_input_state_for(QList<QAction*> actions, const mp::InstanceStatus& stat
 
 mp::ReturnCode cmd::GuiCmd::run(mp::ArgParser* parser)
 {
+    QLockFile is_running{QDir::tempPath() + "/multipass_gui_running"};
+    if (!is_running.tryLock())
+    {
+        cout << "Application is already running";
+        return ReturnCode::Ok;
+    }
+
     if (!QSystemTrayIcon::isSystemTrayAvailable())
     {
         cerr << "System tray not supported\n";


### PR DESCRIPTION
The tray icon application is not aware if there are multiple instances of itself running. This PR adds a lock file to the app in order to make sure that only one instance of the app is allowed to start.

fix #2900 