### PR TITLE
[image_host] Switch to using buildd Simplestreams for snapcraft remote

### DIFF
--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -28,6 +28,8 @@ namespace multipass
 constexpr auto client_name = "multipass";
 constexpr auto daemon_name = "multipassd";
 
+constexpr auto snapcraft_remote = "snapcraft";
+
 constexpr auto min_memory_size = "128M";
 constexpr auto min_disk_size = "512M";
 constexpr auto min_cpu_cores = "1";

--- a/include/multipass/vm_image_info.h
+++ b/include/multipass/vm_image_info.h
@@ -40,5 +40,13 @@ public:
     int64_t size;
     bool verify;
 };
+
+inline bool operator==(const VMImageInfo& a, const VMImageInfo& b)
+{
+    return std::tie(a.aliases, a.os, a.release, a.release_title, a.supported, a.image_location, a.kernel_location,
+                    a.initrd_location, a.id, a.stream_location, a.version, a.size, a.verify) ==
+           std::tie(b.aliases, b.os, b.release, b.release_title, b.supported, b.image_location, b.kernel_location,
+                    b.initrd_location, b.id, b.stream_location, b.version, b.size, b.verify);
+}
 }
 #endif // MULTIPASS_VM_IMAGE_INFO_H

--- a/src/daemon/common_image_host.cpp
+++ b/src/daemon/common_image_host.cpp
@@ -108,10 +108,10 @@ void mp::CommonVMImageHost::check_alias_is_supported(const std::string& alias, c
             "\'{}\' is not a supported alias. Please use `multipass find` for supported image aliases.", alias));
 }
 
-bool mp::CommonVMImageHost::check_all_aliases_are_supported(const QStringList& aliases,
-                                                            const std::string& remote_name) const
+bool mp::CommonVMImageHost::alias_verifies_image_is_supported(const QStringList& aliases,
+                                                              const std::string& remote_name) const
 {
-    return std::all_of(aliases.cbegin(), aliases.cend(), [&remote_name](const auto& alias) {
-        return MP_PLATFORM.is_alias_supported(alias.toStdString(), remote_name);
-    });
+    return aliases.empty() || std::any_of(aliases.cbegin(), aliases.cend(), [&remote_name](const auto& alias) {
+               return MP_PLATFORM.is_alias_supported(alias.toStdString(), remote_name);
+           });
 }

--- a/src/daemon/common_image_host.h
+++ b/src/daemon/common_image_host.h
@@ -41,7 +41,7 @@ protected:
     void on_manifest_empty(const std::string& details);
     void check_remote_is_supported(const std::string& remote_name) const;
     void check_alias_is_supported(const std::string& alias, const std::string& remote_name) const;
-    bool check_all_aliases_are_supported(const QStringList& aliases, const std::string& remote_name) const;
+    bool alias_verifies_image_is_supported(const QStringList& aliases, const std::string& remote_name) const;
 
     virtual void for_each_entry_do_impl(const Action& action) = 0;
     virtual VMImageInfo info_for_full_hash_impl(const std::string& full_hash) = 0;

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -36,7 +36,6 @@ namespace mp = multipass;
 namespace
 {
 constexpr auto no_remote = "";
-constexpr auto snapcraft_remote = "snapcraft";
 
 struct BaseImageInfo
 {
@@ -89,49 +88,6 @@ const QMap<QString, QMap<QString, CustomImageInfo>> multipass_image_info{
         "Core 22",
         "",
         ""}}}}};
