### PR TITLE
[snapshots] Safer threading

### DIFF
--- a/include/multipass/snapshot.h
+++ b/include/multipass/snapshot.h
@@ -36,9 +36,9 @@ class Snapshot : private DisabledCopyMove
 public:
     virtual ~Snapshot() = default;
 
-    virtual const std::string& get_name() const noexcept = 0;
-    virtual const std::string& get_comment() const noexcept = 0;
-    virtual const Snapshot* get_parent() const noexcept = 0;
+    virtual std::string get_name() const noexcept = 0;
+    virtual std::string get_comment() const noexcept = 0;
+    virtual const Snapshot* get_parent() const noexcept = 0; // TODO@ricab shptr
 
     virtual int get_num_cores() const noexcept = 0;
     virtual MemorySize get_mem_size() const noexcept = 0;

--- a/include/multipass/snapshot.h
+++ b/include/multipass/snapshot.h
@@ -37,18 +37,22 @@ class Snapshot : private DisabledCopyMove
 public:
     virtual ~Snapshot() = default;
 
-    virtual std::string get_name() const noexcept = 0;
-    virtual std::string get_comment() const noexcept = 0;
-    virtual std::shared_ptr<const Snapshot> get_parent() const noexcept = 0;
+    virtual std::string get_name() const = 0;
+    virtual std::string get_comment() const = 0;
+    virtual std::shared_ptr<const Snapshot> get_parent() const = 0;
 
     virtual int get_num_cores() const noexcept = 0;
     virtual MemorySize get_mem_size() const noexcept = 0;
     virtual MemorySize get_disk_space() const noexcept = 0;
     virtual VirtualMachine::State get_state() const noexcept = 0;
 
-    // Note that these return references - careful not to change them in the meantime
+    // Note that these return references - careful not to delete the snapshot while they are in use
     virtual const std::unordered_map<std::string, VMMount>& get_mounts() const noexcept = 0;
     virtual const QJsonObject& get_metadata() const noexcept = 0;
+
+    virtual void set_name(const std::string&) = 0;
+    virtual void set_comment(const std::string&) = 0;
+    virtual void set_parent(std::shared_ptr<const Snapshot>) = 0;
 };
 } // namespace multipass
 

--- a/include/multipass/snapshot.h
+++ b/include/multipass/snapshot.h
@@ -21,6 +21,7 @@
 #include "disabled_copy_move.h"
 #include "virtual_machine.h"
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -38,12 +39,14 @@ public:
 
     virtual std::string get_name() const noexcept = 0;
     virtual std::string get_comment() const noexcept = 0;
-    virtual const Snapshot* get_parent() const noexcept = 0; // TODO@ricab shptr
+    virtual std::shared_ptr<const Snapshot> get_parent() const noexcept = 0;
 
     virtual int get_num_cores() const noexcept = 0;
     virtual MemorySize get_mem_size() const noexcept = 0;
     virtual MemorySize get_disk_space() const noexcept = 0;
     virtual VirtualMachine::State get_state() const noexcept = 0;
+
+    // Note that these return references - careful not to change them in the meantime
     virtual const std::unordered_map<std::string, VMMount>& get_mounts() const noexcept = 0;
     virtual const QJsonObject& get_metadata() const noexcept = 0;
 };

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -27,7 +27,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include <shared_mutex> // TODO@snapshots replace with generic utility for safe const refs
@@ -87,8 +86,8 @@ public:
                                                                     const std::string& target,
                                                                     const VMMount& mount) = 0;
 
-    using SnapshotMap = std::unordered_map<std::string, std::unique_ptr<Snapshot>>;
-    virtual const SnapshotMap& get_snapshots() const noexcept = 0; // TODO@snapshots lock it
+    using SnapshotVista = std::vector<std::shared_ptr<const Snapshot>>; // using vista to avoid confusion with C++ views
+    virtual SnapshotVista view_snapshots() const noexcept = 0;
 
     using LockingConstSnapshotRef =
         std::pair<const Snapshot&, std::shared_lock<std::shared_mutex>>; // TODO@snapshots generalize

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -29,9 +29,6 @@
 #include <string>
 #include <vector>
 
