### PR TITLE
[image vault] Refactor error handling

### DIFF
--- a/include/multipass/default_vm_blueprint_provider.h
+++ b/include/multipass/default_vm_blueprint_provider.h
@@ -51,7 +51,7 @@ public:
                               ClientLaunchData& client_launch_data) override;
     Query blueprint_from_file(const std::string& path, const std::string& blueprint_name,
                               VirtualMachineDescription& vm_desc, ClientLaunchData& client_launch_data) override;
-    VMImageInfo info_for(const std::string& blueprint_name) override;
+    std::optional<VMImageInfo> info_for(const std::string& blueprint_name) override;
     std::vector<VMImageInfo> all_blueprints() override;
     std::string name_from_blueprint(const std::string& blueprint_name) override;
     int blueprint_timeout(const std::string& blueprint_name) override;

--- a/include/multipass/exceptions/image_vault_exceptions.h
+++ b/include/multipass/exceptions/image_vault_exceptions.h
@@ -27,10 +27,8 @@ namespace multipass
 class ImageNotFoundException : public std::runtime_error
 {
 public:
-    ImageNotFoundException(const std::string& image)
-        : runtime_error(fmt::format("Unable to find an image matching \"{}\"."
-                                    " Please use `multipass find` for supported remotes and images.",
-                                    image))
+    ImageNotFoundException(const std::string& image, const std::string& remote)
+        : runtime_error(fmt::format("Unable to find an image matching \"{}\" in remote \"{}\".", image, remote))
     {
     }
 };

--- a/include/multipass/vm_blueprint_provider.h
+++ b/include/multipass/vm_blueprint_provider.h
@@ -24,6 +24,7 @@
 #include "virtual_machine_description.h"
 #include "vm_image_info.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ public:
                                       ClientLaunchData& client_launch_data) = 0;
     virtual Query blueprint_from_file(const std::string& path, const std::string& blueprint_name,
                                       VirtualMachineDescription& vm_desc, ClientLaunchData& client_launch_data) = 0;
-    virtual VMImageInfo info_for(const std::string& blueprint_name) = 0;
+    virtual std::optional<VMImageInfo> info_for(const std::string& blueprint_name) = 0;
     virtual std::vector<VMImageInfo> all_blueprints() = 0;
     virtual std::string name_from_blueprint(const std::string& blueprint_name) = 0;
     virtual int blueprint_timeout(const std::string& blueprint_name) = 0;

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -202,7 +202,7 @@ std::string mp::TableFormatter::format(const FindReply& reply) const
     fmt::memory_buffer buf;
 
     if (reply.images_info().empty())
-        return "No images found.\n";
+        return "No images or Blueprints found.\n";
 
     fmt::format_to(std::back_inserter(buf), "{:<28}{:<18}{:<17}{:<}\n", "Image", "Aliases", "Version", "Description");
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -25,6 +25,7 @@
 #include <multipass/exceptions/blueprint_exceptions.h>
 #include <multipass/exceptions/create_image_exception.h>
 #include <multipass/exceptions/exitless_sshprocess_exception.h>
+#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/invalid_memory_size_exception.h>
 #include <multipass/exceptions/not_implemented_on_this_backend_exception.h>
 #include <multipass/exceptions/sshfs_missing_error.h>
@@ -1147,14 +1148,8 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
                     }
                     return true;
                 };
-                try
-                {
-                    config->vault->update_images(config->factory->fetch_type(), prepare_action, download_monitor);
-                }
-                catch (const std::exception& e)
-                {
-                    mpl::log(mpl::Level::error, category, fmt::format("Error updating images: {}", e.what()));
-                }
+
+                config->vault->update_images(config->factory->fetch_type(), prepare_action, download_monitor);
             });
         }
     });

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1250,7 +1250,8 @@ try // clang-format on
         catch (const std::exception& e)
         {
             mpl::log(mpl::Level::warning, category,
-                     fmt::format("An unexpected error occurred while fetching images: {}", e.what()));
+                     fmt::format("An unexpected error occurred while fetching images matching \"{}\": {}",
+                                 request->search_string(), e.what()));
         }
 
         try
