### PR TITLE
Add bridged interfaces in macOS QEMU

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2923,14 +2923,21 @@ void mp::Daemon::configure_new_interfaces(const std::string& name, mp::VirtualMa
 
         auto& commands = run_at_boot[name];
 
-        for (const auto i : new_interfaces)
+        try
         {
-            vm.add_network_interface(i, specs.extra_interfaces[i]);
+            for (const auto i : new_interfaces)
+            {
+                vm.add_network_interface(i, specs.extra_interfaces[i]);
 
-            commands.push_back(generate_netplan_script(i, specs.extra_interfaces[i].mac_address));
+                commands.push_back(generate_netplan_script(i, specs.extra_interfaces[i].mac_address));
+            }
+
+            commands.push_back("sudo netplan apply");
         }
-
-        commands.push_back("sudo netplan apply");
+        catch (const mp::NotImplementedOnThisBackendException&)
+        {
+            run_at_boot.erase(name);
+        }
     }
 }
 

--- a/src/platform/backends/qemu/linux/qemu_platform_detail.h
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail.h
@@ -41,6 +41,7 @@ public:
     void remove_resources_for(const std::string& name) override;
     void platform_health_check() override;
     QStringList vm_platform_args(const VirtualMachineDescription& vm_desc) override;
+    void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& net) override;
 
 private:
     const QString bridge_name;

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -195,6 +195,17 @@ QStringList mp::QemuPlatformDetail::vm_platform_args(const VirtualMachineDescrip
     return opts;
 }
 
+void mp::QemuPlatformDetail::add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& net)
+{
+    // TODO: Do not uncomment the following line when implementing bridging in Linux QEMU. Since implementing it would
+    // yield the same exact implementation than in macOS, we need to move the code out of here, and put it only once
+    // in src/platform/backends/qemu/qemu_virtual_machine.[h|cpp].
+    // desc.extra_interfaces.push_back(net);
+
+    // For the time being, just complain:
+    throw NotImplementedOnThisBackendException("add interfaces");
+}
+
 mp::QemuPlatform::UPtr mp::QemuPlatformFactory::make_qemu_platform(const Path& data_dir) const
 {
     return std::make_unique<mp::QemuPlatformDetail>(data_dir);

--- a/src/platform/backends/qemu/qemu_platform.h
+++ b/src/platform/backends/qemu/qemu_platform.h
@@ -58,6 +58,7 @@ public:
     {
         throw NotImplementedOnThisBackendException("networks");
     };
+    virtual void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& net) = 0;
 
 protected:
     explicit QemuPlatform() = default;

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -623,6 +623,11 @@ void mp::QemuVirtualMachine::resize_disk(const MemorySize& new_size)
     desc.disk_space = new_size;
 }
 
+void mp::QemuVirtualMachine::add_network_interface(int /* not used on this backend */, const NetworkInterface& net)
+{
+    return qemu_platform->add_network_interface(desc, net);
+}
+
 mp::MountHandler::UPtr mp::QemuVirtualMachine::make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
                                                                          const std::string& target,
                                                                          const VMMount& mount)

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -22,6 +22,7 @@
 
 #include <shared/base_virtual_machine.h>
 
+#include <multipass/network_interface.h>
 #include <multipass/process/process.h>
 #include <multipass/virtual_machine_description.h>
 
@@ -60,6 +61,7 @@ public:
     void update_cpus(int num_cores) override;
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
+    virtual void add_network_interface(int index, const NetworkInterface& net) override;
     virtual MountArgs& modifiable_mount_args();
     std::unique_ptr<MountHandler> make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
                                                             const std::string& target, const VMMount& mount) override;

--- a/tests/qemu/linux/test_qemu_platform_detail.cpp
+++ b/tests/qemu/linux/test_qemu_platform_detail.cpp
@@ -208,3 +208,12 @@ TEST_F(QemuPlatformDetail, writing_ipforward_file_failure_logs_expected_message)
 
     mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
 }
+
+TEST_F(QemuPlatformDetail, add_network_interface_throws)
+{
+    mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
+
+    mp::VirtualMachineDescription desc;
+    mp::NetworkInterface net{"id", "52:54:00:98:76:54", true};
+    EXPECT_THROW(qemu_platform_detail.add_network_interface(desc, net), mp::NotImplementedOnThisBackendException);
+}

--- a/tests/qemu/mock_qemu_platform.h
+++ b/tests/qemu/mock_qemu_platform.h
@@ -42,6 +42,7 @@ struct MockQemuPlatform : public QemuPlatform
     MOCK_METHOD(QStringList, vmstate_platform_args, (), (override));
     MOCK_METHOD(QStringList, vm_platform_args, (const VirtualMachineDescription&), (override));
     MOCK_METHOD(QString, get_directory_name, (), (override));
+    MOCK_METHOD(void, add_network_interface, (VirtualMachineDescription&, const NetworkInterface&), (override));
 };
 
 struct MockQemuPlatformFactory : public QemuPlatformFactory


### PR DESCRIPTION
This branch implements the Linux platform code for adding bridged network interfaces on QEMU. Since it will be available first in macOS, here the implementation just throws.