### PR TITLE
[dbus] Avoid DBus calls with invalid variant args

### DIFF
--- a/src/platform/backends/shared/linux/dbus_wrappers.h
+++ b/src/platform/backends/shared/linux/dbus_wrappers.h
@@ -81,6 +81,13 @@ protected:
                                    const QVariant& arg2, const QVariant& arg3)
     {
         assert(iface);
+        if (!arg1.isValid())
+            return iface->call(mode, method);
+        if (!arg2.isValid())
+            return iface->call(mode, method, arg1);
+        if (!arg3.isValid())
+            return iface->call(mode, method, arg1, arg2);
+
         return iface->call(mode, method, arg1, arg2, arg3);
     }
 


### PR DESCRIPTION
Fixes #3035.