### PR TITLE
lxd native mount

### DIFF
--- a/include/multipass/id_mappings.h
+++ b/include/multipass/id_mappings.h
@@ -31,7 +31,7 @@ namespace mpl = multipass::logging;
 
 namespace multipass
 {
-typedef typename std::vector<std::pair<int, int>> id_mappings;
+using id_mappings = std::vector<std::pair<int, int>>;
 
 inline id_mappings unique_id_mappings(const id_mappings& xid_mappings)
 {

--- a/include/multipass/mount_handler.h
+++ b/include/multipass/mount_handler.h
@@ -42,19 +42,19 @@ public:
 
     virtual ~MountHandler() = default;
 
-    void start(ServerVariant server, std::chrono::milliseconds timeout = std::chrono::minutes(5))
+    void activate(ServerVariant server, std::chrono::milliseconds timeout = std::chrono::minutes(5))
     {
         std::lock_guard active_lock{active_mutex};
         if (!is_active())
-            start_impl(server, timeout);
+            activate_impl(server, timeout);
         active = true;
     }
 
-    void stop(bool force = false)
+    void deactivate(bool force = false)
     {
         std::lock_guard active_lock{active_mutex};
         if (is_active())
-            stop_impl(force);
+            deactivate_impl(force);
         active = false;
     }
 
@@ -88,8 +88,8 @@ protected:
             throw std::runtime_error(fmt::format("Mount source path \"{}\" is not readable.", source));
     };
 
-    virtual void start_impl(ServerVariant server, std::chrono::milliseconds timeout) = 0;
-    virtual void stop_impl(bool force) = 0;
+    virtual void activate_impl(ServerVariant server, std::chrono::milliseconds timeout) = 0;
+    virtual void deactivate_impl(bool force) = 0;
 
     template <typename Reply, typename Request>
     static Reply make_reply_from_server(grpc::ServerReaderWriterInterface<Reply, Request>*)

--- a/include/multipass/mount_handler.h
+++ b/include/multipass/mount_handler.h
@@ -72,9 +72,9 @@ public:
         return active;
     }
 
-    virtual bool is_sticky() // whether the mount sticks to the instance regardless of instance state (backend managed)
+    virtual bool is_mount_managed_by_backend()
     {
-        return true;
+        return false;
     }
 
 protected:

--- a/include/multipass/mount_handler.h
+++ b/include/multipass/mount_handler.h
@@ -63,6 +63,11 @@ public:
         return active;
     }
 
+    virtual bool can_stop()
+    {
+        return true;
+    }
+
 protected:
     MountHandler() = default;
     MountHandler(VirtualMachine* vm, const SSHKeyProvider* ssh_key_provider, const std::string& target,

--- a/include/multipass/mount_handler.h
+++ b/include/multipass/mount_handler.h
@@ -63,7 +63,7 @@ public:
         return active;
     }
 
-    virtual bool can_stop()
+    virtual bool is_sticky()
     {
         return true;
     }

--- a/include/multipass/mount_handler.h
+++ b/include/multipass/mount_handler.h
@@ -63,7 +63,7 @@ public:
         return active;
     }
 
-    virtual bool is_sticky()
+    virtual bool is_sticky() // whether the mount sticks to the instance regardless of instance state (backend managed)
     {
         return true;
     }

--- a/include/multipass/mount_handler.h
+++ b/include/multipass/mount_handler.h
@@ -35,6 +35,15 @@ using ServerVariant = std::variant<grpc::ServerReaderWriterInterface<StartReply,
                                    grpc::ServerReaderWriterInterface<MountReply, MountRequest>*,
                                    grpc::ServerReaderWriterInterface<RestartReply, RestartRequest>*>;
 
