### PR TITLE
Refactor bridge prompt

### DIFF
--- a/include/multipass/cli/prompters.h
+++ b/include/multipass/cli/prompters.h
@@ -18,7 +18,9 @@
 #include <multipass/disabled_copy_move.h>
 #include <multipass/terminal.h>
 
+#include <regex>
 #include <string>
+#include <vector>
 
 #ifndef MULTIPASS_CLI_PROMPTERS_H
 #define MULTIPASS_CLI_PROMPTERS_H
@@ -87,6 +89,24 @@ public:
     using PassphrasePrompter::PassphrasePrompter;
 
     std::string prompt(const std::string& text = "Please re-enter passphrase") const override;
+};
+
+class BridgePrompter : private DisabledCopyMove
+{
+public:
+    explicit BridgePrompter(Terminal* term) : term(term){};
+
+    ~BridgePrompter() = default;
+
+    bool bridge_prompt(std::vector<std::string>& nets_need_bridging) const;
+
+private:
+    BridgePrompter() = default;
+
+    Terminal* term;
+
+    const std::regex yes{"y|yes", std::regex::icase | std::regex::optimize};
+    const std::regex no{"n|no", std::regex::icase | std::regex::optimize};
 };
 } // namespace multipass
 

--- a/tests/test_cli_prompters.cpp
+++ b/tests/test_cli_prompters.cpp
@@ -164,3 +164,71 @@ TEST_P(CLIPromptersBadCinState, PlainThrows)
 
 INSTANTIATE_TEST_SUITE_P(CLIPrompters, CLIPromptersBadCinState,
                          Values(std::ios::eofbit, std::ios::failbit, std::ios::badbit));
+
+class BridgePrompterTests : public CLIPrompters,
+                            public WithParamInterface<std::tuple<std::vector<std::string>, std::string, bool>>
+{
+};
+
+TEST_F(CLIPrompters, failsIfNoNetworks)
+{
+    std::vector<std::string> nets{};
+
+    mpt::MockTerminal mock_terminal;
+
+    mp::BridgePrompter prompter{&mock_terminal};
+
+    ASSERT_DEBUG_DEATH(prompter.bridge_prompt(nets), "[Aa]ssert");
+}
+
+TEST_P(BridgePrompterTests, correctlyReturns)
+{
+    auto [nets, answer, ret] = GetParam();
+
+    mpt::MockTerminal mock_terminal;
+    EXPECT_CALL(mock_terminal, cout()).WillRepeatedly(ReturnRef(cout));
+    EXPECT_CALL(mock_terminal, cout_is_live()).WillOnce(Return(true));
+    EXPECT_CALL(mock_terminal, cin()).WillOnce(ReturnRef(cin));
+    EXPECT_CALL(mock_terminal, cin_is_live()).WillOnce(Return(true));
+
+    cin.str(answer + "\n");
+
+    mp::BridgePrompter prompter{&mock_terminal};
+
+    EXPECT_EQ(prompter.bridge_prompt(nets), ret);
+}
+
+INSTANTIATE_TEST_SUITE_P(CLIPrompters, BridgePrompterTests,
+                         Values(std::make_tuple(std::vector<std::string>{"eth1"}, "yes", true),
+                                std::make_tuple(std::vector<std::string>{"eth1", "eth3"}, "y", true),
+                                std::make_tuple(std::vector<std::string>{"eth1", "eth3"}, "no", false),
+                                std::make_tuple(std::vector<std::string>{"eth1"}, "n", false)));
+
+TEST_F(CLIPrompters, handlesWrongAnswer)
+{
+    mpt::MockTerminal mock_terminal;
+    EXPECT_CALL(mock_terminal, cout()).WillRepeatedly(ReturnRef(cout));
+    EXPECT_CALL(mock_terminal, cout_is_live()).WillOnce(Return(true));
+    EXPECT_CALL(mock_terminal, cin()).WillRepeatedly(ReturnRef(cin));
+    EXPECT_CALL(mock_terminal, cin_is_live()).WillOnce(Return(true));
+
+    cin.str("qqq\nyes\n");
+
+    mp::BridgePrompter prompter{&mock_terminal};
+
+    std::vector<std::string> nets{"eth2"};
+
+    EXPECT_EQ(prompter.bridge_prompt(nets), true);
+}
+
+TEST_F(CLIPrompters, falseOnNonLiveTerminal)
+{
+    mpt::MockTerminal mock_terminal;
+    EXPECT_CALL(mock_terminal, cin_is_live()).WillOnce(Return(false));
+
+    mp::BridgePrompter prompter{&mock_terminal};
+
+    std::vector<std::string> nets{"eth2"};
+
+    EXPECT_EQ(prompter.bridge_prompt(nets), false);
+}


### PR DESCRIPTION
When adding a bridged interface to an existing instance, the user must be prompted to allow adding a network bridge disrupting connectivity. This is already implemented, but the code lies in the implementation of the `launch` command. This PR moves this code to the part common to all clients.