### PR TITLE
[sftp] Restrict sshfs perms to mapped ids

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -66,6 +66,8 @@ public:
     virtual bool exists(const QFileInfo& file) const;
     virtual bool isDir(const QFileInfo& file) const;
     virtual bool isReadable(const QFileInfo& file) const;
+    virtual uint ownerId(const QFileInfo& file) const;
+    virtual uint groupId(const QFileInfo& file) const;
 
     // QFile operations
     virtual bool exists(const QFile& file) const;

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -695,6 +695,16 @@ int mp::SftpServer::handle_opendir(sftp_client_message msg)
         return reply_perm_denied(msg);
     }
 
+    QFileInfo file_info{filename};
+    if (!has_uid_mapping_for(file_info.ownerId()) || !has_gid_mapping_for(file_info.groupId()))
+    {
+        mpl::log(
+            mpl::Level::trace,
+            category,
+            fmt::format("{}: cannot access path \'{}\' without id mapping: permission denied", __FUNCTION__, filename));
+        return reply_perm_denied(msg);
+    }
+
     SftpHandleUPtr sftp_handle{sftp_handle_alloc(sftp_server_session.get(), dir_iterator.get()), ssh_string_free};
     if (!sftp_handle)
     {

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -314,30 +314,30 @@ inline int mp::SftpServer::reverse_gid_for(const int gid, const int default_id)
 
 inline bool mp::SftpServer::has_uid_mapping_for(const int uid)
 {
-    return std::find_if(uid_mappings.begin(), uid_mappings.end(), [uid](std::pair<int, int> p) {
-               return uid == p.first;
-           }) != uid_mappings.end();
+    return std::any_of(uid_mappings.begin(), uid_mappings.end(), [uid](std::pair<int, int> p) {
+        return uid == p.first;
+    });
 }
 
 inline bool mp::SftpServer::has_gid_mapping_for(const int gid)
 {
-    return std::find_if(gid_mappings.begin(), gid_mappings.end(), [gid](std::pair<int, int> p) {
-               return gid == p.first;
-           }) != gid_mappings.end();
+    return std::any_of(gid_mappings.begin(), gid_mappings.end(), [gid](std::pair<int, int> p) {
+        return gid == p.first;
+    });
 }
 
 inline bool mp::SftpServer::has_reverse_uid_mapping_for(const int uid)
 {
-    return std::find_if(uid_mappings.cbegin(), uid_mappings.cend(), [uid](std::pair<int, int> p) {
-               return uid == p.second;
-           }) != uid_mappings.end();
+    return std::any_of(uid_mappings.cbegin(), uid_mappings.cend(), [uid](std::pair<int, int> p) {
+        return uid == p.second;
+    });
 }
 
 inline bool mp::SftpServer::has_reverse_gid_mapping_for(const int gid)
 {
-    return std::find_if(gid_mappings.cbegin(), gid_mappings.cend(), [gid](std::pair<int, int> p) {
-               return gid == p.second;
-           }) != gid_mappings.end();
+    return std::any_of(gid_mappings.cbegin(), gid_mappings.cend(), [gid](std::pair<int, int> p) {
+        return gid == p.second;
+    });
 }
 
 void mp::SftpServer::process_message(sftp_client_message msg)

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -856,6 +856,16 @@ int mp::SftpServer::handle_remove(sftp_client_message msg)
         return reply_perm_denied(msg);
     }
 
+    QFileInfo file_info{filename};
+    if (file_info.exists() && (!has_uid_mapping_for(file_info.ownerId()) || !has_gid_mapping_for(file_info.groupId())))
+    {
+        mpl::log(
+            mpl::Level::trace,
+            category,
+            fmt::format("{}: cannot access path \'{}\' without id mapping: permission denied", __FUNCTION__, filename));
+        return reply_perm_denied(msg);
+    }
+
     std::error_code err;
     if (!MP_FILEOPS.remove(filename, err) && !err)
         err = std::make_error_code(std::errc::no_such_file_or_directory);

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -611,7 +611,9 @@ int mp::SftpServer::handle_open(sftp_client_message msg)
     const auto exists = fs::is_symlink(status) || fs::is_regular_file(status);
 
     QFileInfo file_info(filename);
