### PR TITLE
Improve the performance of manifests fetching

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -248,7 +248,7 @@ _multipass_complete()
             opts="${opts} --all --cancel --time"
         ;;
         "find")
-            opts="${opts} --show-unsupported --format"
+            opts="${opts} --show-unsupported --force-update --format"
         ;;
         "aliases")
             opts="${opts} --format"

--- a/include/multipass/async_periodic_task.h
+++ b/include/multipass/async_periodic_task.h
@@ -30,6 +30,22 @@ namespace mpl = multipass::logging;
 
 namespace multipass::utils
 {
+// Because AsyncPeriodicTask needs to be instantiated as data member of a class to work, and Class template argument
+// deduction (CTAD) does not work for data member, so that means we can not deduced type data member from the below code
+// snippet.
+
+// template <typename Callable, typename...Args>
+// class AsyncPeriodicTask
+// {
+// public:
+//     using ReturnType = std::invoke_result_t<std::decay_t<Callable>, std::decay_t<Args>...>;
+//     AsyncPeriodicTask(Callable&& func, Args&&... args);
+//     ...
+// };
+
+// Therefore, the user has to specify the ReturnType as template argument while constructing it.
+
+template <typename ReturnType = void>
 class AsyncPeriodicTask
 {
 public:
@@ -70,7 +86,7 @@ public:
 
 private:
     QTimer timer;
-    std::future<void> future;
+    std::future<ReturnType> future;
 };
 } // namespace multipass::utils
 

--- a/include/multipass/async_periodic_task.h
+++ b/include/multipass/async_periodic_task.h
@@ -59,13 +59,13 @@ public:
         // mock_logger in the unit tests.
 
         // TODO, remove the launch_msg parameter once we have better class separation.
-        mpl::log(mpl::Level::info, "async task", std::string(launch_msg));
+        mpl::log(mpl::Level::debug, "async task", std::string(launch_msg));
         future = std::async(std::launch::async, std::forward<Callable>(func), std::forward<Args>(args)...);
         QObject::connect(&timer, &QTimer::timeout, [launch_msg, this, func, args...]() -> void {
             // skip it if the previous one is still running
             if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
             {
-                mpl::log(mpl::Level::info, "async task", std::string(launch_msg));
+                mpl::log(mpl::Level::debug, "async task", std::string(launch_msg));
                 future = std::async(std::launch::async, func, args...);
             }
         });

--- a/include/multipass/async_periodic_task.h
+++ b/include/multipass/async_periodic_task.h
@@ -30,9 +30,9 @@ namespace mpl = multipass::logging;
 
 namespace multipass::utils
 {
-// Because AsyncPeriodicTask needs to be instantiated as data member of a class to work, and Class template argument
-// deduction (CTAD) does not work for data member, so that means we can not deduced type data member from the below code
-// snippet.
+// Because AsyncPeriodicTask needs to be instantiated as data member of a class to function properly, and Class template
+// argument deduction (CTAD) does not work for data member, so that means we can not deduced type data member from the
+// below code snippet.
 
 // template <typename Callable, typename...Args>
 // class AsyncPeriodicTask
@@ -50,7 +50,7 @@ class AsyncPeriodicTask
 {
 public:
     template <typename Callable, typename... Args>
-    void launch(std::string_view launch_msg, std::chrono::milliseconds msec, Callable&& func, Args&&... args)
+    AsyncPeriodicTask(std::string_view launch_msg, std::chrono::milliseconds msec, Callable&& func, Args&&... args)
     {
         // Log in a side thread will cause some unit tests (like launch_warns_when_overcommitting_disk) to have data
         // race on log, because the side thread log messes with the mock_logger. Because of that, we only allow the
@@ -71,6 +71,7 @@ public:
         });
         timer.start(msec);
     }
+
     void start_timer()
     {
         timer.start();

--- a/include/multipass/async_periodic_task.h
+++ b/include/multipass/async_periodic_task.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_ASYNC_PERIODIC_TASK_H
+#define MULTIPASS_ASYNC_PERIODIC_TASK_H
+
+#include <multipass/logging/log.h>
+
+#include <chrono>
+#include <future>
+#include <string_view>
+
+#include <QTimer>
+
+namespace mpl = multipass::logging;
+
+namespace multipass::utils
+{
+class AsyncPeriodicTask
+{
+public:
+    template <typename Callable, typename... Args>
+    void launch(std::string_view launch_msg, std::chrono::milliseconds msec, Callable&& func, Args&&... args)
+    {
+        // Log in a side thread will cause some unit tests (like launch_warns_when_overcommitting_disk) to have data
+        // race on log, because the side thread log messes with the mock_logger. Because of that, we only allow the
+        // main thread log for now. That is why launch_msg parameter is here. A long-term solution would be a better
+        // separation of classes and mock the corresponding class function, so it will not log and mess with the
+        // mock_logger in the unit tests.
+
+        // TODO, remove the launch_msg parameter once we have better class separation.
+        mpl::log(mpl::Level::info, "async task", std::string(launch_msg));
+        future = std::async(std::launch::async, std::forward<Callable>(func), std::forward<Args>(args)...);
+        QObject::connect(&timer, &QTimer::timeout, [launch_msg, this, func, args...]() -> void {
+            // skip it if the previous one is still running
+            if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+            {
+                mpl::log(mpl::Level::info, "async task", std::string(launch_msg));
+                future = std::async(std::launch::async, func, args...);
+            }
+        });
+        timer.start(msec);
+    }
+    void start_timer()
+    {
+        timer.start();
+    }
+    void stop_timer()
+    {
+        timer.stop();
+    }
+    void wait_ongoing_task_finish() const
+    {
+        future.wait();
+    }
+
+private:
+    QTimer timer;
+    std::future<void> future;
+};
+} // namespace multipass::utils
+
+#endif // MULTIPASS_TIMER_H

--- a/include/multipass/simple_streams_manifest.h
+++ b/include/multipass/simple_streams_manifest.h
@@ -42,6 +42,8 @@ struct SimpleStreamsManifest
     const QString updated_at;
     const std::vector<VMImageInfo> products;
     const QMap<QString, const VMImageInfo*> image_records;
+
+    SimpleStreamsManifest(const QString& update_at, std::vector<VMImageInfo>&& products);
 };
 } // namespace multipass
 #endif // MULTIPASS_SIMPLE_STREAMS_MANIFEST_H

--- a/include/multipass/simple_streams_manifest.h
+++ b/include/multipass/simple_streams_manifest.h
@@ -44,7 +44,6 @@ struct SimpleStreamsManifest
     const QMap<QString, const VMImageInfo*> image_records;
 
     SimpleStreamsManifest(const QString& updated_at, std::vector<VMImageInfo>&& images);
-    SimpleStreamsManifest(const SimpleStreamsManifest& other);
 };
 } // namespace multipass
 #endif // MULTIPASS_SIMPLE_STREAMS_MANIFEST_H

--- a/include/multipass/simple_streams_manifest.h
+++ b/include/multipass/simple_streams_manifest.h
@@ -43,7 +43,8 @@ struct SimpleStreamsManifest
     const std::vector<VMImageInfo> products;
     const QMap<QString, const VMImageInfo*> image_records;
 
-    SimpleStreamsManifest(const QString& update_at, std::vector<VMImageInfo>&& products);
+    SimpleStreamsManifest(const QString& updated_at, std::vector<VMImageInfo>&& images);
+    SimpleStreamsManifest(const SimpleStreamsManifest& other);
 };
 } // namespace multipass
 #endif // MULTIPASS_SIMPLE_STREAMS_MANIFEST_H

--- a/include/multipass/url_downloader.h
+++ b/include/multipass/url_downloader.h
@@ -53,7 +53,7 @@ public:
     virtual void download_to(const QUrl& url, const QString& file_name, int64_t size, const int download_type,
                              const ProgressMonitor& monitor);
     virtual QByteArray download(const QUrl& url);
-    virtual QByteArray download(const QUrl& url, bool is_force_update_from_network);
+    virtual QByteArray download(const QUrl& url, const bool is_force_update_from_network);
     virtual QDateTime last_modified(const QUrl& url);
     virtual void abort_all_downloads();
 

--- a/include/multipass/url_downloader.h
+++ b/include/multipass/url_downloader.h
@@ -53,6 +53,7 @@ public:
     virtual void download_to(const QUrl& url, const QString& file_name, int64_t size, const int download_type,
                              const ProgressMonitor& monitor);
     virtual QByteArray download(const QUrl& url);
+    virtual QByteArray download(const QUrl& url, bool is_force_update_from_network);
     virtual QDateTime last_modified(const QUrl& url);
     virtual void abort_all_downloads();
 
@@ -63,5 +64,5 @@ private:
     const Path cache_dir_path;
     std::chrono::milliseconds timeout;
 };
-}
+} // namespace multipass
 #endif // MULTIPASS_URL_DOWNLOADER_H

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -171,6 +171,23 @@ auto parallel_transform(const Container& input_container, UnaryOperation&& unary
     return results;
 }
 
+template <typename Container, typename UnaryOperation>
+void parallel_for_each(Container& input_container, UnaryOperation&& unary_op)
+{
+    const auto num_elements = input_container.size();
+    std::vector<std::future<void>> empty_futures;
+    empty_futures.reserve(num_elements);
+
+    for (auto& item : input_container)
+    {
+        empty_futures.emplace_back(std::async(std::launch::async, unary_op, std::ref(item)));
+    }
+
+    for (auto& empty_future : empty_futures)
+    {
+        empty_future.get();
+    }
+}
 } // namespace utils
 
 class Utils : public Singleton<Utils>

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -112,7 +112,7 @@ std::string match_line_for(const std::string& output, const std::string& matcher
 // virtual machine helpers
 bool is_running(const VirtualMachine::State& state);
 void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
-    std::function<void()> const& ensure_vm_is_running = []() {});
+                       std::function<void()> const& ensure_vm_is_running = []() {});
 std::string run_in_ssh_session(SSHSession& session, const std::string& cmd);
 
 // yaml helpers

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -162,7 +162,7 @@ auto parallel_transform(const Container& input_container, UnaryOperation&& unary
     for (auto& fut : futures)
     {
         auto item = fut.get();
-        if (!is_default_constructed(fut.get()))
+        if (!is_default_constructed(item))
         {
             results.emplace_back(std::move(item));
         }

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -111,8 +111,7 @@ std::string match_line_for(const std::string& output, const std::string& matcher
 
 // virtual machine helpers
 bool is_running(const VirtualMachine::State& state);
-void wait_until_ssh_up(
-    VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
+void wait_until_ssh_up(VirtualMachine* virtual_machine, std::chrono::milliseconds timeout,
     std::function<void()> const& ensure_vm_is_running = []() {});
 std::string run_in_ssh_session(SSHSession& session, const std::string& cmd);
 

--- a/include/multipass/vm_image_host.h
+++ b/include/multipass/vm_image_host.h
@@ -43,7 +43,7 @@ public:
     virtual std::vector<VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) = 0;
     virtual void for_each_entry_do(const Action& action) = 0;
     virtual std::vector<std::string> supported_remotes() = 0;
-    virtual void update_manifests(bool is_force_update_from_network) = 0;
+    virtual void update_manifests(const bool is_force_update_from_network) = 0;
 
 protected:
     VMImageHost() = default;

--- a/include/multipass/vm_image_host.h
+++ b/include/multipass/vm_image_host.h
@@ -43,7 +43,7 @@ public:
     virtual std::vector<VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) = 0;
     virtual void for_each_entry_do(const Action& action) = 0;
     virtual std::vector<std::string> supported_remotes() = 0;
-    virtual void update_manifests() = 0;
+    virtual void update_manifests(bool is_force_update_from_network) = 0;
 
 protected:
     VMImageHost() = default;

--- a/include/multipass/vm_image_host.h
+++ b/include/multipass/vm_image_host.h
@@ -43,6 +43,7 @@ public:
     virtual std::vector<VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) = 0;
     virtual void for_each_entry_do(const Action& action) = 0;
     virtual std::vector<std::string> supported_remotes() = 0;
+    virtual void update_manifests() = 0;
 
 protected:
     VMImageHost() = default;

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -76,7 +76,7 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
         "format", "Output list in the requested format.\nValid formats are: table (default), json, csv and yaml",
         "format", "table");
     const QCommandLineOption force_manifest_network_download("force-update",
-                                                             "force the manifests update from the network");
+                                                             "Force the image information to update from the network");
     parser->addOptions(
         {unsupportedOption, imagesOnlyOption, blueprintsOnlyOption, formatOption, force_manifest_network_download});
 

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -75,7 +75,8 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
     QCommandLineOption formatOption(
         "format", "Output list in the requested format.\nValid formats are: table (default), json, csv and yaml",
         "format", "table");
-    QCommandLineOption force_manifest_network_download("force-update", "force the manifests update from the network");
+    const QCommandLineOption force_manifest_network_download("force-update",
+                                                             "force the manifests update from the network");
     parser->addOptions(
         {unsupportedOption, imagesOnlyOption, blueprintsOnlyOption, formatOption, force_manifest_network_download});
 

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -75,7 +75,7 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
     QCommandLineOption formatOption(
         "format", "Output list in the requested format.\nValid formats are: table (default), json, csv and yaml",
         "format", "table");
-    QCommandLineOption force_manifest_network_download("force-update", "force the manifests update from network");
+    QCommandLineOption force_manifest_network_download("force-update", "force the manifests update from the network");
     parser->addOptions(
         {unsupportedOption, imagesOnlyOption, blueprintsOnlyOption, formatOption, force_manifest_network_download});
 

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -94,7 +94,6 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
 
     request.set_show_images(!parser->isSet(blueprintsOnlyOption));
     request.set_show_blueprints(!parser->isSet(imagesOnlyOption));
-    request.set_force_manifest_network_download(!parser->isSet(force_manifest_network_download));
 
     if (parser->positionalArguments().count() > 1)
     {
@@ -122,10 +121,8 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
         }
     }
 
-    if (parser->isSet(unsupportedOption))
-    {
-        request.set_allow_unsupported(true);
-    }
+    request.set_allow_unsupported(parser->isSet(unsupportedOption));
+    request.set_force_manifest_network_download(parser->isSet(force_manifest_network_download));
 
     status = handle_format_option(parser, &chosen_formatter, cerr);
 

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -95,7 +95,7 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
 
     if (parser->isSet(force_manifest_network_download) && parser->isSet(blueprintsOnlyOption))
     {
-        cerr << "Force updating blueprints are not currently supported\n";
+        cerr << "Force updating blueprints is not currently supported\n";
         return ParseCode::CommandLineError;
     }
 

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -92,6 +92,12 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
         return ParseCode::CommandLineError;
     }
 
+    if (parser->isSet(force_manifest_network_download) && parser->isSet(blueprintsOnlyOption))
+    {
+        cerr << "Force updating blueprints are not currently supported\n";
+        return ParseCode::CommandLineError;
+    }
+
     request.set_show_images(!parser->isSet(blueprintsOnlyOption));
     request.set_show_blueprints(!parser->isSet(imagesOnlyOption));
 

