### PR TITLE
Create dynamic libraries with C interfaces for Dart FFI

### DIFF
--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -86,6 +86,7 @@ option(YAML_CPP_BUILD_CONTRIB OFF)
 option(YAML_CPP_BUILD_TESTS OFF)
 
 add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
+set_target_properties(yaml-cpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(yaml INTERFACE)
 
@@ -121,6 +122,7 @@ set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(semver EXCLUDE_FROM_ALL)
 target_include_directories(semver INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/semver/include)
+set_target_properties(semver PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # xz-decoder config
 add_subdirectory(xz-decoder EXCLUDE_FROM_ALL)

--- a/include/multipass/cli/client_common.h
+++ b/include/multipass/cli/client_common.h
@@ -67,9 +67,9 @@ namespace client
 {
 QString persistent_settings_filename();
 void register_global_settings_handlers();
-std::shared_ptr<grpc::Channel> make_channel(const std::string& server_address, CertProvider* cert_provider);
+std::shared_ptr<grpc::Channel> make_channel(const std::string& server_address, const CertProvider& cert_provider);
 std::string get_server_address();
-std::unique_ptr<SSLCertProvider> get_cert_provider();
+std::unique_ptr<SSLCertProvider> get_cert_provider(const std::string& server_address);
 void set_logger();
 void set_logger(multipass::logging::Level verbosity); // full param qualification makes sure msvc is happy
 void pre_setup();

--- a/include/multipass/dart_ffi.h
+++ b/include/multipass/dart_ffi.h
@@ -1,0 +1,18 @@
+#ifndef MULTIPASS_DART_FFI_H
+#define MULTIPASS_DART_FFI_H
+
+extern "C" const char* multipass_version();
+
+extern "C" const char* generate_petname();
+
+extern "C" const char* get_server_address();
+
+extern "C" struct KeyCertificatePair
+{
+    const char* pem_cert;
+    const char* pem_priv_key;
+};
+
+extern "C" struct KeyCertificatePair get_cert_pair();
+
+#endif // MULTIPASS_DART_FFI_H

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -74,7 +74,7 @@ auto make_handler_unregisterer(mp::SettingsHandler* handler)
 } // namespace
 
 mp::Client::Client(ClientConfig& config)
-    : stub{mp::Rpc::NewStub(mp::client::make_channel(config.server_address, config.cert_provider.get()))},
+    : stub{mp::Rpc::NewStub(mp::client::make_channel(config.server_address, *config.cert_provider))},
       term{config.term},
       aliases{config.term}
 {

--- a/src/client/cli/main.cpp
+++ b/src/client/cli/main.cpp
@@ -38,7 +38,9 @@ int main_impl(int argc, char* argv[])
 
     mp::client::register_global_settings_handlers();
 
-    mp::ClientConfig config{mp::client::get_server_address(), mp::client::get_cert_provider(), term.get()};
+    auto server_address = mp::client::get_server_address();
+    mp::ClientConfig config{mp::client::get_server_address(), mp::client::get_cert_provider(server_address),
+                            term.get()};
     mp::Client client{config};
 
     return client.run(QCoreApplication::arguments());

--- a/src/client/desktop_gui/CMakeLists.txt
+++ b/src/client/desktop_gui/CMakeLists.txt
@@ -21,3 +21,12 @@ if(MULTIPASS_ENABLE_FLUTTER_GUI)
 
   include("CMakeLists.txt.linux")
 endif()
+
+add_library(dart_ffi SHARED ffi/dart_ffi.cpp)
+
+target_link_libraries(dart_ffi
+  petname
+  client_common
+)
+
+install(TARGETS dart_ffi LIBRARY COMPONENT multipass)

--- a/src/client/desktop_gui/ffi/dart_ffi.cpp
+++ b/src/client/desktop_gui/ffi/dart_ffi.cpp
@@ -1,0 +1,76 @@
+#include "multipass/dart_ffi.h"
+#include "multipass/cli/client_common.h"
+#include "multipass/format.h"
+#include "multipass/logging/log.h"
+#include "multipass/name_generator.h"
+#include "multipass/version.h"
+
+namespace mp = multipass;
+namespace mpc = multipass::client;
+namespace mpl = multipass::logging;
+
+constexpr auto category = "dart-ffi";
+
+extern "C" const char* multipass_version()
+{
+    return mp::version_string;
+}
+
+extern "C" const char* generate_petname()
+try
+{
+    static mp::NameGenerator::UPtr generator = mp::make_default_name_generator();
+    const auto name = generator->make_name();
+    return strdup(name.c_str());
+}
+catch (const std::exception& e)
+{
+    mpl::log(mpl::Level::warning, category, fmt::format("failed generating petname: {}", e.what()));
+    return nullptr;
+}
+catch (...)
+{
+    mpl::log(mpl::Level::warning, category, "failed generating petname");
+    return nullptr;
+}
+
+extern "C" const char* get_server_address()
+try
+{
+    const auto address = mpc::get_server_address();
+    return strdup(address.c_str());
+}
+catch (const std::exception& e)
+{
+    mpl::log(mpl::Level::warning, category, fmt::format("failed retrieving server address: {}", e.what()));
+    return nullptr;
+}
+catch (...)
+{
+    mpl::log(mpl::Level::warning, category, "failed retrieving server address");
+    return nullptr;
+}
+
+extern "C" struct KeyCertificatePair get_cert_pair()
+try
+{
+    const auto provider = mpc::get_cert_provider(mpc::get_server_address());
+    const auto cert = provider->PEM_certificate();
+    const auto key = provider->PEM_signing_key();
+    struct KeyCertificatePair pair
+    {
+    };
+    pair.pem_cert = strdup(cert.c_str());
+    pair.pem_priv_key = strdup(key.c_str());
+    return pair;
+}
+catch (const std::exception& e)
+{
+    mpl::log(mpl::Level::warning, category, fmt::format("failed retrieving certificate key pair: {}", e.what()));
+    return KeyCertificatePair{nullptr, nullptr};
+}
+catch (...)
+{
+    mpl::log(mpl::Level::warning, category, "failed retrieving certificate key pair");
+    return KeyCertificatePair{nullptr, nullptr};
+}

--- a/src/client/gui/client_gui.cpp
+++ b/src/client/gui/client_gui.cpp
@@ -27,7 +27,7 @@ namespace mp = multipass;
 namespace mpl = multipass::logging;
 
 mp::ClientGui::ClientGui(ClientConfig& config)
-    : stub{mp::Rpc::NewStub(mp::client::make_channel(config.server_address, config.cert_provider.get()))},
+    : stub{mp::Rpc::NewStub(mp::client::make_channel(config.server_address, *config.cert_provider))},
       gui_cmd{std::make_unique<cmd::GuiCmd>(*stub, null_stream, null_stream)}
 {
 }

--- a/src/client/gui/main.cpp
+++ b/src/client/gui/main.cpp
@@ -36,7 +36,8 @@ int main_impl(int argc, char* argv[])
 
     mp::client::register_global_settings_handlers();
 
-    mp::ClientConfig config{mp::client::get_server_address(), mp::client::get_cert_provider()};
+    auto server_address = mp::client::get_server_address();
+    mp::ClientConfig config{server_address, mp::client::get_cert_provider(server_address)};
     mp::ClientGui client{config};
 
     return client.run(app.arguments());

--- a/tests/mock_cert_provider.h
+++ b/tests/mock_cert_provider.h
@@ -62,12 +62,12 @@ struct MockCertProvider : public CertProvider
 {
     MockCertProvider()
     {
-        EXPECT_CALL(*this, PEM_certificate()).WillRepeatedly(Return(client_cert));
-        EXPECT_CALL(*this, PEM_signing_key()).WillRepeatedly(Return(client_key));
+        ON_CALL(*this, PEM_certificate).WillByDefault(Return(client_cert));
+        ON_CALL(*this, PEM_signing_key).WillByDefault(Return(client_key));
     }
 
-    MOCK_METHOD(std::string, PEM_certificate, (), (const, override));
-    MOCK_METHOD(std::string, PEM_signing_key, (), (const, override));
+    MOCK_METHOD(std::string, PEM_certificate, (), (override, const));
+    MOCK_METHOD(std::string, PEM_signing_key, (), (override, const));
 };
 } // namespace multipass::test
 #endif // MULTIPASS_MOCK_CERT_PROVIDER_H

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -155,9 +155,6 @@ struct Client : public Test
             .Times(AnyNumber())
             .WillRepeatedly(Return("")); /* Avoid writing to Windows Terminal settings. We use an "expectation" so that
                                             it gets reset at the end of each test (by VerifyAndClearExpectations) */
-
-        EXPECT_CALL(*client_cert_provider, PEM_certificate()).WillOnce(Return(mpt::client_cert));
-        EXPECT_CALL(*client_cert_provider, PEM_signing_key()).WillOnce(Return(mpt::client_key));
     }
 
     void TearDown() override
@@ -171,7 +168,7 @@ struct Client : public Test
 
     int setup_client_and_run(const std::vector<std::string>& command, mp::Terminal& term)
     {
-        mp::ClientConfig client_config{server_address, std::move(client_cert_provider), &term};
+        mp::ClientConfig client_config{server_address, get_client_cert_provider(), &term};
         mp::Client client{client_config};
         QStringList args = QStringList() << "multipass_test";
 
@@ -359,7 +356,10 @@ struct Client : public Test
 #else
     std::string server_address{"unix:/tmp/test-multipassd.socket"};
 #endif
-    std::unique_ptr<mpt::MockCertProvider> client_cert_provider{std::make_unique<mpt::MockCertProvider>()};
+    static std::unique_ptr<mpt::MockCertProvider> get_client_cert_provider()
+    {
+        return std::make_unique<mpt::MockCertProvider>();
+    };
     std::unique_ptr<mpt::MockCertProvider> daemon_cert_provider{std::make_unique<mpt::MockCertProvider>()};
     mpt::MockPlatform::GuardedMock attr{mpt::MockPlatform::inject<NiceMock>()};
     mpt::MockPlatform* mock_platform = attr.first;

--- a/tests/test_client_common.cpp
+++ b/tests/test_client_common.cpp
@@ -73,7 +73,7 @@ TEST_F(TestClientCommon, usesCommonCertWhenItExists)
     mpt::make_file_with_content(common_client_cert_file, mpt::client_cert);
     mpt::make_file_with_content(common_client_key_file, mpt::client_key);
 
-    EXPECT_TRUE(mp::client::make_channel(server_address, mp::client::get_cert_provider().get()));
+    EXPECT_TRUE(mp::client::make_channel(server_address, *mp::client::get_cert_provider(server_address)));
 }
 
 TEST_F(TestClientCommon, usesExistingGuiCert)
@@ -88,7 +88,7 @@ TEST_F(TestClientCommon, usesExistingGuiCert)
 
     mpt::MockDaemon daemon{make_secure_server()};
 
-    EXPECT_TRUE(mp::client::make_channel(server_address, mp::client::get_cert_provider().get()));
+    EXPECT_TRUE(mp::client::make_channel(server_address, *mp::client::get_cert_provider(server_address)));
     EXPECT_FALSE(QFile::exists(gui_cert_dir));
 }
 
