### PR TITLE
[daemon] Increase timeout in Hyperkit migration

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3058,7 +3058,9 @@ grpc::Status mp::Daemon::migrate_from_hyperkit(grpc::ServerReaderWriterInterface
                 auto qemuimg_proc = mp::platform::make_process(
                     std::make_unique<CustomQemuImgProcessSpec>(std::move(qemuimg_args), new_image));
 
-                if (const auto qemuimg_state = qemuimg_proc->execute(); !qemuimg_state.completed_successfully())
+                const auto repair_timeout = 300000; // allow 5 minutes to repair large images
+                if (const auto qemuimg_state = qemuimg_proc->execute(repair_timeout);
+                    !qemuimg_state.completed_successfully())
                     throw HyperkitMigrationRecoverableError{vm_name, "could not fix image metadata",
                                                             qemuimg_state.failure_message()};
 


### PR DESCRIPTION
Increase the timeout of the image repair step of the migration of Hyperkit instances to QEMU, to 5 minutes. Fixes https://github.com/canonical/multipass/issues/2938.