-
-const QMap<QString, QMap<QString, CustomImageInfo>> snapcraft_image_info{
-    {{"x86_64"},
-     {{{"bionic-server-cloudimg-amd64-disk.img"},
-       {"https://cloud-images.ubuntu.com/buildd/releases/bionic/release/",
-        {"core18", "18.04"},
-        "",
-        "snapcraft-core18",
-        "Snapcraft builder for Core 18",
-        "https://cloud-images.ubuntu.com/buildd/releases/bionic/release/unpacked/"
-        "bionic-server-cloudimg-amd64-vmlinuz-generic",
-        "https://cloud-images.ubuntu.com/buildd/releases/bionic/release/unpacked/"
-        "bionic-server-cloudimg-amd64-initrd-generic"}},
-      {{"focal-server-cloudimg-amd64-disk.img"},
-       {"https://cloud-images.ubuntu.com/buildd/releases/focal/release/",
-        {"core20", "20.04"},
-        "",
-        "snapcraft-core20",
-        "Snapcraft builder for Core 20",
-        "https://cloud-images.ubuntu.com/buildd/releases/focal/release/unpacked/"
-        "focal-server-cloudimg-amd64-vmlinuz-generic",
-        "https://cloud-images.ubuntu.com/buildd/releases/focal/release/unpacked/"
-        "focal-server-cloudimg-amd64-initrd-generic"}},
-      {{"jammy-server-cloudimg-amd64-disk.img"},
-       {"https://cloud-images.ubuntu.com/buildd/releases/jammy/release/",
-        {"core22", "22.04"},
-        "",
-        "snapcraft-core22",
-        "Snapcraft builder for Core 22",
-        "https://cloud-images.ubuntu.com/buildd/releases/jammy/release/unpacked/"
-        "jammy-server-cloudimg-amd64-vmlinuz-generic",
-        "https://cloud-images.ubuntu.com/buildd/releases/jammy/release/unpacked/"
-        "jammy-server-cloudimg-amd64-initrd-generic"}},
-      {{"lunar-server-cloudimg-amd64-disk1.img"},
-       {"https://cloud-images.ubuntu.com/buildd/daily/lunar/current/",
-        {"devel"},
-        "",
-        "snapcraft-devel",
-        "Snapcraft builder for the devel series",
-        "https://cloud-images.ubuntu.com/buildd/daily/lunar/current/unpacked/"
-        "lunar-server-cloudimg-amd64-vmlinuz-generic",
-        "https://cloud-images.ubuntu.com/buildd/daily/lunar/current/unpacked/"
-        "lunar-server-cloudimg-amd64-initrd-generic"}}}}};
 
 auto base_image_info_for(mp::URLDownloader* url_downloader, const QString& image_url, const QString& hash_url,
                          const QString& image_file)
