### PR TITLE
[snapshots] record snapshot creation time

### DIFF
--- a/include/multipass/snapshot.h
+++ b/include/multipass/snapshot.h
@@ -40,6 +40,7 @@ public: // TODO@snapshots drop any accessors that we end up not needing
     virtual std::string get_name() const = 0;
     virtual std::string get_comment() const = 0;
     virtual std::string get_parent_name() const = 0;
+    virtual QDateTime get_creation_timestamp() const = 0;
     virtual std::shared_ptr<const Snapshot> get_parent() const = 0;
     virtual std::shared_ptr<Snapshot> get_parent() = 0;
 
@@ -56,6 +57,7 @@ public: // TODO@snapshots drop any accessors that we end up not needing
 
     virtual void set_name(const std::string&) = 0; // TODO@snapshots don't forget to rename json file
     virtual void set_comment(const std::string&) = 0;
+    virtual void set_creation_timestamp(const QDateTime&) = 0;
     virtual void set_parent(std::shared_ptr<Snapshot>) = 0;
 
     virtual void capture() = 0; // not using the constructor, we need snapshot objects for existing snapshots too

--- a/include/multipass/snapshot.h
+++ b/include/multipass/snapshot.h
@@ -57,7 +57,6 @@ public: // TODO@snapshots drop any accessors that we end up not needing
 
     virtual void set_name(const std::string&) = 0; // TODO@snapshots don't forget to rename json file
     virtual void set_comment(const std::string&) = 0;
-    virtual void set_creation_timestamp(const QDateTime&) = 0;
     virtual void set_parent(std::shared_ptr<Snapshot>) = 0;
 
     virtual void capture() = 0; // not using the constructor, we need snapshot objects for existing snapshots too

--- a/include/multipass/snapshot.h
+++ b/include/multipass/snapshot.h
@@ -26,6 +26,7 @@
 #include <unordered_map>
 
 class QJsonObject;
+class QDateTime;
 
 namespace multipass
 {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1761,7 +1761,10 @@ try // clang-format on
             fundamentals->set_snapshot_name(snapshot->get_name());
             fundamentals->set_parent(snapshot->get_parent_name());
             fundamentals->set_comment(snapshot->get_comment());
-            // TODO@snapshots populate snapshot creation time once available
+
+            auto timestamp = fundamentals->mutable_creation_timestamp();
+            timestamp->set_seconds(snapshot->get_creation_timestamp().toSecsSinceEpoch());
+            timestamp->set_nanos(snapshot->get_creation_timestamp().time().msec() * 1000000);
         };
 
         if (const auto& it = instance_snapshots_map.find(name);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1764,7 +1764,7 @@ try // clang-format on
 
             auto timestamp = fundamentals->mutable_creation_timestamp();
             timestamp->set_seconds(snapshot->get_creation_timestamp().toSecsSinceEpoch());
-            timestamp->set_nanos(snapshot->get_creation_timestamp().time().msec() * 1000000);
+            timestamp->set_nanos(snapshot->get_creation_timestamp().time().msec() * 1'000'000);
         };
 
         if (const auto& it = instance_snapshots_map.find(name);

--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -65,7 +65,7 @@ void checked_exec_qemu_img(std::unique_ptr<mp::QemuImgProcessSpec> spec)
 
 mp::QemuSnapshot::QemuSnapshot(const std::string& name, const std::string& comment, const VMSpecs& specs,
                                const QString& image_path, std::shared_ptr<Snapshot> parent)
-    : BaseSnapshot(name, comment, QDateTime::currentDateTimeUtc(), specs, std::move(parent)), image_path{image_path}
+    : BaseSnapshot(name, comment, specs, std::move(parent)), image_path{image_path}
 {
 }
 

--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -65,7 +65,7 @@ void checked_exec_qemu_img(std::unique_ptr<mp::QemuImgProcessSpec> spec)
 
 mp::QemuSnapshot::QemuSnapshot(const std::string& name, const std::string& comment, const VMSpecs& specs,
                                const QString& image_path, std::shared_ptr<Snapshot> parent)
-    : BaseSnapshot(name, comment, specs, std::move(parent)), image_path{image_path}
+    : BaseSnapshot(name, comment, QDateTime::currentDateTimeUtc(), specs, std::move(parent)), image_path{image_path}
 {
 }
 

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -78,12 +78,14 @@ std::shared_ptr<mp::Snapshot> find_parent(const QJsonObject& json, mp::VirtualMa
 }
 } // namespace
 
-mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, int num_cores, MemorySize mem_size,
-                               MemorySize disk_space, VirtualMachine::State state,
+mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment,
+                               const QDateTime& creation_timestamp, // NOLINT(modernize-pass-by-value)
+                               int num_cores, MemorySize mem_size, MemorySize disk_space, VirtualMachine::State state,
                                std::unordered_map<std::string, VMMount> mounts, QJsonObject metadata,
                                std::shared_ptr<Snapshot> parent)
     : name{name},
       comment{comment},
+      creation_timestamp{creation_timestamp},
       num_cores{num_cores},
       mem_size{mem_size},
       disk_space{disk_space},
@@ -102,10 +104,10 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comme
         throw std::runtime_error{fmt::format("Invalid disk size for snapshot: {}", disk_bytes)};
 }
 
-mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, const VMSpecs& specs,
-                               std::shared_ptr<Snapshot> parent)
-    : BaseSnapshot{name,        comment,      specs.num_cores, specs.mem_size,   specs.disk_space,
-                   specs.state, specs.mounts, specs.metadata,  std::move(parent)}
+mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, const QDateTime& creation_timestamp,
+                               const VMSpecs& specs, std::shared_ptr<Snapshot> parent)
+    : BaseSnapshot{name,        comment,      creation_timestamp, specs.num_cores,  specs.mem_size, specs.disk_space,
+                   specs.state, specs.mounts, specs.metadata,     std::move(parent)}
 {
 }
 
@@ -115,8 +117,10 @@ mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm)
 }
 
 mp::BaseSnapshot::BaseSnapshot(InnerJsonTag, const QJsonObject& json, VirtualMachine& vm)
-    : BaseSnapshot{json["name"].toString().toStdString(),                         // name
-                   json["comment"].toString().toStdString(),                      // comment
+    : BaseSnapshot{json["name"].toString().toStdString(),    // name
+                   json["comment"].toString().toStdString(), // comment
+                   QDateTime::fromString(json["creation_timestamp"].toString(),
+                                         "yyyy-MM-ddTHH:mm:ss.zzzZ"),             // creation_timestamp
                    json["num_cores"].toInt(),                                     // num_cores
                    MemorySize{json["mem_size"].toString().toStdString()},         // mem_size
                    MemorySize{json["disk_space"].toString().toStdString()},       // disk_space
@@ -134,6 +138,7 @@ QJsonObject multipass::BaseSnapshot::serialize() const
 
     snapshot.insert("name", QString::fromStdString(name));
     snapshot.insert("comment", QString::fromStdString(comment));
+    snapshot.insert("creation_timestamp", creation_timestamp.toString("yyyy-MM-ddTHH:mm:ss.zzzZ"));
     snapshot.insert("num_cores", num_cores);
     snapshot.insert("mem_size", QString::number(mem_size.in_bytes()));
     snapshot.insert("disk_space", QString::number(disk_space.in_bytes()));

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -78,8 +78,7 @@ std::shared_ptr<mp::Snapshot> find_parent(const QJsonObject& json, mp::VirtualMa
 }
 } // namespace
 
-mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment,
-                               const QDateTime& creation_timestamp, // NOLINT(modernize-pass-by-value)
+mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, const QDateTime& creation_timestamp,
                                int num_cores, MemorySize mem_size, MemorySize disk_space, VirtualMachine::State state,
                                std::unordered_map<std::string, VMMount> mounts, QJsonObject metadata,
                                std::shared_ptr<Snapshot> parent)
