### PR TITLE
[url_downloader] Add HTTP UserAgent header info

### DIFF
--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -22,6 +22,8 @@
 #include <multipass/file_ops.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
+#include <multipass/platform.h>
+#include <multipass/version.h>
 
 #include <QDir>
 #include <QEventLoop>
@@ -85,6 +87,10 @@ QByteArray download(QNetworkAccessManager* manager, const Time& timeout, QUrl co
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute,
                          force_cache ? QNetworkRequest::AlwaysCache : QNetworkRequest::PreferNetwork);
+    request.setHeader(
+        QNetworkRequest::UserAgentHeader,
+        QString::fromStdString(fmt::format("Multipass/{} ({}; {})", multipass::version_string,
+                                           mp::platform::host_version(), QSysInfo::currentCpuArchitecture())));
 
     NetworkReplyUPtr reply{manager->get(request)};
 


### PR DESCRIPTION
Fixes #3049

---

@nathan-j-hart This will be in the form of something like:
`Multipass/1.11.1 (macos-11.3; arm64)`

Let me know what you think.