### PR TITLE
[sftp server] reverse map default ids

### DIFF
--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -61,6 +61,8 @@ set(libssh_VERSION_MAJOR "${CMAKE_MATCH_1}")
 set(libssh_VERSION_MINOR "${CMAKE_MATCH_2}")
 set(libssh_VERSION_PATCH "${CMAKE_MATCH_3}")
 
+add_compile_options(-DCHUNKSIZE=65536)
+
 string(REGEX REPLACE "^set\\(LIBRARY_VERSION \"(.*)\"\\)$" "\\1"
        LIBRARY_VERSION "${LIBRARY_VERSION}")
 if (NOT LIBRARY_VERSION)

--- a/3rd-party/submodule_info.md
+++ b/3rd-party/submodule_info.md
@@ -12,8 +12,8 @@ Version: 1.52.1 (+[our patches](https://github.com/CanonicalLtd/grpc/compare/v1.
 <https://github.com/grpc/grpc/releases>
 
 ### libssh
-Version: 0.10.4 (+[our patches](https://github.com/CanonicalLtd/libssh/compare/libssh-0.10.4..3413f2fe)) |
-<https://github.com/CanonicalLtd/libssh.git> |
+Version: 0.10.5 (+[our patches](https://github.com/canonical/libssh/compare/libssh-0.10.5..843b97db)) |
+<https://github.com/canonical/libssh.git> |
 <https://www.libssh.org/>
 
 ### fmt

--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -57,6 +57,8 @@ public:
     virtual bool exists(const QFileInfo& file) const;
     virtual bool isDir(const QFileInfo& file) const;
     virtual bool isReadable(const QFileInfo& file) const;
+    virtual uint ownerId(const QFileInfo& file) const;
+    virtual uint groupId(const QFileInfo& file) const;
 
     // QFile operations
     virtual bool exists(const QFile& file) const;

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -270,14 +270,14 @@ int mapped_id_for(const mp::id_mappings& id_maps, const int id, const int id_if_
     return id;
 }
 
-int reverse_id_for(const mp::id_mappings& id_maps, const int id, const int rev_id_if_not_found)
+int reverse_id_for(const mp::id_mappings& id_maps, const int id, const int default_id)
 {
     auto found = std::find_if(id_maps.cbegin(), id_maps.cend(), [id](std::pair<int, int> p) { return id == p.second; });
-    auto default_found = std::find_if(id_maps.cbegin(), id_maps.cend(), [rev_id_if_not_found](std::pair<int, int> p) {
-        return rev_id_if_not_found == p.second;
+    auto default_found = std::find_if(id_maps.cbegin(), id_maps.cend(), [default_id](std::pair<int, int> p) {
+        return default_id == p.second;
     });
 
-    return found == id_maps.cend() ? (default_found == id_maps.cend() ? rev_id_if_not_found : default_found->first)
+    return found == id_maps.cend() ? (default_found == id_maps.cend() ? default_id : default_found->first)
                                    : found->first;
 }
 } // namespace
@@ -339,14 +339,14 @@ inline int mp::SftpServer::mapped_gid_for(const int gid)
     return mapped_id_for(gid_mappings, gid, default_gid);
 }
 
-inline int mp::SftpServer::reverse_uid_for(const int uid, const int rev_uid_if_not_found)
+inline int mp::SftpServer::reverse_uid_for(const int uid, const int default_id)
 {
-    return reverse_id_for(uid_mappings, uid, rev_uid_if_not_found);
+    return reverse_id_for(uid_mappings, uid, default_id);
 }
 
-inline int mp::SftpServer::reverse_gid_for(const int gid, const int rev_gid_if_not_found)
+inline int mp::SftpServer::reverse_gid_for(const int gid, const int default_id)
 {
-    return reverse_id_for(gid_mappings, gid, rev_gid_if_not_found);
+    return reverse_id_for(gid_mappings, gid, default_id);
 }
 
 void mp::SftpServer::process_message(sftp_client_message msg)

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -346,14 +346,14 @@ inline int mp::SftpServer::mapped_gid_for(const int gid)
     return mapped_id_for(gid_mappings, gid, default_gid);
 }
 
-inline int mp::SftpServer::reverse_uid_for(const int uid, const int default_id)
+inline int mp::SftpServer::reverse_uid_for(const int uid, const int rev_uid_if_not_found)
 {
-    return reverse_id_for(uid_mappings, uid, default_id);
+    return reverse_id_for(uid_mappings, uid, rev_uid_if_not_found);
 }
 
-inline int mp::SftpServer::reverse_gid_for(const int gid, const int default_id)
+inline int mp::SftpServer::reverse_gid_for(const int gid, const int rev_gid_if_not_found)
 {
-    return reverse_id_for(gid_mappings, gid, default_id);
+    return reverse_id_for(gid_mappings, gid, rev_gid_if_not_found);
 }
 
 inline int mp::SftpServer::reverse_uid_for(const int uid)

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -935,6 +935,17 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
         }
     }
 
+    if ((msg->attr->uid == 0 && reverse_uid_for(msg->attr->uid) == -1) ||
+        (msg->attr->gid == 0 && reverse_gid_for(msg->attr->gid) == -1))
+    {
+        mpl::log(mpl::Level::trace,
+                 category,
+                 fmt::format("{}: permission denied: cannot modify path \'{}\' without reverse mapping for root",
+                             __FUNCTION__,
+                             filename));
+        return reply_perm_denied(msg);
+    }
+
     QFile file{filename};
 
     if (msg->attr->flags & SSH_FILEXFER_ATTR_SIZE)

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -273,8 +273,12 @@ int mapped_id_for(const mp::id_mappings& id_maps, const int id, const int id_if_
 int reverse_id_for(const mp::id_mappings& id_maps, const int id, const int rev_id_if_not_found)
 {
     auto found = std::find_if(id_maps.cbegin(), id_maps.cend(), [id](std::pair<int, int> p) { return id == p.second; });
+    auto default_found = std::find_if(id_maps.cbegin(), id_maps.cend(), [rev_id_if_not_found](std::pair<int, int> p) {
+        return rev_id_if_not_found == p.second;
+    });
 
-    return found == id_maps.cend() ? rev_id_if_not_found : found->first;
+    return found == id_maps.cend() ? (default_found == id_maps.cend() ? rev_id_if_not_found : default_found->first)
+                                   : found->first;
 }
 } // namespace
 

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -1036,6 +1036,16 @@ int mp::SftpServer::handle_stat(sftp_client_message msg, const bool follow)
         attr = attr_from(file_info);
     }
 
+    if ((attr.uid == 0 && reverse_uid_for(attr.uid) == -1) || (attr.gid == 0 && reverse_gid_for(attr.gid) == -1))
+    {
+        mpl::log(mpl::Level::trace,
+                 category,
+                 fmt::format("{}: permission denied: cannot access path \'{}\' without mapping for root",
+                             __FUNCTION__,
+                             filename));
+        return reply_perm_denied(msg);
+    }
+
     return sftp_reply_attr(msg, &attr);
 }
 

--- a/src/sshfs_mount/sftp_server.h
+++ b/src/sshfs_mount/sftp_server.h
@@ -57,6 +57,8 @@ private:
     int mapped_gid_for(const int gid);
     int reverse_uid_for(const int uid, const int rev_uid_if_not_found);
     int reverse_gid_for(const int gid, const int rev_gid_if_not_found);
+    int reverse_uid_for(const int uid);
+    int reverse_gid_for(const int gid);
 
     int handle_close(sftp_client_message msg);
     int handle_fstat(sftp_client_message msg);

--- a/src/sshfs_mount/sftp_server.h
+++ b/src/sshfs_mount/sftp_server.h
@@ -52,7 +52,6 @@ public:
 
 private:
     void process_message(sftp_client_message msg);
-    sftp_attributes_struct get_uid_gid_from(const QFileInfo& file_info);
     sftp_attributes_struct attr_from(const QFileInfo& file_info);
     int mapped_uid_for(const int uid);
     int mapped_gid_for(const int gid);
@@ -60,6 +59,8 @@ private:
     int reverse_gid_for(const int gid, const int rev_gid_if_not_found);
     bool has_uid_mapping_for(const int uid);
     bool has_gid_mapping_for(const int gid);
+    bool has_reverse_uid_mapping_for(const int uid);
+    bool has_reverse_gid_mapping_for(const int gid);
     bool validate_permissions(const QString& filename);
     bool validate_path(const std::string& source_path, const std::string& current_path);
 

--- a/src/sshfs_mount/sftp_server.h
+++ b/src/sshfs_mount/sftp_server.h
@@ -52,13 +52,16 @@ public:
 
 private:
     void process_message(sftp_client_message msg);
+    sftp_attributes_struct get_uid_gid_from(const QFileInfo& file_info);
     sftp_attributes_struct attr_from(const QFileInfo& file_info);
     int mapped_uid_for(const int uid);
     int mapped_gid_for(const int gid);
     int reverse_uid_for(const int uid, const int rev_uid_if_not_found);
     int reverse_gid_for(const int gid, const int rev_gid_if_not_found);
-    int reverse_uid_for(const int uid);
-    int reverse_gid_for(const int gid);
+    bool has_uid_mapping_for(const int uid);
+    bool has_gid_mapping_for(const int gid);
+    bool validate_permissions(const QString& filename);
+    bool validate_path(const std::string& source_path, const std::string& current_path);
 
     int handle_close(sftp_client_message msg);
     int handle_fstat(sftp_client_message msg);

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -105,7 +105,7 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
         }
         else
         {
-            sshfs_exec += " -o dcache_timeout=3";
+            sshfs_exec += " -o dcache_timeout=3 -o dir_cache=no";
         }
     }
     else

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -72,6 +72,16 @@ bool mp::FileOps::isReadable(const QFileInfo& file) const
     return file.isReadable();
 }
 
