### PR TITLE
Added ccache to cmakefile and updated the corresponding patches.

### DIFF
--- a/.github/workflows/linux-Clang.patch
+++ b/.github/workflows/linux-Clang.patch
@@ -1,21 +1,21 @@
 diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
-index 0b4136fa..0eabe4ae 100644
+index a72d9f09a..f9abac410 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -94,6 +94,7 @@ parts:
+@@ -112,6 +112,7 @@ parts:
      - on armhf: [libgles2-mesa-dev]
      - build-essential
      - ccache
 +    - clang-11
      - git
-     - golang
      - libapparmor-dev
-@@ -126,6 +127,8 @@ parts:
+     - libqt5x11extras5-dev
+@@ -143,6 +144,8 @@ parts:
+     - -DCMAKE_INSTALL_PREFIX=/
+     - -DMULTIPASS_ENABLE_TESTS=off
      - -DMULTIPASS_UPSTREAM=origin
-     - -DCMAKE_C_COMPILER_LAUNCHER=ccache
-     - -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 +    - -DCMAKE_C_COMPILER=clang-11
 +    - -DCMAKE_CXX_COMPILER=clang++-11
      override-build: |
-       snapcraftctl build
+       craftctl default
        set -e

--- a/.github/workflows/linux-Coverage.patch
+++ b/.github/workflows/linux-Coverage.patch
@@ -1,6 +1,8 @@
+diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
+index a72d9f09a..d23ed58e3 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -95,6 +95,7 @@ parts:
+@@ -121,6 +121,7 @@ parts:
      - pkg-config
      - qtbase5-dev
      - qtbase5-dev-tools
@@ -8,7 +10,7 @@
      stage-packages:
      - apparmor
      - on amd64: [libgl1]
-@@ -113,9 +114,8 @@ parts:
+@@ -139,9 +140,8 @@ parts:
      - dnsmasq-utils
      source: .
      cmake-parameters:
@@ -17,5 +19,5 @@
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off
      - -DMULTIPASS_UPSTREAM=origin
-     - -DCMAKE_C_COMPILER_LAUNCHER=ccache
-     - -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+     override-build: |
+       craftctl default

--- a/.github/workflows/linux-Debug.patch
+++ b/.github/workflows/linux-Debug.patch
@@ -1,6 +1,8 @@
+diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
+index a72d9f09a..d3316be58 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -113,9 +113,8 @@ parts:
+@@ -139,9 +139,8 @@ parts:
      - dnsmasq-utils
      source: .
      cmake-parameters:
@@ -9,5 +11,5 @@
      - -DCMAKE_INSTALL_PREFIX=/
 -    - -DMULTIPASS_ENABLE_TESTS=off
      - -DMULTIPASS_UPSTREAM=origin
-     - -DCMAKE_C_COMPILER_LAUNCHER=ccache
-     - -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+     override-build: |
+       craftctl default

--- a/.github/workflows/linux.patch
+++ b/.github/workflows/linux.patch
@@ -1,21 +1,12 @@
 diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
-index 2853b71f..0b4136fa 100644
+index 8a8671bed..a72d9f09a 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -93,6 +93,7 @@ parts:
+@@ -111,6 +111,7 @@ parts:
      - on arm64: [libgles2-mesa-dev]
      - on armhf: [libgles2-mesa-dev]
      - build-essential
 +    - ccache
      - git
-     - golang
      - libapparmor-dev
-@@ -123,6 +124,8 @@ parts:
-     - -DCMAKE_INSTALL_PREFIX=/
-     - -DMULTIPASS_ENABLE_TESTS=off
-     - -DMULTIPASS_UPSTREAM=origin
-+    - -DCMAKE_C_COMPILER_LAUNCHER=ccache
-+    - -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-     override-build: |
-       snapcraftctl build
-       set -e
+     - libqt5x11extras5-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ if (APPLE)
   set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
 endif()
 
+# Use ccache if it's installed
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 project(Multipass)
 
 option(MULTIPASS_ENABLE_TESTS "Build tests" ON)


### PR DESCRIPTION
This is a small improvement for developers who use ccache to accelerate the multipass build. With the change, the developer only has to install ccache and does not have to manually append the cmake arguments because it is taken care of by the cmake script itself.  
Reference: https://crascit.com/2016/04/09/using-ccache-with-cmake/