### PR TITLE
Filter duplicate instances

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -746,10 +746,16 @@ InstanceSelectionReport select_instances(InstanceTable& operative_instances, Ins
     }
     else
     {
+        std::unordered_set<std::string> seen_instances;
+
         for (const auto& name : names)
         {
-            auto trail = find_instance(operative_instances, deleted_instances, name);
-            rank_instance(name, trail, ret);
+            if (seen_instances.find(name) == seen_instances.end())
+            {
+                auto trail = find_instance(operative_instances, deleted_instances, name);
+                rank_instance(name, trail, ret);
+                seen_instances.insert(name);
+            }
         }
     }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -750,11 +750,10 @@ InstanceSelectionReport select_instances(InstanceTable& operative_instances, Ins
 
         for (const auto& name : names)
         {
-            if (seen_instances.find(name) == seen_instances.end())
+            if (seen_instances.insert(name).second)
             {
                 auto trail = find_instance(operative_instances, deleted_instances, name);
                 rank_instance(name, trail, ret);
-                seen_instances.insert(name);
             }
         }
     }


### PR DESCRIPTION
Replaces #3056. That work becomes outdated if this is merged in.

Fixes #3055 