### PR TITLE
[iso] Complement error message on failure to open

### DIFF
--- a/src/iso/CMakeLists.txt
+++ b/src/iso/CMakeLists.txt
@@ -18,4 +18,5 @@ add_library(iso STATIC
   cloud_init_iso.cpp)
 
 target_link_libraries(iso
+  fmt
   Qt6::Core)

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <multipass/cloud_init_iso.h>
+#include <multipass/format.h>
 
 #include <QFile>
 
@@ -389,7 +390,8 @@ void mp::CloudInitIso::write_to(const Path& path)
 {
     QFile f{path};
     if (!f.open(QIODevice::WriteOnly))
-        throw std::runtime_error{"failed to open file for writing during cloud-init generation"};
+        throw std::runtime_error{fmt::format(
+            "Failed to open file for writing during cloud-init generation: {}; path: {}", f.errorString(), path)};
 
     const uint32_t num_reserved_bytes = 32768u;
     const uint32_t num_reserved_blocks = num_blocks(num_reserved_bytes);


### PR DESCRIPTION
Add more information to the exception that is thrown when `QFile` fails to `open` to create a cloud-init ISO, in the hope that we can gain some insight into why this keeps failing in CI (e.g. https://github.com/canonical/multipass/actions/runs/5690481781/job/15423903919#step:13:101)