+uint mp::FileOps::ownerId(const QFileInfo& file) const
+{
+    return file.ownerId();
+}
+
+uint mp::FileOps::groupId(const QFileInfo& file) const
+{
+    return file.groupId();
+}
+
 bool mp::FileOps::is_open(const QFile& file) const
 {
     return file.isOpen();

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -41,6 +41,8 @@ public:
     MOCK_METHOD(bool, exists, (const QFileInfo&), (const, override));
     MOCK_METHOD(bool, isDir, (const QFileInfo&), (const, override));
     MOCK_METHOD(bool, isReadable, (const QFileInfo&), (const, override));
+    MOCK_METHOD(uint, ownerId, (const QFileInfo&), (const, override));
+    MOCK_METHOD(uint, groupId, (const QFileInfo&), (const, override));
 
     // QFile mock methods
     MOCK_METHOD(bool, exists, (const QFile&), (const, override));

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -193,7 +193,7 @@ struct SshfsMount : public mp::test::SftpServerTest
         {"id -u", "1000\n"},
         {"id -g", "1000\n"},
         {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o allow_other -o "
-         "Compression=no -o dcache_timeout=3 :\"source\" "
+         "Compression=no -o dcache_timeout=3 -o dir_cache=no:\"source\" "
          "\"target\"",
          "don't care\n"}};
 };


### PR DESCRIPTION
Not all commands result in the same sequence of messages being received by the sftp server. For some commands (ie `touch file.txt`), the uid/gid of a created file is not received and the uid/gid of the parent directory is used instead. When residing in the top level directory of a share, a uid/gid of 1000/1000 is used. If a mapping for these ids is specified, then the ids should be translated.

Fixes #3179 