### PR TITLE
Fix bridging authorization

### DIFF
--- a/src/client/cli/cmd/remote_settings_handler.cpp
+++ b/src/client/cli/cmd/remote_settings_handler.cpp
@@ -130,8 +130,10 @@ public:
         mp::AnimatedSpinner spinner{cout};
 
         auto streaming_confirmation_callback =
-            [&term](mp::SetReply& reply, grpc::ClientReaderWriterInterface<mp::SetRequest, mp::SetReply>* client) {
-                if (reply.needs_authorization())
+            [&key, &term](mp::SetReply& reply,
+                          grpc::ClientReaderWriterInterface<mp::SetRequest, mp::SetReply>* client) {
+                if (key.startsWith(mp::daemon_settings_root) && key.endsWith(mp::bridged_network_name) &&
+                    reply.needs_authorization())
                 {
                     auto bridged_network = reply.reply_message();
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -225,7 +225,7 @@ private:
     SettingsHandler* instance_mod_handler;
     SettingsHandler* snapshot_mod_handler;
     std::unordered_map<std::string, std::unordered_map<std::string, MountHandler::UPtr>> mounts;
-    bool user_authorized_bridge = false;
+    bool user_authorized = false;
 };
 } // namespace multipass
 #endif // MULTIPASS_DAEMON_H

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -225,6 +225,7 @@ private:
     SettingsHandler* instance_mod_handler;
     SettingsHandler* snapshot_mod_handler;
     std::unordered_map<std::string, std::unordered_map<std::string, MountHandler::UPtr>> mounts;
+    bool user_authorized_bridge = false;
 };
 } // namespace multipass
 #endif // MULTIPASS_DAEMON_H

--- a/src/daemon/instance_settings_handler.h
+++ b/src/daemon/instance_settings_handler.h
@@ -74,6 +74,15 @@ public:
     InstanceSettingsException(const std::string& reason, const std::string& instance, const std::string& detail);
 };
 
+class NonAuthorizedBridgeSettingsException : public InstanceSettingsException
+{
+public:
+    NonAuthorizedBridgeSettingsException(const std::string& reason, const std::string& instance, const std::string& net)
+        : InstanceSettingsException{reason, instance, fmt::format("Need user authorization to bridge {}", net)}
+    {
+    }
+};
+
 } // namespace multipass
 
 #endif // MULTIPASS_INSTANCE_SETTINGS_HANDLER_H

--- a/src/daemon/instance_settings_handler.h
+++ b/src/daemon/instance_settings_handler.h
@@ -45,7 +45,8 @@ public:
                             std::function<void()> instance_persister,
                             std::function<std::string()> bridged_interface,
                             std::function<std::string()> bridge_name,
-                            std::function<std::vector<NetworkInterfaceInfo>()> host_networks);
+                            std::function<std::vector<NetworkInterfaceInfo>()> host_networks,
+                            std::function<bool()> user_authorized);
 
     std::set<QString> keys() const override;
     QString get(const QString& key) const override;
@@ -66,6 +67,7 @@ private:
     std::function<std::string()> bridged_interface;
     std::function<std::string()> bridge_name;
     std::function<std::vector<NetworkInterfaceInfo>()> host_networks;
+    std::function<bool()> user_authorized_bridge;
 };
 
 class InstanceSettingsException : public SettingsException

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -470,12 +470,13 @@ message SetRequest {
     string key = 1;
     string val = 2;
     int32 verbosity_level = 3;
-    bool permission_to_bridge = 4;
+    bool authorized = 4;
 }
 
 message SetReply {
     string log_line = 1;
     string reply_message = 2;
+    bool needs_authorization = 3;
 }
 
 message KeysRequest {

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -470,6 +470,7 @@ message SetRequest {
     string key = 1;
     string val = 2;
     int32 verbosity_level = 3;
+    bool permission_to_bridge = 4;
 }
 
 message SetReply {

--- a/tests/test_common_callbacks.cpp
+++ b/tests/test_common_callbacks.cpp
@@ -168,3 +168,21 @@ TEST_F(TestSpinnerCallbacks, iterativeSpinnerCallbackHandlesPasswordRequest)
     EXPECT_THAT(err.str(), IsEmpty());
     EXPECT_THAT(out.str(), clearStreamMatcher());
 }
+
+TEST_F(TestSpinnerCallbacks, confirmationCallbackAnswers)
+{
+    constexpr auto key = "local.instance-name.bridged";
+
+    mpt::MockClientReaderWriter<mp::SetRequest, mp::SetReply> mock_client;
+
+    mp::SetReply reply;
+    reply.set_needs_authorization(true);
+
+    EXPECT_CALL(mock_client, Write(_, _)).WillOnce(Return(true));
+
+    auto callback = mp::make_confirmation_callback<mp::SetRequest, mp::SetReply>(term, key);
+    callback(reply, &mock_client);
+
+    EXPECT_THAT(err.str(), IsEmpty());
+    EXPECT_THAT(out.str(), clearStreamMatcher());
+}

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -41,6 +41,7 @@
 #include "tracking_url_downloader.h"
 
 #include <src/daemon/default_vm_image_vault.h>
+#include <src/daemon/instance_settings_handler.h>
 
 #include <multipass/constants.h>
 #include <multipass/default_vm_blueprint_provider.h>
@@ -2126,10 +2127,16 @@ TEST_P(DaemonSetExceptions, setHandlesSettingsException)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    Daemon, DaemonSetExceptions,
-    Values(std::tuple{mp::UnrecognizedSettingException{"foo"}, grpc::StatusCode::INVALID_ARGUMENT,
+    Daemon,
+    DaemonSetExceptions,
+    Values(std::tuple{mp::NonAuthorizedBridgeSettingsException{"reason", "instance", "eth8"},
+                      grpc::StatusCode::INTERNAL,
+                      HasSubstr("Need user authorization to bridge eth8")},
+           std::tuple{mp::UnrecognizedSettingException{"foo"},
+                      grpc::StatusCode::INVALID_ARGUMENT,
                       AllOf(HasSubstr("Unrecognized"), HasSubstr("foo"))},
-           std::tuple{mp::InvalidSettingException{"foo", "bar", "err"}, grpc::StatusCode::INVALID_ARGUMENT,
+           std::tuple{mp::InvalidSettingException{"foo", "bar", "err"},
+                      grpc::StatusCode::INVALID_ARGUMENT,
                       AllOf(HasSubstr("Invalid"), HasSubstr("foo"), HasSubstr("bar"), HasSubstr("err"))},
            std::tuple{std::runtime_error{"Other"}, grpc::StatusCode::INTERNAL, HasSubstr("Other")}));
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -127,6 +127,7 @@ struct Daemon : public mpt::DaemonTestFixture
         EXPECT_CALL(mock_settings, get(Eq(mp::mounts_key))).WillRepeatedly(Return("true")); /* TODO should probably add
                              a few more tests for `false`, since there are different portions of code depending on it */
         EXPECT_CALL(mock_settings, get(Eq(mp::winterm_key))).WillRepeatedly(Return("none"));
+        EXPECT_CALL(mock_settings, get(Eq(mp::bridged_interface_key))).WillRepeatedly(Return("eth8"));
     }
 
     mpt::MockUtils::GuardedMock mock_utils_injection{mpt::MockUtils::inject<NiceMock>()};
@@ -2139,6 +2140,76 @@ INSTANTIATE_TEST_SUITE_P(
                       grpc::StatusCode::INVALID_ARGUMENT,
                       AllOf(HasSubstr("Invalid"), HasSubstr("foo"), HasSubstr("bar"), HasSubstr("err"))},
            std::tuple{std::runtime_error{"Other"}, grpc::StatusCode::INTERNAL, HasSubstr("Other")}));
