### PR TITLE
Complain on snapshot operations if unsupported

### DIFF
--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -89,7 +89,7 @@ public:
 
     using SnapshotVista = std::vector<std::shared_ptr<const Snapshot>>; // using vista to avoid confusion with C++ views
     virtual SnapshotVista view_snapshots() const = 0;
-    virtual int get_num_snapshots() const noexcept = 0;
+    virtual int get_num_snapshots() const = 0;
 
     virtual std::shared_ptr<const Snapshot> get_snapshot(const std::string& name) const = 0;
     virtual std::shared_ptr<const Snapshot> get_snapshot(int index) const = 0;

--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -69,6 +69,7 @@ public:
 
     // List all the network interfaces seen by the backend.
     virtual std::vector<NetworkInterfaceInfo> networks() const = 0;
+    virtual void require_snapshots_support() const = 0;
 
 protected:
     VirtualMachineFactory() = default;

--- a/src/client/cli/formatter/json_formatter.cpp
+++ b/src/client/cli/formatter/json_formatter.cpp
@@ -101,7 +101,9 @@ QJsonObject generate_instance_details(const mp::DetailedInfoItem& item)
     instance_info.insert("image_release", QString::fromStdString(instance_details.image_release()));
     instance_info.insert("release", QString::fromStdString(instance_details.current_release()));
     instance_info.insert("cpu_count", QString::fromStdString(item.cpu_count()));
-    instance_info.insert("snapshot_count", QString::number(instance_details.num_snapshots()));
+
+    if (instance_details.has_num_snapshots())
+        instance_info.insert("snapshot_count", QString::number(instance_details.num_snapshots()));
 
     QJsonArray load;
     if (!instance_details.load().empty())

--- a/src/client/cli/formatter/table_formatter.cpp
+++ b/src/client/cli/formatter/table_formatter.cpp
@@ -125,7 +125,9 @@ std::string generate_instance_details(const mp::DetailedInfoItem& item)
                    "{:<16}{}\n",
                    "State:",
                    mp::format::status_string_for(item.instance_status()));
-    fmt::format_to(std::back_inserter(buf), "{:<16}{}\n", "Snapshots:", instance_details.num_snapshots());
+
+    if (instance_details.has_num_snapshots())
+        fmt::format_to(std::back_inserter(buf), "{:<16}{}\n", "Snapshots:", instance_details.num_snapshots());
 
     int ipv4_size = instance_details.ipv4_size();
     fmt::format_to(std::back_inserter(buf), "{:<16}{}\n", "IPv4:", ipv4_size ? instance_details.ipv4(0) : "--");

--- a/src/client/cli/formatter/yaml_formatter.cpp
+++ b/src/client/cli/formatter/yaml_formatter.cpp
@@ -96,7 +96,10 @@ YAML::Node generate_instance_details(const mp::DetailedInfoItem& item)
     YAML::Node instance_node;
 
     instance_node["state"] = mp::format::status_string_for(item.instance_status());
