### PR TITLE
[snapshots] Fix interpreting empty snapshot name in snapshot args

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1166,13 +1166,12 @@ InstanceSnapshotsMap map_snapshots_to_instances(const InstanceSnapshotPairs& ins
     for (const auto& it : instances_snapshots)
     {
         const auto& instance = it.instance_name();
-        const auto& snapshot = it.snapshot_name();
         auto& snapshot_pick = instance_snapshots_map[instance];
 
-        if (snapshot.empty())
+        if (!it.has_snapshot_name())
             snapshot_pick.all_or_none = true;
         else
-            snapshot_pick.pick.insert(snapshot);
+            snapshot_pick.pick.insert(it.snapshot_name());
     }
 
     return instance_snapshots_map;


### PR DESCRIPTION
Fix interpreting of snapshot arguments with empty name, i.e. ending in dot (like "\<instance\>."). Refuse such arguments, instead of interpreting them as instance arguments (i.e. equivalent to "\<instance\>").

This affects `info` and `delete`.

```
$ multipass info foo. # before
[info on instance foo]
$ multipass info foo. # after
info failed: The following errors occurred:
No such snapshot: a.
```