-#include <shared_mutex> // TODO@snapshots replace with generic utility for safe const refs
-#include <utility>      // TODO@snapshots replace with generic utility for safe const refs
-
 namespace multipass
 {
 class MemorySize;
@@ -89,10 +86,8 @@ public:
     using SnapshotVista = std::vector<std::shared_ptr<const Snapshot>>; // using vista to avoid confusion with C++ views
     virtual SnapshotVista view_snapshots() const noexcept = 0;
 
-    using LockingConstSnapshotRef =
-        std::pair<const Snapshot&, std::shared_lock<std::shared_mutex>>; // TODO@snapshots generalize
-    virtual LockingConstSnapshotRef take_snapshot(const VMSpecs& specs, const std::string& name,
-                                                  const std::string& comment) = 0;
+    virtual std::shared_ptr<const Snapshot> take_snapshot(const VMSpecs& specs, const std::string& name,
+                                                          const std::string& comment) = 0;
 
     VirtualMachine::State state;
     const std::string vm_name;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2422,11 +2422,10 @@ try
         SnapshotReply reply;
 
         {
-            const auto& [snapshot, lock] =
-                vm_ptr->take_snapshot(spec_it->second, request->snapshot(), request->comment());
+            auto snapshot = vm_ptr->take_snapshot(spec_it->second, request->snapshot(), request->comment());
             // TODO@snapshots persist generic snapshot info
 
-            reply.set_snapshot(snapshot.get_name());
+            reply.set_snapshot(snapshot->get_name());
         }
 
         server->Write(reply);

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -23,12 +23,12 @@
 namespace mp = multipass;
 
 mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, // NOLINT(modernize-pass-by-value)
-                               const mp::Snapshot* parent, int num_cores, mp::MemorySize mem_size,
-                               mp::MemorySize disk_space, mp::VirtualMachine::State state,
+                               std::shared_ptr<const Snapshot> parent, int num_cores, MemorySize mem_size,
+                               MemorySize disk_space, VirtualMachine::State state,
                                std::unordered_map<std::string, VMMount> mounts, QJsonObject metadata)
     : name{name},
       comment{comment},
-      parent{parent},
+      parent{std::move(parent)},
       num_cores{num_cores},
       mem_size{mem_size},
       disk_space{disk_space},
@@ -38,9 +38,9 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comme
 {
 }
 
-mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, const mp::Snapshot* parent,
-                               const mp::VMSpecs& specs)
-    : BaseSnapshot{name,        comment,      parent,        specs.num_cores, specs.mem_size, specs.disk_space,
+mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment,
+                               std::shared_ptr<const Snapshot> parent, const VMSpecs& specs)
+    : BaseSnapshot{name,        comment,      std::move(parent), specs.num_cores, specs.mem_size, specs.disk_space,
                    specs.state, specs.mounts, specs.metadata}
 {
 }

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -32,15 +32,16 @@ struct VMSpecs;
 class BaseSnapshot : public Snapshot
 {
 public:
-    BaseSnapshot(const std::string& name, const std::string& comment, const Snapshot* parent, int num_cores,
-                 MemorySize mem_size, MemorySize disk_space, VirtualMachine::State state,
+    BaseSnapshot(const std::string& name, const std::string& comment, std::shared_ptr<const Snapshot> parent,
+                 int num_cores, MemorySize mem_size, MemorySize disk_space, VirtualMachine::State state,
                  std::unordered_map<std::string, VMMount> mounts, QJsonObject metadata);
 
-    BaseSnapshot(const std::string& name, const std::string& comment, const Snapshot* parent, const VMSpecs& specs);
+    BaseSnapshot(const std::string& name, const std::string& comment, std::shared_ptr<const Snapshot> parent,
+                 const VMSpecs& specs);
 
     std::string get_name() const noexcept override;
     std::string get_comment() const noexcept override;
-    const Snapshot* get_parent() const noexcept override;
+    std::shared_ptr<const Snapshot> get_parent() const noexcept override;
     int get_num_cores() const noexcept override;
     MemorySize get_mem_size() const noexcept override;
     MemorySize get_disk_space() const noexcept override;
@@ -51,7 +52,7 @@ public:
 private:
     std::string name;
     std::string comment;
-    const Snapshot* parent;
+    std::shared_ptr<const Snapshot> parent;
     int num_cores;
     MemorySize mem_size;
     MemorySize disk_space;
@@ -71,7 +72,7 @@ inline std::string multipass::BaseSnapshot::get_comment() const noexcept
     return comment;
 }
 
-inline auto multipass::BaseSnapshot::get_parent() const noexcept -> const Snapshot*
+inline auto multipass::BaseSnapshot::get_parent() const noexcept -> std::shared_ptr<const Snapshot>
 {
     return parent;
 }

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -38,8 +38,8 @@ public:
 
     BaseSnapshot(const std::string& name, const std::string& comment, const Snapshot* parent, const VMSpecs& specs);
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_comment() const noexcept override;
+    std::string get_name() const noexcept override;
+    std::string get_comment() const noexcept override;
     const Snapshot* get_parent() const noexcept override;
     int get_num_cores() const noexcept override;
     MemorySize get_mem_size() const noexcept override;
@@ -61,12 +61,12 @@ private:
 };
 } // namespace multipass
 