-    if (exists && (!has_uid_mapping_for(file_info.ownerId()) || !has_gid_mapping_for(file_info.groupId())))
+    QFileInfo current_dir(file_info.path());
+    if ((exists && (!has_uid_mapping_for(file_info.ownerId()) || !has_gid_mapping_for(file_info.groupId()))) ||
+        (!exists && (!has_uid_mapping_for(current_dir.ownerId()) || !has_gid_mapping_for(current_dir.groupId()))))
     {
         mpl::log(
             mpl::Level::trace,
@@ -657,9 +659,6 @@ int mp::SftpServer::handle_open(sftp_client_message msg)
 
     if (!exists)
     {
-        QFileInfo current_file(filename);
-        QFileInfo current_dir(current_file.path());
-
         auto new_uid = reverse_uid_for(current_dir.ownerId(), current_dir.ownerId());
         auto new_gid = reverse_gid_for(current_dir.groupId(), current_dir.groupId());
 

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -233,14 +233,14 @@ int mapped_id_for(const mp::id_mappings& id_maps, const int id, const int id_if_
     return id;
 }
 
-int reverse_id_for(const mp::id_mappings& id_maps, const int id, const int rev_id_if_not_found)
+int reverse_id_for(const mp::id_mappings& id_maps, const int id, const int default_id)
 {
     auto found = std::find_if(id_maps.cbegin(), id_maps.cend(), [id](std::pair<int, int> p) { return id == p.second; });
-    auto default_found = std::find_if(id_maps.cbegin(), id_maps.cend(), [rev_id_if_not_found](std::pair<int, int> p) {
-        return rev_id_if_not_found == p.second;
+    auto default_found = std::find_if(id_maps.cbegin(), id_maps.cend(), [default_id](std::pair<int, int> p) {
+        return default_id == p.second;
     });
 
-    return found == id_maps.cend() ? (default_found == id_maps.cend() ? rev_id_if_not_found : default_found->first)
+    return found == id_maps.cend() ? (default_found == id_maps.cend() ? default_id : default_found->first)
                                    : found->first;
 }
 } // namespace
@@ -302,14 +302,14 @@ inline int mp::SftpServer::mapped_gid_for(const int gid)
     return mapped_id_for(gid_mappings, gid, default_gid);
 }
 
-inline int mp::SftpServer::reverse_uid_for(const int uid, const int rev_uid_if_not_found)
+inline int mp::SftpServer::reverse_uid_for(const int uid, const int default_id)
 {
-    return reverse_id_for(uid_mappings, uid, rev_uid_if_not_found);
+    return reverse_id_for(uid_mappings, uid, default_id);
 }
 
-inline int mp::SftpServer::reverse_gid_for(const int gid, const int rev_gid_if_not_found)
+inline int mp::SftpServer::reverse_gid_for(const int gid, const int default_id)
 {
-    return reverse_id_for(gid_mappings, gid, rev_gid_if_not_found);
+    return reverse_id_for(gid_mappings, gid, default_id);
 }
 
 void mp::SftpServer::process_message(sftp_client_message msg)

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -805,6 +805,16 @@ int mp::SftpServer::handle_readlink(sftp_client_message msg)
         return sftp_reply_status(msg, SSH_FX_NO_SUCH_FILE, "invalid link");
     }
 
+    QFileInfo file_info{filename};
+    if (!has_uid_mapping_for(file_info.ownerId()) || !has_gid_mapping_for(file_info.groupId()))
+    {
+        mpl::log(
+            mpl::Level::trace,
+            category,
+            fmt::format("{}: cannot access path \'{}\' without id mapping: permission denied", __FUNCTION__, filename));
+        return reply_perm_denied(msg);
+    }
+
     sftp_attributes_struct attr{};
     sftp_reply_names_add(msg, link.toStdString().c_str(), link.toStdString().c_str(), &attr);
     return sftp_reply_names(msg);

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -236,8 +236,12 @@ int mapped_id_for(const mp::id_mappings& id_maps, const int id, const int id_if_
 int reverse_id_for(const mp::id_mappings& id_maps, const int id, const int rev_id_if_not_found)
 {
     auto found = std::find_if(id_maps.cbegin(), id_maps.cend(), [id](std::pair<int, int> p) { return id == p.second; });
+    auto default_found = std::find_if(id_maps.cbegin(), id_maps.cend(), [rev_id_if_not_found](std::pair<int, int> p) {
+        return rev_id_if_not_found == p.second;
+    });
 
-    return found == id_maps.cend() ? rev_id_if_not_found : found->first;
+    return found == id_maps.cend() ? (default_found == id_maps.cend() ? rev_id_if_not_found : default_found->first)
+                                   : found->first;
 }
 } // namespace
 

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -831,6 +831,16 @@ int mp::SftpServer::handle_realpath(sftp_client_message msg)
         return reply_perm_denied(msg);
     }
 
+    QFileInfo file_info{filename};
+    if (!has_uid_mapping_for(file_info.ownerId()) || !has_gid_mapping_for(file_info.groupId()))
+    {
+        mpl::log(
+            mpl::Level::trace,
+            category,
+            fmt::format("{}: cannot access path \'{}\' without id mapping: permission denied", __FUNCTION__, filename));
+        return reply_perm_denied(msg);
+    }
+
     auto realpath = QFileInfo(filename).absoluteFilePath();
     return sftp_reply_name(msg, realpath.toStdString().c_str(), nullptr);
 }

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -1111,13 +1111,23 @@ int mp::SftpServer::handle_stat(sftp_client_message msg, const bool follow)
 int mp::SftpServer::handle_symlink(sftp_client_message msg)
 {
     const auto old_name = sftp_client_message_get_filename(msg);
-
     const auto new_name = sftp_client_message_get_data(msg);
+
     if (!validate_path(source_path, new_name))
     {
         mpl::log(
             mpl::Level::trace, category,
             fmt::format("{}: cannot validate path \'{}\' against source \'{}\'", __FUNCTION__, new_name, source_path));
+        return reply_perm_denied(msg);
+    }
+
+    QFileInfo file_info{old_name};
+    if (file_info.exists() && (!has_uid_mapping_for(file_info.ownerId()) || !has_gid_mapping_for(file_info.groupId())))
+    {
+        mpl::log(
+            mpl::Level::trace,
+            category,
+            fmt::format("{}: cannot access path \'{}\' without id mapping: permission denied", __FUNCTION__, old_name));
         return reply_perm_denied(msg);
     }
 

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -550,6 +550,17 @@ int mp::SftpServer::handle_rmdir(sftp_client_message msg)
         return reply_perm_denied(msg);
     }
 