--- a/src/client/cli/cmd/find.cpp
+++ b/src/client/cli/cmd/find.cpp
@@ -75,7 +75,9 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
     QCommandLineOption formatOption(
         "format", "Output list in the requested format.\nValid formats are: table (default), json, csv and yaml",
         "format", "table");
-    parser->addOptions({unsupportedOption, imagesOnlyOption, blueprintsOnlyOption, formatOption});
+    QCommandLineOption force_manifest_network_download("force-update", "force the manifests update from network");
+    parser->addOptions(
+        {unsupportedOption, imagesOnlyOption, blueprintsOnlyOption, formatOption, force_manifest_network_download});
 
     auto status = parser->commandParse(this);
 
@@ -92,6 +94,7 @@ mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
 
     request.set_show_images(!parser->isSet(blueprintsOnlyOption));
     request.set_show_blueprints(!parser->isSet(imagesOnlyOption));
+    request.set_force_manifest_network_download(!parser->isSet(force_manifest_network_download));
 
     if (parser->positionalArguments().count() > 1)
     {

--- a/src/daemon/common_image_host.cpp
+++ b/src/daemon/common_image_host.cpp
@@ -33,11 +33,6 @@ namespace
 constexpr auto category = "VMImageHost";
 }
 
-mp::CommonVMImageHost::CommonVMImageHost(std::chrono::seconds manifest_time_to_live)
-    : manifest_time_to_live{manifest_time_to_live}, last_update{}
-{
-}
-
 void mp::CommonVMImageHost::for_each_entry_do(const Action& action)
 {
     for_each_entry_do_impl(action);
@@ -50,16 +45,8 @@ auto mp::CommonVMImageHost::info_for_full_hash(const std::string& full_hash) -> 
 
 void mp::CommonVMImageHost::update_manifests()
 {
-    const auto now = std::chrono::steady_clock::now();
-    if ((now - last_update) > manifest_time_to_live || need_extra_update)
-    {
-        need_extra_update = false;
-
-        clear();
-        fetch_manifests();
-
-        last_update = now;
-    }
+    clear();
+    fetch_manifests();
 }
 
 void mp::CommonVMImageHost::on_manifest_empty(const std::string& details)
@@ -69,7 +56,6 @@ void mp::CommonVMImageHost::on_manifest_empty(const std::string& details)
 
 void mp::CommonVMImageHost::on_manifest_update_failure(const std::string& details)
 {
-    need_extra_update = true;
     mpl::log(mpl::Level::warning, category, fmt::format("Could not update manifest: {}", details));
 }
 

--- a/src/daemon/common_image_host.cpp
+++ b/src/daemon/common_image_host.cpp
@@ -43,7 +43,7 @@ auto mp::CommonVMImageHost::info_for_full_hash(const std::string& full_hash) -> 
     return info_for_full_hash_impl(full_hash);
 }
 
-void mp::CommonVMImageHost::update_manifests()
+void mp::CommonVMImageHost::update_manifests(bool is_force_update_from_network)
 {
     clear();
     fetch_manifests();

--- a/src/daemon/common_image_host.cpp
+++ b/src/daemon/common_image_host.cpp
@@ -34,36 +34,17 @@ constexpr auto category = "VMImageHost";
 }
 
 mp::CommonVMImageHost::CommonVMImageHost(std::chrono::seconds manifest_time_to_live)
-  : manifest_time_to_live{manifest_time_to_live}, last_update{}
+    : manifest_time_to_live{manifest_time_to_live}, last_update{}
 {
-    // careful: the functor below relies on polymorphic behavior, which is not available in constructors
-    // fine here as the call is deferred to after the constructor is done (independently of connection type)
-    QObject::connect(&manifest_single_shot, &QTimer::timeout, [this]() {
-        try
-        {
-            update_manifests();
-        }
-        catch (const std::exception& e)
-        {
-            mpl::log(mpl::Level::error, category, e.what());
-        }
-    });
-
-    manifest_single_shot.setSingleShot(true);
-    manifest_single_shot.start(0);
 }
 
 void mp::CommonVMImageHost::for_each_entry_do(const Action& action)
 {
-    update_manifests();
-
     for_each_entry_do_impl(action);
 }
 
 auto mp::CommonVMImageHost::info_for_full_hash(const std::string& full_hash) -> VMImageInfo
 {
-    update_manifests();
-
     return info_for_full_hash_impl(full_hash);
 }
 

--- a/src/daemon/common_image_host.cpp
+++ b/src/daemon/common_image_host.cpp
@@ -46,7 +46,7 @@ auto mp::CommonVMImageHost::info_for_full_hash(const std::string& full_hash) -> 
 void mp::CommonVMImageHost::update_manifests(bool is_force_update_from_network)
 {
     clear();
-    fetch_manifests();
+    fetch_manifests(is_force_update_from_network);
 }
 
 void mp::CommonVMImageHost::on_manifest_empty(const std::string& details)

--- a/src/daemon/common_image_host.cpp
+++ b/src/daemon/common_image_host.cpp
@@ -43,7 +43,7 @@ auto mp::CommonVMImageHost::info_for_full_hash(const std::string& full_hash) -> 
     return info_for_full_hash_impl(full_hash);
 }
 
-void mp::CommonVMImageHost::update_manifests(bool is_force_update_from_network)
+void mp::CommonVMImageHost::update_manifests(const bool is_force_update_from_network)
 {
     clear();
     fetch_manifests(is_force_update_from_network);

--- a/src/daemon/common_image_host.h
+++ b/src/daemon/common_image_host.h
@@ -45,7 +45,7 @@ protected:
     virtual void for_each_entry_do_impl(const Action& action) = 0;
     virtual VMImageInfo info_for_full_hash_impl(const std::string& full_hash) = 0;
     virtual void clear() = 0;
-    virtual void fetch_manifests() = 0;
+    virtual void fetch_manifests(bool is_force_update_from_network) = 0;
 };
 
 } // namespace multipass

--- a/src/daemon/common_image_host.h
+++ b/src/daemon/common_image_host.h
@@ -33,7 +33,7 @@ class CommonVMImageHost : public VMImageHost
 public:
     void for_each_entry_do(const Action& action) final;
     VMImageInfo info_for_full_hash(const std::string& full_hash) final;
-    void update_manifests();
+    void update_manifests(bool is_force_update_from_network);
 
 protected:
     void on_manifest_update_failure(const std::string& details);

--- a/src/daemon/common_image_host.h
+++ b/src/daemon/common_image_host.h
@@ -33,7 +33,7 @@ class CommonVMImageHost : public VMImageHost
 public:
     void for_each_entry_do(const Action& action) final;
     VMImageInfo info_for_full_hash(const std::string& full_hash) final;
-    void update_manifests(bool is_force_update_from_network);
+    void update_manifests(const bool is_force_update_from_network);
 
 protected:
     void on_manifest_update_failure(const std::string& details);
@@ -45,7 +45,7 @@ protected:
     virtual void for_each_entry_do_impl(const Action& action) = 0;
     virtual VMImageInfo info_for_full_hash_impl(const std::string& full_hash) = 0;
     virtual void clear() = 0;
-    virtual void fetch_manifests(bool is_force_update_from_network) = 0;
+    virtual void fetch_manifests(const bool is_force_update_from_network) = 0;
 };
 
 } // namespace multipass

--- a/src/daemon/common_image_host.h
+++ b/src/daemon/common_image_host.h
@@ -31,7 +31,6 @@ namespace multipass
 class CommonVMImageHost : public VMImageHost
 {
 public:
-    CommonVMImageHost(std::chrono::seconds manifest_time_to_live);
     void for_each_entry_do(const Action& action) final;
     VMImageInfo info_for_full_hash(const std::string& full_hash) final;
     void update_manifests();
@@ -47,12 +46,6 @@ protected:
     virtual VMImageInfo info_for_full_hash_impl(const std::string& full_hash) = 0;
     virtual void clear() = 0;
     virtual void fetch_manifests() = 0;
-
-private:
-    std::chrono::seconds manifest_time_to_live;
-    std::chrono::steady_clock::time_point last_update;
-    bool need_extra_update = true;
-    QTimer manifest_single_shot;
 };
 
 } // namespace multipass

--- a/src/daemon/common_image_host.h
+++ b/src/daemon/common_image_host.h
@@ -34,9 +34,9 @@ public:
     CommonVMImageHost(std::chrono::seconds manifest_time_to_live);
     void for_each_entry_do(const Action& action) final;
     VMImageInfo info_for_full_hash(const std::string& full_hash) final;
+    void update_manifests();
 
 protected:
-    void update_manifests();
     void on_manifest_update_failure(const std::string& details);
     void on_manifest_empty(const std::string& details);
     void check_remote_is_supported(const std::string& remote_name) const;
@@ -55,7 +55,6 @@ private:
     QTimer manifest_single_shot;
 };
 
-}
-
+} // namespace multipass
 
 #endif /* MULTIPASS_COMMON_IMAGE_HOST_H_ */

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -160,13 +160,8 @@ auto full_image_info_for(const QMap<QString, CustomImageInfo>& custom_image_info
 
 } // namespace
 
-mp::CustomVMImageHost::CustomVMImageHost(const QString& arch, URLDownloader* downloader,
-                                         std::chrono::seconds manifest_time_to_live)
-    : CommonVMImageHost{manifest_time_to_live},
-      arch{arch},
-      url_downloader{downloader},
-      custom_image_info{},
-      remotes{no_remote}
+mp::CustomVMImageHost::CustomVMImageHost(const QString& arch, URLDownloader* downloader)
+    : arch{arch}, url_downloader{downloader}, custom_image_info{}, remotes{no_remote}
 {
 }
 

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -153,12 +153,15 @@ auto full_image_info_for(const QMap<QString, CustomImageInfo>& custom_image_info
         empty_future.get(); // use get instead of wait to retain the exception throwing
     }
 
-    auto map = map_aliases_to_vm_info_for(default_images);
-
-    return std::unique_ptr<mp::CustomManifest>(new mp::CustomManifest{std::move(default_images), std::move(map)});
+    return std::make_unique<mp::CustomManifest>(std::move(default_images));
 }
 
 } // namespace
