### PR TITLE
Fix newlines and empty strings which go through SSH

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -248,7 +248,15 @@ std::string mp::utils::escape_char(const std::string& in, char c)
 // Escape all characters which need to be escaped in the shell.
 std::string mp::utils::escape_for_shell(const std::string& in)
 {
+    // If the input string is empty, it means that the shell received an empty string enclosed in quotes and removed
+    // them. It must be quoted again for the shell to recognize it.
+    if (in.empty())
+    {
+        return "\'\'";
+    }
+
     std::string ret;
+
     std::back_insert_iterator<std::string> ret_insert = std::back_inserter(ret);
 
     for (char c : in)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -253,13 +253,22 @@ std::string mp::utils::escape_for_shell(const std::string& in)
 
     for (char c : in)
     {
-        // If the character is in one of these code ranges, then it must be escaped.
-        if (c < 0x25 || c > 0x7a || (c > 0x25 && c < 0x2b) || (c > 0x5a && c < 0x5f) || 0x2c == c || 0x3b == c ||
-            0x3c == c || 0x3e == c || 0x3f == c || 0x60 == c)
+        if (0xa == c) // newline
         {
-            *ret_insert++ = '\\';
+            *ret_insert++ = 0x5c; // backslash
+            *ret_insert++ = 0x20; // space
         }
-        *ret_insert++ = c;
+        else
+        {
+            // If the character is in one of these code ranges, then it must be escaped.
+            if (c < 0x25 || c > 0x7a || (c > 0x25 && c < 0x2b) || (c > 0x5a && c < 0x5f) || 0x2c == c || 0x3b == c ||
+                0x3c == c || 0x3e == c || 0x3f == c || 0x60 == c)
+            {
+                *ret_insert++ = 0x5c; // backslash
+            }
+
+            *ret_insert++ = c;
+        }
     }
 
     return ret;

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -426,6 +426,13 @@ TEST(Utils, escape_for_shell_actually_escapes)
     EXPECT_THAT(res, ::testing::StrEq("I\\'ve\\ got\\ \\\"quotes\\\""));
 }
 
+TEST(Utils, escape_for_shell_replaces_newlines_with_spaces)
+{
+    std::string s{"I've got\nnewlines"};
+    auto res = mp::utils::escape_for_shell(s);
+    EXPECT_THAT(res, ::testing::StrEq("I\\'ve\\ got\\ newlines"));
+}
+
 TEST(Utils, try_action_actually_times_out)
 {
     bool on_timeout_called{false};

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -433,6 +433,13 @@ TEST(Utils, escape_for_shell_replaces_newlines_with_spaces)
     EXPECT_THAT(res, ::testing::StrEq("I\\'ve\\ got\\ newlines"));
 }
 
+TEST(Utils, escape_for_shell_quotes_empty_string)
+{
+    std::string s{""};
+    auto res = mp::utils::escape_for_shell(s);
+    EXPECT_THAT(res, ::testing::StrEq("''"));
+}
+
 TEST(Utils, try_action_actually_times_out)
 {
     bool on_timeout_called{false};


### PR DESCRIPTION
This fixes #3116, the execution of strings containing quotes and newlines, like `multipass exec instance -- bash -c 'blah\nblah'`.

This also fixes #3119, the execution of strings containing empty substrings delimited with single or double quotes.