+
+TEST_F(Daemon, setWorksIfUserAuthorizes)
+{
+    const std::string key{"local.instance.bridged"}, value{"true"};
+
+    mp::Daemon daemon{config_builder.build()};
+
+    auto logger_scope = mpt::MockLogger::inject();
+    logger_scope.mock_logger->screen_logs(mpl::Level::debug);
+    logger_scope.mock_logger->expect_log(mpl::Level::debug,
+                                         fmt::format("Asking for user authorization to set {}={}", key, value));
+    logger_scope.mock_logger->expect_log(mpl::Level::debug, fmt::format("Succeeded setting {}={}", key, value));
+
+    mp::SetRequest request;
+    request.set_key(key);
+    request.set_val(value);
+
+    const auto& exception = mp::NonAuthorizedBridgeSettingsException{"reason", "instance", "eth8"};
+
+    EXPECT_CALL(mock_settings, set).WillOnce(Throw(exception)).WillOnce(Return());
+
+    auto mock_server = StrictMock<mpt::MockServerReaderWriter<mp::SetReply, mp::SetRequest>>{};
+
+    EXPECT_CALL(mock_server, Write(_, _)).WillOnce([](mp::SetReply reply, auto) {
+        EXPECT_TRUE(reply.needs_authorization());
+        return true;
+    });
+
+    EXPECT_CALL(mock_server, Read(_)).WillOnce([](mp::SetRequest* request) {
+        request->set_authorized(true);
+        return true;
+    });
+
+    EXPECT_TRUE(call_daemon_slot(daemon, &mp::Daemon::set, request, mock_server).ok());
+}
+
+TEST_F(Daemon, setDoesNotSetIfUserDeniesAuthorization)
+{
+    const std::string key{"local.instance.bridged"}, value{"true"};
+
+    mp::Daemon daemon{config_builder.build()};
+
+    auto logger_scope = mpt::MockLogger::inject();
+    logger_scope.mock_logger->screen_logs(mpl::Level::debug);
+    logger_scope.mock_logger->expect_log(mpl::Level::debug,
+                                         fmt::format("Asking for user authorization to set {}={}", key, value));
+    logger_scope.mock_logger->expect_log(mpl::Level::debug, "User did not authorize, cancelling");
+
+    mp::SetRequest request;
+    request.set_key(key);
+    request.set_val(value);
+
+    const auto& exception = mp::NonAuthorizedBridgeSettingsException{"reason", "instance", "eth8"};
+
+    EXPECT_CALL(mock_settings, set).WillOnce(Throw(exception));
+
+    auto mock_server = StrictMock<mpt::MockServerReaderWriter<mp::SetReply, mp::SetRequest>>{};
+
+    EXPECT_CALL(mock_server, Write(_, _)).WillOnce([](mp::SetReply reply, auto) {
+        EXPECT_TRUE(reply.needs_authorization());
+        return true;
+    });
+
+    EXPECT_CALL(mock_server, Read(_)).WillOnce([](mp::SetRequest* request) {
+        request->set_authorized(false);
+        return true;
+    });
+
+    EXPECT_FALSE(call_daemon_slot(daemon, &mp::Daemon::set, request, mock_server).ok());
+}
 
 TEST_F(Daemon, requests_networks)
 {


### PR DESCRIPTION
The prompt asking the user for authorization to disrupt networking to create a bridge was not working. This PR fixes issue 1 of [this review](https://github.com/canonical/multipass/pull/3195#pullrequestreview-1765804396).