@@ -208,7 +164,7 @@ mp::CustomVMImageHost::CustomVMImageHost(const QString& arch, URLDownloader* dow
       arch{arch},
       url_downloader{downloader},
       custom_image_info{},
-      remotes{no_remote, snapcraft_remote}
+      remotes{no_remote}
 {
 }
 
@@ -276,8 +232,7 @@ std::vector<std::string> mp::CustomVMImageHost::supported_remotes()
 
 void mp::CustomVMImageHost::fetch_manifests()
 {
-    for (const auto& spec : {std::make_pair(no_remote, multipass_image_info[arch]),
-                             std::make_pair(snapcraft_remote, snapcraft_image_info[arch])})
+    for (const auto& spec : {std::make_pair(no_remote, multipass_image_info[arch])})
     {
         try
         {

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -205,7 +205,7 @@ std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for(const std::st
     auto custom_manifest = manifest_from(remote_name);
 
     auto pred = [this, &remote_name](const auto& product) {
-        return check_all_aliases_are_supported(product.aliases, remote_name);
+        return alias_verifies_image_is_supported(product.aliases, remote_name);
     };
 
     std::copy_if(custom_manifest->products.begin(), custom_manifest->products.end(), std::back_inserter(images), pred);
@@ -219,7 +219,7 @@ void mp::CustomVMImageHost::for_each_entry_do_impl(const Action& action)
     {
         for (const auto& info : manifest.second->products)
         {
-            if (check_all_aliases_are_supported(info.aliases, manifest.first))
+            if (alias_verifies_image_is_supported(info.aliases, manifest.first))
                 action(manifest.first, info);
         }
     }

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -143,6 +143,8 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
                                                          std::make_optional<QString>(mp::mirror_key)}},
                 {mp::daily_remote, UbuntuVMImageRemote{"https://cloud-images.ubuntu.com/", "daily/",
                                                        std::make_optional<QString>(mp::mirror_key)}},
+                {mp::snapcraft_remote, UbuntuVMImageRemote{"https://cloud-images.ubuntu.com/", "buildd/daily/",
+                                                           std::make_optional<QString>(mp::mirror_key)}},
                 {mp::appliance_remote, UbuntuVMImageRemote{"https://cdimage.ubuntu.com/", "ubuntu-core/appliances/"}}},
             url_downloader.get(), manifest_ttl));
     }

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -193,7 +193,7 @@ std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::st
 
     for (const auto& entry : manifest->products)
     {
-        if ((entry.supported || allow_unsupported) && check_all_aliases_are_supported(entry.aliases, remote_name))
+        if ((entry.supported || allow_unsupported) && alias_verifies_image_is_supported(entry.aliases, remote_name))
         {
             images.push_back(with_location_fully_resolved(QString::fromStdString(remote_url_from(remote_name)), entry));
         }
@@ -211,7 +211,7 @@ void mp::UbuntuVMImageHost::for_each_entry_do_impl(const Action& action)
     {
         for (const auto& product : manifest.second->products)
         {
-            if (check_all_aliases_are_supported(product.aliases, manifest.first))
+            if (alias_verifies_image_is_supported(product.aliases, manifest.first))
             {
                 action(manifest.first,
                        with_location_fully_resolved(QString::fromStdString(remote_url_from(manifest.first)), product));

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -31,6 +31,7 @@ namespace multipass
 {
 constexpr auto release_remote = "release";
 constexpr auto daily_remote = "daily";
+constexpr auto snapcraft_remote = "snapcraft";
 constexpr auto appliance_remote = "appliance";
 
 class URLDownloader;

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -19,7 +19,9 @@
 #define MULTIPASS_UBUNTU_IMAGE_HOST_H
 
 #include "common_image_host.h"
-#include "multipass/simple_streams_manifest.h"
+
+#include <multipass/constants.h>
+#include <multipass/simple_streams_manifest.h>
 
 #include <QString>
 
@@ -31,7 +33,6 @@ namespace multipass
 {
 constexpr auto release_remote = "release";
 constexpr auto daily_remote = "daily";
-constexpr auto snapcraft_remote = "snapcraft";
 constexpr auto appliance_remote = "appliance";
 
 class URLDownloader;

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -256,6 +256,11 @@ QString mp::platform::Platform::get_blueprints_url_override() const
 
 bool mp::platform::Platform::is_alias_supported(const std::string& alias, const std::string& remote) const
 {
+    if (remote == mp::snapcraft_remote)
+    {
+        return supported_snapcraft_aliases.find(alias) != supported_snapcraft_aliases.end();
+    }
+
     return true;
 }
 

--- a/src/platform/platform_shared.h
+++ b/src/platform/platform_shared.h
@@ -18,10 +18,21 @@
 #ifndef MULTIPASS_PLATFORM_SHARED_H
 #define MULTIPASS_PLATFORM_SHARED_H
 
+#include <string>
+#include <unordered_set>
+
 #include <QString>
 
 namespace multipass::platform
 {
+const std::unordered_set<std::string> supported_snapcraft_aliases{"core18",
+                                                                  "18.04",
+                                                                  "core20",
+                                                                  "20.04"
+                                                                  "core22",
+                                                                  "22.04",
+                                                                  "devel"};
+
 QString interpret_hotkey(const QString& val);
 } // namespace multipass::platform
 

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -49,12 +49,7 @@ constexpr auto sha256_sums =
     "934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7 *ubuntu-core-16-amd64.img.xz\n"
     "1ffea8a9caf5a4dcba4f73f9144cb4afe1e4fc1987f4ab43bed4c02fad9f087f *ubuntu-core-18-amd64.img.xz\n"
     "52a4606b0b3b28e4cb64e2c2595ef8fdbb4170bfd3596f4e0b84f4d84511b614 *ubuntu-core-20-amd64.img.xz\n"
-    "6378b1fa3db76cdf18c905c8282ebc97401951a9338722486f653dbf16eb7915 *ubuntu-core-22-amd64.img.xz\n"
-    "a6e6db185f53763d9d6607b186f1e6ae2dc02f8da8ea25e58d92c0c0c6dc4e48  ubuntu-16.04-minimal-cloudimg-amd64-disk1.img\n"
-    "96107afaa1673577c91dfbe2905a823043face65be6e8a0edc82f6b932d8380c  bionic-server-cloudimg-amd64-disk.img\n"
-    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  focal-server-cloudimg-amd64-disk.img\n"
-    "aa61059ac29fcca26b19256d3b6dcebc8ade03f96ebf0fa201d5f6210eaa0e0c  jammy-server-cloudimg-amd64-disk.img\n"
-    "872e3f03b57300260c3f982f07183a8480d724d566c686fddc1a2fde0d411ec5  lunar-server-cloudimg-amd64-disk1.img";
+    "6378b1fa3db76cdf18c905c8282ebc97401951a9338722486f653dbf16eb7915 *ubuntu-core-22-amd64.img.xz\n";
 
 struct CustomImageHost : public Test
 {
@@ -110,44 +105,12 @@ TEST_P(ExpectedDataSuite, returns_expected_data)
 
 INSTANTIATE_TEST_SUITE_P(
     CustomImageHost, ExpectedDataSuite,
-    Values(
-        CustomData{std::vector<std::string>{"core", "core16"}, "",
-                   "https://cdimage.ubuntu.com/ubuntu-core/16/stable/current/ubuntu-core-16-amd64.img.xz",
-                   "934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7", "core-16", "Core 16"},
-        CustomData{std::vector<std::string>{"core18"}, "",
-                   "https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz",
-                   "1ffea8a9caf5a4dcba4f73f9144cb4afe1e4fc1987f4ab43bed4c02fad9f087f", "core-18", "Core 18"},
-        CustomData{
-            std::vector<std::string>{"core18", "18.04"}, "snapcraft",
-            "https://cloud-images.ubuntu.com/buildd/releases/bionic/release/bionic-server-cloudimg-amd64-disk.img",
-            "96107afaa1673577c91dfbe2905a823043face65be6e8a0edc82f6b932d8380c", "snapcraft-core18",
-            "Snapcraft builder for Core 18"},
-        CustomData{std::vector<std::string>{"core20", "20.04"}, "snapcraft",
-                   "https://cloud-images.ubuntu.com/buildd/releases/focal/release/focal-server-cloudimg-amd64-disk.img",
-                   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "snapcraft-core20",
-                   "Snapcraft builder for Core 20"},
-        CustomData{std::vector<std::string>{"core22", "22.04"}, "snapcraft",
-                   "https://cloud-images.ubuntu.com/buildd/releases/jammy/release/jammy-server-cloudimg-amd64-disk.img",
-                   "aa61059ac29fcca26b19256d3b6dcebc8ade03f96ebf0fa201d5f6210eaa0e0c", "snapcraft-core22",
-                   "Snapcraft builder for Core 22"},
-        CustomData{std::vector<std::string>{"devel"}, "snapcraft",
-                   "https://cloud-images.ubuntu.com/buildd/daily/lunar/current/lunar-server-cloudimg-amd64-disk1.img",
-                   "872e3f03b57300260c3f982f07183a8480d724d566c686fddc1a2fde0d411ec5", "snapcraft-devel",
-                   "Snapcraft builder for the devel series"}));
-
-TEST_F(CustomImageHost, returns_empty_for_snapcraft_core16)
-{
-    mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, default_ttl};
-
-    auto info = host.info_for(make_query("core16", "snapcraft"));
-    EXPECT_FALSE(info);
-
-    info = host.info_for(make_query("core", "snapcraft"));
-    EXPECT_FALSE(info);
-
-    info = host.info_for(make_query("16.04", "snapcraft"));
-    EXPECT_FALSE(info);
-}
+    Values(CustomData{std::vector<std::string>{"core", "core16"}, "",
+                      "https://cdimage.ubuntu.com/ubuntu-core/16/stable/current/ubuntu-core-16-amd64.img.xz",
+                      "934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7", "core-16", "Core 16"},
+           CustomData{std::vector<std::string>{"core18"}, "",
+                      "https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz",
+                      "1ffea8a9caf5a4dcba4f73f9144cb4afe1e4fc1987f4ab43bed4c02fad9f087f", "core-18", "Core 18"}));
 
 TEST_F(CustomImageHost, iterates_over_all_entries)
 {
@@ -160,11 +123,7 @@ TEST_F(CustomImageHost, iterates_over_all_entries)
     EXPECT_THAT(ids, UnorderedElementsAre("934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7",
                                           "1ffea8a9caf5a4dcba4f73f9144cb4afe1e4fc1987f4ab43bed4c02fad9f087f",
                                           "52a4606b0b3b28e4cb64e2c2595ef8fdbb4170bfd3596f4e0b84f4d84511b614",
-                                          "6378b1fa3db76cdf18c905c8282ebc97401951a9338722486f653dbf16eb7915",
-                                          "96107afaa1673577c91dfbe2905a823043face65be6e8a0edc82f6b932d8380c",
-                                          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                                          "aa61059ac29fcca26b19256d3b6dcebc8ade03f96ebf0fa201d5f6210eaa0e0c",
-                                          "872e3f03b57300260c3f982f07183a8480d724d566c686fddc1a2fde0d411ec5"));
+                                          "6378b1fa3db76cdf18c905c8282ebc97401951a9338722486f653dbf16eb7915"));
 }
 
 TEST_F(CustomImageHost, unsupported_alias_iterates_over_expected_entries)
@@ -178,7 +137,7 @@ TEST_F(CustomImageHost, unsupported_alias_iterates_over_expected_entries)
 
     host.for_each_entry_do(action);
 
-    const size_t expected_entries{6};
+    const size_t expected_entries{3};
     EXPECT_EQ(ids.size(), expected_entries);
 }
 
@@ -189,43 +148,43 @@ TEST_F(CustomImageHost, unsupported_remote_iterates_over_expected_entries)
     std::unordered_set<std::string> ids;
     auto action = [&ids](const std::string& remote, const mp::VMImageInfo& info) { ids.insert(info.id.toStdString()); };
 
-    const std::string unsupported_remote{"snapcraft"};
+    const std::string unsupported_remote{""};
     EXPECT_CALL(*mock_platform, is_remote_supported(unsupported_remote)).WillRepeatedly(Return(false));
 
     host.for_each_entry_do(action);
 
-    const size_t expected_entries{4};
+    const size_t expected_entries{0};
     EXPECT_EQ(ids.size(), expected_entries);
 }
 
-TEST_F(CustomImageHost, all_images_for_snapcraft_returns_appropriate_matches)
+TEST_F(CustomImageHost, all_images_for_no_remote_returns_appropriate_matches)
 {
     mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, default_ttl};
 
-    auto images = host.all_images_for("snapcraft", false);
+    auto images = host.all_images_for("", false);
 
     const size_t expected_matches{4};
     EXPECT_THAT(images.size(), Eq(expected_matches));
 }
 