-inline const std::string& multipass::BaseSnapshot::get_name() const noexcept
+inline std::string multipass::BaseSnapshot::get_name() const noexcept
 {
     return name;
 }
 
-inline const std::string& multipass::BaseSnapshot::get_comment() const noexcept
+inline std::string multipass::BaseSnapshot::get_comment() const noexcept
 {
     return comment;
 }

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -34,8 +34,6 @@ BaseVirtualMachine::BaseVirtualMachine(VirtualMachine::State state, const std::s
 
 BaseVirtualMachine::BaseVirtualMachine(const std::string& vm_name) : VirtualMachine(vm_name){};
 
-BaseVirtualMachine::~BaseVirtualMachine() = default; // Snapshot is now fully defined, this can call unique_ptr's dtor
-
 std::vector<std::string> BaseVirtualMachine::get_all_ipv4(const SSHKeyProvider& key_provider)
 {
     std::vector<std::string> all_ipv4;

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -73,8 +73,8 @@ std::vector<std::string> BaseVirtualMachine::get_all_ipv4(const SSHKeyProvider& 
     return all_ipv4;
 }
 
-BaseVirtualMachine::LockingConstSnapshotRef
-BaseVirtualMachine::take_snapshot(const VMSpecs& specs, const std::string& name, const std::string& comment)
+std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs& specs, const std::string& name,
+                                                                  const std::string& comment)
 {
     // TODO@snapshots generate name
     // TODO@snapshots generate implementation-specific snapshot instead

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -97,8 +97,7 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs&
 
         if (success)
         {
-            auto ret = it->second;
-            head_snapshot = ret.get();
+            auto ret = head_snapshot = it->second;
             auto num_snapshots = snapshots.size();
             write_lock.unlock();
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -93,11 +93,12 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs&
         std::unique_lock write_lock{snapshot_mutex};
 
         const auto [it, success] =
-            snapshots.try_emplace(name, std::make_unique<BaseSnapshot>(name, comment, head_snapshot, specs));
+            snapshots.try_emplace(name, std::make_shared<BaseSnapshot>(name, comment, head_snapshot, specs));
 
         if (success)
         {
-            head_snapshot = it->second.get();
+            auto ret = it->second;
+            head_snapshot = ret.get();
 
             // No writing from this point on
             std::shared_lock read_lock{snapshot_mutex, std::defer_lock};
@@ -121,7 +122,7 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs&
                                      num_snapshots));
             }
 
-            return {*head_snapshot, std::move(read_lock)};
+            return ret;
         }
     }
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -71,6 +71,18 @@ std::vector<std::string> BaseVirtualMachine::get_all_ipv4(const SSHKeyProvider& 
     return all_ipv4;
 }
 