@@ -1261,7 +1262,8 @@ try // clang-format on
         catch (const std::exception& e)
         {
             mpl::log(mpl::Level::warning, category,
-                     fmt::format("An unexpected error occurred while fetching blueprints: {}", e.what()));
+                     fmt::format("An unexpected error occurred while fetching blueprints matching \"{}\": {}",
+                                 request->search_string(), e.what()));
         }
 
         for (const auto& [remote, info] : vm_images_info)

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -19,6 +19,7 @@
 
 #include <multipass/exceptions/aborted_download_exception.h>
 #include <multipass/exceptions/create_image_exception.h>
+#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/unsupported_image_exception.h>
 #include <multipass/json_writer.h>
 #include <multipass/logging/log.h>
@@ -374,8 +375,10 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
         else
         {
             const auto info = info_for(query);
+            if (!info)
+                throw mp::ImageNotFoundException(query.release, query.remote_name);
 
-            id = info.id.toStdString();
+            id = info->id.toStdString();
 
             std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
             if (!query.name.empty())
@@ -414,12 +417,12 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type, co
             else
             {
                 const auto image_dir =
-                    MP_UTILS.make_dir(images_dir, QString("%1-%2").arg(info.release).arg(info.version));
+                    MP_UTILS.make_dir(images_dir, QString("%1-%2").arg(info->release).arg(info->version));
 
                 // Had to use std::bind here to workaround the 5 allowable function arguments constraint of
                 // QtConcurrent::run()
                 future = QtConcurrent::run(std::bind(&DefaultVMImageVault::download_and_prepare_source_image, this,
-                                                     info, source_image, image_dir, fetch_type, prepare, monitor));
+                                                     *info, source_image, image_dir, fetch_type, prepare, monitor));
 
                 in_progress_image_fetches[id] = future;
             }
@@ -514,12 +517,12 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
             try
             {
                 auto info = info_for(record.second.query);
-                if (info.id.toStdString() != record.first)
+                if (info->id.toStdString() != record.first)
                 {
                     keys_to_update.push_back(record.first);
                 }
             }
-            catch (const mp::UnsupportedImageException& e)
+            catch (const std::exception& e)
             {
                 mpl::log(mpl::Level::warning, category, fmt::format("Skipping update: {}", e.what()));
             }
