### PR TITLE
[snapshots] Improve purge wording

### DIFF
--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -92,7 +92,7 @@ mp::ParseCode cmd::Delete::parse_args(mp::ArgParser* parser)
                                   "<instance>[.snapshot] [<instance>[.snapshot] ...]");
 
     QCommandLineOption all_option(all_option_name, "Delete all instances and snapshots");
-    QCommandLineOption purge_option({"p", "purge"}, "Purge specified instances and snapshots immediately");
+    QCommandLineOption purge_option({"p", "purge"}, "Permanently delete specified instances and snapshots immediately");
     parser->addOptions({all_option, purge_option});
 
     auto status = parser->commandParse(this);

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -24,6 +24,13 @@
 namespace mp = multipass;
 namespace cmd = multipass::cmd;
 
+namespace
+{
+constexpr auto no_purge_base_error_msg =
+    "Snapshots can only be purged (after deletion, they cannot be recovered). Please use the `--purge` "
+    "flag if that is what you want";
+}
+
 mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
 {
     auto ret = parse_args(parser);
@@ -125,10 +132,6 @@ mp::ParseCode cmd::Delete::parse_args(mp::ArgParser* parser)
 
     if (snapshot_found && !request.purge())
     {
-        auto no_purge_base_error_msg =
-            "Snapshots can only be purged (after deletion, they cannot be recovered). Please use the `--purge` "
-            "flag if that is what you want";
-
         if (instance_found)
             cerr << fmt::format("{}:\n\n\tmultipass delete --purge {}\n\nYou can use a separate command to delete "
                                 "instances without purging them:\n\n\tmultipass delete {}\n",

--- a/src/client/cli/cmd/delete.h
+++ b/src/client/cli/cmd/delete.h
@@ -45,6 +45,9 @@ private:
     DeleteRequest request;
 
     ParseCode parse_args(ArgParser* parser);
+    ParseCode parse_instances_snapshots(ArgParser* parser);
+    ParseCode enforce_purged_snapshots(std::string& instances, std::string& snapshots, bool instance_found,
+                                       bool snapshot_found);
 };
 } // namespace cmd
 } // namespace multipass


### PR DESCRIPTION
Added a confirmation action that a user must answer if purging snapshots and instances together in the same command. If you think about it, specifying both instances and snapshots together in a deletion command is a little bit odd and not something that user who is unfamiliar with the command would do. So, if they do happen to specify both, we ask them to confirm the action.