+    QFileInfo current_dir(filename);
+    if (current_dir.exists() &&
+        (!has_uid_mapping_for(current_dir.ownerId()) || !has_gid_mapping_for(current_dir.groupId())))
+    {
+        mpl::log(
+            mpl::Level::trace,
+            category,
+            fmt::format("{}: cannot access path \'{}\' without id mapping: permission denied", __FUNCTION__, filename));
+        return reply_perm_denied(msg);
+    }
+
     std::error_code err;
     if (!MP_FILEOPS.remove(filename, err) && !err)
         err = std::make_error_code(std::errc::no_such_file_or_directory);

--- a/src/sshfs_mount/sftp_server.h
+++ b/src/sshfs_mount/sftp_server.h
@@ -57,8 +57,8 @@ private:
     sftp_attributes_struct attr_from(const QFileInfo& file_info);
     int mapped_uid_for(const int uid);
     int mapped_gid_for(const int gid);
-    int reverse_uid_for(const int uid, const int rev_uid_if_not_found);
-    int reverse_gid_for(const int gid, const int rev_gid_if_not_found);
+    int reverse_uid_for(const int uid, const int default_id);
+    int reverse_gid_for(const int gid, const int default_id);
 
     int handle_close(sftp_client_message msg);
     int handle_fstat(sftp_client_message msg);

--- a/src/sshfs_mount/sftp_server.h
+++ b/src/sshfs_mount/sftp_server.h
@@ -59,6 +59,8 @@ private:
     int mapped_gid_for(const int gid);
     int reverse_uid_for(const int uid, const int default_id);
     int reverse_gid_for(const int gid, const int default_id);
+    bool has_uid_mapping_for(const int uid);
+    bool has_gid_mapping_for(const int gid);
 
     int handle_close(sftp_client_message msg);
     int handle_fstat(sftp_client_message msg);

--- a/src/sshfs_mount/sftp_server.h
+++ b/src/sshfs_mount/sftp_server.h
@@ -63,6 +63,7 @@ private:
     bool has_gid_mapping_for(const int gid);
     bool has_reverse_uid_mapping_for(const int uid);
     bool has_reverse_gid_mapping_for(const int gid);
+    bool has_id_mappings_for(const QFileInfo& file_info);
 
     int handle_close(sftp_client_message msg);
     int handle_fstat(sftp_client_message msg);

--- a/src/sshfs_mount/sftp_server.h
+++ b/src/sshfs_mount/sftp_server.h
@@ -61,6 +61,8 @@ private:
     int reverse_gid_for(const int gid, const int default_id);
     bool has_uid_mapping_for(const int uid);
     bool has_gid_mapping_for(const int gid);
