### PR TITLE
add the minimum resource error improvement

### DIFF
--- a/include/multipass/exceptions/blueprint_exceptions.h
+++ b/include/multipass/exceptions/blueprint_exceptions.h
@@ -32,6 +32,11 @@ public:
         : runtime_error(fmt::format("Requested {} is less than Blueprint minimum of {}", type, min_val))
     {
     }
+
+    BlueprintMinimumException(const std::string& type, const std::string& min_val, const std::string& min_resource_str)
+        : runtime_error(fmt::format("Requested {} is less than Blueprint minimum of {}", type, min_val) + "\n" + min_resource_str)
+    {
+    }
 };
 
 class InvalidBlueprintException : public std::runtime_error

--- a/include/multipass/exceptions/blueprint_exceptions.h
+++ b/include/multipass/exceptions/blueprint_exceptions.h
@@ -39,13 +39,13 @@ public:
     }
 
 private:
-    static std::string left_trim_and_replace_last_comma_with_and(const std::string& inputStr)
+    static std::string left_trim_and_replace_last_comma_with_and(const std::string& input_str)
     {
-        if (inputStr.empty())
+        if (input_str.empty())
             return {};
 
         // trim leftest comma first and replace the last comma with " and" if that last comma exist
-        auto left_trimmed_str = inputStr.substr(1, inputStr.size() - 1);
+        auto left_trimmed_str = input_str.substr(1, input_str.size() - 1);
         const auto last_comma_pos = left_trimmed_str.find_last_of(',');
         return last_comma_pos != std::string::npos ? left_trimmed_str.replace(last_comma_pos, 1, " and")
                                                    : left_trimmed_str;

--- a/include/multipass/exceptions/blueprint_exceptions.h
+++ b/include/multipass/exceptions/blueprint_exceptions.h
@@ -34,7 +34,8 @@ public:
     }
 
     BlueprintMinimumException(const std::string& type, const std::string& min_val, const std::string& min_resource_str)
-        : runtime_error(fmt::format("Requested {} is less than Blueprint minimum of {}", type, min_val) + "\n" + min_resource_str)
+        : runtime_error(fmt::format("Requested {} is less than Blueprint minimum of {}", type, min_val) + "\n" +
+                        min_resource_str)
     {
     }
 };

--- a/include/multipass/exceptions/blueprint_exceptions.h
+++ b/include/multipass/exceptions/blueprint_exceptions.h
@@ -23,20 +23,57 @@
 #include <stdexcept>
 #include <string>
 
