### PR TITLE
Message only on SSH execution error

### DIFF
--- a/include/multipass/exceptions/ssh_exception.h
+++ b/include/multipass/exceptions/ssh_exception.h
@@ -30,5 +30,13 @@ public:
     {
     }
 };
+
+class SSHExecFailure : public SSHException
+{
+public:
+    SSHExecFailure(const std::string& what_arg) : SSHException(what_arg)
+    {
+    }
+};
 } // namespace multipass
 #endif // MULTIPASS_SSH_EXCEPTION_H

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3081,7 +3081,7 @@ mp::Daemon::async_wait_for_ready_all(grpc::ServerReaderWriterInterface<Reply, Re
                         mpu::run_in_ssh_session(session, command);
                     }
                 }
-                catch (const std::runtime_error&) // In case there is an error executing the command, report it.
+                catch (const mp::SSHExecFailure&) // In case there is an error executing the command, report it.
                 {
                     // Currently, the only use of running commands at boot is to configure networks. For this reason,
                     // the warning shown here refers to that use. In the future, in case of using the feature for other

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -380,7 +380,7 @@ std::string mp::utils::run_in_ssh_session(mp::SSHSession& session, const std::st
         auto error_msg = proc.read_std_error();
         mpl::log(mpl::Level::warning, category,
                  fmt::format("failed to run '{}', error message: '{}'", cmd, mp::utils::trim_end(error_msg)));
-        throw std::runtime_error(mp::utils::trim_end(error_msg));
+        throw mp::SSHExecFailure(mp::utils::trim_end(error_msg));
     }
 
     auto output = proc.read_std_output();


### PR DESCRIPTION
The execution of commands through SSH used to throw `std::runtime_error` when the return value was not `0`. This PR adds a new exception to be thrown in that case, making better catching an execution failure. This permitted us to show the interface configuration message only when needed.