### PR TITLE
[cli] Add valid name desc to help

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -224,9 +224,7 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
                                          "letter, and must end with an alphanumeric character."};
     const auto name_option_desc =
         petenv_name.isEmpty()
-            ? QString{"Name for the instance.\nValid names must consist of letters, numbers, or hyphens, must start "
-                      "with a letter, and must end with an alphanumeric character.\n%3"}
-                  .arg(valid_name_desc)
+            ? QString{"Name for the instance.\n%1"}.arg(valid_name_desc)
             : QString{"Name for the instance. If it is '%1' (the configured primary instance name), the user's home "
                       "directory is mounted inside the newly launched instance, in '%2'.\n%3"}
                   .arg(petenv_name, mp::home_automount_dir, valid_name_desc);

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -220,12 +220,16 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
         QString::fromUtf8(default_memory_size));
     memOptionDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
 
+    const auto valid_name_desc = QString{"Valid names must consist of letters, numbers, or hyphens, must start with a "
+                                         "letter, and must end with an alphanumeric character."};
     const auto name_option_desc =
         petenv_name.isEmpty()
-            ? QString{"Name for the instance."}
+            ? QString{"Name for the instance.\nValid names must consist of letters, numbers, or hyphens, must start "
+                      "with a letter, and must end with an alphanumeric character.\n%3"}
+                  .arg(valid_name_desc)
             : QString{"Name for the instance. If it is '%1' (the configured primary instance name), the user's home "
-                      "directory is mounted inside the newly launched instance, in '%2'."}
-                  .arg(petenv_name, mp::home_automount_dir);
+                      "directory is mounted inside the newly launched instance, in '%2'.\n%3"}
+                  .arg(petenv_name, mp::home_automount_dir, valid_name_desc);
 
     QCommandLineOption nameOption({"n", "name"}, name_option_desc, "name");
     QCommandLineOption cloudInitOption(


### PR DESCRIPTION
Add an explanation to the `launch --help` for what valid instance names are.

TODO: If the wording looks good, [multipass.run](https://multipass.run/docs/launch-command) docs needs to be updated as well

Fixes #1277