+
+mp::CustomManifest::CustomManifest(std::vector<VMImageInfo>&& images)
+    : products{std::move(images)}, image_records{map_aliases_to_vm_info_for(products)}
+{
+}
 
 mp::CustomVMImageHost::CustomVMImageHost(const QString& arch, URLDownloader* downloader)
     : arch{arch}, url_downloader{downloader}, custom_image_info{}, remotes{no_remote}

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -222,7 +222,6 @@ std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for(const std::st
 
 void mp::CustomVMImageHost::for_each_entry_do_impl(const Action& action)
 {
-    const std::lock_guard<std::mutex> lock{custom_image_info_mutex};
     for (const auto& manifest : custom_image_info)
     {
         for (const auto& info : manifest.second->products)
@@ -247,7 +246,6 @@ void mp::CustomVMImageHost::fetch_manifests(bool is_force_update_from_network)
             check_remote_is_supported(spec.first);
             std::unique_ptr<mp::CustomManifest> custom_manifest =
                 full_image_info_for(spec.second, url_downloader, is_force_update_from_network);
-            const std::lock_guard<std::mutex> lock{custom_image_info_mutex};
             // deep copy of custom_manifest is needed to separate the side thread parallel download (write operation)
             // from the main thread read so we can have a minimized critical section.
             custom_image_info.emplace(spec.first, std::make_unique<mp::CustomManifest>(*custom_manifest));
@@ -269,7 +267,6 @@ void mp::CustomVMImageHost::fetch_manifests(bool is_force_update_from_network)
 
 void mp::CustomVMImageHost::clear()
 {
-    const std::lock_guard<std::mutex> lock{custom_image_info_mutex};
     custom_image_info.clear();
 }
 
@@ -277,7 +274,6 @@ mp::CustomManifest* mp::CustomVMImageHost::manifest_from(const std::string& remo
 {
     check_remote_is_supported(remote_name);
 
-    const std::lock_guard<std::mutex> lock{custom_image_info_mutex};
     auto it = custom_image_info.find(remote_name);
     if (it == custom_image_info.end())
         throw std::runtime_error(fmt::format("Remote \"{}\" is unknown or unreachable.", remote_name));

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -246,7 +246,7 @@ void mp::CustomVMImageHost::fetch_manifests(bool is_force_update_from_network)
         }
         catch (mp::DownloadException& e)
         {
-            if (is_force_update_from_network == true)
+            if (is_force_update_from_network)
             {
                 throw e;
             }

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -253,8 +253,6 @@ mp::CustomManifest* mp::CustomVMImageHost::manifest_from(const std::string& remo
 {
     check_remote_is_supported(remote_name);
 
-    update_manifests();
-
     auto it = custom_image_info.find(remote_name);
     if (it == custom_image_info.end())
         throw std::runtime_error(fmt::format("Remote \"{}\" is unknown or unreachable.", remote_name));

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -30,7 +30,6 @@
 #include <QMap>
 #include <QUrl>
 
-#include <future>
 #include <utility>
 
 namespace mp = multipass;

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -166,10 +166,6 @@ mp::CustomManifest::CustomManifest(std::vector<VMImageInfo>&& images)
 {
 }
 
-mp::CustomManifest::CustomManifest(const mp::CustomManifest& other)
-    : products{other.products}, image_records{map_aliases_to_vm_info_for(products)}
-{
-}
 mp::CustomVMImageHost::CustomVMImageHost(const QString& arch, URLDownloader* downloader)
     : arch{arch}, url_downloader{downloader}, custom_image_info{}, remotes{no_remote}
 {
@@ -246,9 +242,7 @@ void mp::CustomVMImageHost::fetch_manifests(bool is_force_update_from_network)
             check_remote_is_supported(spec.first);
             std::unique_ptr<mp::CustomManifest> custom_manifest =
                 full_image_info_for(spec.second, url_downloader, is_force_update_from_network);
-            // deep copy of custom_manifest is needed to separate the side thread parallel download (write operation)
-            // from the main thread read so we can have a minimized critical section.
-            custom_image_info.emplace(spec.first, std::make_unique<mp::CustomManifest>(*custom_manifest));
+            custom_image_info.emplace(spec.first, std::move(custom_manifest));
         }
         catch (mp::DownloadException& e)
         {

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -235,7 +235,7 @@ std::vector<std::string> mp::CustomVMImageHost::supported_remotes()
     return remotes;
 }
 
-void mp::CustomVMImageHost::fetch_manifests()
+void mp::CustomVMImageHost::fetch_manifests(bool is_force_update_from_network)
 {
     for (const auto& spec : {std::make_pair(no_remote, multipass_image_info[arch])})
     {

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -74,7 +74,7 @@ bool is_default_constructed(const mp::VMImageInfo& image_info)
 }
 
 auto base_image_info_for(mp::URLDownloader* url_downloader, const QString& image_url, const QString& hash_url,
-                         const QString& image_file, bool is_force_update_from_network = false)
+                         const QString& image_file, const bool is_force_update_from_network = false)
 {
     const auto last_modified = QLocale::c().toString(url_downloader->last_modified({image_url}), "yyyyMMdd");
     const auto sha256_sums = url_downloader->download({hash_url}, is_force_update_from_network).split('\n');
@@ -112,7 +112,7 @@ auto map_aliases_to_vm_info_for(const std::vector<mp::VMImageInfo>& images)
 }
 
 auto full_image_info_for(const QMap<QString, CustomImageInfo>& custom_image_info, mp::URLDownloader* url_downloader,
-                         bool is_force_update_from_network = false)
+                         const bool is_force_update_from_network = false)
 {
     std::vector<mp::VMImageInfo> default_images(custom_image_info.size());
 
@@ -233,7 +233,7 @@ std::vector<std::string> mp::CustomVMImageHost::supported_remotes()
     return remotes;
 }
 
-void mp::CustomVMImageHost::fetch_manifests(bool is_force_update_from_network)
+void mp::CustomVMImageHost::fetch_manifests(const bool is_force_update_from_network)
 {
     for (const auto& spec : {std::make_pair(no_remote, multipass_image_info[arch])})
     {

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -254,6 +254,10 @@ void mp::CustomVMImageHost::fetch_manifests(bool is_force_update_from_network)
         }
         catch (mp::DownloadException& e)
         {
+            if (is_force_update_from_network == true)
+            {
+                throw e;
+            }
             on_manifest_update_failure(e.what());
         }
         catch (const mp::UnsupportedRemoteException&)

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -163,6 +163,10 @@ mp::CustomManifest::CustomManifest(std::vector<VMImageInfo>&& images)
 {
 }
 
+mp::CustomManifest::CustomManifest(const mp::CustomManifest& other)
+    : products{other.products}, image_records{map_aliases_to_vm_info_for(products)}
+{
+}
 mp::CustomVMImageHost::CustomVMImageHost(const QString& arch, URLDownloader* downloader)
     : arch{arch}, url_downloader{downloader}, custom_image_info{}, remotes{no_remote}
 {
@@ -240,7 +244,7 @@ void mp::CustomVMImageHost::fetch_manifests()
             check_remote_is_supported(spec.first);
             std::unique_ptr<mp::CustomManifest> custom_manifest = full_image_info_for(spec.second, url_downloader);
             const std::lock_guard<std::mutex> lock{custom_image_info_mutex};
-            custom_image_info.emplace(spec.first, std::move(custom_manifest));
+            custom_image_info.emplace(spec.first, std::make_unique<mp::CustomManifest>(*custom_manifest));
         }
         catch (mp::DownloadException& e)
         {

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -77,7 +77,7 @@ auto base_image_info_for(mp::URLDownloader* url_downloader, const QString& image
                          const QString& image_file, bool is_force_update_from_network = false)
 {
     const auto last_modified = QLocale::c().toString(url_downloader->last_modified({image_url}), "yyyyMMdd");
-    const auto sha256_sums = url_downloader->download({hash_url}).split('\n');
+    const auto sha256_sums = url_downloader->download({hash_url}, is_force_update_from_network).split('\n');
     QString hash;
 
     for (const QString line : sha256_sums) // intentional copy

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -244,6 +244,8 @@ void mp::CustomVMImageHost::fetch_manifests()
             check_remote_is_supported(spec.first);
             std::unique_ptr<mp::CustomManifest> custom_manifest = full_image_info_for(spec.second, url_downloader);
             const std::lock_guard<std::mutex> lock{custom_image_info_mutex};
+            // deep copy of custom_manifest is needed to separate the side thread parallel download (write operation)
+            // from the main thread read so we can have a minimized critical section.
             custom_image_info.emplace(spec.first, std::make_unique<mp::CustomManifest>(*custom_manifest));
         }
         catch (mp::DownloadException& e)

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -106,10 +106,10 @@ auto map_aliases_to_vm_info_for(const std::vector<mp::VMImageInfo>& images)
 auto full_image_info_for(const QMap<QString, CustomImageInfo>& custom_image_info, mp::URLDownloader* url_downloader,
                          const bool is_force_update_from_network = false)
 {
-    auto fetch_one_image_info = [is_force_update_from_network, url_downloader](
-                                    const std::pair<QString, CustomImageInfo>& image_info_pair) -> mp::VMImageInfo {
-        const QString& image_file_name = image_info_pair.first;
-        const CustomImageInfo& custom_image_info = image_info_pair.second;
+    auto fetch_one_image_info =
+        [is_force_update_from_network,
+         url_downloader](const std::pair<const QString, CustomImageInfo>& image_info_pair) -> mp::VMImageInfo {
+        const auto& [image_file_name, custom_image_info] = image_info_pair;
         const QString image_url{custom_image_info.url_prefix + image_info_pair.first};
         const QString hash_url{custom_image_info.url_prefix + QStringLiteral("SHA256SUMS")};
 

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -37,6 +37,8 @@ struct CustomManifest
 {
     const std::vector<VMImageInfo> products;
     const std::unordered_map<std::string, const VMImageInfo*> image_records;
+
+    CustomManifest(std::vector<VMImageInfo>&& images);
 };
 
 class CustomVMImageHost final : public CommonVMImageHost

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -42,7 +42,7 @@ struct CustomManifest
 class CustomVMImageHost final : public CommonVMImageHost
 {
 public:
-    CustomVMImageHost(const QString& arch, URLDownloader* downloader, std::chrono::seconds manifest_time_to_live);
+    CustomVMImageHost(const QString& arch, URLDownloader* downloader);
 
     std::optional<VMImageInfo> info_for(const Query& query) override;
     std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) override;

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -39,7 +39,6 @@ struct CustomManifest
     const std::unordered_map<std::string, const VMImageInfo*> image_records;
 
     CustomManifest(std::vector<VMImageInfo>&& images);
-    CustomManifest(const CustomManifest& other);
 };
 
 class CustomVMImageHost final : public CommonVMImageHost

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -23,6 +23,7 @@
 #include <QString>
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -58,6 +59,7 @@ private:
     const QString arch;
     URLDownloader* const url_downloader;
     std::unordered_map<std::string, std::unique_ptr<CustomManifest>> custom_image_info;
+    std::mutex custom_image_info_mutex;
     std::vector<std::string> remotes;
 };
 } // namespace multipass

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -23,7 +23,6 @@
 #include <QString>
 
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -55,7 +55,7 @@ public:
 private:
     void for_each_entry_do_impl(const Action& action) override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
-    void fetch_manifests() override;
+    void fetch_manifests(bool is_force_update_from_network) override;
     void clear() override;
     CustomManifest* manifest_from(const std::string& remote_name);
 

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -39,6 +39,7 @@ struct CustomManifest
     const std::unordered_map<std::string, const VMImageInfo*> image_records;
 
     CustomManifest(std::vector<VMImageInfo>&& images);
+    CustomManifest(const CustomManifest& other);
 };
 
 class CustomVMImageHost final : public CommonVMImageHost

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -62,7 +62,6 @@ private:
     const QString arch;
     URLDownloader* const url_downloader;
     std::unordered_map<std::string, std::unique_ptr<CustomManifest>> custom_image_info;
-    std::mutex custom_image_info_mutex;
     std::vector<std::string> remotes;
 };
 } // namespace multipass

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -48,13 +48,11 @@ public:
     std::vector<VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) override;
     std::vector<std::string> supported_remotes() override;
 
-protected:
+private:
     void for_each_entry_do_impl(const Action& action) override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
     void fetch_manifests() override;
     void clear() override;
-
-private:
     CustomManifest* manifest_from(const std::string& remote_name);
 
     const QString arch;

--- a/src/daemon/custom_image_host.h
+++ b/src/daemon/custom_image_host.h
@@ -53,7 +53,7 @@ public:
 private:
     void for_each_entry_do_impl(const Action& action) override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
-    void fetch_manifests(bool is_force_update_from_network) override;
+    void fetch_manifests(const bool is_force_update_from_network) override;
     void clear() override;
     CustomManifest* manifest_from(const std::string& remote_name);
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1344,7 +1344,7 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
             update_manifests_all_future = std::async(std::launch::async, &Daemon::update_manifests_all, this);
         }
     });
-    timer_update_manifests.start(100); // keep it 10 seconds for now for testing
+    timer_update_manifests.start(10000); // keep it 10 seconds for now for testing
 }
 
 mp::Daemon::~Daemon()
@@ -1500,6 +1500,15 @@ try // clang-format on
     }
     else if (request->remote_name().empty())
     {
+
+        if (request->force_manifest_network_download())
+        {
+            update_manifests_all_future.wait();
+            timer_update_manifests.stop();
+            update_manifests_all_future = std::async(std::launch::async, &Daemon::update_manifests_all, this);
+            timer_update_manifests.start();
+        }
+
         if (request->show_images())
         {
             for (const auto& image_host : config->image_hosts)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1335,29 +1335,13 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     });
     source_images_maintenance_task.start(config->image_refresh_timer);
 
-    auto update_manifests_all = [this]() -> void {
-        //        mpl::log(mpl::Level::info, "daemon",
-        //                 fmt::format("update manifests from thread: {}", QThread::currentThreadId()));
-        std::vector<std::future<void>> empty_futures;
-        empty_futures.reserve(config->image_hosts.size());
-        for (const auto& image_host : config->image_hosts)
-        {
-            empty_futures.emplace_back(
-                std::async(std::launch::async, &VMImageHost::update_manifests, image_host.get()));
-        }
-        for (auto& empty_future : empty_futures)
-        {
-            empty_future.get();
-        }
-    };
-
     // kick it off right away and launch it periodically after
-    void_future = std::async(std::launch::async, update_manifests_all);
-    QObject::connect(&timer_update_manifests, &QTimer::timeout, [update_manifests_all, this]() -> void {
+    void_future = std::async(std::launch::async, &Daemon::update_manifests_all, this);
+    QObject::connect(&timer_update_manifests, &QTimer::timeout, [this]() -> void {
         // just check in case the previous launch did not finish yet. 0 seconds implies no wait.
         if (void_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
         {
-            void_future = std::async(std::launch::async, update_manifests_all);
+            void_future = std::async(std::launch::async, &Daemon::update_manifests_all, this);
         }
     });
     timer_update_manifests.start(100); // keep it 10 seconds for now for testing
@@ -3045,4 +3029,20 @@ void mp::Daemon::finish_async_operation(const std::string& async_future_key)
 
     if (async_op_result.status_promise)
         async_op_result.status_promise->set_value(async_op_result.status);
+}
+
+void mp::Daemon::update_manifests_all()
+{
+    //        mpl::log(mpl::Level::info, "daemon",
+    //                 fmt::format("update manifests from thread: {}", QThread::currentThreadId()));
+    std::vector<std::future<void>> empty_futures;
+    empty_futures.reserve(config->image_hosts.size());
+    for (const auto& image_host : config->image_hosts)
+    {
+        empty_futures.emplace_back(std::async(std::launch::async, &VMImageHost::update_manifests, image_host.get()));
+    }
+    for (auto& empty_future : empty_futures)
+    {
+        empty_future.get();
+    }
 }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3038,7 +3038,7 @@ void mp::Daemon::update_manifests_all(const bool is_force_update_from_network)
     }
 }
 
-void mp::Daemon::wait_update_manifests_all_and_optionally_applied_force(bool force_manifest_network_download)
+void mp::Daemon::wait_update_manifests_all_and_optionally_applied_force(const bool force_manifest_network_download)
 {
     update_manifests_all_task.wait_ongoing_task_finish();
     if (force_manifest_network_download)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3044,7 +3044,7 @@ void mp::Daemon::wait_update_manifests_all_and_optionally_applied_force(const bo
     if (force_manifest_network_download)
     {
         update_manifests_all_task.stop_timer();
-        mpl::log(mpl::Level::info, "async task", "fetch manifest from the internet");
+        mpl::log(mpl::Level::debug, "async task", "fetch manifest from the internet");
         update_manifests_all(true);
         update_manifests_all_task.start_timer();
     }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3023,7 +3023,7 @@ void mp::Daemon::finish_async_operation(const std::string& async_future_key)
         async_op_result.status_promise->set_value(async_op_result.status);
 }
 
-void mp::Daemon::update_manifests_all(bool is_force_update_from_network)
+void mp::Daemon::update_manifests_all(const bool is_force_update_from_network)
 {
     std::vector<std::future<void>> empty_futures;
     empty_futures.reserve(config->image_hosts.size());

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1505,7 +1505,7 @@ try // clang-format on
         {
             update_manifests_all_future.wait();
             timer_update_manifests.stop();
-            update_manifests_all_future = std::async(std::launch::async, &Daemon::update_manifests_all, this, true);
+            update_manifests_all(true);
             timer_update_manifests.start();
         }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1354,7 +1354,11 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     // kick it off right away and launch it periodically after
     void_future = std::async(std::launch::async, update_manifests_all);
     QObject::connect(&timer_update_manifests, &QTimer::timeout, [update_manifests_all, this]() -> void {
-        void_future = std::async(std::launch::async, update_manifests_all);
+        // just check in case the previous launch did not finish yet. 0 seconds implies no wait.
+        if (void_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+        {
+            void_future = std::async(std::launch::async, update_manifests_all);
+        }
     });
     timer_update_manifests.start(100); // keep it 10 seconds for now for testing
 }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1336,8 +1336,8 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     source_images_maintenance_task.start(config->image_refresh_timer);
 
     auto update_manifests_all = [this]() -> void {
-        mpl::log(mpl::Level::info, "daemon",
-                 fmt::format("update manifests from thread: {}", QThread::currentThreadId()));
+        //        mpl::log(mpl::Level::info, "daemon",
+        //                 fmt::format("update manifests from thread: {}", QThread::currentThreadId()));
         std::vector<std::future<void>> empty_futures;
         empty_futures.reserve(config->image_hosts.size());
         for (const auto& image_host : config->image_hosts)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1336,12 +1336,12 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     source_images_maintenance_task.start(config->image_refresh_timer);
 
     // kick it off right away and launch it periodically after
-    void_future = std::async(std::launch::async, &Daemon::update_manifests_all, this);
+    update_manifests_all_future = std::async(std::launch::async, &Daemon::update_manifests_all, this);
     QObject::connect(&timer_update_manifests, &QTimer::timeout, [this]() -> void {
         // just check in case the previous launch did not finish yet. 0 seconds implies no wait.
-        if (void_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+        if (update_manifests_all_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
         {
-            void_future = std::async(std::launch::async, &Daemon::update_manifests_all, this);
+            update_manifests_all_future = std::async(std::launch::async, &Daemon::update_manifests_all, this);
         }
     });
     timer_update_manifests.start(100); // keep it 10 seconds for now for testing

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1352,10 +1352,11 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
     };
 
     // kick it off right away and launch it periodically after
-    QtConcurrent::run(update_manifests_all);
-    QObject::connect(&timer_update_manifests, &QTimer::timeout,
-                     [update_manifests_all]() -> void { QtConcurrent::run(update_manifests_all); });
-    timer_update_manifests.start(10000); // keep it 10 seconds for now for testing
+    void_future = std::async(std::launch::async, update_manifests_all);
+    QObject::connect(&timer_update_manifests, &QTimer::timeout, [update_manifests_all, this]() -> void {
+        void_future = std::async(std::launch::async, update_manifests_all);
+    });
+    timer_update_manifests.start(100); // keep it 10 seconds for now for testing
 }
 
 mp::Daemon::~Daemon()

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1334,9 +1334,6 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
         }
     });
     source_images_maintenance_task.start(config->image_refresh_timer);
