### PR TITLE
[3rd-party] Update gRPC branch

### DIFF
--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -3,7 +3,7 @@ set(FETCHCONTENT_QUIET FALSE)
 
 FetchContent_Declare(gRPC
   GIT_REPOSITORY https://github.com/CanonicalLtd/grpc.git
-  GIT_TAG ba8e7f72
+  GIT_TAG e3acf245
   GIT_SHALLOW TRUE
   GIT_SUBMODULES "third_party/abseil-cpp third_party/cares/cares third_party/protobuf third_party/re2 third_party/zlib"
   GIT_SUBMODULES_RECURSE false


### PR DESCRIPTION
There is a regression seen on macOS in the latest gRPC branch we used for the 1.12 release.  The gRPC branch has been updated to revert the problematic commits.

Fixes #3142

---

Here are the relevant changes in our gRPC branch: https://github.com/CanonicalLtd/grpc/commit/e796379a445776c34d5146afcad0ba1902783ff1 and https://github.com/CanonicalLtd/grpc/commit/e3acf245a91630fe4d464091ba5446f6a638d82f.