### PR TITLE
tweak snapshot cmd

### DIFF
--- a/src/client/cli/cmd/snapshot.cpp
+++ b/src/client/cli/cmd/snapshot.cpp
@@ -75,7 +75,7 @@ mp::ParseCode cmd::Snapshot::parse_args(mp::ArgParser* parser)
         "[snapshot]");
 
     QCommandLineOption comment_opt{
-        {"comment", "m"}, "An optional free comment to associate with the snapshot.", "comment"};
+        {"comment", "c", "m"}, "An optional free comment to associate with the snapshot.", "comment"};
     parser->addOption(comment_opt);
 
     if (auto status = parser->commandParse(this); status != ParseCode::Ok)

--- a/src/client/cli/cmd/snapshot.cpp
+++ b/src/client/cli/cmd/snapshot.cpp
@@ -67,14 +67,13 @@ QString cmd::Snapshot::description() const
 mp::ParseCode cmd::Snapshot::parse_args(mp::ArgParser* parser)
 {
     parser->addPositionalArgument("instance", "The instance to take a snapshot of.");
-    parser->addPositionalArgument("snapshot",
-                                  "An optional name for the snapshot (default: \"snapshotN\", where N is one plus the "
-                                  "number of snapshot that were ever taken for <instance>.",
-                                  "[snapshot]");
-
+    QCommandLineOption name_opt({"n", "name"},
+                                "An optional name for the snapshot (default: \"snapshotN\", where N is one plus the "
+                                "number of snapshot that were ever taken for <instance>.",
+                                "name");
     QCommandLineOption comment_opt{
         {"comment", "c", "m"}, "An optional free comment to associate with the snapshot.", "comment"};
-    parser->addOption(comment_opt);
+    parser->addOptions({name_opt, comment_opt});
 
     if (auto status = parser->commandParse(this); status != ParseCode::Ok)
         return status;
@@ -87,7 +86,7 @@ mp::ParseCode cmd::Snapshot::parse_args(mp::ArgParser* parser)
         return ParseCode::CommandLineError;
     }
 
-    if (num_args > 2)
+    if (num_args > 1)
     {
         cerr << "Too many arguments supplied\n";
         return ParseCode::CommandLineError;
@@ -95,10 +94,7 @@ mp::ParseCode cmd::Snapshot::parse_args(mp::ArgParser* parser)
 
     request.set_instance(positional_args.first().toStdString());
     request.set_comment(parser->value(comment_opt).toStdString());
-
-    if (num_args == 2)
-        request.set_snapshot(positional_args.at(1).toStdString());
-
+    request.set_snapshot(parser->value(name_opt).toStdString());
     request.set_verbosity_level(parser->verbosityLevel());
 
     return ParseCode::Ok;

--- a/src/client/cli/cmd/snapshot.cpp
+++ b/src/client/cli/cmd/snapshot.cpp
@@ -67,12 +67,10 @@ QString cmd::Snapshot::description() const
 mp::ParseCode cmd::Snapshot::parse_args(mp::ArgParser* parser)
 {
     parser->addPositionalArgument("instance", "The instance to take a snapshot of.");
-    parser->addPositionalArgument(
-        "snapshot",
-        "An optional name for the snapshot (default: \"snapshotN\", where N is an index number, i.e. the next "
-        "non-negative integer that has not been used to generate a snapshot name for <instance> yet, and which is "
-        "currently available).",
-        "[snapshot]");
+    parser->addPositionalArgument("snapshot",
+                                  "An optional name for the snapshot (default: \"snapshotN\", where N is one plus the "
+                                  "number of snapshot that were ever taken for <instance>.",
+                                  "[snapshot]");
 
     QCommandLineOption comment_opt{
         {"comment", "c", "m"}, "An optional free comment to associate with the snapshot.", "comment"};

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -3123,6 +3123,22 @@ TEST_F(Client, snapshotCmdGoodArgsOk)
     EXPECT_EQ(send_command({"snapshot", "foo", "rocky"}), mp::ReturnCode::Ok);
 }
 
+TEST_F(Client, snapshotCmdCommentOptionAlternativesOk)
+{
+    EXPECT_CALL(mock_daemon, snapshot).Times(3);
+    EXPECT_EQ(send_command({"snapshot", "--comment", "a comment", "foo"}), mp::ReturnCode::Ok);
+    EXPECT_EQ(send_command({"snapshot", "-c", "a comment", "foo"}), mp::ReturnCode::Ok);
+    EXPECT_EQ(send_command({"snapshot", "-m", "a comment", "foo"}), mp::ReturnCode::Ok);
+}
+
+TEST_F(Client, snapshotCmdCommentConsumesArg)
+{
+    EXPECT_CALL(mock_daemon, snapshot).Times(0);
+    EXPECT_EQ(send_command({"snapshot", "--comment", "foo"}), mp::ReturnCode::CommandLineError);
+    EXPECT_EQ(send_command({"snapshot", "-c", "foo"}), mp::ReturnCode::CommandLineError);
+    EXPECT_EQ(send_command({"snapshot", "-m", "foo"}), mp::ReturnCode::CommandLineError);
+}
+
 TEST_F(Client, snapshotCmdTooFewArgsFails)
 {
     EXPECT_EQ(send_command({"snapshot", "-m", "Who controls the past controls the future"}),

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -3117,10 +3117,24 @@ TEST_F(Client, snapshotCmdHelpOk)
     EXPECT_EQ(send_command({"snapshot", "--help"}), mp::ReturnCode::Ok);
 }
 
-TEST_F(Client, snapshotCmdGoodArgsOk)
+TEST_F(Client, snapshotCmdNoOptionsOk)
 {
     EXPECT_CALL(mock_daemon, snapshot);
-    EXPECT_EQ(send_command({"snapshot", "foo", "rocky"}), mp::ReturnCode::Ok);
+    EXPECT_EQ(send_command({"snapshot", "foo"}), mp::ReturnCode::Ok);
+}
+
+TEST_F(Client, snapshotCmdNameAlternativesOk)
+{
+    EXPECT_CALL(mock_daemon, snapshot).Times(2);
+    EXPECT_EQ(send_command({"snapshot", "-n", "bar", "foo"}), mp::ReturnCode::Ok);
+    EXPECT_EQ(send_command({"snapshot", "--name", "bar", "foo"}), mp::ReturnCode::Ok);
+}
+
+TEST_F(Client, snapshotCmdNameConsumesArg)
+{
+    EXPECT_CALL(mock_daemon, snapshot).Times(0);
+    EXPECT_EQ(send_command({"snapshot", "--name", "foo"}), mp::ReturnCode::CommandLineError);
+    EXPECT_EQ(send_command({"snapshot", "-n", "foo"}), mp::ReturnCode::CommandLineError);
 }
 
 TEST_F(Client, snapshotCmdCommentOptionAlternativesOk)
@@ -3147,7 +3161,7 @@ TEST_F(Client, snapshotCmdTooFewArgsFails)
 
 TEST_F(Client, snapshotCmdTooManyArgsFails)
 {
-    EXPECT_EQ(send_command({"snaphot", "foo", "bar"}), mp::ReturnCode::CommandLineError);
+    EXPECT_EQ(send_command({"snapshot", "foo", "bar"}), mp::ReturnCode::CommandLineError);
 }
 
 TEST_F(Client, snapshotCmdInvalidOptionFails)


### PR DESCRIPTION
Turn name into an option in `snapshot` and allow `-c` for comments.