-
-    update_manifests_all_task.launch("fetch manifest periodically", std::chrono::seconds(10),
-                                     &Daemon::update_manifests_all, this, false);
 }
 
 mp::Daemon::~Daemon()

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -164,6 +164,7 @@ private:
                              std::promise<grpc::Status>* status_promise, const std::string& errors);
     void finish_async_operation(const std::string& async_future_key);
     QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});
+    void update_manifests_all();
 
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -167,7 +167,7 @@ private:
     QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});
     void update_manifests_all(const bool is_force_update_from_network = false);
     // it is applied in Daemon::find wherever the image info fetching is involved, aka non-only-blueprints case
-    void wait_update_manifests_all_and_optionally_applied_force(bool force_manifest_network_download);
+    void wait_update_manifests_all_and_optionally_applied_force(const bool force_manifest_network_download);
 
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -152,7 +152,11 @@ private:
         grpc::Status status;
         std::promise<grpc::Status>* status_promise;
     };
-
+    struct AsyncPeriodicTaskFacility
+    {
+        QTimer timer;
+        std::future<void> future;
+    };
     // These async_* methods need to operate on instance names and look up the VMs again, lest they be gone or moved.
     template <typename Reply, typename Request>
     std::string async_wait_for_ssh_and_start_mounts_for(const std::string& name, const std::chrono::seconds& timeout,
@@ -176,8 +180,7 @@ private:
     std::unordered_set<std::string> allocated_mac_addrs;
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
-    QTimer timer_update_manifests;
-    std::future<void> update_manifests_all_future;
+    AsyncPeriodicTaskFacility update_manifests_all_task;
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -177,7 +177,8 @@ private:
     std::unordered_set<std::string> allocated_mac_addrs;
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
-    multipass::utils::AsyncPeriodicTask<void> update_manifests_all_task;
+    multipass::utils::AsyncPeriodicTask<void> update_manifests_all_task{
+        "fetch manifest periodically", std::chrono::seconds(10), &Daemon::update_manifests_all, this, false};
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -165,6 +165,8 @@ private:
     void finish_async_operation(const std::string& async_future_key);
     QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});
     void update_manifests_all(bool is_force_update_from_network = false);
+    // it is applied in Daemon::find wherever the image info fetching is involved, aka non-only-blueprints case
+    void wait_update_manifests_all_and_optionally_applied_force(bool force_manifest_network_download);
 
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -177,7 +177,7 @@ private:
     std::unordered_set<std::string> allocated_mac_addrs;
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
-    multipass::utils::AsyncPeriodicTask update_manifests_all_task;
+    multipass::utils::AsyncPeriodicTask<void> update_manifests_all_task;
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -165,7 +165,7 @@ private:
                              std::promise<grpc::Status>* status_promise, const std::string& errors);
     void finish_async_operation(const std::string& async_future_key);
     QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});
-    void update_manifests_all(bool is_force_update_from_network = false);
+    void update_manifests_all(const bool is_force_update_from_network = false);
     // it is applied in Daemon::find wherever the image info fetching is involved, aka non-only-blueprints case
     void wait_update_manifests_all_and_optionally_applied_force(bool force_manifest_network_download);
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -172,6 +172,10 @@ private:
     // it is applied in Daemon::find wherever the image info fetching is involved, aka non-only-blueprints case
     void wait_update_manifests_all_and_optionally_applied_force(bool force_manifest_network_download);
 
+    template <typename Func, typename... Args>
+    void launch_async_periodic_task(std::chrono::milliseconds msec, AsyncPeriodicTaskFacility& facility, Func&& func,
+                                    Args&&... args);
+
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;
     std::unordered_map<std::string, VirtualMachine::ShPtr> operative_instances;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -175,7 +175,7 @@ private:
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
     QTimer timer_update_manifests;
-    std::future<void> void_future;
+    std::future<void> update_manifests_all_future;
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -174,6 +174,7 @@ private:
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
     QTimer timer_update_manifests;
+    std::future<void> void_future;
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -173,6 +173,7 @@ private:
     std::unordered_set<std::string> allocated_mac_addrs;
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
+    QTimer timer_update_manifests;
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -164,7 +164,7 @@ private:
                              std::promise<grpc::Status>* status_promise, const std::string& errors);
     void finish_async_operation(const std::string& async_future_key);
     QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});
