### PR TITLE
[vm] Default auto snapshot answer to yes on restore question

### DIFF
--- a/src/client/cli/cmd/restore.cpp
+++ b/src/client/cli/cmd/restore.cpp
@@ -141,11 +141,11 @@ bool cmd::Restore::confirm_destruction(const QString& instance_name)
 {
     static constexpr auto prompt_text =
         "Do you want to take a snapshot of {} before discarding its current state? (Yes/no)";
-    static constexpr auto invalid_input = "Please answer yes/no";
+    static constexpr auto invalid_input = "Please answer Yes/no";
     mp::PlainPrompter prompter(term);
 
     auto answer = prompter.prompt(fmt::format(prompt_text, instance_name));
-    while (!std::regex_match(answer, yes) && !std::regex_match(answer, no))
+    while (!answer.empty() && !std::regex_match(answer, yes) && !std::regex_match(answer, no))
         answer = prompter.prompt(invalid_input);
 
     return std::regex_match(answer, no);


### PR DESCRIPTION
Accept empty answer and default to yes on the snapshot question asking whether an automatic snapshot should be taken on restore. 

This is unlike what we do in the bridging question because here we have a natural, safe, default answer, unlike in that other one.