+#include <yaml-cpp/yaml.h>
+
 namespace multipass
 {
+
 class BlueprintMinimumException : public std::runtime_error
 {
 public:
-    BlueprintMinimumException(const std::string& type, const std::string& min_val)
-        : runtime_error(fmt::format("Requested {} is less than Blueprint minimum of {}", type, min_val))
+    BlueprintMinimumException(const std::string& type, const YAML::Node& limits_min_resource_node,
+                              const std::string& blueprint_name)
+        : runtime_error(fmt::format("Requested {} is less than Blueprint minimum.", type) + "\n" +
+                        query_min_resource_info(limits_min_resource_node, blueprint_name))
     {
     }
 
-    BlueprintMinimumException(const std::string& type, const std::string& min_val, const std::string& min_resource_str)
-        : runtime_error(fmt::format("Requested {} is less than Blueprint minimum of {}", type, min_val) + "\n" +
-                        min_resource_str)
+private:
+    static std::string left_trim_and_replace_last_comma_with_and(const std::string& inputStr)
     {
+        if (inputStr.empty())
+            return {};
+
+        // trim leftest comma first and replace the last comma with " and" if that last comma exist
+        auto left_trimmed_str = inputStr.substr(1, inputStr.size() - 1);
+        const auto last_comma_pos = left_trimmed_str.find_last_of(',');
+        return last_comma_pos != std::string::npos ? left_trimmed_str.replace(last_comma_pos, 1, " and")
+                                                   : left_trimmed_str;
+    }
+
+    [[nodiscard]] static std::string query_min_resource_info(const YAML::Node& limits_min_resource_node,
+                                                             const std::string& blueprint_name)
+    {
+        const auto& limits_min_cpu_node = limits_min_resource_node["min-cpu"];
+        // limits_min_cpu_node.as<int>() can not throw here because query_min_resource_info function is only called in
+        // BlueprintMinimumException branch
+        const std::string min_cpu_info_str =
+            limits_min_cpu_node ? fmt::format(", {} CPUs", limits_min_cpu_node.as<int>()) : std::string();
+
+        const auto& limits_min_mem_node = limits_min_resource_node["min-mem"];
+        const std::string min_mem_info_str =
+            limits_min_mem_node ? fmt::format(", {} of memory", limits_min_mem_node.as<std::string>()) : std::string();
+
+        const auto& limits_min_disk_node = limits_min_resource_node["min-disk"];
+        const std::string min_disk_info_str =
+            limits_min_disk_node ? fmt::format(", {} of disk space", limits_min_disk_node.as<std::string>())
+                                 : std::string();
+
+        const std::string whole_min_resource_info_str = fmt::format(
+            "The {} requires at least{}.", blueprint_name,
+            left_trim_and_replace_last_comma_with_and(min_cpu_info_str + min_mem_info_str + min_disk_info_str));
+
+        return whole_min_resource_info_str;
     }
 };
 

--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -67,9 +67,10 @@ std::string leftTrimAndReplaceLastCommaWithAnd(std::string inputStr)
     if (inputStr.empty())
         return {};
 
-    size_t lastCommaPos = inputStr.find_last_of(',');
-    // replace the last comman with "and" and left trim (remove the front comma) the string
-    return inputStr.replace(lastCommaPos, 1, " and").substr(1, inputStr.size() - 1);
+    // trim leftest comma first and replace the last comma with " and" if that last comma exist
+    auto leftTrimmedStr = inputStr.substr(1, inputStr.size() - 1);
+    const auto lastCommaPos = leftTrimmedStr.find_last_of(',');
+    return lastCommaPos != std::string::npos ? leftTrimmedStr.replace(lastCommaPos, 1, " and") : leftTrimmedStr;
 }
 
 [[nodiscard]] MinResourceInfo query_min_resource_info(const YAML::Node& limits_min_resource_node,

--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -62,14 +62,25 @@ struct MinResourceInfo
     const std::string whole_min_resource_info_str;
 };
 