-    void update_manifests_all();
+    void update_manifests_all(bool is_force_update_from_network = false);
 
     std::unique_ptr<const DaemonConfig> config;
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -178,7 +178,7 @@ private:
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
     multipass::utils::AsyncPeriodicTask<void> update_manifests_all_task{
-        "fetch manifest periodically", std::chrono::seconds(10), &Daemon::update_manifests_all, this, false};
+        "fetch manifest periodically", std::chrono::minutes(15), &Daemon::update_manifests_all, this, false};
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -135,8 +135,8 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
         update_prompt = platform::make_update_prompt();
     if (image_hosts.empty())
     {
-        image_hosts.push_back(std::make_unique<mp::CustomVMImageHost>(QSysInfo::currentCpuArchitecture(),
-                                                                      url_downloader.get(), manifest_ttl));
+        image_hosts.push_back(
+            std::make_unique<mp::CustomVMImageHost>(QSysInfo::currentCpuArchitecture(), url_downloader.get()));
         image_hosts.push_back(std::make_unique<mp::UbuntuVMImageHost>(
             std::vector<std::pair<std::string, UbuntuVMImageRemote>>{
                 {mp::release_remote, UbuntuVMImageRemote{"https://cloud-images.ubuntu.com/", "releases/",
@@ -146,7 +146,7 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
                 {mp::snapcraft_remote, UbuntuVMImageRemote{"https://cloud-images.ubuntu.com/", "buildd/daily/",
                                                            std::make_optional<QString>(mp::mirror_key)}},
                 {mp::appliance_remote, UbuntuVMImageRemote{"https://cdimage.ubuntu.com/", "ubuntu-core/appliances/"}}},
-            url_downloader.get(), manifest_ttl));
+            url_downloader.get()));
     }
     if (vault == nullptr)
     {

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -50,10 +50,10 @@ bool is_default_constructed(const std::pair<std::string, std::unique_ptr<mp::Sim
 
 auto download_manifest(const QString& host_url, mp::URLDownloader* url_downloader, bool is_force_update_from_network)
 {
-    auto json_index = url_downloader->download({host_url + index_path});
+    auto json_index = url_downloader->download({host_url + index_path}, is_force_update_from_network);
     auto index = mp::SimpleStreamsIndex::fromJson(json_index);
 
-    auto json_manifest = url_downloader->download({host_url + index.manifest_path});
+    auto json_manifest = url_downloader->download({host_url + index.manifest_path}, is_force_update_from_network);
     return json_manifest;
 }
 

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -294,10 +294,11 @@ void mp::UbuntuVMImageHost::fetch_manifests()
     const std::lock_guard<std::mutex> lock{manifests_mutex};
     for (auto& local_manifest : local_manifests)
     {
-        // non default entry filtering after parallel writing
         if (!is_default_constructed(local_manifest))
         {
-            manifests.emplace_back(std::move(local_manifest));
+            auto local_manifest_copy =
+                std::make_pair(local_manifest.first, std::make_unique<SimpleStreamsManifest>(*local_manifest.second));
+            manifests.emplace_back(std::move(local_manifest_copy));
         }
     }
 }

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -168,7 +168,6 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_
 
 mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string& full_hash)
 {
-    const std::lock_guard<std::mutex> lock{manifests_mutex};
     for (const auto& manifest : manifests)
     {
         for (const auto& product : manifest.second->products)
@@ -207,7 +206,6 @@ std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::st
 
 void mp::UbuntuVMImageHost::for_each_entry_do_impl(const Action& action)
 {
-    const std::lock_guard<std::mutex> lock{manifests_mutex};
     for (const auto& manifest : manifests)
     {
         for (const auto& product : manifest.second->products)
@@ -296,7 +294,6 @@ void mp::UbuntuVMImageHost::fetch_manifests(bool is_force_update_from_network)
     }
 
     // only collect the non-default ones so the behaviour is same as the original sequential code
-    const std::lock_guard<std::mutex> lock{manifests_mutex};
     for (auto& local_manifest : local_manifests)
     {
         if (!is_default_constructed(local_manifest))
@@ -310,7 +307,6 @@ void mp::UbuntuVMImageHost::fetch_manifests(bool is_force_update_from_network)
 
 void mp::UbuntuVMImageHost::clear()
 {
-    const std::lock_guard<std::mutex> lock{manifests_mutex};
     manifests.clear();
 }
 
@@ -318,7 +314,6 @@ mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(const std::strin
 {
     check_remote_is_supported(remote);
 
-    const std::lock_guard<std::mutex> lock{manifests_mutex};
     const auto it =
         std::find_if(manifests.cbegin(), manifests.cend(),
                      [&remote](const std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>& element) {

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -269,6 +269,10 @@ void mp::UbuntuVMImageHost::fetch_manifests(bool is_force_update_from_network)
         }
         catch (mp::DownloadException& e)
         {
+            if (is_force_update_from_network == true)
+            {
+                throw e;
+            }
             on_manifest_update_failure(e.what());
         }
         catch (const mp::UnsupportedRemoteException&)

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -267,7 +267,7 @@ void mp::UbuntuVMImageHost::fetch_manifests(bool is_force_update_from_network)
         }
         catch (mp::DownloadException& e)
         {
-            if (is_force_update_from_network == true)
+            if (is_force_update_from_network)
             {
                 throw e;
             }

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -233,7 +233,7 @@ std::vector<std::string> mp::UbuntuVMImageHost::supported_remotes()
     return supported_remotes;
 }
 
-void mp::UbuntuVMImageHost::fetch_manifests()
+void mp::UbuntuVMImageHost::fetch_manifests(bool is_force_update_from_network)
 {
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> local_manifests(remotes.size());
     auto fetch_one_remote_and_write_to_index = [this,

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -298,9 +298,7 @@ void mp::UbuntuVMImageHost::fetch_manifests(bool is_force_update_from_network)
     {
         if (!is_default_constructed(local_manifest))
         {
-            auto local_manifest_copy =
-                std::make_pair(local_manifest.first, std::make_unique<SimpleStreamsManifest>(*local_manifest.second));
-            manifests.emplace_back(std::move(local_manifest_copy));
+            manifests.emplace_back(std::move(local_manifest));
         }
     }
 }

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -48,7 +48,8 @@ bool is_default_constructed(const std::pair<std::string, std::unique_ptr<mp::Sim
     return manifest_pair == std::pair<std::string, std::unique_ptr<mp::SimpleStreamsManifest>>{};
 }
 
-auto download_manifest(const QString& host_url, mp::URLDownloader* url_downloader, bool is_force_update_from_network)
+auto download_manifest(const QString& host_url, mp::URLDownloader* url_downloader,
+                       const bool is_force_update_from_network)
 {
     auto json_index = url_downloader->download({host_url + index_path}, is_force_update_from_network);
     auto index = mp::SimpleStreamsIndex::fromJson(json_index);
@@ -231,7 +232,7 @@ std::vector<std::string> mp::UbuntuVMImageHost::supported_remotes()
     return supported_remotes;
 }
 
-void mp::UbuntuVMImageHost::fetch_manifests(bool is_force_update_from_network)
+void mp::UbuntuVMImageHost::fetch_manifests(const bool is_force_update_from_network)
 {
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> local_manifests(remotes.size());
     auto fetch_one_remote_and_write_to_index =

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -312,8 +312,6 @@ mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(const std::strin
 {
     check_remote_is_supported(remote);
 
-    update_manifests();
-
     auto it = std::find_if(manifests.begin(), manifests.end(),
                            [&remote](const std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>& element) {
                                return element.first == remote;

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -35,7 +35,6 @@
 #include <QUrl>
 
 #include <algorithm>
-#include <future>
 #include <unordered_set>
 
 namespace mp = multipass;

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -77,8 +77,8 @@ auto key_from(const std::string& search_string)
 } // namespace
 
 mp::UbuntuVMImageHost::UbuntuVMImageHost(std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes,
-                                         URLDownloader* downloader, std::chrono::seconds manifest_time_to_live)
-    : CommonVMImageHost{manifest_time_to_live}, url_downloader{downloader}, remotes{std::move(remotes)}
+                                         URLDownloader* downloader)
+    : url_downloader{downloader}, remotes{std::move(remotes)}
 {
 }
 

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -45,7 +45,7 @@ constexpr auto index_path = "streams/v1/index.json";
 
 bool is_default_constructed(const std::pair<std::string, std::unique_ptr<mp::SimpleStreamsManifest>>& manifest_pair)
 {
-    return manifest_pair.first.empty() && manifest_pair.second == nullptr;
+    return manifest_pair == std::pair<std::string, std::unique_ptr<mp::SimpleStreamsManifest>>{};
 }
 
 auto download_manifest(const QString& host_url, mp::URLDownloader* url_downloader)
@@ -294,6 +294,7 @@ void mp::UbuntuVMImageHost::fetch_manifests()
     const std::lock_guard<std::mutex> lock{manifests_mutex};
     for (auto& local_manifest : local_manifests)
     {
+        // non default entry filtering after parallel writing
         if (!is_default_constructed(local_manifest))
         {
             manifests.emplace_back(std::move(local_manifest));

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -48,7 +48,7 @@ bool is_default_constructed(const std::pair<std::string, std::unique_ptr<mp::Sim
     return manifest_pair == std::pair<std::string, std::unique_ptr<mp::SimpleStreamsManifest>>{};
 }
 
-auto download_manifest(const QString& host_url, mp::URLDownloader* url_downloader)
+auto download_manifest(const QString& host_url, mp::URLDownloader* url_downloader, bool is_force_update_from_network)
 {
     auto json_index = url_downloader->download({host_url + index_path});
     auto index = mp::SimpleStreamsIndex::fromJson(json_index);
@@ -236,20 +236,21 @@ std::vector<std::string> mp::UbuntuVMImageHost::supported_remotes()
 void mp::UbuntuVMImageHost::fetch_manifests(bool is_force_update_from_network)
 {
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> local_manifests(remotes.size());
-    auto fetch_one_remote_and_write_to_index = [this,
-                                                &local_manifests](int index, const std::string& remote_name,
-                                                                  const UbuntuVMImageRemote& remote_info) -> void {
+    auto fetch_one_remote_and_write_to_index =
+        [this, &local_manifests, is_force_update_from_network](int index, const std::string& remote_name,
+                                                               const UbuntuVMImageRemote& remote_info) -> void {
         try
         {
             check_remote_is_supported(remote_name);
             auto official_site = remote_info.get_official_url();
-            auto manifest_bytes_from_official = download_manifest(official_site, url_downloader);
+            auto manifest_bytes_from_official =
+                download_manifest(official_site, url_downloader, is_force_update_from_network);
 
             auto mirror_site = remote_info.get_mirror_url();
             std::optional<QByteArray> manifest_bytes_from_mirror = std::nullopt;
             if (mirror_site)
             {
-                auto bytes = download_manifest(mirror_site.value(), url_downloader);
+                auto bytes = download_manifest(mirror_site.value(), url_downloader, is_force_update_from_network);
                 manifest_bytes_from_mirror = std::make_optional(bytes);
             }
 

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -55,11 +55,16 @@ auto download_manifest(const QString& host_url, mp::URLDownloader* url_downloade
 
 mp::VMImageInfo with_location_fully_resolved(const QString& host_url, const mp::VMImageInfo& info)
 {
-    return {info.aliases,   info.os,
-            info.release,   info.release_title,
-            info.supported, host_url + info.image_location,
-            info.id,        info.stream_location,
-            info.version,   info.size,
+    return {info.aliases,
+            info.os,
+            info.release,
+            info.release_title,
+            info.supported,
+            host_url + info.image_location,
+            info.id,
+            info.stream_location,
+            info.version,
+            info.size,
             info.verify};
 }
 

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -50,7 +50,7 @@ public:
 private:
     void for_each_entry_do_impl(const Action& action) override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
-    void fetch_manifests(bool is_force_update_from_network) override;
+    void fetch_manifests(const bool is_force_update_from_network) override;
     void clear() override;
     SimpleStreamsManifest* manifest_from(const std::string& remote);
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -57,7 +57,6 @@ private:
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;
 
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> manifests;
-    std::mutex manifests_mutex;
     URLDownloader* const url_downloader;
     std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes;
     std::string remote_url_from(const std::string& remote_name);

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -25,6 +25,7 @@
 
 #include <QString>
 
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -57,6 +58,7 @@ private:
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;
 
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> manifests;
+    std::mutex manifests_mutex;
     URLDownloader* const url_downloader;
     std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes;
     std::string remote_url_from(const std::string& remote_name);

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -48,15 +48,14 @@ public:
     std::vector<VMImageInfo> all_images_for(const std::string& remote_name, const bool allow_unsupported) override;
     std::vector<std::string> supported_remotes() override;
 
-protected:
+private:
     void for_each_entry_do_impl(const Action& action) override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
     void fetch_manifests() override;
     void clear() override;
-
-private:
     SimpleStreamsManifest* manifest_from(const std::string& remote);
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;
+
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> manifests;
     URLDownloader* const url_downloader;
     std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes;

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -51,7 +51,7 @@ public:
 private:
     void for_each_entry_do_impl(const Action& action) override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
-    void fetch_manifests() override;
+    void fetch_manifests(bool is_force_update_from_network) override;
     void clear() override;
     SimpleStreamsManifest* manifest_from(const std::string& remote);
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -25,7 +25,6 @@
 
 #include <QString>
 
-#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/daemon/ubuntu_image_host.h
+++ b/src/daemon/ubuntu_image_host.h
@@ -41,8 +41,7 @@ class UbuntuVMImageRemote;
 class UbuntuVMImageHost final : public CommonVMImageHost
 {
 public:
-    UbuntuVMImageHost(std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes, URLDownloader* downloader,
-                      std::chrono::seconds manifest_time_to_live);
+    UbuntuVMImageHost(std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes, URLDownloader* downloader);
 
     std::optional<VMImageInfo> info_for(const Query& query) override;
     std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) override;

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -235,7 +235,7 @@ QByteArray mp::URLDownloader::download(const QUrl& url)
     return download(url, false);
 }
 
-QByteArray mp::URLDownloader::download(const QUrl& url, bool is_force_update_from_network)
+QByteArray mp::URLDownloader::download(const QUrl& url, const bool is_force_update_from_network)
 {
     auto manager{MP_NETMGRFACTORY.make_network_manager(cache_dir_path)};
 

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -77,7 +77,7 @@ template <typename ProgressAction, typename DownloadAction, typename ErrorAction
 QByteArray
 download(QNetworkAccessManager* manager, const Time& timeout, QUrl const& url, ProgressAction&& on_progress,
          DownloadAction&& on_download, ErrorAction&& on_error, const std::atomic_bool& abort_download,
-         QNetworkRequest::CacheLoadControl cache_load_control = QNetworkRequest::CacheLoadControl::PreferNetwork)
+         const QNetworkRequest::CacheLoadControl cache_load_control = QNetworkRequest::CacheLoadControl::PreferNetwork)
 {
     QTimer download_timeout;
     download_timeout.setInterval(timeout);

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -109,18 +109,15 @@ download(QNetworkAccessManager* manager, const Time& timeout, QUrl const& url, P
             on_error();
             throw mp::AbortedDownloadException{msg};
         }
-        else if (cache_load_control == QNetworkRequest::CacheLoadControl::AlwaysCache)
+        if (cache_load_control == QNetworkRequest::CacheLoadControl::AlwaysCache)
         {
             on_error();
             throw mp::DownloadException{url.toString().toStdString(), msg};
         }
-        else
-        {
-            mpl::log(mpl::Level::warning, category,
-                     fmt::format("Error getting {}: {} - trying cache.", url.toString(), msg));
-            return ::download(manager, timeout, url, on_progress, on_download, on_error, abort_download,
-                              QNetworkRequest::CacheLoadControl::AlwaysCache);
-        }
+        mpl::log(mpl::Level::warning, category,
+                 fmt::format("Error getting {}: {} - trying cache.", url.toString(), msg));
+        return ::download(manager, timeout, url, on_progress, on_download, on_error, abort_download,
+                          QNetworkRequest::CacheLoadControl::AlwaysCache);
     }
 
     mpl::log(mpl::Level::trace, category,
@@ -254,9 +251,9 @@ QByteArray mp::URLDownloader::download(const QUrl& url, bool is_force_update_fro
         download_timeout.start();
     };
 
-    QNetworkRequest::CacheLoadControl cache_load_control = is_force_update_from_network
-                                                               ? QNetworkRequest::CacheLoadControl::AlwaysNetwork
-                                                               : QNetworkRequest::CacheLoadControl::PreferNetwork;
+    const QNetworkRequest::CacheLoadControl cache_load_control = is_force_update_from_network
+                                                                     ? QNetworkRequest::CacheLoadControl::AlwaysNetwork
+                                                                     : QNetworkRequest::CacheLoadControl::PreferNetwork;
 
     return ::download(
         manager.get(), timeout, url, [](QNetworkReply*, qint64, qint64) {}, on_download, [] {}, abort_downloads,

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -235,6 +235,11 @@ void mp::URLDownloader::download_to(const QUrl& url, const QString& file_name, i
 
 QByteArray mp::URLDownloader::download(const QUrl& url)
 {
+    return download(url, false);
+}
+
+QByteArray mp::URLDownloader::download(const QUrl& url, bool is_force_update_from_network)
+{
     auto manager{MP_NETMGRFACTORY.make_network_manager(cache_dir_path)};
 
     // This will connect to the QNetworkReply::readReady signal and when emitted,
@@ -249,8 +254,13 @@ QByteArray mp::URLDownloader::download(const QUrl& url)
         download_timeout.start();
     };
 
+    QNetworkRequest::CacheLoadControl cache_load_control = is_force_update_from_network
+                                                               ? QNetworkRequest::CacheLoadControl::AlwaysNetwork
+                                                               : QNetworkRequest::CacheLoadControl::PreferNetwork;
+
     return ::download(
-        manager.get(), timeout, url, [](QNetworkReply*, qint64, qint64) {}, on_download, [] {}, abort_downloads);
+        manager.get(), timeout, url, [](QNetworkReply*, qint64, qint64) {}, on_download, [] {}, abort_downloads,
+        cache_load_control);
 }
 
 QDateTime mp::URLDownloader::last_modified(const QUrl& url)

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -135,6 +135,7 @@ message FindRequest {
     bool allow_unsupported = 4;
     bool show_images = 5;
     bool show_blueprints = 6;
+    bool force_manifest_network_download = 7;
 }
 
 message FindReply {

--- a/src/simplestreams/simple_streams_manifest.cpp
+++ b/src/simplestreams/simple_streams_manifest.cpp
@@ -83,10 +83,6 @@ mp::SimpleStreamsManifest::SimpleStreamsManifest(const QString& updated_at, std:
     : updated_at{updated_at}, products{std::move(images)}, image_records{qmap_aliases_to_vm_info_for(products)}
 {
 }
-mp::SimpleStreamsManifest::SimpleStreamsManifest(const SimpleStreamsManifest& other)
-    : updated_at{other.updated_at}, products{other.products}, image_records{qmap_aliases_to_vm_info_for(products)}
-{
-}
 
 std::unique_ptr<mp::SimpleStreamsManifest>
 mp::SimpleStreamsManifest::fromJson(const QByteArray& json_from_official,

--- a/src/simplestreams/simple_streams_manifest.cpp
+++ b/src/simplestreams/simple_streams_manifest.cpp
@@ -79,8 +79,12 @@ QMap<QString, const mp::VMImageInfo*> qmap_aliases_to_vm_info_for(const std::vec
 
 } // namespace
 
-mp::SimpleStreamsManifest::SimpleStreamsManifest(const QString& update_at, std::vector<VMImageInfo>&& images)
-    : updated_at{update_at}, products{std::move(images)}, image_records{qmap_aliases_to_vm_info_for(products)}
+mp::SimpleStreamsManifest::SimpleStreamsManifest(const QString& updated_at, std::vector<VMImageInfo>&& images)
+    : updated_at{updated_at}, products{std::move(images)}, image_records{qmap_aliases_to_vm_info_for(products)}
+{
+}
+mp::SimpleStreamsManifest::SimpleStreamsManifest(const SimpleStreamsManifest& other)
+    : updated_at{other.updated_at}, products{other.products}, image_records{qmap_aliases_to_vm_info_for(products)}
 {
 }
 

--- a/src/simplestreams/simple_streams_manifest.cpp
+++ b/src/simplestreams/simple_streams_manifest.cpp
@@ -60,6 +60,23 @@ QString latest_version_in(const QJsonObject& versions)
     }
     return max_version;
 }
+
+QMap<QString, const mp::VMImageInfo*> qmap_aliases_to_vm_info_for(const std::vector<mp::VMImageInfo>& products)
+{
+    QMap<QString, const mp::VMImageInfo*> map;
+
+    for (const auto& product : products)
+    {
+        map[product.id] = &product;
+        for (const auto& alias : product.aliases)
+        {
+            map[alias] = &product;
+        }
+    }
+
+    return map;
+}
+
 } // namespace
 
 std::unique_ptr<mp::SimpleStreamsManifest>
@@ -163,16 +180,7 @@ mp::SimpleStreamsManifest::fromJson(const QByteArray& json_from_official,
     if (products.empty())
         throw mp::EmptyManifestException("No supported products found.");
 
-    QMap<QString, const VMImageInfo*> map;
-
-    for (const auto& product : products)
-    {
-        map[product.id] = &product;
-        for (const auto& alias : product.aliases)
-        {
-            map[alias] = &product;
-        }
-    }
+    auto map = qmap_aliases_to_vm_info_for(products);
 
     return std::unique_ptr<SimpleStreamsManifest>(
         new SimpleStreamsManifest{updated, std::move(products), std::move(map)});

--- a/tests/image_host_remote_count.cpp
+++ b/tests/image_host_remote_count.cpp
@@ -30,6 +30,7 @@ size_t mpt::count_remotes(mp::VMImageHost& host)
 {
     std::set<std::string> remotes;
     auto counting_action = [&remotes](const std::string& remote, const VMImageInfo&) { remotes.insert(remote); };
+    host.update_manifests();
     host.for_each_entry_do(counting_action);
 
     return remotes.size();

--- a/tests/image_host_remote_count.cpp
+++ b/tests/image_host_remote_count.cpp
@@ -30,7 +30,7 @@ size_t mpt::count_remotes(mp::VMImageHost& host)
 {
     std::set<std::string> remotes;
     auto counting_action = [&remotes](const std::string& remote, const VMImageInfo&) { remotes.insert(remote); };
-    host.update_manifests();
+    host.update_manifests(false);
     host.for_each_entry_do(counting_action);
 
     return remotes.size();

--- a/tests/mischievous_url_downloader.cpp
+++ b/tests/mischievous_url_downloader.cpp
@@ -35,7 +35,7 @@ QByteArray mpt::MischievousURLDownloader::download(const QUrl& url)
     return URLDownloader::download(choose_url(url));
 }
 
-QByteArray mpt::MischievousURLDownloader::download(const QUrl& url, bool is_force_update_from_network)
+QByteArray mpt::MischievousURLDownloader::download(const QUrl& url, const bool is_force_update_from_network)
 {
     return URLDownloader::download(choose_url(url), is_force_update_from_network);
 }

--- a/tests/mischievous_url_downloader.cpp
+++ b/tests/mischievous_url_downloader.cpp
@@ -35,6 +35,11 @@ QByteArray mpt::MischievousURLDownloader::download(const QUrl& url)
     return URLDownloader::download(choose_url(url));
 }
 
+QByteArray mpt::MischievousURLDownloader::download(const QUrl& url, bool is_force_update_from_network)
+{
+    return URLDownloader::download(choose_url(url), is_force_update_from_network);
+}
+
 QDateTime mpt::MischievousURLDownloader::last_modified(const QUrl& url)
 {
     return URLDownloader::last_modified(choose_url(url));

--- a/tests/mischievous_url_downloader.h
+++ b/tests/mischievous_url_downloader.h
@@ -34,6 +34,7 @@ public:
     void download_to(const QUrl& url, const QString& file_name, int64_t size, const int download_type,
                      const ProgressMonitor& monitor) override;
     QByteArray download(const QUrl& url) override;
+    QByteArray download(const QUrl& url, bool is_force_update_from_network) override;
     QDateTime last_modified(const QUrl& url) override;
 
 public:

--- a/tests/mischievous_url_downloader.h
+++ b/tests/mischievous_url_downloader.h
@@ -34,7 +34,7 @@ public:
     void download_to(const QUrl& url, const QString& file_name, int64_t size, const int download_type,
                      const ProgressMonitor& monitor) override;
     QByteArray download(const QUrl& url) override;
-    QByteArray download(const QUrl& url, bool is_force_update_from_network) override;
+    QByteArray download(const QUrl& url, const bool is_force_update_from_network) override;
     QDateTime last_modified(const QUrl& url) override;
 
 public:

--- a/tests/mock_image_host.h
+++ b/tests/mock_image_host.h
@@ -94,6 +94,7 @@ public:
     MOCK_METHOD(std::vector<VMImageInfo>, all_images_for, (const std::string&, const bool), (override));
     MOCK_METHOD(void, for_each_entry_do, (const Action&), (override));
     MOCK_METHOD(std::vector<std::string>, supported_remotes, (), (override));
+    MOCK_METHOD(void, update_manifests, (), (override));
 
     TempFile image;
     VMImageInfo mock_bionic_image_info{{default_alias},

--- a/tests/mock_image_host.h
+++ b/tests/mock_image_host.h
@@ -111,9 +111,17 @@ public:
     VMImageInfo mock_snapcraft_image_info{
         {snapcraft_alias},       "Ubuntu", "core20", snapcraft_release_info, true, image.url(), snapcraft_image_id, "",
         snapcraft_image_version, 1,        true};
-    VMImageInfo mock_custom_image_info{
-        {custom_alias},       "Ubuntu", "Custom Core", custom_release_info, true, image.url(), custom_image_id, "",
-        custom_image_version, 1,        false};
+    VMImageInfo mock_custom_image_info{{custom_alias},
+                                       "Ubuntu",
+                                       "Custom Core",
+                                       custom_release_info,
+                                       true,
+                                       image.url(),
+                                       custom_image_id,
+                                       "",
+                                       custom_image_version,
+                                       1,
+                                       false};
     VMImageInfo mock_another_image_info{
         {another_alias},       "Ubuntu", "another", another_release_info, true, image.url(), another_image_id, "",
         another_image_version, 1,        false};

--- a/tests/mock_image_host.h
+++ b/tests/mock_image_host.h
@@ -94,7 +94,7 @@ public:
     MOCK_METHOD(std::vector<VMImageInfo>, all_images_for, (const std::string&, const bool), (override));
     MOCK_METHOD(void, for_each_entry_do, (const Action&), (override));
     MOCK_METHOD(std::vector<std::string>, supported_remotes, (), (override));
-    MOCK_METHOD(void, update_manifests, (), (override));
+    MOCK_METHOD(void, update_manifests, (bool), (override));
 
     TempFile image;
     VMImageInfo mock_bionic_image_info{{default_alias},
@@ -111,17 +111,9 @@ public:
     VMImageInfo mock_snapcraft_image_info{
         {snapcraft_alias},       "Ubuntu", "core20", snapcraft_release_info, true, image.url(), snapcraft_image_id, "",
         snapcraft_image_version, 1,        true};
-    VMImageInfo mock_custom_image_info{{custom_alias},
-                                       "Ubuntu",
-                                       "Custom Core",
-                                       custom_release_info,
-                                       true,
-                                       image.url(),
-                                       custom_image_id,
-                                       "",
-                                       custom_image_version,
-                                       1,
-                                       false};
+    VMImageInfo mock_custom_image_info{
+        {custom_alias},       "Ubuntu", "Custom Core", custom_release_info, true, image.url(), custom_image_id, "",
+        custom_image_version, 1,        false};
     VMImageInfo mock_another_image_info{
         {another_alias},       "Ubuntu", "another", another_release_info, true, image.url(), another_image_id, "",
         another_image_version, 1,        false};

--- a/tests/mock_url_downloader.h
+++ b/tests/mock_url_downloader.h
@@ -29,6 +29,7 @@ struct MockURLDownloader : public multipass::URLDownloader
     MockURLDownloader() : URLDownloader{std::chrono::seconds(10)} {};
 
     MOCK_METHOD(QByteArray, download, (const QUrl&), (override));
+    MOCK_METHOD(QByteArray, download, (const QUrl&, bool), (override));
     MOCK_METHOD(QDateTime, last_modified, (const QUrl&), (override));
     MOCK_METHOD(void, download_to, (const QUrl&, const QString&, int64_t, const int, const ProgressMonitor&),
                 (override));

--- a/tests/stub_image_host.h
+++ b/tests/stub_image_host.h
@@ -56,7 +56,7 @@ struct StubVMImageHost final : public multipass::VMImageHost
         return {};
     }
 
-    void update_manifests(bool is_force_update_from_network) override
+    void update_manifests(const bool is_force_update_from_network) override
     {
     }
 };

--- a/tests/stub_image_host.h
+++ b/tests/stub_image_host.h
@@ -55,6 +55,10 @@ struct StubVMImageHost final : public multipass::VMImageHost
     {
         return {};
     }
+
+    void update_manifests() override
+    {
+    }
 };
 } // namespace test
 } // namespace multipass

--- a/tests/stub_image_host.h
+++ b/tests/stub_image_host.h
@@ -56,7 +56,7 @@ struct StubVMImageHost final : public multipass::VMImageHost
         return {};
     }
 
-    void update_manifests() override
+    void update_manifests(bool is_force_update_from_network) override
     {
     }
 };

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -2797,6 +2797,35 @@ TEST_F(Client, findCmdUnsupportedOptionOk)
     EXPECT_THAT(send_command({"find", "--show-unsupported"}), Eq(mp::ReturnCode::Ok));
 }
 
+TEST_F(Client, findCmdForceUpdateOk)
+{
+    EXPECT_CALL(mock_daemon, find(_, _));
+    EXPECT_EQ(send_command({"find", "--force-update"}), mp::ReturnCode::Ok);
+}
+
+TEST_F(Client, findCmdForceUpdateAndOnlyImagesOk)
+{
+    EXPECT_CALL(mock_daemon, find(_, _));
+    EXPECT_EQ(send_command({"find", "--force-update", "--only-images"}), mp::ReturnCode::Ok);
+}
+
+TEST_F(Client, findCmdForceUpdateAndOnlyBlueprintsError)
+{
+    EXPECT_EQ(send_command({"find", "--force-update", "--only-blueprints"}), mp::ReturnCode::CommandLineError);
+}
+
+TEST_F(Client, findCmdForceUpdateWithRemoteOk)
+{
+    EXPECT_CALL(mock_daemon, find(_, _));
+    EXPECT_EQ(send_command({"find", "foo:", "--force-update"}), mp::ReturnCode::Ok);
+}
+
+TEST_F(Client, findCmdForceUpdateWithRemoteAndSearchNameOk)
+{
+    EXPECT_CALL(mock_daemon, find(_, _));
+    EXPECT_EQ(send_command({"find", "foo:bar", "--force-update"}), mp::ReturnCode::Ok);
+}
+
 TEST_F(Client, findCmdFailsOnMultipleConditions)
 {
     EXPECT_THAT(send_command({"find"

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -60,6 +60,7 @@ struct CustomImageHost : public Test
 
         ON_CALL(mock_url_downloader, last_modified(_)).WillByDefault(Return(QDateTime::currentDateTime()));
         ON_CALL(mock_url_downloader, download(_)).WillByDefault(Return(sha256_sums));
+        ON_CALL(mock_url_downloader, download(_, _)).WillByDefault(Return(sha256_sums));
     }
 
     mp::Query make_query(std::string release, std::string remote)

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -200,14 +200,13 @@ TEST_F(DaemonFind, forByRemoteReturnsExpectedData)
 
 TEST_F(DaemonFind, invalidRemoteNameAndEmptySearchString)
 {
-    const NiceMock<mpt::MockImageHost> mock_image_host;
     auto mock_image_vault = std::make_unique<NiceMock<const mpt::MockVMImageVault>>();
 
     constexpr std::string_view remote_name = "nonsense";
     const std::string error_msg = fmt::format(
         "Remote \'{}\' is not found. Please use `multipass find` for supported remotes and images.", remote_name);
 
-    EXPECT_CALL(*mock_image_vault, image_host_for(_)).Times(1).WillOnce([&error_msg](auto...) {
+    EXPECT_CALL(*mock_image_vault, image_host_for(_)).Times(1).WillOnce([&error_msg]() {
         throw std::runtime_error(error_msg);
         return nullptr;
     });
@@ -226,14 +225,13 @@ TEST_F(DaemonFind, invalidRemoteNameAndEmptySearchString)
 
 TEST_F(DaemonFind, invalidRemoteNameAndNonEmptySearchString)
 {
-    const NiceMock<mpt::MockImageHost> mock_image_host;
     auto mock_image_vault = std::make_unique<NiceMock<const mpt::MockVMImageVault>>();
 
     constexpr std::string_view remote_name = "nonsense";
     const std::string error_msg = fmt::format(
         "Remote \'{}\' is not found. Please use `multipass find` for supported remotes and images.", remote_name);
 
-    EXPECT_CALL(*mock_image_vault, image_host_for(_)).Times(1).WillOnce([&error_msg](auto...) {
+    EXPECT_CALL(*mock_image_vault, image_host_for(_)).Times(1).WillOnce([&error_msg]() {
         throw std::runtime_error(error_msg);
         return nullptr;
     });

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -257,7 +257,7 @@ TEST_F(DaemonFind, findWithoutForceUpdateCheckUpdateManifestsCall)
     EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1);
     // overwrite the defaulty emplaced StubVMImageHost
     config_builder.image_hosts[0] = std::move(mock_image_host);
-    mp::Daemon daemon{config_builder.build()};
+    const mp::Daemon daemon{config_builder.build()};
 
     send_command({"find"});
 }
@@ -267,12 +267,12 @@ TEST_F(DaemonFind, findForceUpdateCheckUpdateManifestsCalls)
     auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
 
     // daemon constructor invoke it first and find --force-update invoke it with force flag true after
-    testing::InSequence sequence; // Force the following expectations to occur in order
+    const testing::InSequence sequence; // Force the following expectations to occur in order
     EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1);
     EXPECT_CALL(*mock_image_host, update_manifests(true)).Times(1);
 
     config_builder.image_hosts[0] = std::move(mock_image_host);
-    mp::Daemon daemon{config_builder.build()};
+    const mp::Daemon daemon{config_builder.build()};
     send_command({"find", "--force-update"});
 }
 
@@ -290,13 +290,13 @@ TEST_F(DaemonFind, findForceUpdateRemoteCheckUpdateManifestsCalls)
         return image_host_ptr;
     });
 
-    testing::InSequence sequence;
+    const testing::InSequence sequence;
     EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1);
     EXPECT_CALL(*mock_image_host, update_manifests(true)).Times(1);
 
     config_builder.vault = std::move(mock_image_vault);
     config_builder.image_hosts[0] = std::move(mock_image_host);
-    mp::Daemon daemon{config_builder.build()};
+    const mp::Daemon daemon{config_builder.build()};
 
     send_command({"find", "release:", "--force-update"});
 }
@@ -305,12 +305,12 @@ TEST_F(DaemonFind, findForceUpdateRemoteSearchNameCheckUpdateManifestsCalls)
 {
     auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
 
-    testing::InSequence sequence;
+    const testing::InSequence sequence;
     EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1);
     EXPECT_CALL(*mock_image_host, update_manifests(true)).Times(1);
 
     config_builder.image_hosts[0] = std::move(mock_image_host);
-    mp::Daemon daemon{config_builder.build()};
+    const mp::Daemon daemon{config_builder.build()};
 
     send_command({"find", "release:22.04", "--force-update"});
 }

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -248,3 +248,69 @@ TEST_F(DaemonFind, invalidRemoteNameAndNonEmptySearchString)
     EXPECT_THAT(cerr_Stream.str(), HasSubstr(error_msg));
     EXPECT_EQ(total_lines_of_output(cerr_Stream), 1);
 }
+
+TEST_F(DaemonFind, findWithoutForceUpdateCheckUpdateManifestsCall)
+{
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+
+    // only the daemon constructor invoke it once
+    EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1);
+    // overwrite the defaulty emplaced StubVMImageHost
+    config_builder.image_hosts[0] = std::move(mock_image_host);
+    mp::Daemon daemon{config_builder.build()};
+
+    send_command({"find"});
+}
+
+TEST_F(DaemonFind, findForceUpdateCheckUpdateManifestsCalls)
+{
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+
+    // daemon constructor invoke it first and find --force-update invoke it with force flag true after
+    testing::InSequence sequence; // Force the following expectations to occur in order
+    EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1);
+    EXPECT_CALL(*mock_image_host, update_manifests(true)).Times(1);
+
+    config_builder.image_hosts[0] = std::move(mock_image_host);
+    mp::Daemon daemon{config_builder.build()};
+    send_command({"find", "--force-update"});
+}
+
+TEST_F(DaemonFind, findForceUpdateRemoteCheckUpdateManifestsCalls)
+{
+    // this unit test requires and mock image_host_for of vault, so
+    // auto image_host = config->vault->image_host_for(remote);
+    // can have a legal value in image_host variable and avoid seg fault in the next
+    // line
+
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+    auto mock_image_vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+
+    EXPECT_CALL(*mock_image_vault, image_host_for(_)).WillOnce([image_host_ptr = mock_image_host.get()](auto...) {
+        return image_host_ptr;
+    });
+
+    testing::InSequence sequence;
+    EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1);
+    EXPECT_CALL(*mock_image_host, update_manifests(true)).Times(1);
+
+    config_builder.vault = std::move(mock_image_vault);
+    config_builder.image_hosts[0] = std::move(mock_image_host);
+    mp::Daemon daemon{config_builder.build()};
+
+    send_command({"find", "release:", "--force-update"});
+}
+
+TEST_F(DaemonFind, findForceUpdateRemoteSearchNameCheckUpdateManifestsCalls)
+{
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+
+    testing::InSequence sequence;
+    EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1);
+    EXPECT_CALL(*mock_image_host, update_manifests(true)).Times(1);
+
+    config_builder.image_hosts[0] = std::move(mock_image_host);
+    mp::Daemon daemon{config_builder.build()};
+
+    send_command({"find", "release:22.04", "--force-update"});
+}

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -96,7 +96,7 @@ struct UbuntuImageHost : public testing::Test
 TEST_F(UbuntuImageHost, returns_expected_info)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
 
     ASSERT_TRUE(info);
@@ -109,7 +109,7 @@ TEST_F(UbuntuImageHost, returns_expected_mirror_info)
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_valid_mirror_host));
 
     mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
     QString expected_location{test_valid_mirror_host + "releases/" + "newest_image.img"};
@@ -124,7 +124,7 @@ TEST_F(UbuntuImageHost, returns_expected_mirror_info_with_most_recent_image)
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_valid_outdated_mirror_host));
 
     mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
     QString expected_location{test_valid_outdated_mirror_host + "releases/" + "test_image.img"};
@@ -140,7 +140,7 @@ TEST_F(UbuntuImageHost, throw_if_mirror_is_invalid)
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_invalid_mirror_host));
 
     mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     EXPECT_THROW(host.info_for(make_query("xenial", release_remote_spec.first)), std::runtime_error);
 }
@@ -148,7 +148,7 @@ TEST_F(UbuntuImageHost, throw_if_mirror_is_invalid)
 TEST_F(UbuntuImageHost, uses_default_on_unspecified_release)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto info = host.info_for(make_query("", release_remote_spec.first));
 
@@ -160,7 +160,7 @@ TEST_F(UbuntuImageHost, uses_default_on_unspecified_release)
 TEST_F(UbuntuImageHost, iterates_over_all_entries)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     std::unordered_set<std::string> ids;
     auto action = [&ids](const std::string& remote, const mp::VMImageInfo& info) { ids.insert(info.id.toStdString()); };
@@ -179,7 +179,7 @@ TEST_F(UbuntuImageHost, iterates_over_all_entries)
 TEST_F(UbuntuImageHost, unsupported_alias_iterates_over_expected_entries)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     std::unordered_set<std::string> ids;
     auto action = [&ids](const std::string& remote, const mp::VMImageInfo& info) { ids.insert(info.id.toStdString()); };
@@ -195,7 +195,7 @@ TEST_F(UbuntuImageHost, unsupported_alias_iterates_over_expected_entries)
 TEST_F(UbuntuImageHost, can_query_by_hash)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
     const auto expected_id = "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac";
     auto info = host.info_for(make_query(expected_id, release_remote_spec.first));
 
@@ -206,7 +206,7 @@ TEST_F(UbuntuImageHost, can_query_by_hash)
 TEST_F(UbuntuImageHost, can_query_by_partial_hash)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
     const auto expected_id = "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac";
 
     QStringList short_hashes;
@@ -228,7 +228,7 @@ TEST_F(UbuntuImageHost, can_query_by_partial_hash)
 TEST_F(UbuntuImageHost, supports_multiple_manifests)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
     QString daily_expected_id{"c09f123b9589c504fe39ec6e9ebe5188c67be7d1fc4fb80c969bf877f5a8333a"};
@@ -249,7 +249,7 @@ TEST_F(UbuntuImageHost, supports_multiple_manifests)
 TEST_F(UbuntuImageHost, looks_for_aliases_before_hashes)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
     QString daily_expected_id{"c09f123b9589c504fe39ec6e9ebe5188c67be7d1fc4fb80c969bf877f5a8333a"};
@@ -264,7 +264,7 @@ TEST_F(UbuntuImageHost, looks_for_aliases_before_hashes)
 TEST_F(UbuntuImageHost, all_info_release_returns_multiple_hash_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto images_info = host.all_info_for(make_query("1", release_remote_spec.first));
 
@@ -275,7 +275,7 @@ TEST_F(UbuntuImageHost, all_info_release_returns_multiple_hash_matches)
 TEST_F(UbuntuImageHost, all_info_daily_no_matches_returns_empty_vector)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto images = host.all_info_for(make_query("1", daily_remote_spec.first));
 
@@ -285,7 +285,7 @@ TEST_F(UbuntuImageHost, all_info_daily_no_matches_returns_empty_vector)
 TEST_F(UbuntuImageHost, all_info_release_returns_one_alias_match)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto images_info = host.all_info_for(make_query("xenial", release_remote_spec.first));
 
@@ -296,7 +296,7 @@ TEST_F(UbuntuImageHost, all_info_release_returns_one_alias_match)
 TEST_F(UbuntuImageHost, all_images_for_release_returns_four_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto images = host.all_images_for(release_remote_spec.first, false);
 
@@ -307,7 +307,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_returns_four_matches)
 TEST_F(UbuntuImageHost, all_images_for_release_unsupported_returns_five_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto images = host.all_images_for(release_remote_spec.first, true);
 
@@ -318,7 +318,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_unsupported_returns_five_matches)
 TEST_F(UbuntuImageHost, all_images_for_daily_returns_all_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto images = host.all_images_for(daily_remote_spec.first, false);
 
@@ -329,7 +329,7 @@ TEST_F(UbuntuImageHost, all_images_for_daily_returns_all_matches)
 TEST_F(UbuntuImageHost, all_images_for_release_unsupported_alias_returns_three_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     EXPECT_CALL(mock_platform, is_alias_supported(AnyOf("zesty", "17.04", "z"), _)).WillRepeatedly(Return(false));
 
@@ -342,7 +342,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_unsupported_alias_returns_three_m
 TEST_F(UbuntuImageHost, supported_remotes_returns_expected_values)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto supported_remotes = host.supported_remotes();
 
@@ -358,7 +358,7 @@ TEST_F(UbuntuImageHost, supported_remotes_returns_expected_values)
 TEST_F(UbuntuImageHost, invalid_remote_throws_error)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     EXPECT_THROW(host.info_for(make_query("xenial", "foo")), std::runtime_error);
 }
@@ -367,13 +367,13 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_initial_network_failure)
 {
     url_downloader.mischiefs = 1000;
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     const auto query = make_query("xenial", release_remote_spec.first);
     EXPECT_THROW(host.info_for(query), std::runtime_error);
 
     url_downloader.mischiefs = 0;
-    host.update_manifests();
+    host.update_manifests(false);
     EXPECT_TRUE(host.info_for(query));
 }
 
@@ -382,22 +382,22 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_later_network_failure)
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
 
     const auto query = make_query("xenial", release_remote_spec.first);
-    host.update_manifests();
+    host.update_manifests(false);
     EXPECT_TRUE(host.info_for(query));
 
     url_downloader.mischiefs = 1000;
-    host.update_manifests();
+    host.update_manifests(false);
     EXPECT_THROW(host.info_for(query), std::runtime_error);
 
     url_downloader.mischiefs = 0;
-    host.update_manifests();
+    host.update_manifests(false);
     EXPECT_TRUE(host.info_for(query));
 }
 
 TEST_F(UbuntuImageHost, handles_and_recovers_from_independent_server_failures)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     const auto num_remotes = mpt::count_remotes(host);
     EXPECT_GT(num_remotes, 0u);
@@ -412,7 +412,7 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_independent_server_failures)
 TEST_F(UbuntuImageHost, throws_unsupported_image_when_image_not_supported)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     EXPECT_THROW(host.info_for(make_query("artful", release_remote_spec.first)), mp::UnsupportedImageException);
 }
