### PR TITLE
Catch timeout on commands at boot

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3671,6 +3671,12 @@ void mp::Daemon::run_commands_at_boot_on_instance(const std::string& name, fmt::
 
             warned_exec_failure = true;
         }
+        catch (const ExitlessSSHProcessException& e) // Timeout does not mean there is a configuration error.
+        {
+            mpl::log(mpl::Level::warning,
+                     category,
+                     fmt::format("Exception when executing command at boot in {}: {}", name, e.what()));
+        }
         catch (const SSHException&) // The SSH session could not be created.
         {
             add_fmt_to(warnings,

--- a/tests/test_daemon_start.cpp
+++ b/tests/test_daemon_start.cpp
@@ -195,6 +195,44 @@ TEST_P(WithSSH, startConfiguresInterfaces)
     EXPECT_TRUE(status.ok());
 }
 
+TEST_F(TestDaemonStart, exitlessSshProcessExceptionDoesNotShowMessage)
+{
+    auto event_dopoll = [](auto...) { return SSH_ERROR; };
+    REPLACE(ssh_event_dopoll, event_dopoll);
+
+    std::vector<mp::NetworkInterface> unconfigured{{"eth7", "", true}};
+
+    auto mock_factory = use_a_mock_vm_factory();
+    const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, unconfigured));
+
+    auto instance_ptr = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
+    EXPECT_CALL(*mock_factory, create_virtual_machine(_, _)).WillOnce([&instance_ptr](const auto&, auto&) {
+        return std::move(instance_ptr);
+    });
+
+    EXPECT_CALL(*instance_ptr, wait_until_ssh_up).WillRepeatedly(Return());
+    EXPECT_CALL(*instance_ptr, current_state()).WillRepeatedly(Return(mp::VirtualMachine::State::off));
+    EXPECT_CALL(*instance_ptr, start()).Times(1);
+    EXPECT_CALL(*instance_ptr, add_network_interface(_, _)).Times(1);
+
+    config_builder.data_directory = temp_dir->path();
+    config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+
+    mp::Daemon daemon{config_builder.build()};
+
+    mp::StartRequest request;
+    request.mutable_instance_names()->add_instance_name(mock_instance_name);
+
+    StrictMock<mpt::MockServerReaderWriter<mp::StartReply, mp::StartRequest>> server;
+
+    EXPECT_CALL(server, Write(_, _)).Times(0);
+
+    auto status = call_daemon_slot(daemon, &mp::Daemon::start, request, std::move(server));
+
+    EXPECT_THAT(status.error_message(), StrEq(""));
+    EXPECT_TRUE(status.ok());
+}
+
 INSTANTIATE_TEST_SUITE_P(TestDaemonStart, WithSSH, Values(0, 1, -1));
 
 TEST_F(TestDaemonStart, unknownStateDoesNotStart)


### PR DESCRIPTION
Some executions can give a timeout for several reasons, but does not necessarily mean there was an error. However, the daemon used to fail on timeouts as it failed in severe cases like not being able to create a SSH connection. This PR makes the daemon catch the timeout exception, avoiding an error be shown to the user.