### PR TITLE
Update min cmake version

### DIFF
--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -76,7 +76,7 @@ target_link_libraries(gRPC INTERFACE
   zlibstatic)
 
 if (NOT MSVC)
-  target_compile_options(gRPC INTERFACE "-Wno-unused-parameter" "-Wno-non-virtual-dtor")
+  target_compile_options(gRPC INTERFACE "-Wno-unused-parameter" "-Wno-non-virtual-dtor" "-Wno-pedantic")
 endif ()
 
 # YAML C++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.17)
 cmake_policy(SET CMP0079 NEW) # Allow target_link_libraries() in subdirs
 
 if (APPLE)


### PR DESCRIPTION
> We added a new way to fetch the grpc module and it uses the GIT_SUBMODULES_RECURSE directive for [FetchContent_Declare](https://cmake.org/cmake/help/latest/module/ExternalProject.html) and unfortunately, that directive was made available starting with cmake version 3.17.

Fixes #2959 