@@ -420,7 +420,7 @@ TEST_F(UbuntuImageHost, throws_unsupported_image_when_image_not_supported)
 TEST_F(UbuntuImageHost, devel_request_with_no_remote_returns_expected_info)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
     QString daily_expected_id{"c09f123b9589c504fe39ec6e9ebe5188c67be7d1fc4fb80c969bf877f5a8333a"};
@@ -435,7 +435,7 @@ TEST_F(UbuntuImageHost, devel_request_with_no_remote_returns_expected_info)
 TEST_F(UbuntuImageHost, info_for_too_many_hash_matches_throws)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     const std::string release{"1"};
 
@@ -446,7 +446,7 @@ TEST_F(UbuntuImageHost, info_for_too_many_hash_matches_throws)
 TEST_F(UbuntuImageHost, info_for_same_full_hash_in_both_remotes_does_not_throw)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     const auto hash_query{"ab115b83e7a8bebf3d3a02bf55ad0cb75a0ed515fcbc65fb0c9abe76c752921c"};
 
@@ -456,7 +456,7 @@ TEST_F(UbuntuImageHost, info_for_same_full_hash_in_both_remotes_does_not_throw)
 TEST_F(UbuntuImageHost, info_for_partial_hash_in_both_remotes_throws)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     const auto hash_query{"ab115"};
 
