### PR TITLE
[ci] Add the edge channel for pushes to main

### DIFF
--- a/.github/actions/build-params/action.yml
+++ b/.github/actions/build-params/action.yml
@@ -48,6 +48,7 @@ runs:
       # This includes `main`, as `edge` will get published from automatic builds on snapcraft.io.
       elif [[ ${{ github.event_name }} == "push" || ${{ github.event_name }} == "workflow_dispatch" ]]; then
         echo "label=ci${{ github.run_number }}" >> $GITHUB_OUTPUT
+        echo "channel=edge" >> $GITHUB_OUTPUT
 
       # This shouldn't happen.
       else

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -275,11 +275,12 @@ jobs:
       with:
         token: ${{ secrets.PRIVATE_GITHUB_TOKEN }}
         workflow: Integration
-        ref: ${{ steps.dispatch-params.outputs.ref }}
-        sha: ${{ steps.dispatch-params.outputs.sha }}
+        ref: ${{ steps.dispatch-params.outputs.head_ref }}
+        sha: ${{ steps.dispatch-params.outputs.head_sha }}
         inputs: |
           {
             "snap-channel": "${{ needs.BuildAndTest.outputs.channel }}"
+            "head-sha": "${{ steps.dispatch-params.outputs.head_sha }}"
           }
       # This action will fail if `ref` moved on from `sha` to avoid mistargeting Integration runs.
       continue-on-error: true


### PR DESCRIPTION
Also add the head sha so the Integration workflow can compare the snap in edge with the tip of main to ensure the correct snap is used.