+    bool has_reverse_uid_mapping_for(const int uid);
+    bool has_reverse_gid_mapping_for(const int gid);
 
     int handle_close(sftp_client_message msg);
     int handle_fstat(sftp_client_message msg);

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -105,7 +105,7 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
         }
         else
         {
-            sshfs_exec += " -o dcache_timeout=3";
+            sshfs_exec += " -o dcache_timeout=3 -o dir_cache=no";
         }
     }
     else

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -101,11 +101,11 @@ auto get_sshfs_exec_and_options(mp::SSHSession& session)
         // The option was made the default in libfuse 3.0
         else if (version::Semver200_version(fuse_version) < version::Semver200_version("3.0.0"))
         {
-            sshfs_exec += " -o nonempty -o cache_timeout=3";
+            sshfs_exec += " -o nonempty -o cache=no";
         }
         else
         {
-            sshfs_exec += " -o dcache_timeout=3 -o dir_cache=no";
+            sshfs_exec += " -o dir_cache=no";
         }
     }
     else

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -85,6 +85,16 @@ bool mp::FileOps::isReadable(const QFileInfo& file) const
     return file.isReadable();
 }
 
+uint mp::FileOps::ownerId(const QFileInfo& file) const
+{
+    return file.ownerId();
+}
+
+uint mp::FileOps::groupId(const QFileInfo& file) const
+{
+    return file.groupId();
+}
+
 bool mp::FileOps::is_open(const QFile& file) const
 {
     return file.isOpen();

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -41,6 +41,8 @@ public:
     MOCK_METHOD(bool, exists, (const QFileInfo&), (const, override));
     MOCK_METHOD(bool, isDir, (const QFileInfo&), (const, override));
     MOCK_METHOD(bool, isReadable, (const QFileInfo&), (const, override));
+    MOCK_METHOD(uint, ownerId, (const QFileInfo&), (const, override));
+    MOCK_METHOD(uint, groupId, (const QFileInfo&), (const, override));
 
     // QFile mock methods
     MOCK_METHOD(bool, exists, (const QFile&), (const, override));

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -1276,6 +1276,28 @@ TEST_F(SftpServer, open_no_handle_allocated_fails)
     EXPECT_EQ(failure_num_calls, 1);
 }
 
+TEST_F(SftpServer, openFailsWhenIdsAreNotMapped)
+{
+    mpt::TempDir temp_dir;
+    auto file_name = temp_dir.path() + "/test-file";
+    mpt::make_file_with_content(file_name);
+
+    auto sftp = make_sftpserver(temp_dir.path().toStdString(), {}, {});
+    auto msg = make_msg(SFTP_OPEN);
+    auto name = name_as_char_array(file_name.toStdString());
+    msg->filename = name.data();
+
+    int perm_denied_num_calls{0};
+    auto reply_status = make_reply_status(msg.get(), SSH_FX_PERMISSION_DENIED, perm_denied_num_calls);
+
+    REPLACE(sftp_get_client_message, make_msg_handler());
+    REPLACE(sftp_reply_status, reply_status);
+
+    sftp.run();
+
+    EXPECT_EQ(perm_denied_num_calls, 1);
+}
+
 TEST_F(SftpServer, handles_readdir)
 {
     mpt::TempDir temp_dir;

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -31,6 +31,7 @@
 
 #include <src/sshfs_mount/sftp_server.h>
 
+#include <multipass/cli/client_platform.h>
 #include <multipass/format.h>
 #include <multipass/platform.h>
 #include <multipass/ssh/ssh_session.h>
@@ -55,8 +56,9 @@ struct SftpServer : public mp::test::SftpServerTest
         return make_sftpserver("");
     }
 
-    mp::SftpServer make_sftpserver(const std::string& path, const mp::id_mappings& gid_mappings = {},
-                                   const mp::id_mappings& uid_mappings = {})
+    mp::SftpServer make_sftpserver(const std::string& path,
+                                   const mp::id_mappings& gid_mappings = {{default_id, mp::default_id}},
+                                   const mp::id_mappings& uid_mappings = {{default_id, mp::default_id}})
     {
         mp::SSHSession session{"a", 42, "ubuntu", key_provider};
         return {std::move(session), path, path, gid_mappings, uid_mappings, default_id, default_id, "sshfs"};
@@ -94,10 +96,10 @@ struct SftpServer : public mp::test::SftpServerTest
         return reply_status;
     }
 
+    static const int default_id{1000};
     const mpt::StubSSHKeyProvider key_provider;
     mpt::ExitStatusMock exit_status_mock;
     std::queue<sftp_client_message> messages;
-    int default_id{1000};
     mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject();
 };
 

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -383,7 +383,7 @@ TEST_F(SftpServer, realpathFailsWhenIdsAreNotMapped)
 
     sftp.run();
 
