### PR TITLE
Fix showing alias message on Blueprint creation

### DIFF
--- a/src/client/cli/cmd/create_alias.cpp
+++ b/src/client/cli/cmd/create_alias.cpp
@@ -82,7 +82,10 @@ multipass::ReturnCode multipass::cmd::create_alias(AliasDict& aliases, const std
 
     auto alias_folder = MP_PLATFORM.get_alias_scripts_folder().absolutePath();
 
-    if (empty_before_add && aliases.size() == 1 && std::find(path.cbegin(), path.cend(), alias_folder) == path.cend())
+    // aliases.size() is the amount of contexts defined. If the alias dictionary is empty and a new alias is created
+    // in a context different to the default context, the dictionary will have two contexts, although only one
+    // defined alias.
+    if (empty_before_add && aliases.size() > 0 && std::find(path.cbegin(), path.cend(), alias_folder) == path.cend())
         cout << MP_PLATFORM.alias_path_message();
 
     return ReturnCode::Ok;


### PR DESCRIPTION
The alias message was not shown when launching a Blueprint which defined aliases. The issue was that it was shown only when the size of the alias dictionary was one, and in fact it would be two when the new alias is in a context different to `default`.

This bug was reported [here](https://discourse.ubuntu.com/t/running-a-container-with-the-docker-blueprint-in-multipass/26806/12).