### PR TITLE
[snapshots] Snapshot and update QEMU mount args

### DIFF
--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "qemu_snapshot.h"
-#include "qemu_virtual_machine.h"
 #include "shared/qemu_img_utils/qemu_img_utils.h"
 
 #include <multipass/platform.h>
@@ -68,13 +67,17 @@ void checked_exec_qemu_img(std::unique_ptr<mp::QemuImgProcessSpec> spec)
 } // namespace
 
 mp::QemuSnapshot::QemuSnapshot(const std::string& name, const std::string& comment, const VMSpecs& specs,
-                               std::shared_ptr<Snapshot> parent, VirtualMachineDescription& desc)
-    : BaseSnapshot(name, comment, specs, std::move(parent)), desc{desc}, image_path{desc.image.image_path}
+                               std::shared_ptr<Snapshot> parent, VirtualMachineDescription& desc, MountArgs& mount_args)
+    : BaseSnapshot(name, comment, specs, std::move(parent)),
+      desc{desc},
+      mount_args{mount_args},
+      image_path{desc.image.image_path}
 {
 }
 
-mp::QemuSnapshot::QemuSnapshot(const QJsonObject& json, QemuVirtualMachine& vm, VirtualMachineDescription& desc)
-    : BaseSnapshot(json, vm), desc{desc}, image_path{desc.image.image_path}
+mp::QemuSnapshot::QemuSnapshot(const QJsonObject& json, QemuVirtualMachine& vm, VirtualMachineDescription& desc,
+                               MountArgs& mount_args)
+    : BaseSnapshot(json, vm), desc{desc}, mount_args{mount_args}, image_path{desc.image.image_path}
 {
 }
 

--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -108,6 +108,8 @@ void mp::QemuSnapshot::apply_impl()
     desc.mem_size = get_mem_size();
     desc.disk_space = get_disk_space();
 
+    mount_args = QemuVirtualMachine::mount_args_from_json(BaseSnapshot::get_metadata());
+
     checked_exec_qemu_img(make_restore_spec(derive_tag(), image_path));
     rollback.dismiss();
 }

--- a/src/platform/backends/qemu/qemu_snapshot.h
+++ b/src/platform/backends/qemu/qemu_snapshot.h
@@ -23,15 +23,16 @@
 
 namespace multipass
 {
-class QemuVirtualMachine;
 class VirtualMachineDescription;
 
 class QemuSnapshot : public BaseSnapshot
 {
 public:
+    using MountArgs = QemuVirtualMachine::MountArgs;
     QemuSnapshot(const std::string& name, const std::string& comment, const VMSpecs& specs,
-                 std::shared_ptr<Snapshot> parent, VirtualMachineDescription& desc);
-    QemuSnapshot(const QJsonObject& json, QemuVirtualMachine& vm, VirtualMachineDescription& desc);
+                 std::shared_ptr<Snapshot> parent, VirtualMachineDescription& desc, MountArgs& mount_args);
+    QemuSnapshot(const QJsonObject& json, QemuVirtualMachine& vm, VirtualMachineDescription& desc,
+                 MountArgs& mount_args);
 
 protected:
     void capture_impl() override;
@@ -43,6 +44,7 @@ private:
 
 private:
     VirtualMachineDescription& desc;
+    MountArgs& mount_args;
     const QString& image_path;
 };
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -88,23 +88,6 @@ QStringList get_arguments(const QJsonObject& metadata)
     return args;
 }
 
-auto mount_args_from_json(const QJsonObject& object)
-{
-    mp::QemuVirtualMachine::MountArgs mount_args;
-    auto mount_data_map = object[mount_data_key].toObject();
-    for (const auto& tag : mount_data_map.keys())
-    {
-        const auto mount_data = mount_data_map[tag].toObject();
-        const auto source = mount_data[mount_source_key];
-        const auto args = mount_data[mount_arguments_key].toArray();
-        if (!source.isString() || !std::all_of(args.begin(), args.end(), std::mem_fn(&QJsonValue::isString)))
-            continue;
-        mount_args[tag.toStdString()] = {source.toString().toStdString(),
-                                         QVariant{args.toVariantList()}.toStringList()};
-    }
-    return mount_args;
-}
-
 auto make_qemu_process(const mp::VirtualMachineDescription& desc, const std::optional<QJsonObject>& resume_metadata,
                        const mp::QemuVirtualMachine::MountArgs& mount_args, const QStringList& platform_args)
 {
@@ -610,6 +593,23 @@ mp::MountHandler::UPtr mp::QemuVirtualMachine::make_native_mount_handler(const S
 
 mp::QemuVirtualMachine::MountArgs& mp::QemuVirtualMachine::modifiable_mount_args()
 {
+    return mount_args;
+}
+
+auto mp::QemuVirtualMachine::mount_args_from_json(const QJsonObject& object) -> MountArgs
+{
+    mp::QemuVirtualMachine::MountArgs mount_args;
+    auto mount_data_map = object[mount_data_key].toObject();
+    for (const auto& tag : mount_data_map.keys())
+    {
+        const auto mount_data = mount_data_map[tag].toObject();
+        const auto source = mount_data[mount_source_key];
+        const auto args = mount_data[mount_arguments_key].toArray();
+        if (!source.isString() || !std::all_of(args.begin(), args.end(), std::mem_fn(&QJsonValue::isString)))
+            continue;
+        mount_args[tag.toStdString()] = {source.toString().toStdString(),
+                                         QVariant{args.toVariantList()}.toStringList()};
+    }
     return mount_args;
 }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -618,10 +618,10 @@ auto mp::QemuVirtualMachine::make_specific_snapshot(const std::string& name, con
     -> std::shared_ptr<Snapshot>
 {
     assert(state == VirtualMachine::State::off || state != VirtualMachine::State::stopped); // would need QMP otherwise
-    return std::make_shared<QemuSnapshot>(name, comment, specs, std::move(parent), desc);
+    return std::make_shared<QemuSnapshot>(name, comment, specs, std::move(parent), desc, mount_args);
 }
 
 auto mp::QemuVirtualMachine::make_specific_snapshot(const QJsonObject& json) -> std::shared_ptr<Snapshot>
 {
-    return std::make_shared<QemuSnapshot>(json, *this, desc);
+    return std::make_shared<QemuSnapshot>(json, *this, desc, mount_args);
 }

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -64,6 +64,8 @@ public:
     std::unique_ptr<MountHandler> make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
                                                             const std::string& target, const VMMount& mount) override;
 
+    static MountArgs mount_args_from_json(const QJsonObject& metadata);
+
 signals:
     void on_delete_memory_snapshot();
     void on_reset_network();


### PR DESCRIPTION
Keep reference to mount args in snapshot and update when applying. I am still not sure if this is necessary, since the `QemuMountHandler` updates the mount args upon construction and destruction.
