### PR TITLE
clang-format improvement: remove bin pack arguments/parameters.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,11 @@ BasedOnStyle: LLVM
 Language: Cpp
 IndentWidth: 4
 BreakBeforeBraces: Custom
+BinPackArguments: false
+BinPackParameters: false
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+PenaltyReturnTypeOnItsOwnLine: 120
 BraceWrapping:
   AfterCaseLabel: true
   AfterClass: true


### PR DESCRIPTION
suggestive clang-format improvement:

The function arguments and parameters are always bin-packed in the current clang-format style which can sometimes be hard to read. The improved clang-format formats arguments and parameters in a way that it either does not break the line because the line length is still within the column limit or it breaks each argument/parameter into a separate line. 

This PR contains the clang-format file code change and some sample files in the new format. If this PR is approved, then the sample files will be reverted and only the clang-format change will be merged. 