@@ -113,7 +113,7 @@ TEST_F(TestClientCommon, failsGuiCertUsesExistingCliCert)
 
     mpt::MockDaemon daemon{make_secure_server()};
 
-    EXPECT_TRUE(mp::client::make_channel(server_address, mp::client::get_cert_provider().get()));
+    EXPECT_TRUE(mp::client::make_channel(server_address, *mp::client::get_cert_provider(server_address)));
     EXPECT_FALSE(QFile::exists(gui_cert_dir));
     EXPECT_FALSE(QFile::exists(cli_cert_dir));
 }
@@ -139,7 +139,7 @@ TEST_F(TestClientCommon, noValidCertsCreatesNewCommonCert)
 
     mpt::MockDaemon daemon{make_secure_server()};
 
-    EXPECT_TRUE(mp::client::make_channel(server_address, mp::client::get_cert_provider().get()));
+    EXPECT_TRUE(mp::client::make_channel(server_address, *mp::client::get_cert_provider(server_address)));
     EXPECT_TRUE(QFile::exists(common_cert_dir + "/" + mp::client_cert_file));
     EXPECT_TRUE(QFile::exists(common_cert_dir + "/" + mp::client_key_file));
     EXPECT_FALSE(QFile::exists(gui_cert_dir));


### PR DESCRIPTION
This PR adds a new shared library called `dart_ffi` which contains C interfaces of some of our C++ functions which we'd like to call from Dart using FFI.
Some additional refactoring was needed in order decouple the generation of certificates from the creation of the gRPC channel, so that certificate data can be more easily retrieved using a C interface.