-    instance_node["snapshot_count"] = instance_details.num_snapshots();
+
+    if (instance_details.has_num_snapshots())
+        instance_node["snapshot_count"] = instance_details.num_snapshots();
+
     instance_node["image_hash"] = instance_details.id();
     instance_node["image_release"] = instance_details.image_release();
     instance_node["release"] =

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3467,8 +3467,9 @@ void mp::Daemon::populate_instance_info(VirtualMachine& vm,
     {
         instance_info->set_num_snapshots(vm.get_num_snapshots());
     }
-    catch (const NotImplementedOnThisBackendException&)
+    catch (const NotImplementedOnThisBackendException& e)
     {
+        assert(std::string{e.what()}.find("snapshots") != std::string::npos); // TODO per-feature exception type instead
     }
     instance_info->set_image_release(original_release);
     instance_info->set_id(vm_image.id);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1701,6 +1701,9 @@ try // clang-format on
     bool snapshots_only = request->snapshots();
     response.set_snapshots(snapshots_only);
 
+    if (snapshots_only)
+        config->factory->require_snapshots_support();
+
     auto process_snapshot_pick = [&response, &have_mounts, snapshots_only](VirtualMachine& vm,
                                                                            const SnapshotPick& snapshot_pick) {
         for (const auto& snapshot_name : snapshot_pick.pick)
@@ -1784,7 +1787,14 @@ try // clang-format on
     config->update_prompt->populate_if_time_to_show(response.mutable_update_info());
 
     // Need to 'touch' a report in the response so formatters know what to do with an otherwise empty response
-    request->snapshots() ? (void)response.mutable_snapshot_list() : (void)response.mutable_instance_list();
+    if (request->snapshots())
+    {
+        config->factory->require_snapshots_support();
+        response.mutable_snapshot_list();
+    }
+    else
+        response.mutable_instance_list();
+
     bool deleted = false;
 
     auto fetch_instance = [this, request, &response, &deleted](VirtualMachine& vm) {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2562,6 +2562,9 @@ try
         auto* vm_ptr = std::get<0>(instance_trail)->second.get();
         assert(vm_ptr);
 
+        // Only need to check if snapshots are supported and if the snapshot exists, so the result is discarded
+        vm_ptr->get_snapshot(request->snapshot());
+
         using St = VirtualMachine::State;
         if (auto state = vm_ptr->current_state(); state != St::off && state != St::stopped)
             return status_promise->set_value(
@@ -2570,9 +2573,6 @@ try
         auto spec_it = vm_instance_specs.find(instance_name);
         assert(spec_it != vm_instance_specs.end() && "missing instance specs");
         auto& vm_specs = spec_it->second;
-
-        // Only need to check if the snapshot exists so the result is discarded
-        vm_ptr->get_snapshot(request->snapshot());
 
         if (!request->destructive())
         {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2508,6 +2508,7 @@ try
                                                              *config->logger,
                                                              server};
 
+    config->factory->require_snapshots_support();
     const auto& instance_name = request->instance();
     auto [instance_trail, status] = find_instance_and_react(operative_instances,
                                                             deleted_instances,

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3440,7 +3440,13 @@ void mp::Daemon::populate_instance_info(VirtualMachine& vm,
         }
     }
 
-    instance_info->set_num_snapshots(vm.get_num_snapshots());
+    try
+    {
+        instance_info->set_num_snapshots(vm.get_num_snapshots());
+    }
+    catch (const NotImplementedOnThisBackendException&)
+    {
+    }
     instance_info->set_image_release(original_release);
     instance_info->set_id(vm_image.id);
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -77,6 +77,7 @@ protected:
     {
     }
 
+    void check_snapshots_supported() const override;
     std::shared_ptr<Snapshot> make_specific_snapshot(const QString& filename) override;
     std::shared_ptr<Snapshot> make_specific_snapshot(const std::string& snapshot_name,
                                                      const std::string& comment,
@@ -104,5 +105,9 @@ private:
     std::chrono::steady_clock::time_point network_deadline;
 };
 } // namespace multipass
+
+inline void multipass::QemuVirtualMachine::check_snapshots_supported() const
+{
+}
 
 #endif // MULTIPASS_QEMU_VIRTUAL_MACHINE_H

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -77,7 +77,7 @@ protected:
     {
     }
 
-    void check_snapshots_supported() const override;
+    void require_snapshots_support() const override;
     std::shared_ptr<Snapshot> make_specific_snapshot(const QString& filename) override;
     std::shared_ptr<Snapshot> make_specific_snapshot(const std::string& snapshot_name,
                                                      const std::string& comment,
@@ -106,7 +106,7 @@ private:
 };
 } // namespace multipass
 
-inline void multipass::QemuVirtualMachine::check_snapshots_supported() const
+inline void multipass::QemuVirtualMachine::require_snapshots_support() const
 {
 }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -41,6 +41,7 @@ public:
     QString get_backend_version_string() const override;
     QString get_backend_directory_name() const override;
     std::vector<NetworkInterfaceInfo> networks() const override;
+    void require_snapshots_support() const override;
 
 protected:
     void remove_resources_for_impl(const std::string& name) override;
@@ -51,5 +52,9 @@ private:
     QemuPlatform::UPtr qemu_platform;
 };
 } // namespace multipass