+class MountHandlerActivateException : public std::runtime_error
+{
+public:
+    MountHandlerActivateException(const std::string& vm_name)
+        : std::runtime_error(fmt::format("Please stop the instance {} before mount it natively.", vm_name))
+    {
+    }
+};
+
 class MountHandler : private DisabledCopyMove
 {
 public:

--- a/include/multipass/mount_handler.h
+++ b/include/multipass/mount_handler.h
@@ -35,10 +35,10 @@ using ServerVariant = std::variant<grpc::ServerReaderWriterInterface<StartReply,
                                    grpc::ServerReaderWriterInterface<MountReply, MountRequest>*,
                                    grpc::ServerReaderWriterInterface<RestartReply, RestartRequest>*>;
 
-class MountHandlerActivateException : public std::runtime_error
+class NativeMountNeedsStoppedVMException : public std::runtime_error
 {
 public:
-    MountHandlerActivateException(const std::string& vm_name)
+    NativeMountNeedsStoppedVMException(const std::string& vm_name)
         : std::runtime_error(fmt::format("Please stop the instance {} before attempting native mounts.", vm_name))
     {
     }

--- a/include/multipass/mount_handler.h
+++ b/include/multipass/mount_handler.h
@@ -39,7 +39,7 @@ class MountHandlerActivateException : public std::runtime_error
 {
 public:
     MountHandlerActivateException(const std::string& vm_name)
-        : std::runtime_error(fmt::format("Please stop the instance {} before mount it natively.", vm_name))
+        : std::runtime_error(fmt::format("Please stop the instance {} before attempting native mounts.", vm_name))
     {
     }
 };

--- a/include/multipass/sshfs_mount/sshfs_mount_handler.h
+++ b/include/multipass/sshfs_mount/sshfs_mount_handler.h
@@ -32,8 +32,8 @@ public:
                       const VMMount& mount);
     ~SSHFSMountHandler() override;
 
-    void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
-    void stop_impl(bool force) override;
+    void activate_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
+    void deactivate_impl(bool force) override;
     bool is_active() override;
 
 private:

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1881,7 +1881,7 @@ try // clang-format on
         {
             try
             {
-                vm_mounts[target_path]->start(server);
+                vm_mounts[target_path]->activate(server);
             }
             catch (const mp::SSHFSMissingError&)
             {
@@ -2248,7 +2248,7 @@ try // clang-format on
             const auto& [target, mount] = *expiring_it;
             try
             {
-                mount->stop();
+                mount->deactivate();
                 vm_spec_mounts.erase(target);
                 vm_mounts.erase(expiring_it);
             }
@@ -2914,7 +2914,7 @@ void mp::Daemon::stop_mounts(const std::string& name)
     {
         if (mount->is_sticky())
         {
-            mount->stop(/*force=*/true);
+            mount->deactivate(/*force=*/true);
         }
     }
 }
@@ -2975,7 +2975,7 @@ mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::string& name, con
                 {
                     if (mount->is_sticky())
                     {
-                        mount->start(server);
+                        mount->activate(server);
                     }
                 }
                 catch (const mp::SSHFSMissingError&)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1877,7 +1877,8 @@ try // clang-format on
 
         VMMount vm_mount{request->source_path(), gid_mappings, uid_mappings, mount_type};
         vm_mounts[target_path] = make_mount(vm.get(), target_path, vm_mount);
-        if (vm->current_state() == mp::VirtualMachine::State::running || vm_mounts[target_path]->is_mount_managed_by_backend())
+        if (vm->current_state() == mp::VirtualMachine::State::running ||
+            vm_mounts[target_path]->is_mount_managed_by_backend())
         {
             try
             {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2911,7 +2911,12 @@ void mp::Daemon::init_mounts(const std::string& name)
 void mp::Daemon::stop_mounts(const std::string& name)
 {
     for (auto& [_, mount] : mounts[name])
-        mount->stop(/*force=*/true);
+    {
+        if (mount->can_stop())
+        {
+            mount->stop(/*force=*/true);
+        }
+    }
 }
 
 mp::MountHandler::UPtr mp::Daemon::make_mount(VirtualMachine* vm, const std::string& target, const VMMount& mount)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1877,7 +1877,7 @@ try // clang-format on
 
         VMMount vm_mount{request->source_path(), gid_mappings, uid_mappings, mount_type};
         vm_mounts[target_path] = make_mount(vm.get(), target_path, vm_mount);
-        if (vm->current_state() == mp::VirtualMachine::State::running || !vm_mounts[target_path]->is_sticky())
+        if (vm->current_state() == mp::VirtualMachine::State::running || vm_mounts[target_path]->is_mount_managed_by_backend())
         {
             try
             {
@@ -2912,7 +2912,7 @@ void mp::Daemon::stop_mounts(const std::string& name)
 {
     for (auto& [_, mount] : mounts[name])
     {
-        if (mount->is_sticky())
+        if (!mount->is_mount_managed_by_backend())
         {
             mount->deactivate(/*force=*/true);
         }
@@ -2973,7 +2973,7 @@ mp::Daemon::async_wait_for_ssh_and_start_mounts_for(const std::string& name, con
             for (auto& [target, mount] : vm_mounts)
                 try
                 {
-                    if (mount->is_sticky())
+                    if (!mount->is_mount_managed_by_backend())
                     {
                         mount->activate(server);
                     }

--- a/src/platform/backends/lxd/CMakeLists.txt
+++ b/src/platform/backends/lxd/CMakeLists.txt
@@ -17,7 +17,8 @@ add_library(lxd_backend STATIC
   lxd_request.cpp
   lxd_virtual_machine.cpp
   lxd_virtual_machine_factory.cpp
-  lxd_vm_image_vault.cpp)
+  lxd_vm_image_vault.cpp
+  lxd_mount_handler.cpp)
 
 target_link_libraries(lxd_backend
   Qt5::Core

--- a/src/platform/backends/lxd/CMakeLists.txt
+++ b/src/platform/backends/lxd/CMakeLists.txt
@@ -14,11 +14,11 @@
 #
 
 add_library(lxd_backend STATIC
+  lxd_mount_handler.cpp
   lxd_request.cpp
   lxd_virtual_machine.cpp
   lxd_virtual_machine_factory.cpp
-  lxd_vm_image_vault.cpp
-  lxd_mount_handler.cpp)
+  lxd_vm_image_vault.cpp)
 
 target_link_libraries(lxd_backend
   Qt5::Core

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -94,7 +94,8 @@ void LXDMountHandler::lxd_device_add()
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
     QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
-    const std::string abs_target_path = std::filesystem::path{target}.is_relative() ? "/home/ubuntu/" + target : target;
+    const std::string abs_target_path =
+        std::filesystem::path{target}.is_relative() ? fmt::format("/home/{}/{}", vm->ssh_username(), target) : target;
     const QJsonObject new_device_object{
         {"path", abs_target_path.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
 

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -21,28 +21,30 @@
 namespace
 {
 constexpr std::string_view category = "lxd-mount-handler";
+constexpr int length_of_unique_id_without_prefix = 25;
+constexpr int timeout_millisecond = 300000;
 } // namespace
 
 namespace multipass
 {
-LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* vm,
+LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* lxd_virtual_machine,
                                  const SSHKeyProvider* ssh_key_provider, const std::string& target_path,
                                  const VMMount& mount)
-    : MountHandler{vm, ssh_key_provider, target_path, mount.source_path},
+    : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
       network_manager_{network_manager},
-      lxd_instance_endpoint{QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(vm->vm_name.c_str())},
+      lxd_instance_endpoint{QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(lxd_virtual_machine->vm_name.c_str())},
       // 27 (25 + 2(d_)) letters is the maximal deivce name length that lxd can accepte
-      device_name_{mp::utils::make_uuid(target_path).left(25).prepend("d_").toStdString()}
+      device_name_{mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
 {
-    const VirtualMachine::State state = vm->current_state();
+    const VirtualMachine::State state = lxd_virtual_machine->current_state();
     if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
     {
-        throw std::runtime_error("Please stop the instance " + vm->vm_name + " before mount it natively.");
+        throw std::runtime_error("Please stop the instance " + lxd_virtual_machine->vm_name + " before mount it natively.");
     }
 
-    std::lock_guard active_lock{active_mutex};
+    const std::lock_guard active_lock{active_mutex};
     mpl::log(mpl::Level::info, std::string(category),
-             fmt::format("initializing native mount {} => {} in '{}'", source, target, vm->vm_name));
+             fmt::format("initializing native mount {} => {} in '{}'", source, target, lxd_virtual_machine->vm_name));
     lxd_device_add();
 }
 
@@ -56,7 +58,7 @@ void LXDMountHandler::stop_impl(bool force)
 
 LXDMountHandler::~LXDMountHandler()
 {
-    std::lock_guard active_lock{active_mutex};
+    const std::lock_guard active_lock{active_mutex};
     mpl::log(mpl::Level::info, std::string(category),
              fmt::format("Stopping native mount \"{}\" in instance '{}'", target, vm->vm_name));
     lxd_device_remove();
@@ -72,7 +74,7 @@ void LXDMountHandler::lxd_device_remove()
     instance_info_metadata["devices"] = device_list;
 
     const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint, instance_info_metadata);
-    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, 300000);
+    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_millisecond);
 }
 
 void LXDMountHandler::lxd_device_add()
@@ -87,7 +89,7 @@ void LXDMountHandler::lxd_device_add()
     instance_info_metadata["devices"] = device_list;
 
     const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint, instance_info_metadata);
-    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, 300000);
+    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_millisecond);
 }
 
 } // namespace multipass

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -31,18 +31,18 @@ LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDV
                                  const SSHKeyProvider* ssh_key_provider, const std::string& target_path,
                                  const VMMount& mount)
     : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
-      network_manager_{network_manager},
-      lxd_instance_endpoint_{
+      network_manager{network_manager},
+      lxd_instance_endpoint{
           QString("%1/instances/%2").arg(lxd_socket_url.toString(), lxd_virtual_machine->vm_name.c_str())},
       // make_uuid is a seed based unique id generator, that makes the device_name reproducible if the seed
       // (target_path) is the same. If the seeds are different, then the generated ids are likely to be different as
       // well. 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept and d_ stands for device
       // name.
-      device_name_{mp::utils::make_uuid(target_path)
-                       .remove("-")
-                       .left(length_of_unique_id_without_prefix)
-                       .prepend("d_")
-                       .toStdString()}
+      device_name{mp::utils::make_uuid(target_path)
+                      .remove("-")
+                      .left(length_of_unique_id_without_prefix)
+                      .prepend("d_")
+                      .toStdString()}
 {
 }
 
@@ -77,31 +77,31 @@ LXDMountHandler::~LXDMountHandler() = default;
 
 void LXDMountHandler::lxd_device_remove()
 {
-    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
+    const QJsonObject instance_info = lxd_request(network_manager, "GET", lxd_instance_endpoint);
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
     QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
-    device_list.remove(device_name_.c_str());
+    device_list.remove(device_name.c_str());
     instance_info_metadata["devices"] = device_list;
     // TODO: make this put method If-Match pattern
-    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
-    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
+    const QJsonObject json_reply = lxd_request(network_manager, "PUT", lxd_instance_endpoint, instance_info_metadata);
+    lxd_wait(network_manager, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
 }
 
 void LXDMountHandler::lxd_device_add()
 {
-    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
+    const QJsonObject instance_info = lxd_request(network_manager, "GET", lxd_instance_endpoint);
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
     QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
     const QJsonObject new_device_object{{"path", target.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
 
-    device_list.insert(device_name_.c_str(), new_device_object);
+    device_list.insert(device_name.c_str(), new_device_object);
     instance_info_metadata["devices"] = device_list;
 
     // TODO: make this put method If-Match pattern
-    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
-    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
+    const QJsonObject json_reply = lxd_request(network_manager, "PUT", lxd_instance_endpoint, instance_info_metadata);
+    lxd_wait(network_manager, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
 }
 
 } // namespace multipass

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -40,7 +40,7 @@ LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDV
 {
 }
 
-void LXDMountHandler::start_impl(ServerVariant /**/, std::chrono::milliseconds /**/)
+void LXDMountHandler::activate_impl(ServerVariant /**/, std::chrono::milliseconds /**/)
 {
     const VirtualMachine::State state = vm->current_state();
     if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
@@ -53,7 +53,7 @@ void LXDMountHandler::start_impl(ServerVariant /**/, std::chrono::milliseconds /
     lxd_device_add();
 }
 
-void LXDMountHandler::stop_impl(bool /*force*/)
+void LXDMountHandler::deactivate_impl(bool /*force*/)
 {
     // throw it for now, it can be removed later once lxd fix the hot-unmount bug
     const VirtualMachine::State state = vm->current_state();

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -67,9 +67,7 @@ void LXDMountHandler::deactivate_impl(bool /*force*/)
     lxd_device_remove();
 }
 
-LXDMountHandler::~LXDMountHandler()
-{
-}
+LXDMountHandler::~LXDMountHandler() = default;
 
 void LXDMountHandler::lxd_device_remove()
 {

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -1,100 +1,102 @@
-/*
- * Copyright (C) Canonical, Ltd.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; version 3.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+    /*
+     * Copyright (C) Canonical, Ltd.
+     *
+     * This program is free software; you can redistribute it and/or modify
+     * it under the terms of the GNU General Public License as published by
+     * the Free Software Foundation; version 3.
+     *
+     * This program is distributed in the hope that it will be useful,
+     * but WITHOUT ANY WARRANTY; without even the implied warranty of
+     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     * GNU General Public License for more details.
+     *
+     * You should have received a copy of the GNU General Public License
+     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+     *
+     */
 
-#include "lxd_mount_handler.h"
-#include "lxd_request.h"
+    #include "lxd_mount_handler.h"
+    #include "lxd_request.h"
 
-namespace
-{
-constexpr std::string_view category = "lxd-mount-handler";
-constexpr int length_of_unique_id_without_prefix = 25;
-constexpr int timeout_milliseconds = 30000;
-} // namespace
-
-namespace multipass
-{
-LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* lxd_virtual_machine,
-                                 const SSHKeyProvider* ssh_key_provider, const std::string& target_path,
-                                 const VMMount& mount)
-    : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
-      network_manager_{network_manager},
-      lxd_instance_endpoint_{
-          QString("%1/instances/%2").arg(lxd_socket_url.toString(), lxd_virtual_machine->vm_name.c_str())},
-      // 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept
-      device_name_{
-          mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
-{
-}
-
-void LXDMountHandler::activate_impl(ServerVariant /**/, std::chrono::milliseconds /**/)
-{
-    const VirtualMachine::State state = vm->current_state();
-    if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
+    namespace
     {
-        throw mp::MountHandlerActivateException(vm->vm_name);
+    constexpr std::string_view category = "lxd-mount-handler";
+    constexpr int length_of_unique_id_without_prefix = 25;
+    constexpr int timeout_milliseconds = 30000;
+    } // namespace
+
+    namespace multipass
+    {
+    LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* lxd_virtual_machine,
+                                     const SSHKeyProvider* ssh_key_provider, const std::string& target_path,
+                                     const VMMount& mount)
+        : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
+          network_manager_{network_manager},
+          lxd_instance_endpoint_{
+              QString("%1/instances/%2").arg(lxd_socket_url.toString(), lxd_virtual_machine->vm_name.c_str())},
+          // make_uuid is a seed based unique id generator, that makes the device_name reproducible if the seed
+          // (target_path) is the same. If the seeds are different, then the generated ids are likely to be different as
+          // well. 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept
+          device_name_{
+              mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
+    {
     }
 
-    mpl::log(mpl::Level::info, std::string(category),
-             fmt::format("initializing native mount {} => {} in '{}'", source, target, vm->vm_name));
-    lxd_device_add();
-}
-
-void LXDMountHandler::deactivate_impl(bool /*force*/)
-{
-    // throw it for now, it can be removed later once lxd fix the hot-unmount bug
-    const VirtualMachine::State state = vm->current_state();
-    if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
+    void LXDMountHandler::activate_impl(ServerVariant /**/, std::chrono::milliseconds /**/)
     {
-        throw std::runtime_error("Please stop the instance " + vm->vm_name + " before unmount it natively.");
+        const VirtualMachine::State state = vm->current_state();
+        if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
+        {
+            throw mp::MountHandlerActivateException(vm->vm_name);
+        }
+
+        mpl::log(mpl::Level::info, std::string(category),
+                 fmt::format("initializing native mount {} => {} in '{}'", source, target, vm->vm_name));
+        lxd_device_add();
     }
 
-    mpl::log(mpl::Level::info, std::string(category),
-             fmt::format("Stopping native mount \"{}\" in instance '{}'", target, vm->vm_name));
-    lxd_device_remove();
-}
+    void LXDMountHandler::deactivate_impl(bool /*force*/)
+    {
+        // TODO: remove the throwing and adjust the unit tests once lxd fix the hot-unmount bug
+        const VirtualMachine::State state = vm->current_state();
+        if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
+        {
+            throw std::runtime_error("Please stop the instance " + vm->vm_name + " before unmount it natively.");
+        }
 
-LXDMountHandler::~LXDMountHandler() = default;
+        mpl::log(mpl::Level::info, std::string(category),
+                 fmt::format("Stopping native mount \"{}\" in instance '{}'", target, vm->vm_name));
+        lxd_device_remove();
+    }
 
-void LXDMountHandler::lxd_device_remove()
-{
-    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
-    QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
-    QJsonObject device_list = instance_info_metadata["devices"].toObject();
+    LXDMountHandler::~LXDMountHandler() = default;
 
-    device_list.remove(device_name_.c_str());
-    instance_info_metadata["devices"] = device_list;
+    void LXDMountHandler::lxd_device_remove()
+    {
+        const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
+        QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
+        QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
-    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
-    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
-}
+        device_list.remove(device_name_.c_str());
+        instance_info_metadata["devices"] = device_list;
 
-void LXDMountHandler::lxd_device_add()
-{
-    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
-    QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
-    QJsonObject device_list = instance_info_metadata["devices"].toObject();
+        const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
+        lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
+    }
 
-    const QJsonObject new_device_object{{"path", target.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
+    void LXDMountHandler::lxd_device_add()
+    {
+        const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
+        QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
+        QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
-    device_list.insert(device_name_.c_str(), new_device_object);
-    instance_info_metadata["devices"] = device_list;
+        const QJsonObject new_device_object{{"path", target.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
 
-    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
-    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
-}
+        device_list.insert(device_name_.c_str(), new_device_object);
+        instance_info_metadata["devices"] = device_list;
 
-} // namespace multipass
+        const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
+        lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
+    }
+
+    } // namespace multipass

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -94,7 +94,9 @@ void LXDMountHandler::lxd_device_add()
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
     QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
-    const QJsonObject new_device_object{{"path", target.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
+    const std::string abs_target_path = std::filesystem::path{target}.is_relative() ? "/home/ubuntu/" + target : target;
+    const QJsonObject new_device_object{
+        {"path", abs_target_path.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
 
     device_list.insert(device_name.c_str(), new_device_object);
     instance_info_metadata["devices"] = device_list;

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -1,102 +1,102 @@
-    /*
-     * Copyright (C) Canonical, Ltd.
-     *
-     * This program is free software; you can redistribute it and/or modify
-     * it under the terms of the GNU General Public License as published by
-     * the Free Software Foundation; version 3.
-     *
-     * This program is distributed in the hope that it will be useful,
-     * but WITHOUT ANY WARRANTY; without even the implied warranty of
-     * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-     * GNU General Public License for more details.
-     *
-     * You should have received a copy of the GNU General Public License
-     * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-     *
-     */
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-    #include "lxd_mount_handler.h"
-    #include "lxd_request.h"
+#include "lxd_mount_handler.h"
+#include "lxd_request.h"
 
-    namespace
-    {
-    constexpr std::string_view category = "lxd-mount-handler";
-    constexpr int length_of_unique_id_without_prefix = 25;
-    constexpr int timeout_milliseconds = 30000;
-    } // namespace
+namespace
+{
+constexpr std::string_view category = "lxd-mount-handler";
+constexpr int length_of_unique_id_without_prefix = 25;
+constexpr int timeout_milliseconds = 30000;
+} // namespace
 
-    namespace multipass
+namespace multipass
+{
+LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* lxd_virtual_machine,
+                                 const SSHKeyProvider* ssh_key_provider, const std::string& target_path,
+                                 const VMMount& mount)
+    : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
+      network_manager_{network_manager},
+      lxd_instance_endpoint_{
+          QString("%1/instances/%2").arg(lxd_socket_url.toString(), lxd_virtual_machine->vm_name.c_str())},
+      // make_uuid is a seed based unique id generator, that makes the device_name reproducible if the seed
+      // (target_path) is the same. If the seeds are different, then the generated ids are likely to be different as
+      // well. 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept
+      device_name_{
+          mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
+{
+}
+
+void LXDMountHandler::activate_impl(ServerVariant /**/, std::chrono::milliseconds /**/)
+{
+    const VirtualMachine::State state = vm->current_state();
+    if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
     {
-    LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* lxd_virtual_machine,
-                                     const SSHKeyProvider* ssh_key_provider, const std::string& target_path,
-                                     const VMMount& mount)
-        : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
-          network_manager_{network_manager},
-          lxd_instance_endpoint_{
-              QString("%1/instances/%2").arg(lxd_socket_url.toString(), lxd_virtual_machine->vm_name.c_str())},
-          // make_uuid is a seed based unique id generator, that makes the device_name reproducible if the seed
-          // (target_path) is the same. If the seeds are different, then the generated ids are likely to be different as
-          // well. 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept
-          device_name_{
-              mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
-    {
+        throw mp::MountHandlerActivateException(vm->vm_name);
     }
 
-    void LXDMountHandler::activate_impl(ServerVariant /**/, std::chrono::milliseconds /**/)
-    {
-        const VirtualMachine::State state = vm->current_state();
-        if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
-        {
-            throw mp::MountHandlerActivateException(vm->vm_name);
-        }
+    mpl::log(mpl::Level::info, std::string(category),
+             fmt::format("initializing native mount {} => {} in '{}'", source, target, vm->vm_name));
+    lxd_device_add();
+}
 
-        mpl::log(mpl::Level::info, std::string(category),
-                 fmt::format("initializing native mount {} => {} in '{}'", source, target, vm->vm_name));
-        lxd_device_add();
+void LXDMountHandler::deactivate_impl(bool /*force*/)
+{
+    // TODO: remove the throwing and adjust the unit tests once lxd fix the hot-unmount bug
+    const VirtualMachine::State state = vm->current_state();
+    if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
+    {
+        throw std::runtime_error("Please stop the instance " + vm->vm_name + " before unmount it natively.");
     }
 
-    void LXDMountHandler::deactivate_impl(bool /*force*/)
-    {
-        // TODO: remove the throwing and adjust the unit tests once lxd fix the hot-unmount bug
-        const VirtualMachine::State state = vm->current_state();
-        if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
-        {
-            throw std::runtime_error("Please stop the instance " + vm->vm_name + " before unmount it natively.");
-        }
+    mpl::log(mpl::Level::info, std::string(category),
+             fmt::format("Stopping native mount \"{}\" in instance '{}'", target, vm->vm_name));
+    lxd_device_remove();
+}
 
-        mpl::log(mpl::Level::info, std::string(category),
-                 fmt::format("Stopping native mount \"{}\" in instance '{}'", target, vm->vm_name));
-        lxd_device_remove();
-    }
+LXDMountHandler::~LXDMountHandler() = default;
 
-    LXDMountHandler::~LXDMountHandler() = default;
+void LXDMountHandler::lxd_device_remove()
+{
+    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
+    QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
+    QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
-    void LXDMountHandler::lxd_device_remove()
-    {
-        const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
-        QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
-        QJsonObject device_list = instance_info_metadata["devices"].toObject();
+    device_list.remove(device_name_.c_str());
+    instance_info_metadata["devices"] = device_list;
 
-        device_list.remove(device_name_.c_str());
-        instance_info_metadata["devices"] = device_list;
+    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
+    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
+}
 
-        const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
-        lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
-    }
+void LXDMountHandler::lxd_device_add()
+{
+    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
+    QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
+    QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
-    void LXDMountHandler::lxd_device_add()
-    {
-        const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
-        QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
-        QJsonObject device_list = instance_info_metadata["devices"].toObject();
+    const QJsonObject new_device_object{{"path", target.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
 
-        const QJsonObject new_device_object{{"path", target.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
+    device_list.insert(device_name_.c_str(), new_device_object);
+    instance_info_metadata["devices"] = device_list;
 
-        device_list.insert(device_name_.c_str(), new_device_object);
-        instance_info_metadata["devices"] = device_list;
+    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
+    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
+}
 
-        const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
-        lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
-    }
-
-    } // namespace multipass
+} // namespace multipass

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -36,9 +36,13 @@ LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDV
           QString("%1/instances/%2").arg(lxd_socket_url.toString(), lxd_virtual_machine->vm_name.c_str())},
       // make_uuid is a seed based unique id generator, that makes the device_name reproducible if the seed
       // (target_path) is the same. If the seeds are different, then the generated ids are likely to be different as
-      // well. 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept
-      device_name_{
-          mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
+      // well. 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept and d_ stands for device
+      // name.
+      device_name_{mp::utils::make_uuid(target_path)
+                       .remove("-")
+                       .left(length_of_unique_id_without_prefix)
+                       .prepend("d_")
+                       .toStdString()}
 {
 }
 

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -83,7 +83,7 @@ void LXDMountHandler::lxd_device_remove()
 
     device_list.remove(device_name_.c_str());
     instance_info_metadata["devices"] = device_list;
-
+    // TODO: make this put method If-Match pattern
     const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
     lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
 }
@@ -99,6 +99,7 @@ void LXDMountHandler::lxd_device_add()
     device_list.insert(device_name_.c_str(), new_device_object);
     instance_info_metadata["devices"] = device_list;
 
+    // TODO: make this put method If-Match pattern
     const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
     lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
 }

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -45,7 +45,7 @@ void LXDMountHandler::activate_impl(ServerVariant /**/, std::chrono::millisecond
     const VirtualMachine::State state = vm->current_state();
     if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
     {
-        throw std::runtime_error("Please stop the instance " + vm->vm_name + " before mount it natively.");
+        throw mp::MountHandlerActivateException(vm->vm_name);
     }
 
     mpl::log(mpl::Level::info, std::string(category),

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -33,7 +33,7 @@ LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDV
     : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
       network_manager_{network_manager},
       lxd_instance_endpoint_{
-          QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(lxd_virtual_machine->vm_name.c_str())},
+          QString("%1/instances/%2").arg(lxd_socket_url.toString(), lxd_virtual_machine->vm_name.c_str())},
       // 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept
       device_name_{
           mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -22,7 +22,7 @@ namespace
 {
 constexpr std::string_view category = "lxd-mount-handler";
 constexpr int length_of_unique_id_without_prefix = 25;
-constexpr int timeout_millisecond = 300000;
+constexpr int timeout_milliseconds = 30000;
 } // namespace
 
 namespace multipass
@@ -34,7 +34,7 @@ LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDV
       network_manager_{network_manager},
       lxd_instance_endpoint_{
           QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(lxd_virtual_machine->vm_name.c_str())},
-      // 27 (25 + 2(d_)) letters is the maximal deivce name length that lxd can accepte
+      // 27 (25 + 2(d_)) letters is the maximum device name length that LXD can accept
       device_name_{
           mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
 {
@@ -79,7 +79,7 @@ void LXDMountHandler::lxd_device_remove()
     instance_info_metadata["devices"] = device_list;
 
     const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
-    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_millisecond);
+    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
 }
 
 void LXDMountHandler::lxd_device_add()
@@ -94,7 +94,7 @@ void LXDMountHandler::lxd_device_add()
     instance_info_metadata["devices"] = device_list;
 
     const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
-    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_millisecond);
+    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_milliseconds);
 }
 
 } // namespace multipass

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -33,8 +33,7 @@ LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDV
                                  const VMMount& mount)
     : MountHandler{vm, ssh_key_provider, target, mount.source_path},
       network_manager_{network_manager},
-      lxd_instance_endpoint_new_(
-          QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(vm->vm_name.c_str()))
+      lxd_instance_endpoint_new_(QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(vm->vm_name.c_str()))
 {
     const VirtualMachine::State state = vm->current_state();
     if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -32,14 +32,17 @@ LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDV
                                  const VMMount& mount)
     : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
       network_manager_{network_manager},
-      lxd_instance_endpoint{QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(lxd_virtual_machine->vm_name.c_str())},
+      lxd_instance_endpoint{
+          QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(lxd_virtual_machine->vm_name.c_str())},
       // 27 (25 + 2(d_)) letters is the maximal deivce name length that lxd can accepte
-      device_name_{mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
+      device_name_{
+          mp::utils::make_uuid(target_path).left(length_of_unique_id_without_prefix).prepend("d_").toStdString()}
 {
     const VirtualMachine::State state = lxd_virtual_machine->current_state();
     if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
     {
-        throw std::runtime_error("Please stop the instance " + lxd_virtual_machine->vm_name + " before mount it natively.");
+        throw std::runtime_error("Please stop the instance " + lxd_virtual_machine->vm_name +
+                                 " before mount it natively.");
     }
 
     const std::lock_guard active_lock{active_mutex};

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -32,7 +32,7 @@ LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDV
                                  const VMMount& mount)
     : MountHandler{lxd_virtual_machine, ssh_key_provider, target_path, mount.source_path},
       network_manager_{network_manager},
-      lxd_instance_endpoint{
+      lxd_instance_endpoint_{
           QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(lxd_virtual_machine->vm_name.c_str())},
       // 27 (25 + 2(d_)) letters is the maximal deivce name length that lxd can accepte
       device_name_{
@@ -69,20 +69,20 @@ LXDMountHandler::~LXDMountHandler()
 
 void LXDMountHandler::lxd_device_remove()
 {
-    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint);
+    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
     QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
     device_list.remove(device_name_.c_str());
     instance_info_metadata["devices"] = device_list;
 
-    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint, instance_info_metadata);
+    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
     lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_millisecond);
 }
 
 void LXDMountHandler::lxd_device_add()
 {
-    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint);
+    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_);
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
     QJsonObject device_list = instance_info_metadata["devices"].toObject();
 
@@ -91,7 +91,7 @@ void LXDMountHandler::lxd_device_add()
     device_list.insert(device_name_.c_str(), new_device_object);
     instance_info_metadata["devices"] = device_list;
 
-    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint, instance_info_metadata);
+    const QJsonObject json_reply = lxd_request(network_manager_, "PUT", lxd_instance_endpoint_, instance_info_metadata);
     lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, timeout_millisecond);
 }
 

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -51,7 +51,7 @@ void LXDMountHandler::activate_impl(ServerVariant /**/, std::chrono::millisecond
     const VirtualMachine::State state = vm->current_state();
     if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
     {
-        throw mp::MountHandlerActivateException(vm->vm_name);
+        throw mp::NativeMountNeedsStoppedVMException(vm->vm_name);
     }
 
     mpl::log(mpl::Level::info, std::string(category),

--- a/src/platform/backends/lxd/lxd_mount_handler.cpp
+++ b/src/platform/backends/lxd/lxd_mount_handler.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "lxd_mount_handler.h"
+#include "lxd_request.h"
+
+// namespace mpl = multipass::logging;
+// namespace mpu = multipass::utils;
+
+namespace
+{
+// constexpr std::string_view category = "lxd-mount-handler";
+} // namespace
+
+namespace multipass
+{
+LXDMountHandler::LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* vm,
+                                 const SSHKeyProvider* ssh_key_provider, const std::string& target,
+                                 const VMMount& mount)
+    : MountHandler{vm, ssh_key_provider, target, mount.source_path},
+      network_manager_{network_manager},
+      lxd_instance_endpoint_new_(
+          QString("%1/instances/%2").arg(lxd_socket_url.toString()).arg(vm->vm_name.c_str()))
+{
+    const VirtualMachine::State state = vm->current_state();
+    if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
+    {
+        throw std::runtime_error("Please stop the instance " + vm->vm_name + " before mount it natively.");
+    }
+
+    std::lock_guard active_lock{active_mutex};
+    lxd_device_add();
+}
+
+void LXDMountHandler::start_impl(ServerVariant /**/, std::chrono::milliseconds /**/)
+{
+}
+
+void LXDMountHandler::stop_impl(bool force)
+{
+}
+
+LXDMountHandler::~LXDMountHandler()
+{
+    vm->stop();
+    std::lock_guard active_lock{active_mutex};
+    lxd_device_remove();
+}
+
+void LXDMountHandler::lxd_device_remove()
+{
+    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_new_);
+    QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
+    QJsonObject device_list = instance_info_metadata["devices"].toObject();
+
+    // mydisk is the hard coded name for now, it will be replaced by proper generated later
+    device_list.remove("mydisk");
+    instance_info_metadata["devices"] = device_list;
+
+    const QJsonObject json_reply =
+        lxd_request(network_manager_, "PUT", lxd_instance_endpoint_new_, instance_info_metadata);
+    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, 300000);
+}
+
+void LXDMountHandler::lxd_device_add()
+{
+    const QJsonObject instance_info = lxd_request(network_manager_, "GET", lxd_instance_endpoint_new_);
+    QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
+    QJsonObject device_list = instance_info_metadata["devices"].toObject();
+
+    const QJsonObject new_device_object{{"path", target.c_str()}, {"source", source.c_str()}, {"type", "disk"}};
+
+    // mydisk is the hard coded name for now, it will be replaced by proper generated later
+    device_list.insert("mydisk", new_device_object);
+    instance_info_metadata["devices"] = device_list;
+
+    const QJsonObject json_reply =
+        lxd_request(network_manager_, "PUT", lxd_instance_endpoint_new_, instance_info_metadata);
+    lxd_wait(network_manager_, multipass::lxd_socket_url, json_reply, 300000);
+}
+
+} // namespace multipass

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -26,14 +26,14 @@ namespace multipass
 class LXDMountHandler : public MountHandler
 {
 public:
-    LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* vm,
+    LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* lxd_virtual_machine,
                     const SSHKeyProvider* ssh_key_provider, const std::string& target_path, const VMMount& mount);
     ~LXDMountHandler() override;
 
     void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
     void stop_impl(bool force) override;
 
-    bool can_stop() override
+    bool is_sticky() override
     {
         return false;
     }

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -30,8 +30,8 @@ public:
                     const SSHKeyProvider* ssh_key_provider, const std::string& target_path, const VMMount& mount);
     ~LXDMountHandler() override;
 
-    void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
-    void stop_impl(bool force) override;
+    void activate_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
+    void deactivate_impl(bool force) override;
 
     bool is_sticky() override
     {

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -29,7 +29,7 @@ class LXDMountHandler : public MountHandler
 {
 public:
     LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* vm,
-                    const SSHKeyProvider* ssh_key_provider, const std::string& target, const VMMount& mount);
+                    const SSHKeyProvider* ssh_key_provider, const std::string& target_path, const VMMount& mount);
     ~LXDMountHandler() override;
 
     void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
@@ -41,7 +41,8 @@ private:
 
     // data memeber
     mp::NetworkAccessManager* network_manager_{nullptr};
-    const QUrl lxd_instance_endpoint_new_{};
+    const QUrl lxd_instance_endpoint{};
+    const std::string device_name_{};
 };
 
 } // namespace multipass

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -33,6 +33,11 @@ public:
     void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
     void stop_impl(bool force) override;
 
+    bool can_stop() override
+    {
+        return false;
+    }
+
 private:
     void lxd_device_add();
     void lxd_device_remove();

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_LXD_MOUNT_HANDLER_H
+#define MULTIPASS_LXD_MOUNT_HANDLER_H
+
+#include "lxd_virtual_machine.h"
+#include "multipass/mount_handler.h"
+
+class LXDVirtualMachine;
+
+namespace multipass
+{
+class LXDMountHandler : public MountHandler
+{
+public:
+    LXDMountHandler(mp::NetworkAccessManager* network_manager, LXDVirtualMachine* vm,
+                    const SSHKeyProvider* ssh_key_provider, const std::string& target, const VMMount& mount);
+    ~LXDMountHandler() override;
+
+    void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
+    void stop_impl(bool force) override;
+
+private:
+    void lxd_device_add();
+    void lxd_device_remove();
+
+    // data memeber
+    mp::NetworkAccessManager* network_manager_{nullptr};
+    const QUrl lxd_instance_endpoint_new_{};
+};
+
+} // namespace multipass
+#endif // MULTIPASS_LXD_MOUNT_HANDLER_H

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -21,8 +21,6 @@
 #include "lxd_virtual_machine.h"
 #include "multipass/mount_handler.h"
 
-class LXDVirtualMachine;
-
 namespace multipass
 {
 class LXDMountHandler : public MountHandler
@@ -41,7 +39,7 @@ private:
 
     // data memeber
     mp::NetworkAccessManager* network_manager_{nullptr};
-    const QUrl lxd_instance_endpoint{};
+    const QUrl lxd_instance_endpoint_{};
     const std::string device_name_{};
 };
 

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -33,9 +33,9 @@ public:
     void activate_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
     void deactivate_impl(bool force) override;
 
-    bool is_sticky() override
+    bool is_mount_managed_by_backend() override
     {
-        return false;
+        return true;
     }
 
 private:

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -42,7 +42,7 @@ private:
     void lxd_device_add();
     void lxd_device_remove();
 
-    // data memeber
+    // data member
     mp::NetworkAccessManager* network_manager_{nullptr};
     const QUrl lxd_instance_endpoint_{};
     const std::string device_name_{};

--- a/src/platform/backends/lxd/lxd_mount_handler.h
+++ b/src/platform/backends/lxd/lxd_mount_handler.h
@@ -43,9 +43,9 @@ private:
     void lxd_device_remove();
 
     // data member
-    mp::NetworkAccessManager* network_manager_{nullptr};
-    const QUrl lxd_instance_endpoint_{};
-    const std::string device_name_{};
+    mp::NetworkAccessManager* network_manager{nullptr};
+    const QUrl lxd_instance_endpoint{};
+    const std::string device_name{};
 };
 
 } // namespace multipass

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -465,5 +465,10 @@ std::unique_ptr<multipass::MountHandler>
 mp::LXDVirtualMachine::make_native_mount_handler(const SSHKeyProvider* ssh_key_provider, const std::string& target,
                                                  const VMMount& mount)
 {
+    if (!mount.gid_mappings.empty() || !mount.uid_mappings.empty())
+    {
+        throw std::runtime_error("lxd native mount does not accept gid or uid.");
+    }
+
     return std::make_unique<LXDMountHandler>(manager, this, ssh_key_provider, target, mount);
 }

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -16,8 +16,8 @@
  */
 
 #include "lxd_virtual_machine.h"
-#include "lxd_request.h"
 #include "lxd_mount_handler.h"
+#include "lxd_request.h"
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -461,8 +461,9 @@ void mp::LXDVirtualMachine::resize_disk(const MemorySize& new_size)
     lxd_request(manager, "PATCH", url(), patch_json);
 }
 
-std::unique_ptr<multipass::MountHandler>  mp::LXDVirtualMachine::make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
-                                                        const std::string& target, const VMMount& mount)
+std::unique_ptr<multipass::MountHandler>
+mp::LXDVirtualMachine::make_native_mount_handler(const SSHKeyProvider* ssh_key_provider, const std::string& target,
+                                                 const VMMount& mount)
 {
     return std::make_unique<LXDMountHandler>(manager, this, ssh_key_provider, target, mount);
 }

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -477,7 +477,7 @@ mp::LXDVirtualMachine::make_native_mount_handler(const SSHKeyProvider* ssh_key_p
 {
     if (!is_default_Gid_Uid(mount))
     {
-        throw std::runtime_error("LXD native mount does not accept user provided gid or uid.");
+        throw std::runtime_error("LXD native mount does not accept custom gid or uid.");
     }
 
     return std::make_unique<LXDMountHandler>(manager, this, ssh_key_provider, target, mount);

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -17,6 +17,7 @@
 
 #include "lxd_virtual_machine.h"
 #include "lxd_request.h"
+#include "lxd_mount_handler.h"
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -458,4 +459,10 @@ void mp::LXDVirtualMachine::resize_disk(const MemorySize& new_size)
         {"path", "/"}, {"pool", storage_pool}, {"size", QString::number(new_size.in_bytes())}, {"type", "disk"}};
     QJsonObject patch_json{{"devices", QJsonObject{{"root", root_json}}}};
     lxd_request(manager, "PATCH", url(), patch_json);
+}
+
+std::unique_ptr<multipass::MountHandler>  mp::LXDVirtualMachine::make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
+                                                        const std::string& target, const VMMount& mount)
+{
+    return std::make_unique<LXDMountHandler>(manager, this, ssh_key_provider, target, mount);
 }

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -159,9 +159,9 @@ bool is_default_Gid_Uid(const multipass::VMMount& mount)
     const auto& gid_mappings = mount.gid_mappings;
     const auto& uid_mappings = mount.uid_mappings;
 
-    // -1 is the default value for gid and uid, user specified
-    return gid_mappings.size() == 1 && gid_mappings.front().second == -1 &&
-           uid_mappings.size() == 1 && uid_mappings.front().second == -1;
+    // -1 is the default value for gid and uid
+    return gid_mappings.size() == 1 && gid_mappings.front().second == -1 && uid_mappings.size() == 1 &&
+           uid_mappings.front().second == -1;
 }
 
 } // namespace

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -154,7 +154,7 @@ QJsonObject generate_devices_config(const multipass::VirtualMachineDescription& 
     return devices;
 }
 
-bool is_default_Gid_Uid(const multipass::VMMount& mount)
+bool uses_default_id_mappings(const multipass::VMMount& mount)
 {
     const auto& gid_mappings = mount.gid_mappings;
     const auto& uid_mappings = mount.uid_mappings;
@@ -475,7 +475,7 @@ std::unique_ptr<multipass::MountHandler>
 mp::LXDVirtualMachine::make_native_mount_handler(const SSHKeyProvider* ssh_key_provider, const std::string& target,
                                                  const VMMount& mount)
 {
-    if (!is_default_Gid_Uid(mount))
+    if (!uses_default_id_mappings(mount))
     {
         throw std::runtime_error("LXD native mount does not accept custom ID mappings.");
     }

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -477,7 +477,7 @@ mp::LXDVirtualMachine::make_native_mount_handler(const SSHKeyProvider* ssh_key_p
 {
     if (!is_default_Gid_Uid(mount))
     {
-        throw std::runtime_error("LXD native mount does not accept custom gid or uid.");
+        throw std::runtime_error("LXD native mount does not accept custom ID mappings.");
     }
 
     return std::make_unique<LXDMountHandler>(manager, this, ssh_key_provider, target, mount);

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -55,6 +55,7 @@ public:
     void resize_disk(const MemorySize& new_size) override;
     std::unique_ptr<MountHandler> make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
                                                             const std::string& target, const VMMount& mount) override;
+
 private:
     const QString name;
     const std::string username;

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -30,7 +30,7 @@ class NetworkAccessManager;
 class VirtualMachineDescription;
 class VMStatusMonitor;
 
-class LXDVirtualMachine final : public BaseVirtualMachine
+class LXDVirtualMachine : public BaseVirtualMachine
 {
 public:
     LXDVirtualMachine(const VirtualMachineDescription& desc, VMStatusMonitor& monitor, NetworkAccessManager* manager,

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -53,7 +53,8 @@ public:
     void update_cpus(int num_cores) override;
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
-
+    std::unique_ptr<MountHandler> make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
+                                                            const std::string& target, const VMMount& mount) override;
 private:
     const QString name;
     const std::string username;

--- a/src/platform/backends/qemu/qemu_mount_handler.cpp
+++ b/src/platform/backends/qemu/qemu_mount_handler.cpp
@@ -81,7 +81,7 @@ catch (const std::exception& e)
     return false;
 }
 
-void QemuMountHandler::start_impl(ServerVariant, std::chrono::milliseconds)
+void QemuMountHandler::activate_impl(ServerVariant, std::chrono::milliseconds)
 {
     SSHSession session{vm->ssh_hostname(), vm->ssh_port(), vm->ssh_username(), *ssh_key_provider};
 
@@ -104,7 +104,7 @@ void QemuMountHandler::start_impl(ServerVariant, std::chrono::milliseconds)
         session, fmt::format("sudo mount -t 9p {} {} -o trans=virtio,version=9p2000.L,msize=536870912", tag, target));
 }
 
-void QemuMountHandler::stop_impl(bool force)
+void QemuMountHandler::deactivate_impl(bool force)
 try
 {
     mpl::log(mpl::Level::info, category,
@@ -122,7 +122,7 @@ catch (const std::exception& e)
 
 QemuMountHandler::~QemuMountHandler()
 {
-    stop(/*force=*/true);
+    deactivate(/*force=*/true);
     vm_mount_args.erase(tag);
 }
 } // namespace multipass

--- a/src/platform/backends/qemu/qemu_mount_handler.cpp
+++ b/src/platform/backends/qemu/qemu_mount_handler.cpp
@@ -48,7 +48,9 @@ QemuMountHandler::QemuMountHandler(QemuVirtualMachine* vm, const SSHKeyProvider*
     }
 
     if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
-        throw std::runtime_error("Please shutdown the instance before attempting native mounts.");
+    {
+        throw mp::MountHandlerActivateException(vm->vm_name);
+    }
 
     // Need to ensure no more than one uid/gid map is passed in here.
     if (mount.uid_mappings.size() > 1 || mount.gid_mappings.size() > 1)

--- a/src/platform/backends/qemu/qemu_mount_handler.cpp
+++ b/src/platform/backends/qemu/qemu_mount_handler.cpp
@@ -49,7 +49,7 @@ QemuMountHandler::QemuMountHandler(QemuVirtualMachine* vm, const SSHKeyProvider*
 
     if (state != VirtualMachine::State::off && state != VirtualMachine::State::stopped)
     {
-        throw mp::MountHandlerActivateException(vm->vm_name);
+        throw mp::NativeMountNeedsStoppedVMException(vm->vm_name);
     }
 
     // Need to ensure no more than one uid/gid map is passed in here.

--- a/src/platform/backends/qemu/qemu_mount_handler.h
+++ b/src/platform/backends/qemu/qemu_mount_handler.h
@@ -31,8 +31,8 @@ public:
                      const VMMount& mount);
     ~QemuMountHandler() override;
 
-    void start_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
-    void stop_impl(bool force) override;
+    void activate_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
+    void deactivate_impl(bool force) override;
     bool is_active() override;
 
 private:

--- a/src/sshfs_mount/sshfs_mount_handler.cpp
+++ b/src/sshfs_mount/sshfs_mount_handler.cpp
@@ -144,7 +144,7 @@ catch (const std::exception& e)
     return false;
 }
 
-void SSHFSMountHandler::start_impl(ServerVariant server, std::chrono::milliseconds timeout)
+void SSHFSMountHandler::activate_impl(ServerVariant server, std::chrono::milliseconds timeout)
 {
     SSHSession session{vm->ssh_hostname(), vm->ssh_port(), vm->ssh_username(), *ssh_key_provider};
     if (!has_sshfs(vm->vm_name, session))
@@ -209,7 +209,7 @@ void SSHFSMountHandler::start_impl(ServerVariant server, std::chrono::millisecon
             fmt::format("{}: {}", process_state.failure_message(), process->read_all_standard_error()));
 }
 
-void SSHFSMountHandler::stop_impl(bool force)
+void SSHFSMountHandler::deactivate_impl(bool force)
 {
     mpl::log(mpl::Level::info, category, fmt::format("Stopping mount \"{}\" in instance '{}'", target, vm->vm_name));
     QObject::disconnect(process.get(), &Process::error_occurred, nullptr, nullptr);
@@ -228,6 +228,6 @@ void SSHFSMountHandler::stop_impl(bool force)
 
 SSHFSMountHandler::~SSHFSMountHandler()
 {
-    stop(/*force=*/true);
+    deactivate(/*force=*/true);
 }
 } // namespace multipass

--- a/tests/lxd/CMakeLists.txt
+++ b/tests/lxd/CMakeLists.txt
@@ -16,4 +16,5 @@
 target_sources(multipass_tests
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/test_lxd_backend.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/test_lxd_image_vault.cpp)
+    ${CMAKE_CURRENT_LIST_DIR}/test_lxd_image_vault.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_lxd_mount_handler.cpp)

--- a/tests/lxd/test_lxd_mount_handler.cpp
+++ b/tests/lxd/test_lxd_mount_handler.cpp
@@ -175,7 +175,7 @@ TEST_P(LXDMountHandlerInvalidGidUidParameterTests, mountWithGidOrUid)
 
     MP_EXPECT_THROW_THAT(lxd_vm.make_native_mount_handler(&key_provider, target_path, vm_mount);
                          , std::runtime_error,
-                         mpt::match_what(StrEq("LXD native mount does not accept custom gid or uid.")));
+                         mpt::match_what(StrEq("LXD native mount does not accept custom ID mappings.")));
 }
 
 INSTANTIATE_TEST_SUITE_P(mountWithGidOrUidInstantiation, LXDMountHandlerInvalidGidUidParameterTests,

--- a/tests/lxd/test_lxd_mount_handler.cpp
+++ b/tests/lxd/test_lxd_mount_handler.cpp
@@ -127,7 +127,7 @@ TEST_F(LXDMountHandlerTestFixture, startThrowsIfVMIsRunning)
     EXPECT_CALL(lxd_vm, current_state).WillOnce(Return(multipass::VirtualMachine::State::running));
     const mp::ServerVariant dummy_server;
     MP_EXPECT_THROW_THAT(
-        lxd_mount_handler.activate(dummy_server), mp::MountHandlerActivateException,
+        lxd_mount_handler.activate(dummy_server), mp::NativeMountNeedsStoppedVMException,
         mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before attempting native mounts."))));
 }
 

--- a/tests/lxd/test_lxd_mount_handler.cpp
+++ b/tests/lxd/test_lxd_mount_handler.cpp
@@ -19,11 +19,11 @@
 #include "mock_network_access_manager.h"
 #include "tests/mock_file_ops.h"
 #include "tests/mock_logger.h"
+#include "tests/mock_virtual_machine.h"
 #include "tests/stub_ssh_key_provider.h"
 #include "tests/stub_status_monitor.h"
 
 #include "src/platform/backends/lxd/lxd_mount_handler.h"
-#include "src/platform/backends/lxd/lxd_virtual_machine.h"
 
 #include <multipass/utils.h>
 #include <multipass/virtual_machine_description.h>
@@ -34,17 +34,16 @@ namespace mpt = multipass::test;
 
 namespace
 {
-class MockLXDVirtualMachine : public mp::LXDVirtualMachine
+class MockLXDVirtualMachine : public mpt::MockVirtualMachineT<mp::LXDVirtualMachine>
+
 {
 public:
     MockLXDVirtualMachine(const mp::VirtualMachineDescription& desc, mp::VMStatusMonitor& monitor,
                           mp::NetworkAccessManager* manager, const QUrl& base_url, const QString& bridge_name,
                           const QString& storage_pool)
-        : LXDVirtualMachine{desc, monitor, manager, base_url, bridge_name, storage_pool}
+        : mpt::MockVirtualMachineT<mp::LXDVirtualMachine>{desc, monitor, manager, base_url, bridge_name, storage_pool}
     {
     }
-
-    MOCK_METHOD(multipass::VirtualMachine::State, current_state, (), (override));
 };
 
 struct LXDMountHandlerTestFixture : public testing::Test
@@ -55,7 +54,6 @@ struct LXDMountHandlerTestFixture : public testing::Test
             .Times(AtMost(6))
             .WillRepeatedly(
                 [](QNetworkAccessManager::Operation, const QNetworkRequest& request, QIODevice* outgoingData) {
-                    // add the request for adding and removing device later
                     return new mpt::MockLocalSocketReply(mpt::vm_state_stopped_data);
                 });
 

--- a/tests/lxd/test_lxd_mount_handler.cpp
+++ b/tests/lxd/test_lxd_mount_handler.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mock_lxd_server_responses.h"
+#include "mock_network_access_manager.h"
+#include "tests/mock_file_ops.h"
+#include "tests/mock_logger.h"
+#include "tests/stub_ssh_key_provider.h"
+#include "tests/stub_status_monitor.h"
+
+#include "src/platform/backends/lxd/lxd_mount_handler.h"
+#include "src/platform/backends/lxd/lxd_virtual_machine.h"
+
+#include <multipass/utils.h>
+#include <multipass/virtual_machine_description.h>
+#include <multipass/vm_mount.h>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+namespace
+{
+class MockLXDVirtualMachine : public mp::LXDVirtualMachine
+{
+public:
+    MockLXDVirtualMachine(const mp::VirtualMachineDescription& desc, mp::VMStatusMonitor& monitor,
+                          mp::NetworkAccessManager* manager, const QUrl& base_url, const QString& bridge_name,
+                          const QString& storage_pool)
+        : LXDVirtualMachine{desc, monitor, manager, base_url, bridge_name, storage_pool}
+    {
+    }
+
+    MOCK_METHOD(multipass::VirtualMachine::State, current_state, (), (override));
+};
+
+struct LXDMountHandlerTestFixture : public testing::Test
+{
+    LXDMountHandlerTestFixture()
+    {
+        EXPECT_CALL(mock_network_access_manager, createRequest(_, _, _))
+            .Times(AtMost(6))
+            .WillRepeatedly(
+                [](QNetworkAccessManager::Operation, const QNetworkRequest& request, QIODevice* outgoingData) {
+                    // add the request for adding and removing device later
+                    return new mpt::MockLocalSocketReply(mpt::vm_state_stopped_data);
+                });
+
+        EXPECT_CALL(mock_file_ops, status)
+            .Times(AtMost(1))
+            .WillRepeatedly(Return(mp::fs::file_status{mp::fs::file_type::directory, mp::fs::perms::all}));
+
+        logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    }
+
+    const std::string source_path{"sourcePath"};
+    const std::string target_path{"targetPath"};
+    mpt::MockFileOps::GuardedMock mock_file_ops_injection = mpt::MockFileOps::inject();
+    mpt::MockFileOps& mock_file_ops = *mock_file_ops_injection.first;
+
+    mpt::MockNetworkAccessManager mock_network_access_manager;
+
+    mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject();
+
+    const mpt::StubSSHKeyProvider key_provider;
+    const mp::VMMount vm_mount{source_path, {}, {}, mp::VMMount::MountType::Native};
+    const QUrl base_url{"unix:///foo@1.0"};
+    const QString default_storage_pool{"default"};
+    mpt::StubVMStatusMonitor stub_monitor;
+    const QString bridge_name{"mpbr0"};
+    const mp::VirtualMachineDescription default_description{2,
+                                                            mp::MemorySize{"3M"},
+                                                            mp::MemorySize{}, // not used
+                                                            "pied-piper-valley",
+                                                            "00:16:3e:fe:f2:b9",
+                                                            {},
+                                                            "yoda",
+                                                            {},
+                                                            "",
+                                                            {},
+                                                            {},
+                                                            {},
+                                                            {}};
+};
+} // namespace
+
+TEST_F(LXDMountHandlerTestFixture, startNoThrowsIfVMIsStopped)
+{
+    NiceMock<MockLXDVirtualMachine> lxd_vm{
+        default_description, stub_monitor, &mock_network_access_manager, base_url, bridge_name, default_storage_pool};
+
+    mp::LXDMountHandler lxd_mount_handler(&mock_network_access_manager, &lxd_vm, &key_provider, target_path, vm_mount);
+
+    EXPECT_CALL(lxd_vm, current_state).WillOnce(Return(multipass::VirtualMachine::State::stopped));
+    const mp::ServerVariant dummy_server;
+    logger_scope.mock_logger->expect_log(mpl::Level::info, "initializing native mount ");
+    EXPECT_NO_THROW(lxd_mount_handler.activate(dummy_server));
+}
+
+TEST_F(LXDMountHandlerTestFixture, startThrowsIfVMIsRunning)
+{
+    NiceMock<MockLXDVirtualMachine> lxd_vm{
+        default_description, stub_monitor, &mock_network_access_manager, base_url, bridge_name, default_storage_pool};
+    mp::LXDMountHandler lxd_mount_handler(&mock_network_access_manager, &lxd_vm, &key_provider, target_path, vm_mount);
+
+    EXPECT_CALL(lxd_vm, current_state).WillOnce(Return(multipass::VirtualMachine::State::running));
+    const mp::ServerVariant dummy_server;
+    MP_EXPECT_THROW_THAT(
+        lxd_mount_handler.activate(dummy_server), std::runtime_error,
+        mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before mount it natively."))));
+}
+
+TEST_F(LXDMountHandlerTestFixture, stopNoThrowsIfVMIsStopped)
+{
+    NiceMock<MockLXDVirtualMachine> lxd_vm{
+        default_description, stub_monitor, &mock_network_access_manager, base_url, bridge_name, default_storage_pool};
+    mp::LXDMountHandler lxd_mount_handler(&mock_network_access_manager, &lxd_vm, &key_provider, target_path, vm_mount);
+
+    EXPECT_CALL(lxd_vm, current_state)
+        .Times(AtMost(2))
+        .WillRepeatedly(Return(multipass::VirtualMachine::State::stopped));
+    const mp::ServerVariant dummy_server;
+    lxd_mount_handler.activate(dummy_server);
+    logger_scope.mock_logger->expect_log(mpl::Level::info, "Stopping native mount ");
+    EXPECT_NO_THROW(lxd_mount_handler.deactivate());
+}
+
+TEST_F(LXDMountHandlerTestFixture, stopThrowsIfVMIsRunning)
+{
+    NiceMock<MockLXDVirtualMachine> lxd_vm{
+        default_description, stub_monitor, &mock_network_access_manager, base_url, bridge_name, default_storage_pool};
+
+    mp::LXDMountHandler lxd_mount_handler(&mock_network_access_manager, &lxd_vm, &key_provider, target_path, vm_mount);
+
+    EXPECT_CALL(lxd_vm, current_state).WillOnce(Return(multipass::VirtualMachine::State::stopped));
+    const mp::ServerVariant dummy_server;
+    lxd_mount_handler.activate(dummy_server);
+
+    EXPECT_CALL(lxd_vm, current_state).WillOnce(Return(multipass::VirtualMachine::State::running));
+    MP_EXPECT_THROW_THAT(
+        lxd_mount_handler.deactivate(), std::runtime_error,
+        mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before unmount it natively."))));
+}

--- a/tests/lxd/test_lxd_mount_handler.cpp
+++ b/tests/lxd/test_lxd_mount_handler.cpp
@@ -128,7 +128,7 @@ TEST_F(LXDMountHandlerTestFixture, startThrowsIfVMIsRunning)
     const mp::ServerVariant dummy_server;
     MP_EXPECT_THROW_THAT(
         lxd_mount_handler.activate(dummy_server), mp::MountHandlerActivateException,
-        mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before mount it natively."))));
+        mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before attempting native mounts."))));
 }
 
 TEST_F(LXDMountHandlerTestFixture, stopDoesNotThrowIfVMIsStopped)

--- a/tests/lxd/test_lxd_mount_handler.cpp
+++ b/tests/lxd/test_lxd_mount_handler.cpp
@@ -129,7 +129,7 @@ TEST_F(LXDMountHandlerTestFixture, startThrowsIfVMIsRunning)
     EXPECT_CALL(lxd_vm, current_state).WillOnce(Return(multipass::VirtualMachine::State::running));
     const mp::ServerVariant dummy_server;
     MP_EXPECT_THROW_THAT(
-        lxd_mount_handler.activate(dummy_server), std::runtime_error,
+        lxd_mount_handler.activate(dummy_server), mp::MountHandlerActivateException,
         mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before mount it natively."))));
 }
 

--- a/tests/lxd/test_lxd_mount_handler.cpp
+++ b/tests/lxd/test_lxd_mount_handler.cpp
@@ -107,7 +107,7 @@ struct LXDMountHandlerValidGidUidParameterTests : public LXDMountHandlerTestFixt
 };
 } // namespace
 
-TEST_F(LXDMountHandlerTestFixture, startNoThrowsIfVMIsStopped)
+TEST_F(LXDMountHandlerTestFixture, startDoesNotThrowIfVMIsStopped)
 {
     NiceMock<MockLXDVirtualMachine> lxd_vm{
         default_description, stub_monitor, &mock_network_access_manager, base_url, bridge_name, default_storage_pool};
@@ -133,7 +133,7 @@ TEST_F(LXDMountHandlerTestFixture, startThrowsIfVMIsRunning)
         mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before mount it natively."))));
 }
 
-TEST_F(LXDMountHandlerTestFixture, stopNoThrowsIfVMIsStopped)
+TEST_F(LXDMountHandlerTestFixture, stopDoesNotThrowIfVMIsStopped)
 {
     NiceMock<MockLXDVirtualMachine> lxd_vm{
         default_description, stub_monitor, &mock_network_access_manager, base_url, bridge_name, default_storage_pool};

--- a/tests/mock_mount_handler.h
+++ b/tests/mock_mount_handler.h
@@ -25,8 +25,8 @@ namespace multipass::test
 class MockMountHandler : public MountHandler
 {
 public:
-    MOCK_METHOD(void, start_impl, (ServerVariant, std::chrono::milliseconds), (override));
-    MOCK_METHOD(void, stop_impl, (bool), (override));
+    MOCK_METHOD(void, activate_impl, (ServerVariant, std::chrono::milliseconds), (override));
+    MOCK_METHOD(void, deactivate_impl, (bool), (override));
     MOCK_METHOD(bool, is_active, (), (override));
 };
 } // namespace multipass::test

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -33,7 +33,8 @@ namespace test
 template <typename T = VirtualMachine, typename = std::enable_if_t<std::is_base_of_v<VirtualMachine, T>>>
 struct MockVirtualMachineT : public T
 {
-    MockVirtualMachineT(const std::string vm_name) : T{vm_name}
+    template <typename... Args>
+    MockVirtualMachineT(Args&&... args) : T{args...}
     {
         ON_CALL(*this, current_state()).WillByDefault(Return(multipass::VirtualMachine::State::off));
         ON_CALL(*this, ssh_port()).WillByDefault(Return(42));

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -34,7 +34,7 @@ template <typename T = VirtualMachine, typename = std::enable_if_t<std::is_base_
 struct MockVirtualMachineT : public T
 {
     template <typename... Args>
-    MockVirtualMachineT(Args&&... args) : T{args...}
+    MockVirtualMachineT(Args&&... args) : T{std::forward<Args>(args)...}
     {
         ON_CALL(*this, current_state()).WillByDefault(Return(multipass::VirtualMachine::State::off));
         ON_CALL(*this, ssh_port()).WillByDefault(Return(42));

--- a/tests/qemu/test_qemu_mount_handler.cpp
+++ b/tests/qemu/test_qemu_mount_handler.cpp
@@ -172,7 +172,7 @@ TEST_F(QemuMountHandlerTest, mount_fails_when_vm_not_stopped)
 {
     EXPECT_CALL(vm, current_state()).WillOnce(Return(mp::VirtualMachine::State::running));
     MP_EXPECT_THROW_THAT(
-        mp::QemuMountHandler(&vm, &key_provider, default_target, mount), mp::MountHandlerActivateException,
+        mp::QemuMountHandler(&vm, &key_provider, default_target, mount), mp::NativeMountNeedsStoppedVMException,
         mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before attempting native mounts."))));
 }
 

--- a/tests/qemu/test_qemu_mount_handler.cpp
+++ b/tests/qemu/test_qemu_mount_handler.cpp
@@ -223,8 +223,8 @@ TEST_F(QemuMountHandlerTest, start_success_stop_success)
     REPLACE(ssh_channel_read_timeout, mocked_ssh_channel_read_timeout(ssh_command_output));
 
     mp::QemuMountHandler handler{&vm, &key_provider, default_target, mount};
-    EXPECT_NO_THROW(handler.start(&server));
-    EXPECT_NO_THROW(handler.stop());
+    EXPECT_NO_THROW(handler.activate(&server));
+    EXPECT_NO_THROW(handler.deactivate());
 }
 
 TEST_F(QemuMountHandlerTest, stop_fail_nonforce_throws)
@@ -237,8 +237,8 @@ TEST_F(QemuMountHandlerTest, stop_fail_nonforce_throws)
     REPLACE(ssh_channel_read_timeout, mocked_ssh_channel_read_timeout(ssh_command_output));
 
     mp::QemuMountHandler handler{&vm, &key_provider, default_target, mount};
-    EXPECT_NO_THROW(handler.start(&server));
-    MP_EXPECT_THROW_THAT(handler.stop(), std::runtime_error, mpt::match_what(StrEq(error)));
+    EXPECT_NO_THROW(handler.activate(&server));
+    MP_EXPECT_THROW_THAT(handler.deactivate(), std::runtime_error, mpt::match_what(StrEq(error)));
 }
 
 TEST_F(QemuMountHandlerTest, stop_fail_force_logs)
@@ -250,7 +250,7 @@ TEST_F(QemuMountHandlerTest, stop_fail_force_logs)
     REPLACE(ssh_channel_read_timeout, mocked_ssh_channel_read_timeout(ssh_command_output));
 
     mp::QemuMountHandler handler{&vm, &key_provider, default_target, mount};
-    EXPECT_NO_THROW(handler.start(&server));
+    EXPECT_NO_THROW(handler.activate(&server));
     EXPECT_CALL(*logger_scope.mock_logger, log).WillRepeatedly(Return());
     logger_scope.mock_logger->expect_log(
         mpl::Level::warning,
@@ -271,7 +271,7 @@ TEST_F(QemuMountHandlerTest, target_directory_missing)
     REPLACE(ssh_channel_read_timeout, mocked_ssh_channel_read_timeout(ssh_command_output));
 
     mp::QemuMountHandler handler{&vm, &key_provider, default_target, mount};
-    EXPECT_NO_THROW(handler.start(&server));
+    EXPECT_NO_THROW(handler.activate(&server));
 }
 
 INSTANTIATE_TEST_SUITE_P(QemuMountHandlerFailCommand, QemuMountHandlerFailCommand,
@@ -290,5 +290,5 @@ TEST_P(QemuMountHandlerFailCommand, throw_on_fail)
     REPLACE(ssh_channel_read_timeout, mocked_ssh_channel_read_timeout(ssh_command_output));
 
     mp::QemuMountHandler handler{&vm, &key_provider, default_target, mount};
-    MP_EXPECT_THROW_THAT(handler.start(&server), std::runtime_error, mpt::match_what(StrEq(error)));
+    MP_EXPECT_THROW_THAT(handler.activate(&server), std::runtime_error, mpt::match_what(StrEq(error)));
 }

--- a/tests/qemu/test_qemu_mount_handler.cpp
+++ b/tests/qemu/test_qemu_mount_handler.cpp
@@ -173,7 +173,7 @@ TEST_F(QemuMountHandlerTest, mount_fails_when_vm_not_stopped)
     EXPECT_CALL(vm, current_state()).WillOnce(Return(mp::VirtualMachine::State::running));
     MP_EXPECT_THROW_THAT(
         mp::QemuMountHandler(&vm, &key_provider, default_target, mount), mp::MountHandlerActivateException,
-        mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before mount it natively."))));
+        mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before attempting native mounts."))));
 }
 
 TEST_F(QemuMountHandlerTest, mount_fails_on_multiple_id_mappings)

--- a/tests/qemu/test_qemu_mount_handler.cpp
+++ b/tests/qemu/test_qemu_mount_handler.cpp
@@ -171,8 +171,9 @@ struct QemuMountHandlerFailCommand : public QemuMountHandlerTest, public testing
 TEST_F(QemuMountHandlerTest, mount_fails_when_vm_not_stopped)
 {
     EXPECT_CALL(vm, current_state()).WillOnce(Return(mp::VirtualMachine::State::running));
-    MP_EXPECT_THROW_THAT(mp::QemuMountHandler(&vm, &key_provider, default_target, mount), std::runtime_error,
-                         mpt::match_what(StrEq("Please shutdown the instance before attempting native mounts.")));
+    MP_EXPECT_THROW_THAT(
+        mp::QemuMountHandler(&vm, &key_provider, default_target, mount), mp::MountHandlerActivateException,
+        mpt::match_what(AllOf(HasSubstr("Please stop the instance"), HasSubstr("before mount it natively."))));
 }
 
 TEST_F(QemuMountHandlerTest, mount_fails_on_multiple_id_mappings)

--- a/tests/stub_mount_handler.h
+++ b/tests/stub_mount_handler.h
@@ -24,11 +24,11 @@ namespace multipass::test
 {
 struct StubMountHandler : public MountHandler
 {
-    void start_impl(ServerVariant, std::chrono::milliseconds) override
+    void activate_impl(ServerVariant, std::chrono::milliseconds) override
     {
     }
 
-    void stop_impl(bool) override
+    void deactivate_impl(bool) override
     {
     }
 };

--- a/tests/test_daemon_mount.cpp
+++ b/tests/test_daemon_mount.cpp
@@ -161,7 +161,7 @@ TEST_F(TestDaemonMount, skipStartMountIfInstanceIsNotRunning)
     const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, extra_interfaces));
     config_builder.data_directory = temp_dir->path();
 
-    EXPECT_CALL(*mock_mount_handler, start_impl).Times(0);
+    EXPECT_CALL(*mock_mount_handler, activate_impl).Times(0);
 
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
     EXPECT_CALL(*mock_vm, current_state).WillRepeatedly(Return(mp::VirtualMachine::State::stopped));
@@ -189,7 +189,7 @@ TEST_F(TestDaemonMount, startsMountIfInstanceRunning)
     const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, extra_interfaces));
     config_builder.data_directory = temp_dir->path();
 
-    EXPECT_CALL(*mock_mount_handler, start_impl).Times(1);
+    EXPECT_CALL(*mock_mount_handler, activate_impl).Times(1);
 
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
     EXPECT_CALL(*mock_vm, current_state).WillRepeatedly(Return(mp::VirtualMachine::State::running));
@@ -218,7 +218,7 @@ TEST_F(TestDaemonMount, mountFailsErrorMounting)
     config_builder.data_directory = temp_dir->path();
 
     auto error = "permission denied";
-    EXPECT_CALL(*mock_mount_handler, start_impl).WillOnce(Throw(std::runtime_error(error)));
+    EXPECT_CALL(*mock_mount_handler, activate_impl).WillOnce(Throw(std::runtime_error(error)));
 
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
     EXPECT_CALL(*mock_vm, current_state).WillRepeatedly(Return(mp::VirtualMachine::State::running));

--- a/tests/test_daemon_start.cpp
+++ b/tests/test_daemon_start.cpp
@@ -150,7 +150,7 @@ TEST_F(TestDaemonStart, definedMountsInitializedDuringStart)
     const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, extra_interfaces, mounts));
 
     auto mock_mount_handler = std::make_unique<mpt::MockMountHandler>();
-    EXPECT_CALL(*mock_mount_handler, start_impl).Times(1);
+    EXPECT_CALL(*mock_mount_handler, activate_impl).Times(1);
 
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
     EXPECT_CALL(*mock_vm, wait_until_ssh_up).WillRepeatedly(Return());
@@ -186,7 +186,7 @@ TEST_F(TestDaemonStart, removingMountOnFailedStart)
 
     auto error = "failed to start mount";
     auto mock_mount_handler = std::make_unique<mpt::MockMountHandler>();
-    EXPECT_CALL(*mock_mount_handler, start_impl).WillOnce(Throw(std::runtime_error{error}));
+    EXPECT_CALL(*mock_mount_handler, activate_impl).WillOnce(Throw(std::runtime_error{error}));
 
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
     EXPECT_CALL(*mock_vm, wait_until_ssh_up).WillRepeatedly(Return());

--- a/tests/test_daemon_umount.cpp
+++ b/tests/test_daemon_umount.cpp
@@ -89,8 +89,8 @@ TEST_F(TestDaemonUmount, noTargetsUnmountsAll)
     auto mock_mount_handler2 = std::make_unique<mpt::MockMountHandler>();
     EXPECT_CALL(*mock_mount_handler, is_active).WillOnce(Return(true));
     EXPECT_CALL(*mock_mount_handler2, is_active).WillOnce(Return(true));
-    EXPECT_CALL(*mock_mount_handler, stop_impl(false));
-    EXPECT_CALL(*mock_mount_handler2, stop_impl(false));
+    EXPECT_CALL(*mock_mount_handler, deactivate_impl(false));
+    EXPECT_CALL(*mock_mount_handler2, deactivate_impl(false));
 
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
     EXPECT_CALL(*mock_vm, make_native_mount_handler(_, fake_target_path, _))
@@ -128,9 +128,9 @@ TEST_F(TestDaemonUmount, umountWithTargetOnlyStopsItsHandlers)
     EXPECT_CALL(*mock_mount_handler, is_active).WillOnce(Return(true));
     EXPECT_CALL(*mock_mount_handler2, is_active).Times(0);
     EXPECT_CALL(*mock_mount_handler3, is_active).WillOnce(Return(true));
-    EXPECT_CALL(*mock_mount_handler, stop_impl(false));
-    EXPECT_CALL(*mock_mount_handler2, stop_impl(false)).Times(0);
-    EXPECT_CALL(*mock_mount_handler3, stop_impl(false));
+    EXPECT_CALL(*mock_mount_handler, deactivate_impl(false));
+    EXPECT_CALL(*mock_mount_handler2, deactivate_impl(false)).Times(0);
+    EXPECT_CALL(*mock_mount_handler3, deactivate_impl(false));
 
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
     EXPECT_CALL(*mock_vm, make_native_mount_handler(_, fake_target_path, _))
@@ -192,7 +192,7 @@ TEST_F(TestDaemonUmount, stoppingMountFails)
     auto error = "device is busy";
     auto mock_mount_handler = std::make_unique<mpt::MockMountHandler>();
     EXPECT_CALL(*mock_mount_handler, is_active).WillOnce(Return(true));
-    EXPECT_CALL(*mock_mount_handler, stop_impl(false)).WillOnce(Throw(std::runtime_error{error}));
+    EXPECT_CALL(*mock_mount_handler, deactivate_impl(false)).WillOnce(Throw(std::runtime_error{error}));
 
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
     EXPECT_CALL(*mock_vm, make_native_mount_handler(_, fake_target_path, _))


### PR DESCRIPTION
[JIRA story link](https://warthogs.atlassian.net/browse/MULTI-188)
[spek link](https://docs.google.com/document/d/1LAnT92_lhfsIQD_JIbb4JfsqVakRXVpJnFYT1gpNMCQ/edit#)
The current workflow and behaviors are as follows: 
`./multipass info peaceable-tadpole
`
```
Name:           peaceable-tadpole
State:          Running
IPv4:           10.156.2.154
Release:        Ubuntu 22.04.2 LTS
Image hash:     d900c08af2be (Ubuntu 22.04 LTS)
CPU(s):         1
Load:           0.00 0.00 0.00
Disk usage:     1.6GiB out of 9.5GiB
Memory usage:   190.9MiB out of 946.1MiB
Mounts:         --
```

`./multipass mount -t native /home/georgel/mount peaceable-tadpole:/home/ubuntu/native
`
`mount failed: Please stop the instance peaceable-tadpole before mount it natively.
`

`./multipass stop peaceable-tadpole
`

`./multipass mount -t native /home/georgel/mount peaceable-tadpole:/home/ubuntu/native
`

`./multipass start peaceable-tadpole
`
`./multipass exec peaceable-tadpole bash 
`
`cd native`
Then you can use the shared directory
`exit`

`/multipass unmount peaceable-tadpole:/home/ubuntu/native
`
Here is where it gets interesting, we should not allow hot unplugging, so there are two options for the behaviors. 

1. Throw an error to ask the user to manually stop the instance
2. The unmount does this automatically, that is stopping the instance first if it is still running, then do the unmount.

The current implementation is based on 2nd behavior.

`./multipass info peaceable-tadpole
`
```
Name:           peaceable-tadpole
State:          Stopped
IPv4:           --
Release:        --
Image hash:     d900c08af2be (Ubuntu 22.04 LTS)
CPU(s):         --
Load:           --
Disk usage:     --
Memory usage:   --
Mounts:         --
```
