### PR TITLE
updated x509 certificates to x509v3 and SANs extension

### DIFF
--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -172,6 +172,7 @@ public:
         if (!X509_sign(x509.get(), key.get(), EVP_sha256()))
             throw std::runtime_error("Failed to sign certificate");
     }
+
     std::string as_pem()
     {
         mp::BIOMem mem;

--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -118,7 +118,7 @@ std::string cn_name_from(const std::string& server_name)
     return server_name;
 }
 
-void set_san_name(X509* c, std::string server_name)
+void set_san_name(X509* c, const std::string& server_name)
 {
     std::string san_dns = server_name;
     GENERAL_NAMES* gens = sk_GENERAL_NAME_new_null();

--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -172,7 +172,6 @@ public:
 
         if (!X509_sign(x509.get(), key.get(), EVP_sha256()))
             throw std::runtime_error("Failed to sign certificate");
-
     }
     std::string as_pem()
     {

--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -24,6 +24,7 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 
 #include <QFile>
 
@@ -117,6 +118,21 @@ std::string cn_name_from(const std::string& server_name)
     return server_name;
 }
 
+void set_san_name(X509 *c, std::string server_name)
+{
+    std::string san_dns = server_name;
+    GENERAL_NAMES *gens = sk_GENERAL_NAME_new_null();
+    GENERAL_NAME *gen = GENERAL_NAME_new();
+    ASN1_IA5STRING *ia5 = ASN1_IA5STRING_new();
+    ASN1_STRING_set(ia5, san_dns.data(), san_dns.length());
+    GENERAL_NAME_set0_value(gen, GEN_DNS, ia5);
+    sk_GENERAL_NAME_push(gens, gen);
+
+    X509_add1_ext_i2d(c, NID_subject_alt_name, gens, 0, X509V3_ADD_DEFAULT);
+
+    GENERAL_NAMES_free(gens);
+}
+
 class X509Cert
 {
 public:
@@ -129,6 +145,8 @@ public:
         auto rand_bytes = MP_UTILS.random_bytes(4);
         for (unsigned int i = 0; i < 4u; i++)
             big_num |= rand_bytes[i] << i * 8u;
+
+        X509_set_version(x509.get(), 2);
 
         ASN1_INTEGER_set(X509_get_serialNumber(x509.get()), big_num);
         X509_gmtime_adj(X509_get_notBefore(x509.get()), 0);
@@ -146,6 +164,8 @@ public:
         X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, org.data(), org.size(), APPEND_ENTRY, ADD_RDN);
         X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, cn.data(), cn.size(), APPEND_ENTRY, ADD_RDN);
         X509_set_issuer_name(x509.get(), name);
+        set_san_name(x509.get(), server_name);
+        
 
         if (!X509_set_pubkey(x509.get(), key.get()))
             throw std::runtime_error("Failed to set certificate public key");
@@ -153,7 +173,6 @@ public:
         if (!X509_sign(x509.get(), key.get(), EVP_sha256()))
             throw std::runtime_error("Failed to sign certificate");
     }
-
     std::string as_pem()
     {
         mp::BIOMem mem;

--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -118,12 +118,12 @@ std::string cn_name_from(const std::string& server_name)
     return server_name;
 }
 
-void set_san_name(X509 *c, std::string server_name)
+void set_san_name(X509* c, std::string server_name)
 {
     std::string san_dns = server_name;
-    GENERAL_NAMES *gens = sk_GENERAL_NAME_new_null();
-    GENERAL_NAME *gen = GENERAL_NAME_new();
-    ASN1_IA5STRING *ia5 = ASN1_IA5STRING_new();
+    GENERAL_NAMES* gens = sk_GENERAL_NAME_new_null();
+    GENERAL_NAME* gen = GENERAL_NAME_new();
+    ASN1_IA5STRING* ia5 = ASN1_IA5STRING_new();
     ASN1_STRING_set(ia5, san_dns.data(), san_dns.length());
     GENERAL_NAME_set0_value(gen, GEN_DNS, ia5);
     sk_GENERAL_NAME_push(gens, gen);
@@ -165,7 +165,6 @@ public:
         X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, cn.data(), cn.size(), APPEND_ENTRY, ADD_RDN);
         X509_set_issuer_name(x509.get(), name);
         set_san_name(x509.get(), server_name);
-        
 
         if (!X509_set_pubkey(x509.get(), key.get()))
             throw std::runtime_error("Failed to set certificate public key");

--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -172,6 +172,7 @@ public:
 
         if (!X509_sign(x509.get(), key.get(), EVP_sha256()))
             throw std::runtime_error("Failed to sign certificate");
+
     }
     std::string as_pem()
     {


### PR DESCRIPTION
# Background

While implementing my own Go client for multipass, I noticed that the TLS certificates used by `multipassd`'s RPC server weren't using the SANs x509v3 extension. 

As such you would run into an annoying error when attempting to verify the TLS certificate that was being returned by the RPC server (`multipassd`). 

Go's standard library hasn't supported TLS/x509 certitficates without SANs present for a while now. See https://go.dev/doc/go1.16#minor_library_changes

# What does this change do? 

This change is a modification to the `ssl_cert_provider.cpp`'s x509 certificate generation. Here there are two major changes: 
1. Version of x509 certificate has been bumped to x509v3
2. Added SANs x509v3 Extension to include `DNS:${server_name}`

# Testing

I have managed to get this building and testing locally on my Ubuntu laptop, however I don't have any additional platforms available to me at the moment. 

The certificate is parsed successfully by `openssl x509 -in <>`  the output looks like:

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: ${BLAH}
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: C = US, O = Canonical, CN = localhost
        Validity
            Not Before: Mar 31 10:42:15 2023 GMT
            Not After : Mar 30 10:42:15 2024 GMT
        Subject: C = US, O = Canonical, CN = localhost
        Subject Public Key Info:d
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                  ${BLAH}
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Subject Alternative Name: 
                DNS:localhost
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
      ${BLAH}
```

I have also verified the certificate loads correctly using a small GoLang program which simply establishes a connection against the multipassd unix socket.

# Additional notes

This is a duplicate/updated PR of #3004 as the original commits were not pushed with a correct author's email. 

If there's any questions, or concerns feel free to drop a comment in, I'm happy to facilitate any modifications to help this get merged :) 

Thanks! 

Fixes canonical/multipass#3005
