### PR TITLE
Quote '\n' in strings which go through SSH.

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -263,8 +263,9 @@ std::string mp::utils::escape_for_shell(const std::string& in)
     {
         if (0xa == c) // newline
         {
-            *ret_insert++ = 0x5c; // backslash
-            *ret_insert++ = 0x20; // space
+            *ret_insert++ = 0x22; // double quotes
+            *ret_insert++ = 0xa;  // newline
+            *ret_insert++ = 0x22; // double quotes
         }
         else
         {

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -426,11 +426,11 @@ TEST(Utils, escape_for_shell_actually_escapes)
     EXPECT_THAT(res, ::testing::StrEq("I\\'ve\\ got\\ \\\"quotes\\\""));
 }
 
-TEST(Utils, escape_for_shell_replaces_newlines_with_spaces)
+TEST(Utils, escape_for_shell_quotes_newlines)
 {
     std::string s{"I've got\nnewlines"};
     auto res = mp::utils::escape_for_shell(s);
-    EXPECT_THAT(res, ::testing::StrEq("I\\'ve\\ got\\ newlines"));
+    EXPECT_THAT(res, ::testing::StrEq("I\\'ve\\ got\"\n\"newlines"));
 }
 
 TEST(Utils, escape_for_shell_quotes_empty_string)


### PR DESCRIPTION
When we need to pass a string through SSH, we escape some characters. But we forgot about newlines, which are eliminated unless quoted. This PR just put newlines in double quotes, and leave escaping the rest of the characters untouched.

Fixes https://github.com/canonical/multipass/issues/3116.