### PR TITLE
Remove remaining copyright years

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/blueprint_provider/CMakeLists.txt
+++ b/src/blueprint_provider/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2021-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/client/cli/CMakeLists.txt
+++ b/src/client/cli/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/client/cli/cmd/CMakeLists.txt
+++ b/src/client/cli/cmd/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/client/cli/formatter/CMakeLists.txt
+++ b/src/client/cli/formatter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/client/common/CMakeLists.txt
+++ b/src/client/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2019-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/client/gui/CMakeLists.txt
+++ b/src/client/gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2019-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/client/gui/gui_cmd.cpp
+++ b/src/client/gui/gui_cmd.cpp
@@ -303,7 +303,7 @@ void cmd::GuiCmd::create_menu()
 
     about_client_version.setEnabled(false);
     about_daemon_version.setEnabled(false);
-    about_copyright.setText("Copyright © 2017-2022 Canonical Ltd.");
+    about_copyright.setText("Copyright (C) Canonical, Ltd.");
     about_copyright.setEnabled(false);
 
     about_menu.insertActions(0, {&autostart_option, &about_client_version, &about_daemon_version, &about_copyright});

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/iso/CMakeLists.txt
+++ b/src/iso/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/logging/CMakeLists.txt
+++ b/src/logging/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/petname/CMakeLists.txt
+++ b/src/petname/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/backends/CMakeLists.txt
+++ b/src/platform/backends/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/backends/libvirt/CMakeLists.txt
+++ b/src/platform/backends/libvirt/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Copyright © 2018-2022 Canonical Ltd.
+#Copyright (C) Canonical, Ltd.
 #
 #This program is free software : you can redistribute it and / or modify
 #it under the terms of the GNU General Public License version 3 as

--- a/src/platform/backends/lxd/CMakeLists.txt
+++ b/src/platform/backends/lxd/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2019-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/backends/qemu/CMakeLists.txt
+++ b/src/platform/backends/qemu/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/backends/qemu/linux/CMakeLists.txt
+++ b/src/platform/backends/qemu/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2021-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/backends/shared/CMakeLists.txt
+++ b/src/platform/backends/shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2019-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/backends/shared/linux/CMakeLists.txt
+++ b/src/platform/backends/shared/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/backends/shared/qemu_img_utils/CMakeLists.txt
+++ b/src/platform/backends/shared/qemu_img_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2021-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/client/CMakeLists.txt
+++ b/src/platform/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/console/CMakeLists.txt
+++ b/src/platform/console/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/platform/logger/CMakeLists.txt
+++ b/src/platform/logger/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Copyright © 2018-2022 Canonical Ltd.
+#Copyright (C) Canonical, Ltd.
 #
 #This program is free software : you can redistribute it and / or modify
 #it under the terms of the GNU General Public License version 3 as

--- a/src/platform/update/CMakeLists.txt
+++ b/src/platform/update/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2019-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/process/CMakeLists.txt
+++ b/src/process/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2020-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -1,4 +1,4 @@
-// Copyright © 2017-2022 Canonical Ltd.
+// Copyright (C) Canonical, Ltd.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2021-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/simplestreams/CMakeLists.txt
+++ b/src/simplestreams/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/ssh/CMakeLists.txt
+++ b/src/ssh/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/sshfs_mount/CMakeLists.txt
+++ b/src/sshfs_mount/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/src/xz_decoder/CMakeLists.txt
+++ b/src/xz_decoder/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2018-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2017-2023 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/c_mock_defines.cmake
+++ b/tests/c_mock_defines.cmake
@@ -1,4 +1,4 @@
-# Copyright © 2018-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/lxd/CMakeLists.txt
+++ b/tests/lxd/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2020-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/qemu/linux/CMakeLists.txt
+++ b/tests/qemu/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2021-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/unix/CMakeLists.txt
+++ b/tests/unix/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2021-2022 Canonical Ltd.
+# Copyright (C) Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
Removed missed copyright years from CMake files and GUI.

---
Private side: [pr507](https://github.com/canonical/multipass-private/pull/507)