### PR TITLE
[lxd] Throw not-impl exception from LXD suspend

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -297,7 +297,7 @@ void mp::LXDVirtualMachine::shutdown()
 
 void mp::LXDVirtualMachine::suspend()
 {
-    throw std::runtime_error("suspend is currently not supported");
+    throw NotImplementedOnThisBackendException{"suspend"};
 }
 
 mp::VirtualMachine::State mp::LXDVirtualMachine::current_state()

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1596,8 +1596,9 @@ TEST_F(LXDBackend, unsupported_suspend_throws)
                                   default_storage_pool,
                                   instance_dir.path()};
 
-    MP_EXPECT_THROW_THAT(machine.suspend(), std::runtime_error,
-                         mpt::match_what(StrEq("suspend is currently not supported")));
+    MP_EXPECT_THROW_THAT(machine.suspend(),
+                         mp::NotImplementedOnThisBackendException,
+                         mpt::match_what(HasSubstr("suspend")));
 }
 
 TEST_F(LXDBackend, start_while_frozen_unfreezes)


### PR DESCRIPTION
Replace the existing runtime error with proper not-implemented exception.