+auto multipass::BaseVirtualMachine::view_snapshots() const noexcept -> SnapshotVista
+{
+    SnapshotVista ret;
+
+    std::shared_lock read_lock{snapshot_mutex};
+    ret.reserve(snapshots.size());
+    std::transform(std::cbegin(snapshots), std::cend(snapshots), std::back_inserter(ret),
+                   [](const auto& pair) { return pair.second; });
+
+    return ret;
+}
+
 std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs& specs, const std::string& name,
                                                                   const std::string& comment)
 {

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -99,14 +99,13 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs&
         {
             auto ret = head_snapshot = it->second;
             auto num_snapshots = snapshots.size();
+            auto parent = ret->get_parent();
             write_lock.unlock();
 
+            assert(bool(parent) == bool(num_snapshots - 1) && "null parent <!=> this is the 1st snapshot");
             if (auto log_detail_lvl = mpl::Level::debug; log_detail_lvl <= mpl::get_logging_level())
             {
-                auto* parent = ret->get_parent();
-
-                assert(bool(parent) == bool(num_snapshots - 1) && "null parent <!=> this is the 1st snapshot");
-                const auto& parent_name = parent ? parent->get_name() : "--";
+                auto parent_name = parent ? parent->get_name() : "--";
 
                 mpl::log(log_detail_lvl, vm_name,
                          fmt::format("New snapshot: {}; Descendant of: {}; Total snapshots: {}", name, parent_name,

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -30,7 +30,6 @@
 #include <QString>
 
 #include <memory>
-#include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
 
@@ -63,7 +62,6 @@ protected:
     SnapshotMap snapshots;
     Snapshot* head_snapshot = nullptr;
     mutable std::shared_mutex snapshot_mutex;
-    std::mutex transfer_mutex;
 };
 
 } // namespace multipass

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -62,14 +62,9 @@ protected:
     using SnapshotMap = std::unordered_map<std::string, std::shared_ptr<Snapshot>>;
     SnapshotMap snapshots;
     Snapshot* head_snapshot = nullptr;
-    std::shared_mutex snapshot_mutex; // TODO@snapshots will probably want this to be mutable
+    mutable std::shared_mutex snapshot_mutex;
     std::mutex transfer_mutex;
 };
-
-inline auto multipass::BaseVirtualMachine::view_snapshots() const noexcept -> SnapshotVista
-{
-    return snapshots;
-}
 
 } // namespace multipass
 

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -53,7 +53,7 @@ public:
         throw NotImplementedOnThisBackendException("native mounts");
     };
 
-    const SnapshotMap& get_snapshots() const noexcept override;
+    SnapshotVista view_snapshots() const noexcept override;
     LockingConstSnapshotRef take_snapshot(const VMSpecs& specs, const std::string& name,
                                           const std::string& comment) override;
 
@@ -64,7 +64,7 @@ protected:
     std::mutex transfer_mutex;
 };
 
-inline auto multipass::BaseVirtualMachine::get_snapshots() const noexcept -> const SnapshotMap&
+inline auto multipass::BaseVirtualMachine::view_snapshots() const noexcept -> SnapshotVista
 {
     return snapshots;
 }

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -54,8 +54,8 @@ public:
     };
 
     SnapshotVista view_snapshots() const noexcept override;
-    LockingConstSnapshotRef take_snapshot(const VMSpecs& specs, const std::string& name,
-                                          const std::string& comment) override;
+    std::shared_ptr<const Snapshot> take_snapshot(const VMSpecs& specs, const std::string& name,
+                                                  const std::string& comment) override;
 
 protected:
     SnapshotMap snapshots;

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -60,7 +60,7 @@ public:
 protected:
     using SnapshotMap = std::unordered_map<std::string, std::shared_ptr<Snapshot>>;
     SnapshotMap snapshots;
-    Snapshot* head_snapshot = nullptr;
+    std::shared_ptr<Snapshot> head_snapshot = nullptr;
     mutable std::shared_mutex snapshot_mutex;
 };
 

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -29,8 +29,10 @@
 #include <QRegularExpression>
 #include <QString>
 
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <unordered_map>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -43,7 +45,6 @@ class BaseVirtualMachine : public VirtualMachine
 public:
     BaseVirtualMachine(VirtualMachine::State state, const std::string& vm_name);
     BaseVirtualMachine(const std::string& vm_name);
-    ~BaseVirtualMachine(); // allow composing unique_ptr to fwd-declared Snapshots NOLINT(modernize-use-override)
 
     std::vector<std::string> get_all_ipv4(const SSHKeyProvider& key_provider) override;
     std::unique_ptr<MountHandler> make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
@@ -58,6 +59,7 @@ public:
                                                   const std::string& comment) override;
 
 protected:
+    using SnapshotMap = std::unordered_map<std::string, std::shared_ptr<Snapshot>>;
     SnapshotMap snapshots;
     Snapshot* head_snapshot = nullptr;
     std::shared_mutex snapshot_mutex; // TODO@snapshots will probably want this to be mutable

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -65,8 +65,8 @@ struct MockVirtualMachineT : public T
     MOCK_METHOD1(resize_disk, void(const MemorySize& new_size));
     MOCK_METHOD(std::unique_ptr<MountHandler>, make_native_mount_handler,
                 (const SSHKeyProvider* ssh_key_provider, const std::string& target, const VMMount& mount), (override));
-    MOCK_METHOD(const VirtualMachine::SnapshotMap&, get_snapshots, (), (const, override, noexcept));
-    MOCK_METHOD(VirtualMachine::LockingConstSnapshotRef, take_snapshot,
+    MOCK_METHOD(VirtualMachine::SnapshotVista, view_snapshots, (), (const, override, noexcept));
+    MOCK_METHOD(std::shared_ptr<const Snapshot>, take_snapshot,
                 (const VMSpecs& specs, const std::string& name, const std::string& comment), (override));
 };
 

--- a/tests/stub_snapshot.h
+++ b/tests/stub_snapshot.h
@@ -72,6 +72,18 @@ struct StubSnapshot : public Snapshot
         return metadata;
     }
 
+    void set_name(const std::string&) override
+    {
+    }
+
+    void set_comment(const std::string&) override
+    {
+    }
+
+    void set_parent(std::shared_ptr<const Snapshot>) override
+    {
+    }
+
     std::unordered_map<std::string, VMMount> mounts;
     QJsonObject metadata;
 };

--- a/tests/stub_snapshot.h
+++ b/tests/stub_snapshot.h
@@ -27,14 +27,14 @@ namespace multipass::test
 {
 struct StubSnapshot : public Snapshot
 {
-    const std::string& get_name() const noexcept override
+    std::string get_name() const noexcept override
     {
-        return name;
+        return {};
     }
 
-    const std::string& get_comment() const noexcept override
+    std::string get_comment() const noexcept override
     {
-        return comment;
+        return {};
     }
 
     const Snapshot* get_parent() const noexcept override
@@ -72,8 +72,6 @@ struct StubSnapshot : public Snapshot
         return metadata;
     }
 
-    std::string name{};
-    std::string comment{};
     std::unordered_map<std::string, VMMount> mounts;
     QJsonObject metadata;
 };

--- a/tests/stub_snapshot.h
+++ b/tests/stub_snapshot.h
@@ -37,7 +37,7 @@ struct StubSnapshot : public Snapshot
         return {};
     }
 
-    const Snapshot* get_parent() const noexcept override
+    std::shared_ptr<const Snapshot> get_parent() const noexcept override
     {
         return nullptr;
     }

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -123,8 +123,8 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
         return snapshots;
     }
 
-    LockingConstSnapshotRef take_snapshot(const VMSpecs& specs, const std::string& name,
-                                          const std::string& comment) override
+    std::shared_ptr<const Snapshot> take_snapshot(const VMSpecs& specs, const std::string& name,
+                                                  const std::string& comment) override
     {
         return {snapshot, std::shared_lock<std::shared_mutex>{}};
     }

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -118,7 +118,7 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
         return std::make_unique<StubMountHandler>();
     }
 
-    const SnapshotMap& get_snapshots() const noexcept override
+    SnapshotVista view_snapshots() const noexcept override
     {
         return snapshots;
     }

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -120,16 +120,15 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
 
     SnapshotVista view_snapshots() const noexcept override
     {
-        return snapshots;
+        return {};
     }
 
     std::shared_ptr<const Snapshot> take_snapshot(const VMSpecs& specs, const std::string& name,
                                                   const std::string& comment) override
     {
-        return {snapshot, std::shared_lock<std::shared_mutex>{}};
+        return {};
     }
 
-    SnapshotMap snapshots{};
     StubSnapshot snapshot;
 };
 } // namespace test


### PR DESCRIPTION
Share ownership of a VM's snapshots to avoid locking the VM's client. Lock only VM and Snapshot class's internal code.