-[[nodiscard]]
-MinResourceInfo query_min_resource_info(const YAML::Node& limits_min_resource_node, const std::string& blueprint_name, bool& needs_update)
+std::string leftTrimAndReplaceLastCommaWithAnd(std::string inputStr)
+{
+    if (inputStr.empty())
+        return {};
+
+    size_t lastCommaPos = inputStr.find_last_of(',');
+    // replace the last comman with "and" and left trim (remove the front comma) the string
+    return inputStr.replace(lastCommaPos, 1, " and").substr(1, inputStr.size() - 1);
+}
+
+[[nodiscard]] MinResourceInfo query_min_resource_info(const YAML::Node& limits_min_resource_node,
+                                                      const std::string& blueprint_name, bool& needs_update)
 {
     const auto& limits_min_cpu_node = limits_min_resource_node["min-cpu"];
 
     int min_cpus{};
     std::string min_cpu_info_str;
-    try{
+    try
+    {
         if (limits_min_cpu_node)
         {
             min_cpus = limits_min_cpu_node.as<int>();
@@ -100,11 +111,12 @@ MinResourceInfo query_min_resource_info(const YAML::Node& limits_min_resource_no
         min_disk_info_str = fmt::format(", {} of disk space", min_disk_space_str);
     }
 
-    const std::string whole_min_resource_info_str = fmt::format("The {} requires at least{}{}{}.", blueprint_name, min_cpu_info_str, min_mem_info_str, min_disk_info_str);
+    const std::string whole_min_resource_info_str =
+        fmt::format("The {} requires at least{}.", blueprint_name,
+                    leftTrimAndReplaceLastCommaWithAnd(min_cpu_info_str + min_mem_info_str + min_disk_info_str));
 
     return {min_cpus, min_mem_size_str, min_disk_space_str, whole_min_resource_info_str};
 }
-
 
 bool runs_on(const std::string& blueprint_name, const YAML::Node& blueprint_node, const std::string& arch)
 {

--- a/tests/test_blueprint_provider.cpp
+++ b/tests/test_blueprint_provider.cpp
@@ -48,6 +48,7 @@ namespace
 const QString test_blueprints_zip{"/test-blueprints.zip"};
 const QString multipass_blueprints_zip{"/multipass-blueprints.zip"};
 const char* sha256_checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const std::string min_resource_info_str = "requires at least 2 CPUs, 2G of memory and 25G of disk space.";
 
 struct VMBlueprintProvider : public Test
 {
@@ -298,9 +299,11 @@ TEST_F(VMBlueprintProvider, givenCoresLessThanMinimumThrows)
 
     mp::ClientLaunchData dummy_data;
 
-    MP_EXPECT_THROW_THAT(blueprint_provider.fetch_blueprint_for("test-blueprint1", vm_desc, dummy_data),
+    const std::string blueprint_name = "test-blueprint1";
+    MP_EXPECT_THROW_THAT(blueprint_provider.fetch_blueprint_for(blueprint_name, vm_desc, dummy_data),
                          mp::BlueprintMinimumException,
-                         mpt::match_what(AllOf(HasSubstr("Number of CPUs"), HasSubstr("2"))));
+                         mpt::match_what(AllOf(HasSubstr("Number of CPUs"), HasSubstr("2"), HasSubstr(blueprint_name),
+                                               HasSubstr(min_resource_info_str))));
 }
 
 TEST_F(VMBlueprintProvider, givenMemLessThanMinimumThrows)
@@ -312,9 +315,11 @@ TEST_F(VMBlueprintProvider, givenMemLessThanMinimumThrows)
 
     mp::ClientLaunchData dummy_data;
 
-    MP_EXPECT_THROW_THAT(blueprint_provider.fetch_blueprint_for("test-blueprint1", vm_desc, dummy_data),
+    const std::string blueprint_name = "test-blueprint1";
+    MP_EXPECT_THROW_THAT(blueprint_provider.fetch_blueprint_for(blueprint_name, vm_desc, dummy_data),
                          mp::BlueprintMinimumException,
-                         mpt::match_what(AllOf(HasSubstr("Memory size"), HasSubstr("2G"))));
+                         mpt::match_what(AllOf(HasSubstr("Memory size"), HasSubstr("2G"), HasSubstr(blueprint_name),
+                                               HasSubstr(min_resource_info_str))));
 }
 
 TEST_F(VMBlueprintProvider, givenDiskSpaceLessThanMinimumThrows)
@@ -326,9 +331,11 @@ TEST_F(VMBlueprintProvider, givenDiskSpaceLessThanMinimumThrows)
 
     mp::ClientLaunchData dummy_data;
 
+    const std::string blueprint_name = "test-blueprint1";
     MP_EXPECT_THROW_THAT(blueprint_provider.fetch_blueprint_for("test-blueprint1", vm_desc, dummy_data),
                          mp::BlueprintMinimumException,
-                         mpt::match_what(AllOf(HasSubstr("Disk space"), HasSubstr("25G"))));
+                         mpt::match_what(AllOf(HasSubstr("Disk space"), HasSubstr("25G"), HasSubstr(blueprint_name),
+                                               HasSubstr(min_resource_info_str))));
 }
 
 TEST_F(VMBlueprintProvider, higherOptionsIsNotOverriden)


### PR DESCRIPTION
fixes #2925
This is still a draft implementation, be free to give your comments on it. 
The current output error message is like 
`./multipass launch docker --name load-test --cpus 1 --memory 2G --disk 20GiB
`
```
launch failed: Requested Number of CPUs is less than Blueprint minimum of 2
The docker requires at least 2 CPUs, 4G of memory and 40G of disk space.
```