@@ -713,7 +716,10 @@ mp::VMImage mp::DefaultVMImageVault::finalize_image_records(const Query& query, 
 mp::VMImageInfo mp::DefaultVMImageVault::get_kernel_query_info(const std::string& name)
 {
     Query kernel_query{name, "default", false, "", Query::Type::Alias};
-    return info_for(kernel_query);
+    auto info = info_for(kernel_query);
+    if (!info)
+        throw mp::ImageNotFoundException("default", "");
+    return *info;
 }
 
 namespace

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -517,12 +517,19 @@ void mp::DefaultVMImageVault::update_images(const FetchType& fetch_type, const P
             try
             {
                 auto info = info_for(record.second.query);
+                if (!info)
+                    throw mp::ImageNotFoundException(record.second.query.release, record.second.query.remote_name);
+
                 if (info->id.toStdString() != record.first)
                 {
                     keys_to_update.push_back(record.first);
                 }
             }
-            catch (const std::exception& e)
+            catch (const mp::UnsupportedImageException& e)
+            {
+                mpl::log(mpl::Level::warning, category, fmt::format("Skipping update: {}", e.what()));
+            }
+            catch (const mp::ImageNotFoundException& e)
             {
                 mpl::log(mpl::Level::warning, category, fmt::format("Skipping update: {}", e.what()));
             }

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -19,6 +19,7 @@
 #include "lxd_request.h"
 
 #include <multipass/exceptions/aborted_download_exception.h>
+#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/local_socket_connection_exception.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
@@ -195,7 +196,7 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type, const 
             {
                 const auto info = info_for(image_query);
 
-                source_image.original_release = info.release_title.toStdString();
+                source_image.original_release = info->release_title.toStdString();
             }
             catch (const std::exception&)
             {
@@ -225,7 +226,11 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type, const 
 
     if (query.query_type == Query::Type::Alias)
     {
-        info = info_for(query);
+        if (auto image_info = info_for(query); image_info.has_value())
+            info = *image_info;
+        else
+            throw mp::ImageNotFoundException(query.release, query.remote_name);
+
         id = info.id;
 
         source_image.id = id.toStdString();
@@ -410,13 +415,15 @@ void mp::LXDVMImageVault::update_images(const FetchType& fetch_type, const Prepa
             try
             {
                 auto info = info_for(query);
+                if (!info)
+                    throw mp::ImageNotFoundException(query.release, query.remote_name);
 
-                if (info.id != id)
+                if (info->id != id)
                 {
                     mpl::log(mpl::Level::info, category,
                              fmt::format("Updating {} source image to latest", query.release));
 
-                    lxd_download_image(info, query, monitor, image_info["last_used_at"].toString());
+                    lxd_download_image(*info, query, monitor, image_info["last_used_at"].toString());
 
                     lxd_request(manager, "DELETE", QUrl(QString("%1/images/%2").arg(base_url.toString()).arg(id)));
                 }

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -226,7 +226,7 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type, const 
 
     if (query.query_type == Query::Type::Alias)
     {
-        if (auto image_info = info_for(query); image_info.has_value())
+        if (auto image_info = info_for(query); image_info)
             info = *image_info;
         else
             throw mp::ImageNotFoundException(query.release, query.remote_name);

--- a/src/platform/backends/shared/base_vm_image_vault.h
+++ b/src/platform/backends/shared/base_vm_image_vault.h
@@ -79,7 +79,7 @@ protected:
         {
             for (const auto& image_host : image_hosts)
             {
-                auto info = image_host->info_for(query);
+                info = image_host->info_for(query);
 
                 if (info)
                     break;

--- a/src/platform/backends/shared/base_vm_image_vault.h
+++ b/src/platform/backends/shared/base_vm_image_vault.h
@@ -18,7 +18,6 @@
 #ifndef MULTIPASS_BASE_VM_IMAGE_VAULT_H
 #define MULTIPASS_BASE_VM_IMAGE_VAULT_H
 
-#include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/format.h>
 #include <multipass/query.h>
 #include <multipass/vm_image.h>
@@ -63,22 +62,18 @@ public:
         else
             static_cast<void>(std::any_of(image_hosts.begin(), image_hosts.end(), grab_imgs)); // intentional discard
 
-        if (images_info.empty())
-            throw ImageNotFoundException(query.release);
-
         return images_info;
     };
 
 protected:
-    virtual VMImageInfo info_for(const Query& query) const
+    virtual std::optional<VMImageInfo> info_for(const Query& query) const
     {
+        std::optional<VMImageInfo> info;
+
         if (!query.remote_name.empty())
         {
             auto image_host = image_host_for(query.remote_name);
-            auto info = image_host->info_for(query);
-
-            if (info != std::nullopt)
-                return *info;
+            info = image_host->info_for(query);
         }
         else
         {
@@ -87,13 +82,11 @@ protected:
                 auto info = image_host->info_for(query);
 
                 if (info)
-                {
-                    return *info;
-                }
+                    break;
             }
         }
 
-        throw ImageNotFoundException(query.release);
+        return info;
     };
 
 private:

--- a/tests/lxd/test_lxd_image_vault.cpp
+++ b/tests/lxd/test_lxd_image_vault.cpp
@@ -242,9 +242,8 @@ TEST_F(LXDImageVault, throws_with_invalid_alias)
     MP_EXPECT_THROW_THAT(
         image_vault.fetch_image(mp::FetchType::ImageOnly, query, stub_prepare, stub_monitor, false, std::nullopt),
         std::runtime_error,
-        mpt::match_what(StrEq(fmt::format("Unable to find an image matching \"{}\"."
-                                          " Please use `multipass find` for supported remotes and images.",
-                                          alias))));
+        mpt::match_what(
+            StrEq(fmt::format("Unable to find an image matching \"{}\" in remote \"{}\".", alias, "release"))));
 }
 
 TEST_F(LXDImageVault, throws_with_invalid_remote)

--- a/tests/mock_vm_blueprint_provider.h
+++ b/tests/mock_vm_blueprint_provider.h
@@ -21,13 +21,27 @@
 #include "common.h"
 
 #include <multipass/vm_blueprint_provider.h>
+#include <multipass/vm_image_info.h>
 
 namespace multipass
 {
 namespace test
 {
-struct MockVMBlueprintProvider : public VMBlueprintProvider
+class MockVMBlueprintProvider : public VMBlueprintProvider
 {
+public:
+    MockVMBlueprintProvider()
+    {
+        ON_CALL(*this, info_for(_)).WillByDefault([this](const auto& blueprint_name) {
+            mp::VMImageInfo info;
+
+            info.aliases.append(QString::fromStdString(blueprint_name));
+            info.release_title = QString::fromStdString(fmt::format("This is the {} blueprint", blueprint_name));
+
+            return info;
+        });
+    };
+
     MOCK_METHOD3(fetch_blueprint_for, Query(const std::string&, VirtualMachineDescription&, ClientLaunchData&));
     MOCK_METHOD4(blueprint_from_file,
                  Query(const std::string&, const std::string&, VirtualMachineDescription&, ClientLaunchData&));

--- a/tests/mock_vm_blueprint_provider.h
+++ b/tests/mock_vm_blueprint_provider.h
@@ -31,7 +31,7 @@ struct MockVMBlueprintProvider : public VMBlueprintProvider
     MOCK_METHOD3(fetch_blueprint_for, Query(const std::string&, VirtualMachineDescription&, ClientLaunchData&));
     MOCK_METHOD4(blueprint_from_file,
                  Query(const std::string&, const std::string&, VirtualMachineDescription&, ClientLaunchData&));
-    MOCK_METHOD1(info_for, VMImageInfo(const std::string&));
+    MOCK_METHOD1(info_for, std::optional<VMImageInfo>(const std::string&));
     MOCK_METHOD0(all_blueprints, std::vector<VMImageInfo>());
     MOCK_METHOD1(name_from_blueprint, std::string(const std::string&));
     MOCK_METHOD1(blueprint_timeout, int(const std::string&));

--- a/tests/stub_vm_blueprint_provider.h
+++ b/tests/stub_vm_blueprint_provider.h
@@ -38,7 +38,7 @@ struct StubVMBlueprintProvider final : public VMBlueprintProvider
         throw InvalidBlueprintException("");
     }
 
-    VMImageInfo info_for(const std::string& blueprint_name) override
+    std::optional<VMImageInfo> info_for(const std::string& blueprint_name) override
     {
         return VMImageInfo();
     }

--- a/tests/test_blueprint_provider.cpp
+++ b/tests/test_blueprint_provider.cpp
@@ -355,10 +355,11 @@ TEST_F(VMBlueprintProvider, infoForReturnsExpectedInfo)
 
     auto blueprint = blueprint_provider.info_for("test-blueprint2");
 
-    ASSERT_EQ(blueprint.aliases.size(), 1);
-    EXPECT_EQ(blueprint.aliases[0], "test-blueprint2");
-    EXPECT_EQ(blueprint.release_title, "Another test blueprint");
-    EXPECT_EQ(blueprint.version, "0.1");
+    ASSERT_TRUE(blueprint);
+    ASSERT_EQ(blueprint->aliases.size(), 1);
+    EXPECT_EQ(blueprint->aliases[0], "test-blueprint2");
+    EXPECT_EQ(blueprint->release_title, "Another test blueprint");
+    EXPECT_EQ(blueprint->version, "0.1");
 }
 
 TEST_F(VMBlueprintProvider, allBlueprintsReturnsExpectedInfo)
@@ -644,9 +645,10 @@ TEST_F(VMBlueprintProvider, infoForCompatibleReturnsExpectedInfo)
 
     auto blueprint = blueprint_provider.info_for("arch-only");
 
-    ASSERT_EQ(blueprint.aliases.size(), 1);
-    EXPECT_EQ(blueprint.aliases[0], "arch-only");
-    EXPECT_EQ(blueprint.release_title, "An arch-only blueprint");
+    ASSERT_TRUE(blueprint);
+    ASSERT_EQ(blueprint->aliases.size(), 1);
+    EXPECT_EQ(blueprint->aliases[0], "arch-only");
+    EXPECT_EQ(blueprint->release_title, "An arch-only blueprint");
 }
 
 TEST_F(VMBlueprintProvider, allBlueprintsReturnsExpectedInfoForArch)

--- a/tests/test_blueprint_provider.cpp
+++ b/tests/test_blueprint_provider.cpp
@@ -83,12 +83,12 @@ TEST_F(VMBlueprintProvider, fetchBlueprintForUnknownBlueprintThrows)
     EXPECT_THROW(blueprint_provider.fetch_blueprint_for("phony", vm_desc, dummy_data), std::out_of_range);
 }
 
-TEST_F(VMBlueprintProvider, infoForUnknownBlueprintThrows)
+TEST_F(VMBlueprintProvider, infoForUnknownBlueprintReturnsEmpty)
 {
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
-    EXPECT_THROW(blueprint_provider.info_for("phony"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("phony"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, invalidImageSchemeThrows)
@@ -616,26 +616,26 @@ TEST_F(VMBlueprintProvider, invalidRunsOnThrows)
         mpt::match_what(StrEq(fmt::format("Cannot convert \'description\' key for the {} Blueprint", blueprint))));
 }
 
-TEST_F(VMBlueprintProvider, fetchInvalidRunsOnThrows)
+TEST_F(VMBlueprintProvider, fetchForInvalidReturnsEmpty)
 {
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
     const std::string blueprint{"invalid-arch"};
-    // This call fails with an std::out_of_range exception because the Blueprint is invalid and was filtered out by
+    // This call fails with an std::nullopt exception because the Blueprint is invalid and was filtered out by
     // blueprints_map_for() at provider construction.
-    EXPECT_THROW(blueprint_provider.info_for(blueprint), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for(blueprint), std::nullopt);
 }
 
-TEST_F(VMBlueprintProvider, infoForIncompatibleThrows)
+TEST_F(VMBlueprintProvider, infoForIncompatibleReturnsEmpty)
 {
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
     const std::string blueprint{"arch-only"};
-    // This call fails with an std::out_of_range exception because the Blueprint is invalid and was filtered out by
+    // This call fails with an std::nullopt exception because the Blueprint is invalid and was filtered out by
     // blueprints_map_for() at provider construction.
-    EXPECT_THROW(blueprint_provider.info_for(blueprint), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for(blueprint), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, infoForCompatibleReturnsExpectedInfo)
@@ -675,7 +675,7 @@ TEST_F(VMBlueprintProvider, v2WithNoInstancesKeyNotAdded)
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
-    EXPECT_THROW(blueprint_provider.info_for("no-instances"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("no-instances"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, v2WithNoBlueprintKeyNotAdded)
@@ -683,7 +683,7 @@ TEST_F(VMBlueprintProvider, v2WithNoBlueprintKeyNotAdded)
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
-    EXPECT_THROW(blueprint_provider.info_for("no-blueprint"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("no-blueprint"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, v2WithNoImagesKeyNotAdded)
@@ -691,7 +691,7 @@ TEST_F(VMBlueprintProvider, v2WithNoImagesKeyNotAdded)
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl};
 
-    EXPECT_THROW(blueprint_provider.info_for("no-images"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("no-images"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, v2WithNoUrlKeyNotAdded)
@@ -699,7 +699,7 @@ TEST_F(VMBlueprintProvider, v2WithNoUrlKeyNotAdded)
     mp::DefaultVMBlueprintProvider blueprint_provider{blueprints_zip_url, &url_downloader, cache_dir.path(),
                                                       default_ttl, "multivacs"};
 
-    EXPECT_THROW(blueprint_provider.info_for("no-url"), std::out_of_range);
+    EXPECT_EQ(blueprint_provider.info_for("no-url"), std::nullopt);
 }
 
 TEST_F(VMBlueprintProvider, v2MininalDefinitionAdded)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -1524,7 +1524,7 @@ TEST_F(Daemon, fails_with_image_not_found_also_if_image_is_also_non_bridgeable)
     });
 
     auto mock_blueprint_provider = std::make_unique<NiceMock<mpt::MockVMBlueprintProvider>>();
-    EXPECT_CALL(*mock_blueprint_provider, info_for(_)).WillOnce(Throw(std::out_of_range("")));
+    EXPECT_CALL(*mock_blueprint_provider, info_for(_)).WillOnce(Return(std::nullopt));
 
     config_builder.vault = std::move(mock_image_vault);
     config_builder.blueprint_provider = std::move(mock_blueprint_provider);

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -18,7 +18,6 @@
 #include "common.h"
 #include "daemon_test_fixture.h"
 #include "mock_image_host.h"
-#include "mock_logger.h"
 #include "mock_platform.h"
 #include "mock_settings.h"
 #include "mock_vm_blueprint_provider.h"
@@ -31,7 +30,6 @@
 
 namespace mp = multipass;
 namespace mpt = multipass::test;
-namespace mpl = multipass::logging;
 using namespace testing;
 
 namespace

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -678,7 +678,7 @@ TEST_F(ImageVault, all_info_for_remote_given_returns_expected_data)
     EXPECT_EQ(second_image_info.version.toStdString(), mpt::another_image_version);
 }
 
-TEST_F(ImageVault, all_info_for_no_images_returned_throws)
+TEST_F(ImageVault, allInfoForNoImagesReturnsEmpty)
 {
     mpt::StubURLDownloader stub_url_downloader;
     mp::DefaultVMImageVault vault{hosts, &stub_url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
@@ -686,6 +686,5 @@ TEST_F(ImageVault, all_info_for_no_images_returned_throws)
     const std::string name{"foo"};
     EXPECT_CALL(host, all_info_for(_)).WillOnce(Return(std::vector<std::pair<std::string, mp::VMImageInfo>>{}));
 
-    MP_EXPECT_THROW_THAT(vault.all_info_for({"", name, false, "", mp::Query::Type::Alias, true}), std::runtime_error,
-                         mpt::match_what(HasSubstr(fmt::format("Unable to find an image matching \"{}\"", name))));
+    EXPECT_TRUE(vault.all_info_for({"", name, false, "", mp::Query::Type::Alias, true}).empty());
 }

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -934,7 +934,7 @@ const auto find_one_reply_no_os = construct_find_one_reply_no_os();
 const auto find_multiple_reply_duplicate_image = construct_find_multiple_reply_duplicate_image();
 
 const std::vector<FormatterParamType> find_formatter_outputs{
-    {&table_formatter, &empty_find_reply, "No images found.\n", "table_find_empty"},
+    {&table_formatter, &empty_find_reply, "No images or Blueprints found.\n", "table_find_empty"},
     {&table_formatter, &find_one_reply,
      "Image                       Aliases           Version          Description\n"
      "ubuntu                                        20190516         Ubuntu 18.04 LTS\n",


### PR DESCRIPTION
Refactor where exceptions are thrown when no images are found in the vault. It should not be up to the vault to decide that no images being found should be interpreted as an error. So, this PR removes that behavior and leaves it up to the calling class.