### PR TITLE
[sftp] open local files in binary mode

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -75,8 +75,10 @@ public:
 
     // std operations
     virtual void open(std::fstream& stream, const char* filename, std::ios_base::openmode mode) const;
-    virtual std::unique_ptr<std::ostream> open_write(const fs::path& path) const;
-    virtual std::unique_ptr<std::istream> open_read(const fs::path& path) const;
+    virtual std::unique_ptr<std::ostream> open_write(const fs::path& path,
+                                                     std::ios_base::openmode mode = std::ios_base::out) const;
+    virtual std::unique_ptr<std::istream> open_read(const fs::path& path,
+                                                    std::ios_base::openmode mode = std::ios_base::in) const;
     virtual bool exists(const fs::path& path, std::error_code& err) const;
     virtual bool is_directory(const fs::path& path, std::error_code& err) const;
     virtual bool create_directory(const fs::path& path, std::error_code& err) const;

--- a/src/ssh/sftp_client.cpp
+++ b/src/ssh/sftp_client.cpp
@@ -122,7 +122,7 @@ catch (const SFTPError& e)
 
 void SFTPClient::push_file(const fs::path& source_path, const fs::path& target_path)
 {
-    auto local_file = MP_FILEOPS.open_read(source_path);
+    auto local_file = MP_FILEOPS.open_read(source_path, std::ios_base::in | std::ios_base::binary);
     if (local_file->fail())
         throw SFTPError{"cannot open local file {}: {}", source_path, strerror(errno)};
 
@@ -139,7 +139,7 @@ void SFTPClient::push_file(const fs::path& source_path, const fs::path& target_p
 
 void SFTPClient::pull_file(const fs::path& source_path, const fs::path& target_path)
 {
-    auto local_file = MP_FILEOPS.open_write(target_path);
+    auto local_file = MP_FILEOPS.open_write(target_path, std::ios_base::out | std::ios_base::binary);
     if (local_file->fail())
         throw SFTPError{"cannot open local file {}: {}", target_path, strerror(errno)};
 

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -144,14 +144,14 @@ void mp::FileOps::open(std::fstream& stream, const char* filename, std::ios_base
     stream.open(filename, mode);
 }
 
-std::unique_ptr<std::ostream> mp::FileOps::open_write(const fs::path& path) const
+std::unique_ptr<std::ostream> mp::FileOps::open_write(const fs::path& path, std::ios_base::openmode mode) const
 {
-    return std::make_unique<std::ofstream>(path);
+    return std::make_unique<std::ofstream>(path, mode);
 }
 
-std::unique_ptr<std::istream> mp::FileOps::open_read(const fs::path& path) const
+std::unique_ptr<std::istream> mp::FileOps::open_read(const fs::path& path, std::ios_base::openmode mode) const
 {
-    return std::make_unique<std::ifstream>(path);
+    return std::make_unique<std::ifstream>(path, mode);
 }
 
 bool mp::FileOps::exists(const fs::path& path, std::error_code& err) const

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -64,8 +64,10 @@ public:
 
     // Mock std methods
     MOCK_CONST_METHOD3(open, void(std::fstream&, const char*, std::ios_base::openmode));
-    MOCK_METHOD(std::unique_ptr<std::ostream>, open_write, (const fs::path& path), (override, const));
-    MOCK_METHOD(std::unique_ptr<std::istream>, open_read, (const fs::path& path), (override, const));
+    MOCK_METHOD(std::unique_ptr<std::ostream>, open_write, (const fs::path& path, std::ios_base::openmode mode),
+                (override, const));
+    MOCK_METHOD(std::unique_ptr<std::istream>, open_read, (const fs::path& path, std::ios_base::openmode mode),
+                (override, const));
     MOCK_METHOD(bool, exists, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(bool, is_directory, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(bool, create_directory, (const fs::path& path, std::error_code& err), (override, const));


### PR DESCRIPTION
The SFTP client opened files in text mode, which made the transfer of binary files on Windows fail. This PR makes the SFTP client open files in binary mode.

fix #2990