### PR TITLE
Merge blueprint vendor data

### DIFF
--- a/tests/test_data/blueprints/v1/complex-cloud-init.yaml
+++ b/tests/test_data/blueprints/v1/complex-cloud-init.yaml
@@ -1,0 +1,23 @@
+description: The first test blueprint
+version: 0.1
+
+instances:
+  complex-cloud-init:
+    image: "default"
+    workspace: true
+    limits:
+      min-cpu: 2
+      min-mem: 2G
+      min-disk: 25G
+    timeout: 600
+    cloud-init:
+      vendor-data: |
+        #cloud-config
+        runcmd:
+          - echo abc
+          - echo def
+        system_info:
+          default_user:
+            shell: /bin/zsh
+        growpart:
+          devices: [/]


### PR DESCRIPTION
This PR makes it so that cloud-init vendor data coming from a blueprint is merged with the vendor data that we normally provide. The merging follows these rules:
- If a key refers to a scalar value in both our vendor data and the blueprint vendor data, the blueprint is rejected
- If a key refers to values of different types in our vendor data and the blueprint vendor data, the blueprint is rejected
- If an entry from the blueprint vendor data does not exist in our own vendor data, simply add it
- If a key refers to a sequence in both our vendor data and the blueprint vendor data, append the items from the blueprint sequence to the sequence from our data
- If a key refers to a map in both our vendor data and the blueprint vendor data, recurse this algorithm on each key from the blueprint map

Fixes #3247