### PR TITLE
Pull disk info from home partition

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1480,12 +1480,12 @@ try // clang-format on
             info->set_load(mpu::run_in_ssh_session(session, "cat /proc/loadavg | cut -d ' ' -f1-3"));
             info->set_memory_usage(mpu::run_in_ssh_session(session, "free -b | grep 'Mem:' | awk '{printf $3}'"));
             info->set_memory_total(mpu::run_in_ssh_session(session, "free -b | grep 'Mem:' | awk '{printf $2}'"));
-            info->set_disk_usage(mpu::run_in_ssh_session(
-                session,
-                "df --output=used $(sudo fdisk -l | grep 'Linux filesystem' | awk '{print $1}') -B1 | sed 1d"));
-            info->set_disk_total(mpu::run_in_ssh_session(
-                session,
-                "df --output=size $(sudo fdisk -l | grep 'Linux filesystem' | awk '{print $1}') -B1 | sed 1d"));
+            info->set_disk_usage(
+                mpu::run_in_ssh_session(session, "df --output=used $(sudo fdisk -l | grep 'Linux filesystem' | awk "
+                                                 "'{print $1}') -B1 | sed 1d | sort -n | tail -n 1"));
+            info->set_disk_total(
+                mpu::run_in_ssh_session(session, "df --output=size $(sudo fdisk -l | grep 'Linux filesystem' | awk "
+                                                 "'{print $1}') -B1 | sed 1d | sort -n | tail -n 1"));
             info->set_cpu_count(mpu::run_in_ssh_session(session, "nproc"));
 
             std::string management_ip = vm->management_ipv4();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1480,12 +1480,8 @@ try // clang-format on
             info->set_load(mpu::run_in_ssh_session(session, "cat /proc/loadavg | cut -d ' ' -f1-3"));
             info->set_memory_usage(mpu::run_in_ssh_session(session, "free -b | grep 'Mem:' | awk '{printf $3}'"));
             info->set_memory_total(mpu::run_in_ssh_session(session, "free -b | grep 'Mem:' | awk '{printf $2}'"));
-            info->set_disk_usage(
-                mpu::run_in_ssh_session(session, "df --output=used $(sudo fdisk -l | grep 'Linux filesystem' | awk "
-                                                 "'{print $1}') -B1 | sed 1d | sort -n | tail -n 1"));
-            info->set_disk_total(
-                mpu::run_in_ssh_session(session, "df --output=size $(sudo fdisk -l | grep 'Linux filesystem' | awk "
-                                                 "'{print $1}') -B1 | sed 1d | sort -n | tail -n 1"));
+            info->set_disk_usage(mpu::run_in_ssh_session(session, "df --output=used /home -B1 | sed 1d"));
+            info->set_disk_total(mpu::run_in_ssh_session(session, "df --output=size /home -B1 | sed 1d"));
             info->set_cpu_count(mpu::run_in_ssh_session(session, "nproc"));
 
             std::string management_ip = vm->management_ipv4();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1480,8 +1480,10 @@ try // clang-format on
             info->set_load(mpu::run_in_ssh_session(session, "cat /proc/loadavg | cut -d ' ' -f1-3"));
             info->set_memory_usage(mpu::run_in_ssh_session(session, "free -b | grep 'Mem:' | awk '{printf $3}'"));
             info->set_memory_total(mpu::run_in_ssh_session(session, "free -b | grep 'Mem:' | awk '{printf $2}'"));
-            info->set_disk_usage(mpu::run_in_ssh_session(session, "df --output=used /home -B1 | sed 1d"));
-            info->set_disk_total(mpu::run_in_ssh_session(session, "df --output=size /home -B1 | sed 1d"));
+            info->set_disk_usage(
+                mpu::run_in_ssh_session(session, "df -t ext4 -t vfat --total -B1 --output=used | tail -n 1"));
+            info->set_disk_total(
+                mpu::run_in_ssh_session(session, "df -t ext4 -t vfat --total -B1 --output=size | tail -n 1"));
             info->set_cpu_count(mpu::run_in_ssh_session(session, "nproc"));
 
             std::string management_ip = vm->management_ipv4();


### PR DESCRIPTION
Since there are sometimes multiple entries that are labeled as Linux Filesystem, edit the command to sort them and take the largest one. This is under the assumption that the main filesystem is the largest.

This command is getting a bit convoluted at this point, so other suggestions on where to get this info is welcome.

Fixes #3041