-TEST_F(CustomImageHost, all_images_for_snapcraft_unsupported_alias_returns_appropriate_matches)
+TEST_F(CustomImageHost, all_images_for_no_remote_unsupported_alias_returns_appropriate_matches)
 {
     mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, default_ttl};
     const std::string unsupported_alias{"core18"};
 
     EXPECT_CALL(*mock_platform, is_alias_supported(unsupported_alias, _)).WillOnce(Return(false));
 
-    auto images = host.all_images_for("snapcraft", false);
+    auto images = host.all_images_for("", false);
 
     const size_t expected_matches{3};
     EXPECT_EQ(images.size(), expected_matches);
 }
 
-TEST_F(CustomImageHost, all_info_for_snapcraft_returns_one_alias_match)
+TEST_F(CustomImageHost, all_info_for_no_remote_returns_one_alias_match)
 {
     mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, default_ttl};
 
-    auto images_info = host.all_info_for(make_query("core20", "snapcraft"));
+    auto images_info = host.all_info_for(make_query("core20", ""));
 
     const size_t expected_matches{1};
     EXPECT_THAT(images_info.size(), Eq(expected_matches));
@@ -239,7 +198,7 @@ TEST_F(CustomImageHost, all_info_for_unsupported_alias_throws)
     EXPECT_CALL(*mock_platform, is_alias_supported(unsupported_alias, _)).WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(
-        host.all_info_for(make_query(unsupported_alias, "snapcraft")), mp::UnsupportedAliasException,
+        host.all_info_for(make_query(unsupported_alias, "")), mp::UnsupportedAliasException,
         mpt::match_what(HasSubstr(fmt::format("\'{}\' is not a supported alias.", unsupported_alias))));
 }
 
