### PR TITLE
[qemu] Link backend against `scope_guard`

### DIFF
--- a/src/platform/backends/qemu/CMakeLists.txt
+++ b/src/platform/backends/qemu/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(qemu_backend
   logger
   qemu_img_utils
   qemu_platform_detail
+  scope_guard
   utils
   Qt6::Core)
 


### PR DESCRIPTION
Fixes a build failure on macOS.