@@ -104,10 +103,18 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comme
         throw std::runtime_error{fmt::format("Invalid disk size for snapshot: {}", disk_bytes)};
 }
 
-mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, const QDateTime& creation_timestamp,
-                               const VMSpecs& specs, std::shared_ptr<Snapshot> parent)
-    : BaseSnapshot{name,        comment,      creation_timestamp, specs.num_cores,  specs.mem_size, specs.disk_space,
-                   specs.state, specs.mounts, specs.metadata,     std::move(parent)}
+mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, const VMSpecs& specs,
+                               std::shared_ptr<Snapshot> parent)
+    : BaseSnapshot{name,
+                   comment,
+                   QDateTime::currentDateTimeUtc(),
+                   specs.num_cores,
+                   specs.mem_size,
+                   specs.disk_space,
+                   specs.state,
+                   specs.mounts,
+                   specs.metadata,
+                   std::move(parent)}
 {
 }
 
@@ -120,7 +127,7 @@ mp::BaseSnapshot::BaseSnapshot(InnerJsonTag, const QJsonObject& json, VirtualMac
     : BaseSnapshot{json["name"].toString().toStdString(),    // name
                    json["comment"].toString().toStdString(), // comment
                    QDateTime::fromString(json["creation_timestamp"].toString(),
-                                         "yyyy-MM-ddTHH:mm:ss.zzzZ"),             // creation_timestamp
+                                         Qt::ISODate),                            // creation_timestamp
                    json["num_cores"].toInt(),                                     // num_cores
                    MemorySize{json["mem_size"].toString().toStdString()},         // mem_size
                    MemorySize{json["disk_space"].toString().toStdString()},       // disk_space
@@ -138,7 +145,7 @@ QJsonObject multipass::BaseSnapshot::serialize() const
 
     snapshot.insert("name", QString::fromStdString(name));
     snapshot.insert("comment", QString::fromStdString(comment));
-    snapshot.insert("creation_timestamp", creation_timestamp.toString("yyyy-MM-ddTHH:mm:ss.zzzZ"));
+    snapshot.insert("creation_timestamp", creation_timestamp.toString(Qt::ISODate));
     snapshot.insert("num_cores", num_cores);
     snapshot.insert("mem_size", QString::number(mem_size.in_bytes()));
     snapshot.insert("disk_space", QString::number(disk_space.in_bytes()));

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -128,7 +128,7 @@ mp::BaseSnapshot::BaseSnapshot(InnerJsonTag, const QJsonObject& json, VirtualMac
     : BaseSnapshot{json["name"].toString().toStdString(),    // name
                    json["comment"].toString().toStdString(), // comment
                    QDateTime::fromString(json["creation_timestamp"].toString(),
-                                         Qt::ISODate),                            // creation_timestamp
+                                         Qt::ISODateWithMs),                      // creation_timestamp
                    json["num_cores"].toInt(),                                     // num_cores
                    MemorySize{json["mem_size"].toString().toStdString()},         // mem_size
                    MemorySize{json["disk_space"].toString().toStdString()},       // disk_space
@@ -146,7 +146,7 @@ QJsonObject multipass::BaseSnapshot::serialize() const
 
     snapshot.insert("name", QString::fromStdString(name));
     snapshot.insert("comment", QString::fromStdString(comment));
-    snapshot.insert("creation_timestamp", creation_timestamp.toString(Qt::ISODate));
+    snapshot.insert("creation_timestamp", creation_timestamp.toString(Qt::ISODateWithMs));
     snapshot.insert("num_cores", num_cores);
     snapshot.insert("mem_size", QString::number(mem_size.in_bytes()));
     snapshot.insert("disk_space", QString::number(disk_space.in_bytes()));

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -78,8 +78,9 @@ std::shared_ptr<mp::Snapshot> find_parent(const QJsonObject& json, mp::VirtualMa
 }
 } // namespace
 
-mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, const QDateTime& creation_timestamp,
-                               int num_cores, MemorySize mem_size, MemorySize disk_space, VirtualMachine::State state,
+mp::BaseSnapshot::BaseSnapshot(const std::string& name, const std::string& comment, // NOLINT(modernize-pass-by-value)
+                               const QDateTime& creation_timestamp, int num_cores, MemorySize mem_size,
+                               MemorySize disk_space, VirtualMachine::State state,
                                std::unordered_map<std::string, VMMount> mounts, QJsonObject metadata,
                                std::shared_ptr<Snapshot> parent)
     : name{name},

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -40,8 +40,8 @@ public:
 
     std::string get_name() const override;
     std::string get_comment() const override;
-    std::string get_parent_name() const override;
     QDateTime get_creation_timestamp() const override;
+    std::string get_parent_name() const override;
     std::shared_ptr<const Snapshot> get_parent() const override;
     std::shared_ptr<Snapshot> get_parent() override;
 

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -58,7 +58,6 @@ public:
 
     void set_name(const std::string& n) override;
     void set_comment(const std::string& c) override;
-    void set_creation_timestamp(const QDateTime& t) override;
     void set_parent(std::shared_ptr<Snapshot> p) override;
 
     void capture() final;
@@ -83,7 +82,7 @@ private:
 private:
     std::string name;
     std::string comment;
-    QDateTime creation_timestamp;
+    const QDateTime creation_timestamp;
 
     // This class is non-copyable and having these const simplifies thread safety
     const int num_cores;                                   // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
@@ -113,7 +112,6 @@ inline std::string multipass::BaseSnapshot::get_comment() const
 
 inline QDateTime multipass::BaseSnapshot::get_creation_timestamp() const
 {
-    const std::unique_lock lock{mutex};
     return creation_timestamp;
 }
 
@@ -177,12 +175,6 @@ inline void multipass::BaseSnapshot::set_comment(const std::string& c)
 {
     const std::unique_lock lock{mutex};
     comment = c;
-}
-
-inline void multipass::BaseSnapshot::set_creation_timestamp(const QDateTime& t)
-{
-    const std::unique_lock lock{mutex};
-    creation_timestamp = t;
 }
 
 inline void multipass::BaseSnapshot::set_parent(std::shared_ptr<Snapshot> p)

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -74,7 +74,7 @@ private:
     {
     };
     BaseSnapshot(InnerJsonTag, const QJsonObject& json, VirtualMachine& vm);
-    BaseSnapshot(const std::string& name, const std::string& comment, const QDateTime& creation_timestamp,
+    BaseSnapshot(const std::string& name, const std::string& get_comment, const QDateTime& creation_timestamp,
                  int num_cores, MemorySize mem_size, MemorySize disk_space, VirtualMachine::State state,
                  std::unordered_map<std::string, VMMount> mounts, QJsonObject metadata,
                  std::shared_ptr<Snapshot> parent);
@@ -82,9 +82,9 @@ private:
 private:
     std::string name;
     std::string comment;
-    const QDateTime creation_timestamp;
 
     // This class is non-copyable and having these const simplifies thread safety
+    const QDateTime creation_timestamp;                    // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const int num_cores;                                   // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const MemorySize mem_size;                             // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const MemorySize disk_space;                           // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -34,13 +34,14 @@ struct VMSpecs;
 class BaseSnapshot : public Snapshot
 {
 public:
-    BaseSnapshot(const std::string& name, const std::string& comment, const VMSpecs& specs,
-                 std::shared_ptr<Snapshot> parent);
+    BaseSnapshot(const std::string& name, const std::string& comment, const QDateTime& creation_timestamp,
+                 const VMSpecs& specs, std::shared_ptr<Snapshot> parent);
     BaseSnapshot(const QJsonObject& json, VirtualMachine& vm);
 
     std::string get_name() const override;
     std::string get_comment() const override;
     std::string get_parent_name() const override;
+    QDateTime get_creation_timestamp() const override;
     std::shared_ptr<const Snapshot> get_parent() const override;
     std::shared_ptr<Snapshot> get_parent() override;
 
@@ -57,6 +58,7 @@ public:
 
     void set_name(const std::string& n) override;
     void set_comment(const std::string& c) override;
+    void set_creation_timestamp(const QDateTime& t) override;
     void set_parent(std::shared_ptr<Snapshot> p) override;
 
     void capture() final;
@@ -73,13 +75,15 @@ private:
     {
     };
     BaseSnapshot(InnerJsonTag, const QJsonObject& json, VirtualMachine& vm);
-    BaseSnapshot(const std::string& name, const std::string& comment, int num_cores, MemorySize mem_size,
-                 MemorySize disk_space, VirtualMachine::State state, std::unordered_map<std::string, VMMount> mounts,
-                 QJsonObject metadata, std::shared_ptr<Snapshot> parent);
+    BaseSnapshot(const std::string& name, const std::string& comment, const QDateTime& creation_timestamp,
+                 int num_cores, MemorySize mem_size, MemorySize disk_space, VirtualMachine::State state,
+                 std::unordered_map<std::string, VMMount> mounts, QJsonObject metadata,
+                 std::shared_ptr<Snapshot> parent);
 
 private:
     std::string name;
     std::string comment;
+    QDateTime creation_timestamp;
 
     // This class is non-copyable and having these const simplifies thread safety
     const int num_cores;                                   // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
@@ -105,6 +109,12 @@ inline std::string multipass::BaseSnapshot::get_comment() const
 {
     const std::unique_lock lock{mutex};
     return comment;
+}
+
+inline QDateTime multipass::BaseSnapshot::get_creation_timestamp() const
+{
+    const std::unique_lock lock{mutex};
+    return creation_timestamp;
 }
 
 inline std::string multipass::BaseSnapshot::get_parent_name() const
@@ -167,6 +177,12 @@ inline void multipass::BaseSnapshot::set_comment(const std::string& c)
 {
     const std::unique_lock lock{mutex};
     comment = c;
+}
+
+inline void multipass::BaseSnapshot::set_creation_timestamp(const QDateTime& t)
+{
+    const std::unique_lock lock{mutex};
+    creation_timestamp = t;
 }
 
 inline void multipass::BaseSnapshot::set_parent(std::shared_ptr<Snapshot> p)

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -34,8 +34,8 @@ struct VMSpecs;
 class BaseSnapshot : public Snapshot
 {
 public:
-    BaseSnapshot(const std::string& name, const std::string& comment, const QDateTime& creation_timestamp,
-                 const VMSpecs& specs, std::shared_ptr<Snapshot> parent);
+    BaseSnapshot(const std::string& name, const std::string& comment, const VMSpecs& specs,
+                 std::shared_ptr<Snapshot> parent);
     BaseSnapshot(const QJsonObject& json, VirtualMachine& vm);
 
     std::string get_name() const override;

--- a/tests/stub_snapshot.h
+++ b/tests/stub_snapshot.h
@@ -37,6 +37,11 @@ struct StubSnapshot : public Snapshot
         return {};
     }
 
+    QDateTime get_creation_timestamp() const noexcept override
+    {
+        return QDateTime{};
+    }
+
     std::string get_parent_name() const override
     {
         return {};
@@ -92,6 +97,10 @@ struct StubSnapshot : public Snapshot
     }
 
     void set_comment(const std::string&) override
+    {
+    }
+
+    void set_creation_timestamp(const QDateTime&) override
     {
     }
 

--- a/tests/stub_snapshot.h
+++ b/tests/stub_snapshot.h
@@ -100,10 +100,6 @@ struct StubSnapshot : public Snapshot
     {
     }
 
-    void set_creation_timestamp(const QDateTime&) override
-    {
-    }
-
     void set_parent(std::shared_ptr<Snapshot>) override
     {
     }


### PR DESCRIPTION
Debated the use of `QDateTime` vs `std::chrono::time_point`, but some functions that would be useful for serializing the object to a string and vice versa are only available in C++20. You can still make it work with the C++17 STL, but you will be forced to use `std::time_t` in places. Depending on the platform, `std::time_t` can be only 32 bits, meaning that its maximmum date is sometime in 2038.