@@ -249,11 +208,10 @@ TEST_F(CustomImageHost, supported_remotes_returns_expected_values)
 
     auto supported_remotes = host.supported_remotes();
 
-    const size_t expected_size{2};
+    const size_t expected_size{1};
     EXPECT_THAT(supported_remotes.size(), Eq(expected_size));
 
     EXPECT_TRUE(std::find(supported_remotes.begin(), supported_remotes.end(), "") != supported_remotes.end());
-    EXPECT_TRUE(std::find(supported_remotes.begin(), supported_remotes.end(), "snapcraft") != supported_remotes.end());
 }
 
 TEST_F(CustomImageHost, invalid_image_returns_false)
@@ -275,14 +233,11 @@ TEST_F(CustomImageHost, handles_and_recovers_from_initial_network_failure)
     EXPECT_CALL(mock_url_downloader, last_modified(_))
         .WillOnce(Throw(mp::DownloadException{"", ""}))
         .WillRepeatedly(DoDefault());
-    EXPECT_CALL(mock_url_downloader, download(_))
-        .WillOnce(Throw(mp::DownloadException{"", ""}))
-        .WillRepeatedly(DoDefault());
 
     const auto ttl = 1h; // so that updates are only retried when unsuccessful
     mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, ttl};
 
-    const auto query = make_query("core20", "snapcraft");
+    const auto query = make_query("core20", "");
     EXPECT_THROW(host.info_for(query), std::runtime_error);
 
     EXPECT_TRUE(host.info_for(query));