+
+inline void multipass::QemuVirtualMachineFactory::require_snapshots_support() const
+{
+}
 
 #endif // MULTIPASS_QEMU_VIRTUAL_MACHINE_FACTORY_H

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -518,10 +518,11 @@ void BaseVirtualMachine::restore_rollback_helper(const Path& head_path,
 void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& specs)
 {
     const std::unique_lock lock{snapshot_mutex};
-    assert_vm_stopped(state); // precondition
 
     auto snapshot = get_snapshot(name);
-    assert(snapshot->get_state() == St::off || snapshot->get_state() == St::stopped);
+
+    assert_vm_stopped(state);                 // precondition
+    assert_vm_stopped(snapshot->get_state()); // precondition
 
     snapshot->apply();
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -116,6 +116,7 @@ std::vector<std::string> BaseVirtualMachine::get_all_ipv4(const SSHKeyProvider& 
 
 auto BaseVirtualMachine::view_snapshots() const -> SnapshotVista
 {
+    check_snapshots_supported();
     SnapshotVista ret;
 
     const std::unique_lock lock{snapshot_mutex};
@@ -129,6 +130,7 @@ auto BaseVirtualMachine::view_snapshots() const -> SnapshotVista
 
 std::shared_ptr<const Snapshot> BaseVirtualMachine::get_snapshot(const std::string& name) const
 {
+    check_snapshots_supported();
     const std::unique_lock lock{snapshot_mutex};
     try
     {
@@ -142,6 +144,7 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::get_snapshot(const std::stri
 
 std::shared_ptr<const Snapshot> BaseVirtualMachine::get_snapshot(int index) const
 {
+    check_snapshots_supported();
     const std::unique_lock lock{snapshot_mutex};
 
     auto index_matcher = [index](const auto& elem) { return elem.second->get_index() == index; };
@@ -195,6 +198,8 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs&
                                                                   const std::string& snapshot_name,
                                                                   const std::string& comment)
 {
+    check_snapshots_supported();
+
     std::unique_lock lock{snapshot_mutex};
     assert_vm_stopped(state); // precondition
 
@@ -366,6 +371,7 @@ void BaseVirtualMachine::load_snapshots()
 
 std::vector<std::string> BaseVirtualMachine::get_childrens_names(const Snapshot* parent) const
 {
+    check_snapshots_supported();
     std::vector<std::string> children;
 
     for (const auto& snapshot : view_snapshots())

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -116,7 +116,7 @@ std::vector<std::string> BaseVirtualMachine::get_all_ipv4(const SSHKeyProvider& 
 
 auto BaseVirtualMachine::view_snapshots() const -> SnapshotVista
 {
-    check_snapshots_supported();
+    require_snapshots_support();
     SnapshotVista ret;
 
     const std::unique_lock lock{snapshot_mutex};
@@ -130,7 +130,7 @@ auto BaseVirtualMachine::view_snapshots() const -> SnapshotVista
 
 std::shared_ptr<const Snapshot> BaseVirtualMachine::get_snapshot(const std::string& name) const
 {
-    check_snapshots_supported();
+    require_snapshots_support();
     const std::unique_lock lock{snapshot_mutex};
     try
     {
@@ -144,7 +144,7 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::get_snapshot(const std::stri
 
 std::shared_ptr<const Snapshot> BaseVirtualMachine::get_snapshot(int index) const
 {
-    check_snapshots_supported();
+    require_snapshots_support();
     const std::unique_lock lock{snapshot_mutex};
 
     auto index_matcher = [index](const auto& elem) { return elem.second->get_index() == index; };
@@ -198,7 +198,7 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs&
                                                                   const std::string& snapshot_name,
                                                                   const std::string& comment)
 {
-    check_snapshots_supported();
+    require_snapshots_support();
 
     std::unique_lock lock{snapshot_mutex};
     assert_vm_stopped(state); // precondition
@@ -371,7 +371,7 @@ void BaseVirtualMachine::load_snapshots()
 
 std::vector<std::string> BaseVirtualMachine::get_childrens_names(const Snapshot* parent) const
 {
-    check_snapshots_supported();
+    require_snapshots_support();
     std::vector<std::string> children;
 
     for (const auto& snapshot : view_snapshots())

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -71,7 +71,7 @@ public:
     int get_snapshot_count() const override;
 
 protected:
-    virtual void check_snapshots_supported() const;
+    virtual void require_snapshots_support() const;
     virtual std::shared_ptr<Snapshot> make_specific_snapshot(const QString& filename);
     virtual std::shared_ptr<Snapshot> make_specific_snapshot(const std::string& snapshot_name,
                                                              const std::string& comment,
@@ -132,18 +132,18 @@ private:
 
 inline int multipass::BaseVirtualMachine::get_num_snapshots() const
 {
-    check_snapshots_supported();
+    require_snapshots_support();
     return static_cast<int>(snapshots.size());
 }
 
 inline int multipass::BaseVirtualMachine::get_snapshot_count() const
 {
-    check_snapshots_supported();
+    require_snapshots_support();
     const std::unique_lock lock{snapshot_mutex};
     return snapshot_count;
 }
 
-inline void multipass::BaseVirtualMachine::check_snapshots_supported() const // TODO@nomerge implement on supporting
+inline void multipass::BaseVirtualMachine::require_snapshots_support() const // TODO@nomerge implement on supporting
 {
     throw NotImplementedOnThisBackendException{"Snapshots"};
 }

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -145,7 +145,7 @@ inline int multipass::BaseVirtualMachine::get_snapshot_count() const
 
 inline void multipass::BaseVirtualMachine::require_snapshots_support() const
 {
-    throw NotImplementedOnThisBackendException{"Snapshots"};
+    throw NotImplementedOnThisBackendException{"snapshots"};
 }
 
 #endif // MULTIPASS_BASE_VIRTUAL_MACHINE_H

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -51,7 +51,7 @@ public:
     };
 
     SnapshotVista view_snapshots() const override;
-    int get_num_snapshots() const noexcept override;
+    int get_num_snapshots() const override;
 
     std::shared_ptr<const Snapshot> get_snapshot(const std::string& name) const override;
     std::shared_ptr<const Snapshot> get_snapshot(int index) const override;
@@ -71,6 +71,7 @@ public:
     int get_snapshot_count() const override;
 
 protected:
+    virtual void check_snapshots_supported() const;
     virtual std::shared_ptr<Snapshot> make_specific_snapshot(const QString& filename);
     virtual std::shared_ptr<Snapshot> make_specific_snapshot(const std::string& snapshot_name,
                                                              const std::string& comment,
@@ -129,15 +130,22 @@ private:
 
 } // namespace multipass
 
-inline int multipass::BaseVirtualMachine::get_num_snapshots() const noexcept
+inline int multipass::BaseVirtualMachine::get_num_snapshots() const
 {
+    check_snapshots_supported();
     return static_cast<int>(snapshots.size());
 }
 
 inline int multipass::BaseVirtualMachine::get_snapshot_count() const
 {
+    check_snapshots_supported();
     const std::unique_lock lock{snapshot_mutex};
     return snapshot_count;
+}
+
+inline void multipass::BaseVirtualMachine::check_snapshots_supported() const // TODO@nomerge implement on supporting
+{
+    throw NotImplementedOnThisBackendException{"Snapshots"};
 }
 
 #endif // MULTIPASS_BASE_VIRTUAL_MACHINE_H

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -143,7 +143,7 @@ inline int multipass::BaseVirtualMachine::get_snapshot_count() const
     return snapshot_count;
 }
 
-inline void multipass::BaseVirtualMachine::require_snapshots_support() const // TODO@nomerge implement on supporting
+inline void multipass::BaseVirtualMachine::require_snapshots_support() const
 {
     throw NotImplementedOnThisBackendException{"Snapshots"};
 }

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -106,7 +106,7 @@ inline void multipass::BaseVirtualMachineFactory::remove_resources_for(const std
 
 inline void multipass::BaseVirtualMachineFactory::require_snapshots_support() const
 {
-    throw NotImplementedOnThisBackendException{"Snapshots"};
+    throw NotImplementedOnThisBackendException{"snapshots"};
 }
 
 #endif // MULTIPASS_BASE_VIRTUAL_MACHINE_FACTORY_H

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -73,6 +73,8 @@ public:
         throw NotImplementedOnThisBackendException("networks");
     };
 
+    void require_snapshots_support() const override;
+
 protected:
     static const Path instances_subdir;
 
@@ -100,6 +102,12 @@ inline void multipass::BaseVirtualMachineFactory::remove_resources_for(const std
     remove_resources_for_impl(name);
     QDir instance_dir{get_instance_directory(name)};
     instance_dir.removeRecursively();
+}
+
+inline void
+multipass::BaseVirtualMachineFactory::require_snapshots_support() const // TODO@nomerge override where supported
+{
+    throw NotImplementedOnThisBackendException{"Snapshots"};
 }
 
 #endif // MULTIPASS_BASE_VIRTUAL_MACHINE_FACTORY_H

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -104,8 +104,7 @@ inline void multipass::BaseVirtualMachineFactory::remove_resources_for(const std
     instance_dir.removeRecursively();
 }
 
-inline void
-multipass::BaseVirtualMachineFactory::require_snapshots_support() const // TODO@nomerge override where supported
+inline void multipass::BaseVirtualMachineFactory::require_snapshots_support() const
 {
     throw NotImplementedOnThisBackendException{"Snapshots"};
 }

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -216,7 +216,7 @@ message InstanceDetails {
     string disk_usage = 6;
     repeated string ipv4 = 7;
     repeated string ipv6 = 8;
-    int32 num_snapshots = 9;
+    optional int32 num_snapshots = 9;
 }
 
 message SnapshotFundamentals {

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -76,7 +76,7 @@ struct MockVirtualMachineT : public T
                 (const SSHKeyProvider*, const std::string&, const VMMount&),
                 (override));
     MOCK_METHOD(VirtualMachine::SnapshotVista, view_snapshots, (), (const, override, noexcept));
-    MOCK_METHOD(int, get_num_snapshots, (), (const, override, noexcept));
+    MOCK_METHOD(int, get_num_snapshots, (), (const, override));
     MOCK_METHOD(std::shared_ptr<const Snapshot>, get_snapshot, (const std::string&), (const, override));
     MOCK_METHOD(std::shared_ptr<const Snapshot>, get_snapshot, (int index), (const, override));
     MOCK_METHOD(std::shared_ptr<Snapshot>, get_snapshot, (const std::string&), (override));

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -47,6 +47,7 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
                 (std::vector<VMImageHost*>, URLDownloader*, const Path&, const Path&, const days&), (override));
     MOCK_METHOD(void, configure, (VirtualMachineDescription&), (override));
     MOCK_METHOD(std::vector<NetworkInterfaceInfo>, networks, (), (const, override));
+    MOCK_METHOD(void, require_snapshots_support, (), (const, override));
 
     // originally protected:
     MOCK_METHOD(std::string, create_bridge_with, (const NetworkInterfaceInfo&), (override));

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -131,7 +131,7 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
         return {};
     }
 
-    int get_num_snapshots() const noexcept override
+    int get_num_snapshots() const override
     {
         return 0;
     }


### PR DESCRIPTION
And omit the number of snapshots in `info`.

Fixes #3328 
