### PR TITLE
Confirm snapshot deletion with prompt

### DIFF
--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -75,12 +75,13 @@ mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
         if (!reply.log_line().empty())
             cerr << reply.log_line();
 
+        // TODO refactor with bridging and restore prompts
         if (reply.confirm_snapshot_purging())
         {
             DeleteRequest client_response;
 
             if (term->is_live())
-                client_response.set_purge_snapshots(confirm_snapshot_purge()); // TODO@ricab
+                client_response.set_purge_snapshots(confirm_snapshot_purge());
             else
                 throw std::runtime_error{generate_snapshot_purge_msg()};
 
@@ -150,7 +151,7 @@ mp::ParseCode cmd::Delete::parse_instances_snapshots(mp::ArgParser* parser)
     return mp::ParseCode::Ok;
 }
 
-// TODO@ricab refactor with restore and networks
+// TODO refactor with bridging and restore prompts
 bool multipass::cmd::Delete::confirm_snapshot_purge() const
 {
     static constexpr auto prompt_text = "{}. Are you sure you want to continue? (Yes/no)";

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -27,11 +27,7 @@ namespace cmd = multipass::cmd;
 
 namespace
 {
-// TODO@ricab unduplicate
 constexpr auto snapshot_purge_notice_msg = "Snapshots can only be purged (after deletion, they cannot be recovered)";
-constexpr auto no_purge_base_error_msg = "Unable to query client for confirmation. Snapshots can only be purged (after "
-                                         "deletion, they cannot be recovered). Please use the `--purge` flag if that "
-                                         "is what you want";
 }
 
 mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
@@ -170,6 +166,10 @@ bool multipass::cmd::Delete::confirm_snapshot_purge() const
 
 std::string multipass::cmd::Delete::generate_snapshot_purge_msg() const
 {
+    const auto no_purge_base_error_msg = fmt::format("Unable to query client for confirmation. {}. Please use the "
+                                                     "`--purge` flag if that is what you want",
+                                                     snapshot_purge_notice_msg);
+
     if (!instance_args.empty())
         return fmt::format("{}:\n\n\tmultipass delete --purge {}\n\nYou can use a separate command to delete "
                            "instances without purging them:\n\n\tmultipass delete {}\n",

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -166,7 +166,7 @@ bool multipass::cmd::Delete::confirm_snapshot_purge() const
 
 std::string multipass::cmd::Delete::generate_snapshot_purge_msg() const
 {
-    const auto no_purge_base_error_msg = fmt::format("Unable to query client for confirmation. {}. Please use the "
+    const auto no_purge_base_error_msg = fmt::format("{}. Unable to query client for confirmation. Please use the "
                                                      "`--purge` flag if that is what you want",
                                                      snapshot_purge_notice_msg);
 

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -133,32 +133,15 @@ mp::ParseCode cmd::Delete::parse_args(mp::ArgParser* parser)
 
 mp::ParseCode cmd::Delete::parse_instances_snapshots(mp::ArgParser* parser)
 {
-    bool instance_found = false, snapshot_found = false;
-    std::string instances, snapshots;
     for (const auto& item : cmd::add_instance_and_snapshot_names(parser))
     {
         if (!item.has_snapshot_name())
-        {
-            instances.append(fmt::format("{} ", item.instance_name()));
-            instance_found = true;
-        }
+            instance_args.append(fmt::format("{} ", item.instance_name()));
         else
-        {
-            snapshots.append(fmt::format("{}.{} ", item.instance_name(), item.snapshot_name()));
-            snapshot_found = true;
-        }
+            snapshot_args.append(fmt::format("{}.{} ", item.instance_name(), item.snapshot_name()));
 
         request.add_instance_snapshot_pairs()->CopyFrom(item);
     }
-
-    return enforce_purged_snapshots(instances, snapshots, instance_found, snapshot_found);
-}
-
-mp::ParseCode cmd::Delete::enforce_purged_snapshots(std::string& instances,
-                                                    std::string& snapshots,
-                                                    bool instance_found,
-                                                    bool snapshot_found)
-{
 
     return mp::ParseCode::Ok;
 }

--- a/src/client/cli/cmd/delete.h
+++ b/src/client/cli/cmd/delete.h
@@ -48,6 +48,7 @@ private:
 
     ParseCode parse_args(ArgParser* parser);
     ParseCode parse_instances_snapshots(ArgParser* parser);
+    std::string generate_snapshot_purge_msg() const;
 };
 } // namespace cmd
 } // namespace multipass

--- a/src/client/cli/cmd/delete.h
+++ b/src/client/cli/cmd/delete.h
@@ -43,13 +43,11 @@ public:
 private:
     AliasDict aliases;
     DeleteRequest request;
+    std::string instance_args;
+    std::string snapshot_args;
 
     ParseCode parse_args(ArgParser* parser);
     ParseCode parse_instances_snapshots(ArgParser* parser);
-    ParseCode enforce_purged_snapshots(std::string& instances,
-                                       std::string& snapshots,
-                                       bool instance_found,
-                                       bool snapshot_found);
 };
 } // namespace cmd
 } // namespace multipass

--- a/src/client/cli/cmd/delete.h
+++ b/src/client/cli/cmd/delete.h
@@ -49,6 +49,7 @@ private:
     ParseCode parse_args(ArgParser* parser);
     ParseCode parse_instances_snapshots(ArgParser* parser);
     std::string generate_snapshot_purge_msg() const;
+    bool confirm_snapshot_purge() const;
 };
 } // namespace cmd
 } // namespace multipass

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2242,7 +2242,8 @@ try // clang-format on
         {
             DeleteReply confirm_action{};
             confirm_action.set_confirm_snapshot_purging(true);
-            // TODO@ricab refactor with restore
+
+            // TODO refactor with bridging and restore prompts
             if (!server->Write(confirm_action))
                 throw std::runtime_error("Cannot request confirmation from client. Aborting...");
             DeleteRequest client_response;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2263,15 +2263,13 @@ try // clang-format on
                 auto snapshot_pick_it = instance_snapshots_map.find(instance_name);
                 const auto& [pick, all] = snapshot_pick_it == instance_snapshots_map.end() ? SnapshotPick{{}, true}
                                                                                            : snapshot_pick_it->second;
-                if (all) // we're asked to delete the VM
-                    instances_dirty |= delete_vm(vm_it, purge, response);
-                else // we're asked to delete snapshots
-                {
-                    assert((purge || purge_snapshots) && "precondition: snapshots can only be purged");
 
+                if (!all || !purge) // if we're not purging the instance, we need to delete specified snapshots
                     for (const auto& snapshot_name : pick)
                         vm_it->second->delete_snapshot(snapshot_name);
-                }
+
+                if (all) // we're asked to delete the VM
+                    instances_dirty |= delete_vm(vm_it, purge, response);
             }
         }
 

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -428,11 +428,13 @@ message DeleteRequest {
     repeated InstanceSnapshotPair instance_snapshot_pairs = 1;
     bool purge = 2;
     int32 verbosity_level = 3;
+    bool purge_snapshots = 4;
 }
 
 message DeleteReply {
     string log_line = 1;
     repeated string purged_instances = 2;
+    bool confirm_snapshot_purging = 3;
 }
 
 message UmountRequest {


### PR DESCRIPTION
Confirm snapshot deletion with a prompt to users when they try to delete a snapshot without the `--purge` flag, as long as multipass is running interactively.