### PR TITLE
Do not read global SSH config

### DIFF
--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -30,7 +30,8 @@ set(LIB_INSTALL_DIR lib)
 set(BIN_INSTALL_DIR bin)
 
 set(BUILD_SHARED_LIBS ON)
-set(GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config")
+# space instead of empty string because empty string restults in non-defined GLOBAL_CLIENT_CONFIG in config.h
+set(GLOBAL_CLIENT_CONFIG " ")
 set(GLOBAL_BIND_CONFIG "/etc/ssh/libssh_server_config")
 
 include_directories(${LIBSSH_INCLUDE_DIRS})

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -51,6 +51,8 @@ mp::SSHSession::SSHSession(const std::string& host, int port, const std::string&
     set_option(SSH_OPTIONS_CIPHERS_C_S, "chacha20-poly1305@openssh.com,aes256-ctr");
     set_option(SSH_OPTIONS_CIPHERS_S_C, "chacha20-poly1305@openssh.com,aes256-ctr");
     set_option(SSH_OPTIONS_SSH_DIR, ssh_dir.c_str());
+    const bool load_config_file = false;
+    set_option(SSH_OPTIONS_PROCESS_CONFIG, &load_config_file);
 
     SSH::throw_on_error(session, "ssh connection failed", ssh_connect);
     if (key_provider)

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -51,8 +51,6 @@ mp::SSHSession::SSHSession(const std::string& host, int port, const std::string&
     set_option(SSH_OPTIONS_CIPHERS_C_S, "chacha20-poly1305@openssh.com,aes256-ctr");
     set_option(SSH_OPTIONS_CIPHERS_S_C, "chacha20-poly1305@openssh.com,aes256-ctr");
     set_option(SSH_OPTIONS_SSH_DIR, ssh_dir.c_str());
-    const bool load_config_file = false;
-    set_option(SSH_OPTIONS_PROCESS_CONFIG, &load_config_file);
 
     SSH::throw_on_error(session, "ssh connection failed", ssh_connect);
     if (key_provider)


### PR DESCRIPTION
Fixes #2754
In the orginal code, when multipass `class SSHSession` is being constructed, he always calls libssh function `int ssh_connect(ssh_session session)`. That function by default always tries to load a configuration file either from user or from the system (/etc/ssh/ssh_config ). Setting the option SSH_OPTIONS_PROCESS_CONFIG to false makes him to skip that. 