@@ -467,7 +467,7 @@ TEST_F(UbuntuImageHost, info_for_partial_hash_in_both_remotes_throws)
 TEST_F(UbuntuImageHost, all_info_for_no_remote_query_defaults_to_release)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     auto images_info = host.all_info_for(make_query("1", ""));
 
@@ -478,7 +478,7 @@ TEST_F(UbuntuImageHost, all_info_for_no_remote_query_defaults_to_release)
 TEST_F(UbuntuImageHost, all_info_for_unsupported_image_throw)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     const std::string release{"artful"};
 
@@ -490,7 +490,7 @@ TEST_F(UbuntuImageHost, all_info_for_unsupported_image_throw)
 TEST_F(UbuntuImageHost, all_info_for_unsupported_alias_throws)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     const std::string unsupported_alias{"daily"};
     EXPECT_CALL(mock_platform, is_alias_supported(unsupported_alias, _)).WillOnce(Return(false));
@@ -503,7 +503,7 @@ TEST_F(UbuntuImageHost, all_info_for_unsupported_alias_throws)
 TEST_F(UbuntuImageHost, info_for_unsupported_remote_throws)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     const std::string unsupported_remote{"bar"};
     EXPECT_CALL(mock_platform, is_remote_supported(unsupported_remote)).WillRepeatedly(Return(false));
@@ -516,7 +516,7 @@ TEST_F(UbuntuImageHost, info_for_unsupported_remote_throws)
 TEST_F(UbuntuImageHost, info_for_no_remote_first_unsupported_returns_expected_info)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
-    host.update_manifests();
+    host.update_manifests(false);
 
     EXPECT_CALL(mock_platform, is_remote_supported("release")).Times(AtLeast(1)).WillRepeatedly(Return(false));
 

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -82,7 +82,6 @@ struct UbuntuImageHost : public testing::Test
     std::vector<std::pair<std::string, mp::UbuntuVMImageRemote>> all_remote_specs = {release_remote_spec,
                                                                                      daily_remote_spec};
     mpt::MischievousURLDownloader url_downloader{std::chrono::seconds{10}};
-    std::chrono::seconds default_ttl{1};
     QString expected_location{host_url + "newest_image.img"};
     QString expected_id{"8842e7a8adb01c7a30cc702b01a5330a1951b12042816e87efd24b61c5e2239f"};
 
@@ -96,7 +95,7 @@ struct UbuntuImageHost : public testing::Test
 
 TEST_F(UbuntuImageHost, returns_expected_info)
 {
-    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
     host.update_manifests();
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
 
@@ -109,7 +108,7 @@ TEST_F(UbuntuImageHost, returns_expected_mirror_info)
 {
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_valid_mirror_host));
 
-    mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader};
     host.update_manifests();
 
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
@@ -124,7 +123,7 @@ TEST_F(UbuntuImageHost, returns_expected_mirror_info_with_most_recent_image)
 {
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_valid_outdated_mirror_host));
 
-    mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader};
     host.update_manifests();
 
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
@@ -140,7 +139,7 @@ TEST_F(UbuntuImageHost, throw_if_mirror_is_invalid)
 {
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_invalid_mirror_host));
 
-    mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader};
     host.update_manifests();
 
     EXPECT_THROW(host.info_for(make_query("xenial", release_remote_spec.first)), std::runtime_error);
@@ -148,7 +147,7 @@ TEST_F(UbuntuImageHost, throw_if_mirror_is_invalid)
 
 TEST_F(UbuntuImageHost, uses_default_on_unspecified_release)
 {
-    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
     host.update_manifests();
 
     auto info = host.info_for(make_query("", release_remote_spec.first));
@@ -160,7 +159,7 @@ TEST_F(UbuntuImageHost, uses_default_on_unspecified_release)
 
 TEST_F(UbuntuImageHost, iterates_over_all_entries)
 {
-    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
     host.update_manifests();
 
     std::unordered_set<std::string> ids;
@@ -179,7 +178,7 @@ TEST_F(UbuntuImageHost, iterates_over_all_entries)
 
 TEST_F(UbuntuImageHost, unsupported_alias_iterates_over_expected_entries)
 {
-    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
     host.update_manifests();
 
     std::unordered_set<std::string> ids;
@@ -195,7 +194,7 @@ TEST_F(UbuntuImageHost, unsupported_alias_iterates_over_expected_entries)
 
 TEST_F(UbuntuImageHost, can_query_by_hash)
 {
-    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
     host.update_manifests();
     const auto expected_id = "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac";
     auto info = host.info_for(make_query(expected_id, release_remote_spec.first));
@@ -206,7 +205,7 @@ TEST_F(UbuntuImageHost, can_query_by_hash)
 
 TEST_F(UbuntuImageHost, can_query_by_partial_hash)
 {
-    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
     host.update_manifests();
     const auto expected_id = "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac";
 
@@ -228,7 +227,7 @@ TEST_F(UbuntuImageHost, can_query_by_partial_hash)
 
 TEST_F(UbuntuImageHost, supports_multiple_manifests)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
@@ -249,7 +248,7 @@ TEST_F(UbuntuImageHost, supports_multiple_manifests)
 
 TEST_F(UbuntuImageHost, looks_for_aliases_before_hashes)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
@@ -264,7 +263,7 @@ TEST_F(UbuntuImageHost, looks_for_aliases_before_hashes)
 
 TEST_F(UbuntuImageHost, all_info_release_returns_multiple_hash_matches)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     auto images_info = host.all_info_for(make_query("1", release_remote_spec.first));
@@ -275,7 +274,7 @@ TEST_F(UbuntuImageHost, all_info_release_returns_multiple_hash_matches)
 
 TEST_F(UbuntuImageHost, all_info_daily_no_matches_returns_empty_vector)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     auto images = host.all_info_for(make_query("1", daily_remote_spec.first));
@@ -285,7 +284,7 @@ TEST_F(UbuntuImageHost, all_info_daily_no_matches_returns_empty_vector)
 
 TEST_F(UbuntuImageHost, all_info_release_returns_one_alias_match)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     auto images_info = host.all_info_for(make_query("xenial", release_remote_spec.first));
@@ -296,7 +295,7 @@ TEST_F(UbuntuImageHost, all_info_release_returns_one_alias_match)
 
 TEST_F(UbuntuImageHost, all_images_for_release_returns_four_matches)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     auto images = host.all_images_for(release_remote_spec.first, false);
@@ -307,7 +306,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_returns_four_matches)
 
 TEST_F(UbuntuImageHost, all_images_for_release_unsupported_returns_five_matches)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     auto images = host.all_images_for(release_remote_spec.first, true);
@@ -318,7 +317,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_unsupported_returns_five_matches)
 
 TEST_F(UbuntuImageHost, all_images_for_daily_returns_all_matches)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     auto images = host.all_images_for(daily_remote_spec.first, false);
@@ -329,7 +328,7 @@ TEST_F(UbuntuImageHost, all_images_for_daily_returns_all_matches)
 
 TEST_F(UbuntuImageHost, all_images_for_release_unsupported_alias_returns_three_matches)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     EXPECT_CALL(mock_platform, is_alias_supported(AnyOf("zesty", "17.04", "z"), _)).WillRepeatedly(Return(false));
@@ -342,7 +341,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_unsupported_alias_returns_three_m
 
 TEST_F(UbuntuImageHost, supported_remotes_returns_expected_values)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     auto supported_remotes = host.supported_remotes();
@@ -358,7 +357,7 @@ TEST_F(UbuntuImageHost, supported_remotes_returns_expected_values)
 
 TEST_F(UbuntuImageHost, invalid_remote_throws_error)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     EXPECT_THROW(host.info_for(make_query("xenial", "foo")), std::runtime_error);
@@ -366,9 +365,8 @@ TEST_F(UbuntuImageHost, invalid_remote_throws_error)
 
 TEST_F(UbuntuImageHost, handles_and_recovers_from_initial_network_failure)
 {
-    const auto ttl = 1h; // so that updates are only retried when unsuccessful
     url_downloader.mischiefs = 1000;
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     const auto query = make_query("xenial", release_remote_spec.first);
@@ -381,8 +379,7 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_initial_network_failure)
 
 TEST_F(UbuntuImageHost, handles_and_recovers_from_later_network_failure)
 {
-    const auto ttl = 0s; // to ensure updates are always retried
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
 
     const auto query = make_query("xenial", release_remote_spec.first);
     host.update_manifests();
@@ -399,8 +396,7 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_later_network_failure)
 
 TEST_F(UbuntuImageHost, handles_and_recovers_from_independent_server_failures)
 {
-    const auto ttl = 0h;
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     const auto num_remotes = mpt::count_remotes(host);
@@ -415,7 +411,7 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_independent_server_failures)
 
 TEST_F(UbuntuImageHost, throws_unsupported_image_when_image_not_supported)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     EXPECT_THROW(host.info_for(make_query("artful", release_remote_spec.first)), mp::UnsupportedImageException);
@@ -423,7 +419,7 @@ TEST_F(UbuntuImageHost, throws_unsupported_image_when_image_not_supported)
 
 TEST_F(UbuntuImageHost, devel_request_with_no_remote_returns_expected_info)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
@@ -438,7 +434,7 @@ TEST_F(UbuntuImageHost, devel_request_with_no_remote_returns_expected_info)
 
 TEST_F(UbuntuImageHost, info_for_too_many_hash_matches_throws)
 {
-    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader};
     host.update_manifests();
 
     const std::string release{"1"};
@@ -449,7 +445,7 @@ TEST_F(UbuntuImageHost, info_for_too_many_hash_matches_throws)
 
 TEST_F(UbuntuImageHost, info_for_same_full_hash_in_both_remotes_does_not_throw)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     const auto hash_query{"ab115b83e7a8bebf3d3a02bf55ad0cb75a0ed515fcbc65fb0c9abe76c752921c"};
@@ -459,7 +455,7 @@ TEST_F(UbuntuImageHost, info_for_same_full_hash_in_both_remotes_does_not_throw)
 
 TEST_F(UbuntuImageHost, info_for_partial_hash_in_both_remotes_throws)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     const auto hash_query{"ab115"};
@@ -470,7 +466,7 @@ TEST_F(UbuntuImageHost, info_for_partial_hash_in_both_remotes_throws)
 
 TEST_F(UbuntuImageHost, all_info_for_no_remote_query_defaults_to_release)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     auto images_info = host.all_info_for(make_query("1", ""));
@@ -481,7 +477,7 @@ TEST_F(UbuntuImageHost, all_info_for_no_remote_query_defaults_to_release)
 
 TEST_F(UbuntuImageHost, all_info_for_unsupported_image_throw)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     const std::string release{"artful"};
@@ -493,7 +489,7 @@ TEST_F(UbuntuImageHost, all_info_for_unsupported_image_throw)
 
 TEST_F(UbuntuImageHost, all_info_for_unsupported_alias_throws)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     const std::string unsupported_alias{"daily"};
@@ -506,7 +502,7 @@ TEST_F(UbuntuImageHost, all_info_for_unsupported_alias_throws)
 
 TEST_F(UbuntuImageHost, info_for_unsupported_remote_throws)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     const std::string unsupported_remote{"bar"};
@@ -519,7 +515,7 @@ TEST_F(UbuntuImageHost, info_for_unsupported_remote_throws)
 
 TEST_F(UbuntuImageHost, info_for_no_remote_first_unsupported_returns_expected_info)
 {
-    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader};
     host.update_manifests();
 
     EXPECT_CALL(mock_platform, is_remote_supported("release")).Times(AtLeast(1)).WillRepeatedly(Return(false));

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -97,7 +97,7 @@ struct UbuntuImageHost : public testing::Test
 TEST_F(UbuntuImageHost, returns_expected_info)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
-
+    host.update_manifests();
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
 
     ASSERT_TRUE(info);
@@ -110,6 +110,7 @@ TEST_F(UbuntuImageHost, returns_expected_mirror_info)
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_valid_mirror_host));
 
     mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
     QString expected_location{test_valid_mirror_host + "releases/" + "newest_image.img"};
@@ -124,6 +125,7 @@ TEST_F(UbuntuImageHost, returns_expected_mirror_info_with_most_recent_image)
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_valid_outdated_mirror_host));
 
     mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto info = host.info_for(make_query("xenial", release_remote_spec.first));
     QString expected_location{test_valid_outdated_mirror_host + "releases/" + "test_image.img"};