-    EXPECT_THAT(perm_denied_num_calls, Eq(1));
+    EXPECT_EQ(perm_denied_num_calls, 1);
 }
 
 TEST_F(SftpServer, handles_opendir)
@@ -755,7 +755,7 @@ TEST_F(SftpServer, rmdirFailsToRemoveDirThatsMissingMappedIds)
     sftp.run();
 
     EXPECT_TRUE(dir.exists());
-    EXPECT_THAT(perm_denied_num_calls, Eq(1));
+    EXPECT_EQ(perm_denied_num_calls, 1);
 }
 
 TEST_F(SftpServer, handles_readlink)
@@ -817,7 +817,7 @@ TEST_F(SftpServer, readlinkFailsWhenIdsAreNotMapped)
 
     sftp.run();
 
-    EXPECT_THAT(perm_denied_num_calls, Eq(1));
+    EXPECT_EQ(perm_denied_num_calls, 1);
 }
 
 TEST_F(SftpServer, handles_symlink)
@@ -2019,7 +2019,7 @@ TEST_F(SftpServer, setstatFailsWhenMissingMappedIds)
     sftp.run();
 
     EXPECT_EQ(perm_denied_num_calls, 1);
-    EXPECT_THAT(file.size(), Eq(file_size));
+    EXPECT_EQ(file.size(), file_size);
 }
 
 TEST_F(SftpServer, setstatChownFailsWhenNewIdsAreNotMapped)

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -49,6 +49,7 @@ using StringUPtr = std::unique_ptr<ssh_string_struct, void (*)(ssh_string)>;
 namespace
 {
 constexpr uint8_t SFTP_BAD_MESSAGE{255u};
+constexpr int default_id{1000};
 struct SftpServer : public mp::test::SftpServerTest
 {
     mp::SftpServer make_sftpserver()
@@ -96,7 +97,6 @@ struct SftpServer : public mp::test::SftpServerTest
         return reply_status;
     }
 
-    static const int default_id{1000};
     const mpt::StubSSHKeyProvider key_provider;
     mpt::ExitStatusMock exit_status_mock;
     std::queue<sftp_client_message> messages;

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -289,15 +289,14 @@ INSTANTIATE_TEST_SUITE_P(SshfsMountThrowWhenError, SshfsMountFail,
 CommandVector old_fuse_cmds = {
     {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 2.9.0\n"},
     {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-     "allow_other -o Compression=no -o nonempty -o cache_timeout=3 :\"source\" \"/home/ubuntu/target\"",
+     "allow_other -o Compression=no -o nonempty -o cache=no :\"source\" \"/home/ubuntu/target\"",
      "don't care\n"}};
 
 // Commands to check that a version of FUSE at least 3.0.0 gives a correct answer.
-CommandVector new_fuse_cmds = {
-    {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},
-    {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-     "allow_other -o Compression=no -o dcache_timeout=3 -o dir_cache=no :\"source\" \"/home/ubuntu/target\"",
-     "don't care\n"}};
+CommandVector new_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},
+                               {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
+                                "allow_other -o Compression=no -o dir_cache=no :\"source\" \"/home/ubuntu/target\"",
+                                "don't care\n"}};
 
 // Commands to check that an unknown version of FUSE gives a correct answer.
 CommandVector unk_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "weird fuse version\n"},

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -293,10 +293,11 @@ CommandVector old_fuse_cmds = {
      "don't care\n"}};
 
 // Commands to check that a version of FUSE at least 3.0.0 gives a correct answer.
-CommandVector new_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},
-                               {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
-                                "allow_other -o Compression=no -o dcache_timeout=3 :\"source\" \"/home/ubuntu/target\"",
-                                "don't care\n"}};
+CommandVector new_fuse_cmds = {
+    {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "FUSE library version: 3.0.0\n"},
+    {"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -o slave -o transform_symlinks -o "
+     "allow_other -o Compression=no -o dcache_timeout=3 -o dir_cache=no :\"source\" \"/home/ubuntu/target\"",
+     "don't care\n"}};
 
 // Commands to check that an unknown version of FUSE gives a correct answer.
 CommandVector unk_fuse_cmds = {{"sudo env LD_LIBRARY_PATH=/foo/bar /baz/bin/sshfs -V", "weird fuse version\n"},


### PR DESCRIPTION
File operations in an instance in an sshfs mount are now restricted to only files that have a uid/gid mapping for them (host-to-guest).

Fixes #3179 

Public side of [#571](https://github.com/canonical/multipass-private/pull/571)