### PR TITLE
Revert "[build] Use top commit when determing rc and dev versions"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,11 +97,6 @@ function(determine_version OUTPUT_VARIABLE)
                   OUTPUT_VARIABLE GIT_VERSION
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  execute_process(COMMAND git rev-list --tags --max-count=1
-                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                  OUTPUT_VARIABLE GIT_NEWEST_COMMIT
-		  OUTPUT_STRIP_TRAILING_WHITESPACE)
-
   # only use -rc tags on release/* branches
   string(REGEX MATCH "release/[0-9]+.[0-9]+" GIT_RELEASE_MATCH "${GIT_RELEASE_BRANCH}")
   if(GIT_RELEASE_MATCH)
@@ -116,12 +111,12 @@ function(determine_version OUTPUT_VARIABLE)
                       OUTPUT_STRIP_TRAILING_WHITESPACE
                       ERROR_QUIET)
 
-      execute_process(COMMAND git describe --tags --match *-rc --abbrev=0 "${GIT_NEWEST_COMMIT}"
+      execute_process(COMMAND git describe --tags --match *-rc --abbrev=0
                       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                       OUTPUT_VARIABLE GIT_TAG
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
   else()
-      execute_process(COMMAND git describe --tags --match *-dev --abbrev=0 "${GIT_NEWEST_COMMIT}"
+      execute_process(COMMAND git describe --tags --match *-dev --abbrev=0
                       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                       OUTPUT_VARIABLE GIT_TAG
                       OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
This reverts commit b9a097f6a5a959cf9df59e8ded78b2b44fcf59a3.

---

Seems the change I made before broke the current `dev` build and we get the wrong version for `edge`.  Let's revert this for now and re-evaluate if the `rc` builds get messed up again.