### PR TITLE
#2936  Issue on [cli/info] multipass info --all does not list deleted instances : modify the list_instances function in the multipass-info.cpp and also…

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,20 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "compilerPath": "C:\\Program Files (x86)\\mingw-w64\\i686-8.1.0-posix-dwarf-rt_v6-rev0\\mingw32\\bin\\gcc.exe",
+            "cStandard": "c17",
+            "cppStandard": "gnu++14",
+            "intelliSenseMode": "windows-gcc-x86"
+        }
+    ],
+    "version": 4
+}

--- a/src/client/cli/cmd/info.cpp
+++ b/src/client/cli/cmd/info.cpp
@@ -92,3 +92,4 @@ mp::ParseCode cmd::Info::parse_args(mp::ArgParser* parser)
 
     return status;
 }
+

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -369,6 +369,81 @@ std::unordered_map<std::string, mp::VMSpecs> load_db(const mp::Path& data_path, 
     }
     return reconstructed_records;
 }
+int list_instances(bool show_deleted) {
+    std::vector<instance::Instance> instances = instance::list_all();
+    std::vector<instance::Instance> deleted_instances = instance::list_deleted();
+
+    if (instances.empty() && deleted_instances.empty()) {
+        std::cout << "No instances found." << std::endl;
+        return EXIT_SUCCESS;
+    }
+
+    // Sort instances by name.
+    std::sort(instances.begin(), instances.end(), [](const auto& a, const auto& b) {
+        return a.get_name() < b.get_name();
+    });
+
+    // Print info for each instance.
+    for (const auto& inst : instances) {
+        std::cout << "Name: " << inst.get_name() << std::endl;
+        std::cout << "State: " << inst.get_state() << std::endl;
+        std::cout << "IPv4: " << inst.get_ipv4() << std::endl;
+        std::cout << "Release: " << inst.get_release() << std::endl;
+        std::cout << "Image hash: " << inst.get_image_hash() << std::endl;
+        std::cout << std::endl;
+    }
+
+    // If show_deleted flag is set, print info for each deleted instance.
+    if (show_deleted) {
+        for (const auto& inst : deleted_instances) {
+            std::cout << "Name: " << inst.get_name() << std::endl;
+            std::cout << "State: " << inst.get_state() << std::endl;
+            std::cout << "IPv4: " << inst.get_ipv4() << std::endl;
+            std::cout << "Release: " << inst.get_release() << std::endl;
+            std::cout << "Image hash: " << inst.get_image_hash() << std::endl;
+            std::cout << std::endl;
+        }
+    }
+
+    return EXIT_SUCCESS;
+}
+
+int info_main(int argc, char* argv[]) {
+    // Parse command-line arguments.
+    bool show_deleted = false;
+    std::vector<std::string> instances;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--all") == 0) {
+            show_deleted = true;
+        } else {
+            instances.push_back(argv[i]);
+        }
+    }
+
+    // If no instances were specified, list all instances.
+    if (instances.empty()) {
+        return list_instances(show_deleted);
+    }
+
+    // Print info for each specified instance.
+    for (const auto& inst : instances) {
+        instance::Instance instance(inst);
+        if (!instance.exists()) {
+            std::cerr << "Instance not found: " << inst << std::endl;
+            return EXIT_FAILURE;
+        }
+        std::cout << "Name: " << instance.get_name() << std::endl;
+        std::cout << "State: " << instance.get_state() << std::endl;
+        std::cout << "IPv4: " << instance.get_ipv4() << std::endl;
+        std::cout << "Release: " << instance.get_release() << std::endl;
+        std::cout << "Image hash: " << instance.get_image_hash() << std::endl;
+        std::cout << std::endl;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+
 
 QJsonArray to_json_array(const std::vector<mp::NetworkInterface>& extra_interfaces)
 {


### PR DESCRIPTION
… added main  function to pass the show_deleted flag to it.

I've added a show_deleted parameter to control whether information about deleted instances should be included in the output. I've also added a check for deleted instances and a loop to print information about each deleted instance if the show_deleted flag is set. And In order to use the modified list_instances function, we need to modify the info_main function to pass the show_deleted flag to it.