### PR TITLE
[snapshots] Fix QEMU backend refusing available snapshot names

### DIFF
--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -84,7 +84,7 @@ void mp::QemuSnapshot::capture_impl()
 
     // Avoid creating more than one snapshot with the same tag (creation would succeed, but we'd then be unable to
     // identify the snapshot by tag)
-    if (backend::instance_image_has_snapshot(image_path, tag.toUtf8()))
+    if (backend::instance_image_has_snapshot(image_path, tag))
         throw std::runtime_error{fmt::format(
             "A snapshot with the same tag already exists in the image. Image: {}; tag: {})", image_path, tag)};
 

--- a/src/platform/backends/shared/qemu_img_utils/qemu_img_utils.cpp
+++ b/src/platform/backends/shared/qemu_img_utils/qemu_img_utils.cpp
@@ -89,7 +89,7 @@ mp::Path mp::backend::convert_to_qcow_if_necessary(const mp::Path& image_path)
     }
 }
 
-bool mp::backend::instance_image_has_snapshot(const mp::Path& image_path, const char* snapshot_tag)
+bool mp::backend::instance_image_has_snapshot(const mp::Path& image_path, QString snapshot_tag)
 {
     auto process = mp::platform::make_process(
         std::make_unique<mp::QemuImgProcessSpec>(QStringList{"snapshot", "-l", image_path}, image_path));
@@ -101,6 +101,6 @@ bool mp::backend::instance_image_has_snapshot(const mp::Path& image_path, const 
                                              process_state.failure_message(), process->read_all_standard_error()));
     }
 
-    QRegularExpression regex{QString{R"(%1\s)"}.arg(snapshot_tag)};
+    QRegularExpression regex{snapshot_tag.append(R"(\s)")};
     return QString{process->read_all_standard_output()}.contains(regex);
 }

--- a/src/platform/backends/shared/qemu_img_utils/qemu_img_utils.cpp
+++ b/src/platform/backends/shared/qemu_img_utils/qemu_img_utils.cpp
@@ -25,6 +25,7 @@
 
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QRegularExpression>
 #include <QString>
 #include <QStringList>
 
@@ -100,5 +101,6 @@ bool mp::backend::instance_image_has_snapshot(const mp::Path& image_path, const 
                                              process_state.failure_message(), process->read_all_standard_error()));
     }
 
-    return process->read_all_standard_output().contains(snapshot_tag);
+    QRegularExpression regex{QString{R"(%1\s)"}.arg(snapshot_tag)};
+    return QString{process->read_all_standard_output()}.contains(regex);
 }

--- a/src/platform/backends/shared/qemu_img_utils/qemu_img_utils.h
+++ b/src/platform/backends/shared/qemu_img_utils/qemu_img_utils.h
@@ -28,7 +28,7 @@ namespace backend
 {
 void resize_instance_image(const MemorySize& disk_space, const multipass::Path& image_path);
 Path convert_to_qcow_if_necessary(const Path& image_path);
-bool instance_image_has_snapshot(const Path& image_path, const char* snapshot_tag);
+bool instance_image_has_snapshot(const Path& image_path, QString snapshot_tag);
 
 } // namespace backend
 } // namespace multipass


### PR DESCRIPTION
Fix QEMU backend refusing available snapshot names that are also prefixes in existing snapshot names.
