### PR TITLE
[completions] autocomplete on state

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -19,7 +19,7 @@ _multipass_complete()
         local state=$1
 
         local cmd="multipass list --format=csv --no-ipv4"
-        [ -n "$state" ] && cmd="$cmd | \grep -E '$state'"
+        [ -n "$state" ] && cmd="$cmd | \awk -F',' '\$2 == \"$state\"'"
 
         local instances=$( \eval $cmd | \grep -Ev '(\+--|Name)' | \cut -d',' -f 1 )
 


### PR DESCRIPTION
If an instance contains a string which is used for an instance state, bash completions can suggest the instance in invalid situations. eg. `multipass stop <tab>` will suggest an instance named `Running-Rabbit` even if it's stopped because the name contains the string `Running`.