### PR TITLE
[qemu] Allow more firmware directories in AppArmor

### DIFF
--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -203,7 +203,7 @@ profile %1 flags=(attach_disconnected) {
     catch (const mp::SnapEnvironmentException&)
     {
         signal_peer = "unconfined";
-        firmware = "/usr/share/{seabios,ovmf,qemu-efi}/*";
+        firmware = "/usr{,/local}/share/{seabios,ovmf,qemu,qemu-efi}/*";
     }
 
     return profile_template.arg(apparmor_profile_name(), signal_peer, firmware, root_dir, program(),

--- a/tests/qemu/test_qemu_vm_process_spec.cpp
+++ b/tests/qemu/test_qemu_vm_process_spec.cpp
@@ -183,6 +183,6 @@ TEST_F(TestQemuVMProcessSpec, apparmor_profile_not_running_as_snap_correct)
     mp::QemuVMProcessSpec spec(desc, platform_args, mount_args, std::nullopt);
 
     EXPECT_TRUE(spec.apparmor_profile().contains("signal (receive) peer=unconfined"));
-    EXPECT_TRUE(spec.apparmor_profile().contains("/usr/share/{seabios,ovmf,qemu-efi}/* r,"));
+    EXPECT_TRUE(spec.apparmor_profile().contains("/usr{,/local}/share/{seabios,ovmf,qemu,qemu-efi}/* r,"));
     EXPECT_TRUE(spec.apparmor_profile().contains(" /usr/bin/qemu-system-")); // space wanted
 }


### PR DESCRIPTION
Update the AppArmor profile for QEMU processes, to allow `/usr/local` based firmware directories as well as `qemu` "leave" directories. This caters to locally built QEMU needs.