@@ -139,6 +141,7 @@ TEST_F(UbuntuImageHost, throw_if_mirror_is_invalid)
     EXPECT_CALL(mock_settings, get(Eq(mp::mirror_key))).WillRepeatedly(Return(test_invalid_mirror_host));
 
     mp::UbuntuVMImageHost host{{release_remote_spec_with_mirror_allowed}, &url_downloader, default_ttl};
+    host.update_manifests();
 
     EXPECT_THROW(host.info_for(make_query("xenial", release_remote_spec.first)), std::runtime_error);
 }
@@ -146,6 +149,7 @@ TEST_F(UbuntuImageHost, throw_if_mirror_is_invalid)
 TEST_F(UbuntuImageHost, uses_default_on_unspecified_release)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto info = host.info_for(make_query("", release_remote_spec.first));
 
@@ -157,6 +161,7 @@ TEST_F(UbuntuImageHost, uses_default_on_unspecified_release)
 TEST_F(UbuntuImageHost, iterates_over_all_entries)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    host.update_manifests();
 
     std::unordered_set<std::string> ids;
     auto action = [&ids](const std::string& remote, const mp::VMImageInfo& info) { ids.insert(info.id.toStdString()); };
@@ -175,6 +180,7 @@ TEST_F(UbuntuImageHost, iterates_over_all_entries)
 TEST_F(UbuntuImageHost, unsupported_alias_iterates_over_expected_entries)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    host.update_manifests();
 
     std::unordered_set<std::string> ids;
     auto action = [&ids](const std::string& remote, const mp::VMImageInfo& info) { ids.insert(info.id.toStdString()); };
@@ -190,6 +196,7 @@ TEST_F(UbuntuImageHost, unsupported_alias_iterates_over_expected_entries)
 TEST_F(UbuntuImageHost, can_query_by_hash)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    host.update_manifests();
     const auto expected_id = "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac";
     auto info = host.info_for(make_query(expected_id, release_remote_spec.first));
 
@@ -200,6 +207,7 @@ TEST_F(UbuntuImageHost, can_query_by_hash)
 TEST_F(UbuntuImageHost, can_query_by_partial_hash)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    host.update_manifests();
     const auto expected_id = "1797c5c82016c1e65f4008fcf89deae3a044ef76087a9ec5b907c6d64a3609ac";
 
     QStringList short_hashes;
@@ -221,6 +229,7 @@ TEST_F(UbuntuImageHost, can_query_by_partial_hash)
 TEST_F(UbuntuImageHost, supports_multiple_manifests)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
     QString daily_expected_id{"c09f123b9589c504fe39ec6e9ebe5188c67be7d1fc4fb80c969bf877f5a8333a"};
@@ -241,6 +250,7 @@ TEST_F(UbuntuImageHost, supports_multiple_manifests)
 TEST_F(UbuntuImageHost, looks_for_aliases_before_hashes)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
     QString daily_expected_id{"c09f123b9589c504fe39ec6e9ebe5188c67be7d1fc4fb80c969bf877f5a8333a"};
@@ -255,6 +265,7 @@ TEST_F(UbuntuImageHost, looks_for_aliases_before_hashes)
 TEST_F(UbuntuImageHost, all_info_release_returns_multiple_hash_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto images_info = host.all_info_for(make_query("1", release_remote_spec.first));
 
@@ -265,6 +276,7 @@ TEST_F(UbuntuImageHost, all_info_release_returns_multiple_hash_matches)
 TEST_F(UbuntuImageHost, all_info_daily_no_matches_returns_empty_vector)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto images = host.all_info_for(make_query("1", daily_remote_spec.first));
 
@@ -274,6 +286,7 @@ TEST_F(UbuntuImageHost, all_info_daily_no_matches_returns_empty_vector)
 TEST_F(UbuntuImageHost, all_info_release_returns_one_alias_match)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto images_info = host.all_info_for(make_query("xenial", release_remote_spec.first));
 
@@ -284,6 +297,7 @@ TEST_F(UbuntuImageHost, all_info_release_returns_one_alias_match)
 TEST_F(UbuntuImageHost, all_images_for_release_returns_four_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto images = host.all_images_for(release_remote_spec.first, false);
 
@@ -294,6 +308,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_returns_four_matches)
 TEST_F(UbuntuImageHost, all_images_for_release_unsupported_returns_five_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto images = host.all_images_for(release_remote_spec.first, true);
 
@@ -304,6 +319,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_unsupported_returns_five_matches)
 TEST_F(UbuntuImageHost, all_images_for_daily_returns_all_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto images = host.all_images_for(daily_remote_spec.first, false);
 
@@ -314,6 +330,7 @@ TEST_F(UbuntuImageHost, all_images_for_daily_returns_all_matches)
 TEST_F(UbuntuImageHost, all_images_for_release_unsupported_alias_returns_three_matches)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     EXPECT_CALL(mock_platform, is_alias_supported(AnyOf("zesty", "17.04", "z"), _)).WillRepeatedly(Return(false));
 
@@ -326,6 +343,7 @@ TEST_F(UbuntuImageHost, all_images_for_release_unsupported_alias_returns_three_m
 TEST_F(UbuntuImageHost, supported_remotes_returns_expected_values)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto supported_remotes = host.supported_remotes();
 
@@ -340,8 +358,8 @@ TEST_F(UbuntuImageHost, supported_remotes_returns_expected_values)
 
 TEST_F(UbuntuImageHost, invalid_remote_throws_error)
 {
-    mpt::StubURLDownloader stub_url_downloader;
-    mp::UbuntuVMImageHost host{all_remote_specs, &stub_url_downloader, default_ttl};
+    mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     EXPECT_THROW(host.info_for(make_query("xenial", "foo")), std::runtime_error);
 }
@@ -351,11 +369,13 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_initial_network_failure)
     const auto ttl = 1h; // so that updates are only retried when unsuccessful
     url_downloader.mischiefs = 1000;
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, ttl};
+    host.update_manifests();
 
     const auto query = make_query("xenial", release_remote_spec.first);
     EXPECT_THROW(host.info_for(query), std::runtime_error);
 
     url_downloader.mischiefs = 0;
+    host.update_manifests();
     EXPECT_TRUE(host.info_for(query));
 }
 
@@ -365,12 +385,15 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_later_network_failure)
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, ttl};
 
     const auto query = make_query("xenial", release_remote_spec.first);
+    host.update_manifests();
     EXPECT_TRUE(host.info_for(query));
 
     url_downloader.mischiefs = 1000;
+    host.update_manifests();
     EXPECT_THROW(host.info_for(query), std::runtime_error);
 
     url_downloader.mischiefs = 0;
+    host.update_manifests();
     EXPECT_TRUE(host.info_for(query));
 }
 
@@ -378,6 +401,7 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_independent_server_failures)
 {
     const auto ttl = 0h;
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, ttl};
+    host.update_manifests();
 
     const auto num_remotes = mpt::count_remotes(host);
     EXPECT_GT(num_remotes, 0u);
@@ -392,6 +416,7 @@ TEST_F(UbuntuImageHost, handles_and_recovers_from_independent_server_failures)
 TEST_F(UbuntuImageHost, throws_unsupported_image_when_image_not_supported)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     EXPECT_THROW(host.info_for(make_query("artful", release_remote_spec.first)), mp::UnsupportedImageException);
 }
@@ -399,6 +424,7 @@ TEST_F(UbuntuImageHost, throws_unsupported_image_when_image_not_supported)
 TEST_F(UbuntuImageHost, devel_request_with_no_remote_returns_expected_info)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     QString daily_expected_location{daily_url + "newest-artful.img"};
     QString daily_expected_id{"c09f123b9589c504fe39ec6e9ebe5188c67be7d1fc4fb80c969bf877f5a8333a"};
@@ -413,6 +439,7 @@ TEST_F(UbuntuImageHost, devel_request_with_no_remote_returns_expected_info)
 TEST_F(UbuntuImageHost, info_for_too_many_hash_matches_throws)
 {
     mp::UbuntuVMImageHost host{{release_remote_spec}, &url_downloader, default_ttl};
+    host.update_manifests();
 
     const std::string release{"1"};
 
@@ -423,6 +450,7 @@ TEST_F(UbuntuImageHost, info_for_too_many_hash_matches_throws)
 TEST_F(UbuntuImageHost, info_for_same_full_hash_in_both_remotes_does_not_throw)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     const auto hash_query{"ab115b83e7a8bebf3d3a02bf55ad0cb75a0ed515fcbc65fb0c9abe76c752921c"};
 
@@ -432,6 +460,7 @@ TEST_F(UbuntuImageHost, info_for_same_full_hash_in_both_remotes_does_not_throw)
 TEST_F(UbuntuImageHost, info_for_partial_hash_in_both_remotes_throws)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     const auto hash_query{"ab115"};
 
@@ -442,6 +471,7 @@ TEST_F(UbuntuImageHost, info_for_partial_hash_in_both_remotes_throws)
 TEST_F(UbuntuImageHost, all_info_for_no_remote_query_defaults_to_release)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     auto images_info = host.all_info_for(make_query("1", ""));
 
@@ -452,6 +482,7 @@ TEST_F(UbuntuImageHost, all_info_for_no_remote_query_defaults_to_release)
 TEST_F(UbuntuImageHost, all_info_for_unsupported_image_throw)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     const std::string release{"artful"};
 
@@ -463,6 +494,7 @@ TEST_F(UbuntuImageHost, all_info_for_unsupported_image_throw)
 TEST_F(UbuntuImageHost, all_info_for_unsupported_alias_throws)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     const std::string unsupported_alias{"daily"};
     EXPECT_CALL(mock_platform, is_alias_supported(unsupported_alias, _)).WillOnce(Return(false));
@@ -475,6 +507,7 @@ TEST_F(UbuntuImageHost, all_info_for_unsupported_alias_throws)
 TEST_F(UbuntuImageHost, info_for_unsupported_remote_throws)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     const std::string unsupported_remote{"bar"};
     EXPECT_CALL(mock_platform, is_remote_supported(unsupported_remote)).WillRepeatedly(Return(false));
@@ -487,6 +520,7 @@ TEST_F(UbuntuImageHost, info_for_unsupported_remote_throws)
 TEST_F(UbuntuImageHost, info_for_no_remote_first_unsupported_returns_expected_info)
 {
     mp::UbuntuVMImageHost host{all_remote_specs, &url_downloader, default_ttl};
+    host.update_manifests();
 
     EXPECT_CALL(mock_platform, is_remote_supported("release")).Times(AtLeast(1)).WillRepeatedly(Return(false));
 


### PR DESCRIPTION
This PR contains a few things. 
1. `update_manifests()` function will no longer be called internally in the `UbuntuImageHost` and `CustomImageHost` class, instead it becomes a public method and gets invoked by client code like `daemon.cpp`. 
2. The two `update_manifests()` calls are wrapped into one function and it is launched by the daemon constructor asynchronously and it will run periodically. 
3. Because of the first two, the `manifest_time_to_live` related codes are all removed since it is no longer relevant. 
4. Inside `UbuntuImageHost::update_manifests` and `CustomImageHost::update_manifests`, the parallelization of the manifests fetching is also applied in order to speed it up. 
---
[Epic link](https://warthogs.atlassian.net/browse/MULTI-254)
[issue link](https://github.com/canonical/multipass/issues/1637)