### PR TITLE
[daemon] Edit disk usage info

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1468,9 +1468,11 @@ try // clang-format on
             info->set_memory_usage(mpu::run_in_ssh_session(session, "free -b | grep 'Mem:' | awk '{printf $3}'"));
             info->set_memory_total(mpu::run_in_ssh_session(session, "free -b | grep 'Mem:' | awk '{printf $2}'"));
             info->set_disk_usage(mpu::run_in_ssh_session(
-                session, "df --output=used $(awk '$2 == \"/\" { print $1 }' /proc/mounts) -B1 | sed 1d"));
+                session,
+                "df --output=used $(sudo fdisk -l | grep 'Linux filesystem' | awk '{print $1}') -B1 | sed 1d"));
             info->set_disk_total(mpu::run_in_ssh_session(
-                session, "df --output=size $(awk '$2 == \"/\" { print $1 }' /proc/mounts) -B1 | sed 1d"));
+                session,
+                "df --output=size $(sudo fdisk -l | grep 'Linux filesystem' | awk '{print $1}') -B1 | sed 1d"));
             info->set_cpu_count(mpu::run_in_ssh_session(session, "nproc"));
 
             std::string management_ip = vm->management_ipv4();


### PR DESCRIPTION
Edit how disk usage is gotten so that it outputs the correct in core instance as well as regular ubuntu images. The command now takes the output from `fdisk -l` and courses references the devices found in `df`. Instead of returning the size of the root directory, `/`, the device marked as `Linux filesystem` in `dfisk` will be taken from `df`.

Fixes #1245