### PR TITLE
Honor remote name when used with a Blueprint

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1245,6 +1245,17 @@ try // clang-format on
 
     if (!request->search_string().empty())
     {
+        if (!request->remote_name().empty())
+        {
+            // This is a compromised solution for now, it throws if remote_name is invalid.
+            // In principle, it should catch the returned VMImageHost in the valid remote_name case and
+            // get the found VMImageHost reused in the follow-up code. However, because of the current framework,
+            // That would involve more changes because the query carries the remote name and there is
+            // another dispatch in the all_info_for function.
+            const auto& remote_name = request->remote_name();
+            config->vault->image_host_for(remote_name);
+        }
+
         if (request->show_images())
         {
             std::vector<std::pair<std::string, VMImageInfo>> vm_images_info;


### PR DESCRIPTION
fixed #2957

---

The original behavior is: 
```
./multipass find nonsense:22.10 # the case where the search string is a valid image name
No images or blueprints found.
./multipass find nonsense:22.10 --only-images
No images found.
./multipass find nonsense:22.10 --only-blueprints
No blueprints found.

./multipass find nonsense:charm-dev # the case where the search string is a valid blueprint
Blueprint                   Aliases           Version          Description
charm-dev                                     latest           A development and testing environment for charmers
./multipass find nonsense:charm-dev --only-images
No images found.
./multipass find nonsense:charm-dev --only-blueprints
Blueprint                   Aliases           Version          Description
charm-dev                                     latest           A development and testing environment for charmers

```
it has been changed to:
```
./multipass find nonsense:22.10 # the case where the search string is a valid image name
find failed: Remote 'nonsense' is not found. Please use `multipass find` for supported remotes and images.
./multipass find nonsense:22.10 --only-images
find failed: Remote 'nonsense' is not found. Please use `multipass find` for supported remotes and images.
./multipass find nonsense:22.10 --only-blueprints
find failed: Remote 'nonsense' is not found. Please use `multipass find` for supported remotes and images.

./multipass find nonsense:charm-dev # the case where the search string is a valid blueprint
find failed: Remote 'nonsense' is not found. Please use `multipass find` for supported remotes and images.
./multipass find nonsense:charm-dev --only-images
find failed: Remote 'nonsense' is not found. Please use `multipass find` for supported remotes and images.
./multipass find nonsense:charm-dev --only-blueprints
find failed: Remote 'nonsense' is not found. Please use `multipass find` for supported remotes and images.
```