@@ -293,13 +248,10 @@ TEST_F(CustomImageHost, handles_and_recovers_from_later_network_failure)
     const auto ttl = 0s; // to ensure updates are always retried
     mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, ttl};
 
-    const auto query = make_query("core20", "snapcraft");
+    const auto query = make_query("core20", "");
     EXPECT_TRUE(host.info_for(query));
 
     EXPECT_CALL(mock_url_downloader, last_modified(_))
-        .WillOnce(Throw(mp::DownloadException{"", ""}))
-        .WillRepeatedly(DoDefault());
-    EXPECT_CALL(mock_url_downloader, download(_))
         .WillOnce(Throw(mp::DownloadException{"", ""}))
         .WillRepeatedly(DoDefault());
 
@@ -337,12 +289,21 @@ TEST_F(CustomImageHost, info_for_unsupported_remote_throws)
 {
     mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, default_ttl};
 
-    const std::string unsupported_remote{"snapcraft"};
+    const std::string unsupported_remote{"foo"};
     EXPECT_CALL(*mock_platform, is_remote_supported(unsupported_remote)).WillRepeatedly(Return(false));
 
     MP_EXPECT_THROW_THAT(host.info_for(make_query("xenial", unsupported_remote)), mp::UnsupportedRemoteException,
                          mpt::match_what(HasSubstr(fmt::format(
                              "Remote \'{}\' is not a supported remote for this platform.", unsupported_remote))));
+}
+
+TEST_F(CustomImageHost, info_for_full_hash_returns_empty_image_info)
+{
+    mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, default_ttl};
+
+    auto info = host.info_for_full_hash("934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7");
+
+    EXPECT_EQ(info, mp::VMImageInfo{});
 }
 
 struct EmptyArchSuite : CustomImageHost, WithParamInterface<QString>

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -301,7 +301,7 @@ TEST_F(CustomImageHost, info_for_full_hash_returns_empty_image_info)
 {
     mp::CustomVMImageHost host{"x86_64", &mock_url_downloader, default_ttl};
 
-    auto info = host.info_for_full_hash("934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7");
+    const auto info = host.info_for_full_hash("934d52e4251537ee3bd8c500f212ae4c34992447e7d40d94f00bc7c21f72ceb7");
 
     EXPECT_EQ(info, mp::VMImageInfo{});
 }

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -179,7 +179,7 @@ TEST_F(UbuntuImageHost, unsupported_alias_iterates_over_expected_entries)
     std::unordered_set<std::string> ids;
     auto action = [&ids](const std::string& remote, const mp::VMImageInfo& info) { ids.insert(info.id.toStdString()); };
 
-    EXPECT_CALL(mock_platform, is_alias_supported("zesty", _)).WillRepeatedly(Return(false));
+    EXPECT_CALL(mock_platform, is_alias_supported(AnyOf("zesty", "17.04", "z"), _)).WillRepeatedly(Return(false));
 
     host.for_each_entry_do(action);
 
@@ -315,9 +315,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_unsupported_alias_returns_three_m
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
 
-    const std::string unsupported_alias{"zesty"};
-
-    EXPECT_CALL(mock_platform, is_alias_supported(unsupported_alias, _)).WillOnce(Return(false));
+    EXPECT_CALL(mock_platform, is_alias_supported(AnyOf("zesty", "17.04", "z"), _)).WillRepeatedly(Return(false));
 
     auto images = host.all_images_for(release_remote_spec.first, false);
 


### PR DESCRIPTION
Fixes #3069

---

Corresponding private PR is at canonical/multipass-private#523.

There a couple of things to keep in mind with this PR:
1. The `snapcraft:` remote will no longer show when doing a `multipass find`.  I think this is fine since the `snapcraft` remote is really only intended for Snapcraft usage and should really have never been shown by default in the first place.  That said, `multipass find snapcraft:` will show the supported images.
2. To go along with `multipass find snapcraft:`, there are a couple of extra aliases that are shown from Simplestreams that we don't support in Multipass.  It would require a pretty big refactor to properly filter those out and now is not the time for that.  I think since the `snapcraft` remote would no longer be shown by default, this isn't a big deal and probably would never be noticed by a user.