### PR TITLE
Detect mount active state

### DIFF
--- a/include/multipass/sshfs_mount/sshfs_mount_handler.h
+++ b/include/multipass/sshfs_mount/sshfs_mount_handler.h
@@ -20,6 +20,7 @@
 
 #include <multipass/mount_handler.h>
 #include <multipass/process/process.h>
+#include <multipass/qt_delete_later_unique_ptr.h>
 #include <multipass/sshfs_server_config.h>
 
 namespace multipass
@@ -33,9 +34,10 @@ public:
 
     void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
     void stop_impl(bool force) override;
+    bool is_active() override;
 
 private:
-    Process::UPtr process;
+    qt_delete_later_unique_ptr<Process> process;
     SSHFSServerConfig config;
 };
 } // namespace multipass

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -146,6 +146,7 @@ private:
     grpc::Status cancel_vm_shutdown(const VirtualMachine& vm);
     grpc::Status cmd_vms(const std::vector<std::string>& tgts, std::function<grpc::Status(VirtualMachine&)> cmd);
     void init_mounts(const std::string& name);
+    void stop_mounts(const std::string& name);
     MountHandler::UPtr make_mount(VirtualMachine* vm, const std::string& target, const VMMount& mount);
 
     struct AsyncOperationStatus

--- a/src/platform/backends/qemu/qemu_mount_handler.h
+++ b/src/platform/backends/qemu/qemu_mount_handler.h
@@ -33,6 +33,7 @@ public:
 
     void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
     void stop_impl(bool force) override;
+    bool is_active() override;
 
 private:
     QemuVirtualMachine::MountArgs& vm_mount_args;

--- a/tests/qemu/test_qemu_mount_handler.cpp
+++ b/tests/qemu/test_qemu_mount_handler.cpp
@@ -89,6 +89,11 @@ std::string command_chown(const std::string& parent, const std::string& missing,
                        missing.substr(0, missing.find_first_of('/')));
 }
 
+std::string command_findmnt(const std::string& target)
+{
+    return fmt::format("findmnt --type 9p | grep '{} {}'", target, tag_from_target(target));
+}
+
 struct QemuMountHandlerTest : public ::Test
 {
     QemuMountHandlerTest()
@@ -138,12 +143,15 @@ struct QemuMountHandlerTest : public ::Test
     NiceMock<MockQemuVirtualMachine> vm{"my_instance"};
     mp::QemuVirtualMachine::MountArgs mount_args;
     mp::VMMount mount{default_source, gid_mappings, uid_mappings, mp::VMMount::MountType::Native};
-    CommandOutputs command_outputs{{"echo $PWD/target", {"/home/ubuntu/target"}},
-                                   {command_get_existing_parent("/home/ubuntu/target"), {"/home/ubuntu/target"}},
-                                   {"id -u", {"1000"}},
-                                   {"id -g", {"1000"}},
-                                   {command_mount(default_target), {""}},
-                                   {command_umount(default_target), {""}}};
+    CommandOutputs command_outputs{
+        {"echo $PWD/target", {"/home/ubuntu/target"}},
+        {command_get_existing_parent("/home/ubuntu/target"), {"/home/ubuntu/target"}},
+        {"id -u", {"1000"}},
+        {"id -g", {"1000"}},
+        {command_mount(default_target), {""}},
+        {command_umount(default_target), {""}},
+        {command_findmnt(default_target), {""}},
+    };
 };
 
 struct QemuMountHandlerFailCommand : public QemuMountHandlerTest, public testing::WithParamInterface<std::string>

--- a/tests/test_sshfs_mount_handler.cpp
+++ b/tests/test_sshfs_mount_handler.cpp
@@ -116,9 +116,9 @@ TEST_F(SSHFSMountHandlerTest, mount_creates_sshfs_process)
     factory->register_callback(sshfs_server_callback(sshfs_prints_connected));
 
     mpt::MockVirtualMachine mock_vm{"my_instance"};
-    EXPECT_CALL(mock_vm, ssh_port()).Times(2);
-    EXPECT_CALL(mock_vm, ssh_hostname()).Times(2);
-    EXPECT_CALL(mock_vm, ssh_username()).Times(2);
+    EXPECT_CALL(mock_vm, ssh_port()).Times(3);
+    EXPECT_CALL(mock_vm, ssh_hostname()).Times(3);
+    EXPECT_CALL(mock_vm, ssh_username()).Times(3);
 
     mp::SSHFSMountHandler sshfs_mount_handler{&mock_vm, &key_provider, target_path, mount};
     sshfs_mount_handler.start(&server);


### PR DESCRIPTION
This PR modifies the mount handlers by adding specialized checks for whether a mount is still active or not. It also makes use of the way in which some backends can notify the daemon when a VM reboots, so that the mounts can also be stopped. This allows the mount handlers to have a consistent state when a VM is shut down internally and, in those specific backend cases, when rebooted internally.

fix #2917