### PR TITLE
Filter new extra interfaces before instance start

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3347,6 +3347,7 @@ mp::MountHandler::UPtr mp::Daemon::make_mount(VirtualMachine* vm, const std::str
 
 // This function configures the network interfaces whose MAC address is empty. They will stay in specs.extra_interfaces
 // only if the backend is able to add them to the virtual machine. If not, they will be removed.
+// The return value is a set of networks that couldn't be configured and thus were removed from specs.extra_interfaces.
 std::unordered_set<std::string> mp::Daemon::configure_new_interfaces(const std::string& name,
                                                                      mp::VirtualMachine& vm,
                                                                      mp::VMSpecs& specs)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -172,7 +172,9 @@ private:
                                VirtualMachine* vm);
 
     MountHandler::UPtr make_mount(VirtualMachine* vm, const std::string& target, const VMMount& mount);
-    void configure_new_interfaces(const std::string& name, VirtualMachine& vm, VMSpecs& specs);
+    std::unordered_set<std::string> configure_new_interfaces(const std::string& name,
+                                                             VirtualMachine& vm,
+                                                             VMSpecs& specs);
 
     struct AsyncOperationStatus
     {

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -187,10 +187,12 @@ private:
     std::string async_wait_for_ssh_and_start_mounts_for(const std::string& name, const std::chrono::seconds& timeout,
                                                         grpc::ServerReaderWriterInterface<Reply, Request>* server);
     template <typename Reply, typename Request>
-    AsyncOperationStatus
-    async_wait_for_ready_all(grpc::ServerReaderWriterInterface<Reply, Request>* server,
-                             const std::vector<std::string>& vms, const std::chrono::seconds& timeout,
-                             std::promise<grpc::Status>* status_promise, const std::string& errors);
+    AsyncOperationStatus async_wait_for_ready_all(grpc::ServerReaderWriterInterface<Reply, Request>* server,
+                                                  const std::vector<std::string>& vms,
+                                                  const std::chrono::seconds& timeout,
+                                                  std::promise<grpc::Status>* status_promise,
+                                                  const std::string& errors,
+                                                  const std::string& start_warnings);
     void finish_async_operation(const std::string& async_future_key);
     QFutureWatcher<AsyncOperationStatus>* create_future_watcher(std::function<void()> const& finished_op = []() {});
     void update_manifests_all(const bool is_force_update_from_network = false);

--- a/src/platform/backends/lxd/lxd_request.cpp
+++ b/src/platform/backends/lxd/lxd_request.cpp
@@ -113,7 +113,9 @@ const QJsonObject lxd_request_common(const std::string& method, QUrl& url, int t
     mpl::log(mpl::Level::trace, request_category, fmt::format("Got reply: {}", QJsonDocument(json_reply).toJson()));
 
     if (reply->error() != QNetworkReply::NoError)
-        throw mp::LXDRuntimeError(fmt::format("Network error for {}: {} - {}", url.toString(), reply->errorString(),
+        throw mp::LXDNetworkError(fmt::format("Network error for {}: {} - {}",
+                                              url.toString(),
+                                              reply->errorString(),
                                               json_reply.object()["error"].toString()));
 
     return json_reply.object();
@@ -140,6 +142,12 @@ try
     };
 
     return lxd_request_common(method, url, timeout, handle_request);
+}
+catch (const LXDNetworkError& e)
+{
+    mpl::log(mpl::Level::warning, request_category, e.what());
+
+    throw;
 }
 catch (const LXDRuntimeError& e)
 {

--- a/src/platform/backends/lxd/lxd_request.h
+++ b/src/platform/backends/lxd/lxd_request.h
@@ -48,6 +48,14 @@ public:
     }
 };
 
+class LXDNetworkError : public LXDRuntimeError
+{
+public:
+    LXDNetworkError(const std::string& message) : LXDRuntimeError{message}
+    {
+    }
+};
+
 class LXDJsonParseError : public std::runtime_error
 {
 public:

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1362,7 +1362,8 @@ TEST_F(LXDBackend, lxd_request_bad_request_throws_and_logs)
                                HasSubstr(": Error - Failure"));
 
     EXPECT_CALL(*logger_scope.mock_logger,
-                log(Eq(mpl::Level::error), mpt::MockLogger::make_cstring_matcher(StrEq("lxd request")),
+                log(_,
+                    mpt::MockLogger::make_cstring_matcher(StrEq("lxd request")),
                     mpt::MockLogger::make_cstring_matcher(error_matcher)));
 
     MP_EXPECT_THROW_THAT(mp::lxd_request(mock_network_access_manager.get(), "GET", base_url), std::runtime_error,

--- a/tests/test_daemon_start.cpp
+++ b/tests/test_daemon_start.cpp
@@ -288,11 +288,12 @@ TEST_F(TestDaemonStart, startShowsBridgingErrors)
 
     StrictMock<mpt::MockServerReaderWriter<mp::StartReply, mp::StartRequest>> server;
 
+    std::string log{"Cannot bridge eth47 for instance real-zebraphant. Please see the logs for more details.\n"};
+    EXPECT_CALL(server, Write(Property(&mp::StartReply::log_line, HasSubstr(log)), _)).Times(1);
+
     auto status = call_daemon_slot(daemon, &mp::Daemon::start, request, std::move(server));
 
-    EXPECT_THAT(status.error_message(),
-                StrEq("The following errors occurred:\nCannot bridge eth47 for instance real-zebraphant"));
-    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.ok());
 }
 
 TEST_F(TestDaemonStart, unknownStateDoesNotStart)

--- a/tests/test_daemon_start.cpp
+++ b/tests/test_daemon_start.cpp
@@ -235,6 +235,66 @@ TEST_F(TestDaemonStart, exitlessSshProcessExceptionDoesNotShowMessage)
 
 INSTANTIATE_TEST_SUITE_P(TestDaemonStart, WithSSH, Values(0, 1, -1));
 
+TEST_F(TestDaemonStart, startShowsBridgingErrors)
+{
+    ssh_channel_callbacks callbacks{nullptr};
+    auto add_channel_cbs = [&callbacks](ssh_channel, ssh_channel_callbacks cb) {
+        callbacks = cb;
+        return SSH_OK;
+    };
+    REPLACE(ssh_add_channel_callbacks, add_channel_cbs);
+
+    auto event_dopoll = [&callbacks](auto...) {
+        if (!callbacks)
+            return SSH_ERROR;
+        callbacks->channel_exit_status_function(nullptr, nullptr, 0, callbacks->userdata);
+        return SSH_OK;
+    };
+    REPLACE(ssh_event_dopoll, event_dopoll);
+
+    std::string fake_output{"some output"};
+    auto remaining = fake_output.size();
+    auto channel_read = [&fake_output, &remaining](ssh_channel, void* dest, uint32_t count, int is_stderr, int) {
+        const auto num_to_copy = std::min(count, static_cast<uint32_t>(remaining));
+        const auto begin = fake_output.begin() + fake_output.size() - remaining;
+        std::copy_n(begin, num_to_copy, reinterpret_cast<char*>(dest));
+        remaining -= num_to_copy;
+        return num_to_copy;
+    };
+    REPLACE(ssh_channel_read_timeout, channel_read);
+
+    std::vector<mp::NetworkInterface> unconfigured{{"eth47", "", true}};
+
+    auto mock_factory = use_a_mock_vm_factory();
+    const auto [temp_dir, filename] = plant_instance_json(fake_json_contents(mac_addr, unconfigured));
+
+    auto instance_ptr = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(mock_instance_name);
+    EXPECT_CALL(*mock_factory, create_virtual_machine(_, _)).WillOnce([&instance_ptr](const auto&, auto&) {
+        return std::move(instance_ptr);
+    });
+
+    EXPECT_CALL(*instance_ptr, wait_until_ssh_up).WillRepeatedly(Return());
+    EXPECT_CALL(*instance_ptr, current_state()).WillRepeatedly(Return(mp::VirtualMachine::State::off));
+    EXPECT_CALL(*instance_ptr, start()).Times(1);
+    EXPECT_CALL(*instance_ptr, add_network_interface(_, _)).WillOnce(Throw(std::runtime_error("panic show")));
+
+    config_builder.data_directory = temp_dir->path();
+    config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+
+    mp::Daemon daemon{config_builder.build()};
+
+    mp::StartRequest request;
+    request.mutable_instance_names()->add_instance_name(mock_instance_name);
+
+    StrictMock<mpt::MockServerReaderWriter<mp::StartReply, mp::StartRequest>> server;
+
+    auto status = call_daemon_slot(daemon, &mp::Daemon::start, request, std::move(server));
+
+    EXPECT_THAT(status.error_message(),
+                StrEq("The following errors occurred:\nCannot bridge eth47 for instance real-zebraphant"));
+    EXPECT_FALSE(status.ok());
+}
+
 TEST_F(TestDaemonStart, unknownStateDoesNotStart)
 {
     auto mock_factory = use_a_mock_vm_factory();


### PR DESCRIPTION
Adding interfaces after the instance was created introduced the possibility of some kinds of clashes when the instance starts. To fix this, we check first if the backend is able to add each one of the network interfaces requested by the user. The daemon then filters out the failing interfaces, letting only the interfaces which work be added to the instance.

This PR fixes issue 4 of [this review](https://github.com/canonical/multipass/pull/3195#pullrequestreview-1765804396).