### PR TITLE
CI (workflows): bump actions version; fix node deprecation warning

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 2
 
@@ -81,13 +81,13 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Install Snapcraft
-      uses: samuelmeuli/action-snapcraft@v1
+      uses: samuelmeuli/action-snapcraft@v2
 
     - name: Install LXD
       uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # Need to fetch it all for submodules to work.
         fetch-depth: 0
@@ -200,7 +200,7 @@ jobs:
         echo "::set-output name=snap-file::$( ls *.snap )"
 
     - name: Upload the snap
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ matrix.build-type == 'Release' }}
       with:
         name: ${{ steps.build-snap.outputs.snap-file }}
@@ -224,12 +224,12 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Download the built snap
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ needs.BuildAndTest.outputs.snap-file }}
 
     - name: Install Snapcraft and log in
-      uses: samuelmeuli/action-snapcraft@v1
+      uses: samuelmeuli/action-snapcraft@v2
 
     - name: Publish the snap
       env:

--- a/.github/workflows/snaps.yml
+++ b/.github/workflows/snaps.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
## Changes

- Bump the `actions/checkout` version to `v3` (Node 16) from `v2` (Node 12).
- Bump `samuelmeuli/action-snapcraft` to `v2`.
- Bump the `actions/upload-artifact` version to `v3` (Node 16) from `v2` (Node 12).
- Bump the `actions/download-artifact` version to `v3` (Node 16) from `v2` (Node 12).
- Bump the `setup-python` version to `v4` (Node 16) from `v2` (Node 12).

This PR fixes the Node 12 deprecation warnings displayed under Annotations in Actions runs by bumping the actions to Node 16.