### PR TITLE
[cli] Stop erroneous newlines from appearing in empty terminal

### DIFF
--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -25,7 +25,7 @@ namespace
 {
 void clear_line(std::ostream& out)
 {
-    out << "\x1B[2K";               // Delete current line
+    out << "\x1B[2K\x1B[A";         // Delete current line
     out << "\x1B[0E" << std::flush; // Move cursor to leftmost position of current line
 }
 }

--- a/src/client/cli/cmd/animated_spinner.cpp
+++ b/src/client/cli/cmd/animated_spinner.cpp
@@ -25,7 +25,7 @@ namespace
 {
 void clear_line(std::ostream& out)
 {
-    out << "\x1B[2K\x1B[A";         // Delete current line
+    out << "\x1B[2K\x1B[0A";        // Delete current line
     out << "\x1B[0E" << std::flush; // Move cursor to leftmost position of current line
 }
 }

--- a/tests/test_common_callbacks.cpp
+++ b/tests/test_common_callbacks.cpp
@@ -34,7 +34,7 @@ struct TestSpinnerCallbacks : public Test
     auto clearStreamMatcher()
     {
         static const std::regex clear_regex{
-            R"(\u001B\[2K\u001B\[0E|^$)"}; /* A "clear" stream should have nothing on the current
+            R"(\u001B\[2K\u001B\[0A\u001B\[0E|^$)"}; /* A "clear" stream should have nothing on the current
                                      line and the cursor in the leftmost position */
         return Truly([](const auto& str) {
             return std::regex_match(str, clear_regex); // (gtest regex not cutting it on macOS)


### PR DESCRIPTION
Add an extra ASCII escape character that moves the cursor up 0 lines. This stops newlines from appearing in a new/empty terminal when running a command that uses the animated spinner. Don't ask exactly why this works, but it does :shrug: 

---

Fixes #2953 