### PR TITLE
[snap] Improve snap packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -321,7 +321,6 @@ parts:
       - dmz-cursor-theme
       - libgdk-pixbuf2.0-bin # GDK pixbuf
       - fonts-freefont-ttf
-      - libglib2.0-0
     override-build: |
       craftctl default
       update-mime-database $CRAFT_PART_INSTALL/usr/share/mime
@@ -330,7 +329,32 @@ parts:
       echo "[Icon Theme]" > $CRAFT_PART_INSTALL/usr/share/icons/default/index.theme
       echo "Inherits=DMZ-White" >> $CRAFT_PART_INSTALL/usr/share/icons/default/index.theme
     stage:
-      - -usr/share/doc
+      - -**/X11
+      - -**/pixmaps
+      - -usr/include
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libxfce4kbd-private-3.so.*
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libcolordprivate.so.*
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libdconf.so.*
+      - -usr/lib/*/libicuio.so.*
+      - -usr/lib/*/libicutest.so.*
+      - -usr/lib/*/libicutu.so.*
+      - -usr/share/apport
+      - -usr/share/bug
+      - -usr/share/*doc*
+      - -usr/share/gettext
+      - -usr/share/glade
+      - -usr/share/icons/Adwaita
+      - -usr/share/icons/DMZ-Black
+      - -usr/share/icons/Humanity*
+      - -usr/share/icons/LoginIcons
+      - -usr/share/icons/hicolor
+      - -usr/share/icons/ubuntu-*
+      - -usr/share/libthai
+      - -usr/share/lintian
+      - -usr/share/man
+      - -usr/share/mime
+      - -usr/share/pkgconfig
+      - -usr/share/thumbnailers
     organize:
       usr/bin/xfce4-terminal.wrapper: bin/x-terminal-emulator
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -247,7 +247,9 @@ parts:
     stage-packages:
     - libpixman-1-0
     stage:
+    - -usr/include
     - -usr/lib/*/libssh*
+    - -usr/lib/*/pkgconfig
     - -qemu/efi-*.rom
     - -qemu/pxe-*.rom
     organize:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -249,7 +249,6 @@ parts:
     stage:
     - -usr/include
     - -usr/lib/*/libssh*
-    - -usr/lib/*/pkgconfig
     - -qemu/efi-*.rom
     - -qemu/pxe-*.rom
     organize:
@@ -282,6 +281,7 @@ parts:
     - qemu/vgabios-*.bin*
     - qemu/slof.bin*
     - qemu/bios-256k.bin*
+    - -usr/lib/*/pkgconfig
 
   qemu-firmware:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -289,7 +289,6 @@ parts:
     stage-packages:
     - ipxe-qemu
     - on amd64: [ovmf]
-    - on armhf: [qemu-efi]
     - on arm64: [qemu-efi]
     organize:
       usr/share/ovmf/*: qemu/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,12 @@ adopt-info: multipass
 confinement: strict
 base: core22
 
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+  - build-on: ppc64el
+  - build-on: s390x
+
 layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -106,6 +106,14 @@ parts:
     - libvirt0
     stage:
     - -usr/lib/*/libssh*  # this avoids extra libssh libs in the snap
+    - -usr/lib/*/libvirt-* # No need to include extra libvirt objects in snap
+    - -usr/lib/**/sasl2
+    - -usr/lib/*/libicuio.so.*
+    - -usr/lib/*/libicutest.so.*
+    - -usr/lib/*/libicutu.so.*
+    - -usr/share/doc*
+    - -usr/share/libvirt
+    - -usr/share/lintian
 
   multipass:
     plugin: cmake

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,7 +115,6 @@ parts:
     - PATH: /snap/bin:$PATH
     build-packages:
     - on arm64: [libgles2-mesa-dev]
-    - on armhf: [libgles2-mesa-dev]
     - build-essential
     - git
     - libapparmor-dev
@@ -128,7 +127,6 @@ parts:
     - qt6-base-dev-tools
     stage-packages:
     - apparmor
-    - libc6
     - libpng16-16
     - libqt6core6
     - libqt6gui6
@@ -136,10 +134,40 @@ parts:
     - libqt6widgets6
     - libssl3
     - libxml2
-    - libxrender1
     - dnsmasq-base
     - dnsmasq-utils
     - qt6-qpa-plugins
+    stage:
+    - -**/glvnd
+    - -**/X11
+    - -usr/bin/aa-*
+    - -usr/include
+    - -usr/lib/cmake
+    - -usr/lib/*/libEGL_mesa.so.*
+    - -usr/lib/*/libGLX_mesa.so.*
+    - -usr/lib/*/libGLX_indirect.so.*
+    - -usr/lib/*/libXxf86vm.so.*
+    - -usr/lib/*/libxcb-dri2.so.*
+    - -usr/lib/*/libxcb-present.so.*
+    - -usr/lib/*/libxshmfence.so.*
+    - -usr/lib/*/libicuio.so.*
+    - -usr/lib/*/libicutest.so.*
+    - -usr/lib/*/libicutu.so.*
+    - -usr/lib/*/libLLVM-15.so*
+    - -usr/lib/*/libdrm*
+    - -usr/lib/*/libglapi.so*
+    - -usr/lib/*/libpciaccess.so*
+    - -usr/lib/*/libsensors.so*
+    - -usr/lib/*/libxcb-dri3.so*
+    - -usr/lib/*/dri
+    - -usr/share/apport
+    - -usr/share/bug
+    - -usr/share/doc*
+    - -usr/share/drirc.d
+    - -usr/share/lib*
+    - -usr/share/lintian
+    - -usr/share/man
+    - -usr/share/pkgconfig
     source: .
     cmake-parameters:
     - -DCMAKE_BUILD_TYPE=Release

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -307,6 +307,13 @@ parts:
     - -usr/share/doc
     - -usr/share/man
 
+  compile-schemas:
+    plugin: nil
+    stage-packages:
+    - libglib2.0-0
+    prime:
+    - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/glib-2.0/glib-compile-schemas
+
   terminal:
     plugin: nil
     stage-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,9 +128,6 @@ parts:
     - qt6-base-dev-tools
     stage-packages:
     - apparmor
-    - on amd64: [libgl1]
-    - on armhf: [libgles2-mesa]
-    - on arm64: [libgles2-mesa]
     - libc6
     - libpng16-16
     - libqt6core6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -303,6 +303,9 @@ parts:
     override-pull: ""
     stage-packages:
     - on amd64: [msr-tools]
+    stage:
+    - -usr/share/doc
+    - -usr/share/man
 
   terminal:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,8 +14,8 @@ confinement: strict
 base: core22
 
 layout:
-  /usr/lib/$CRAFT_ARCH_TRIPLET/qemu:
-    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/qemu
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu
   /usr/share/X11:
     bind: $SNAP/usr/share/X11
   /etc/fonts:
@@ -27,9 +27,9 @@ layout:
 
 environment:
   # GDK pixbuf
-  GDK_PIXBUF_MODULEDIR: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/gdk-pixbuf-2.0/2.10.0/loaders
+  GDK_PIXBUF_MODULEDIR: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/gdk-pixbuf-2.0/2.10.0/loaders
   GDK_PIXBUF_MODULE_FILE: $SNAP_COMMON/loaders.cache
-  ARCH_TRIPLET: ${CRAFT_ARCH_TRIPLET}
+  ARCH_TRIPLET: ${CRAFT_ARCH_TRIPLET_BUILD_FOR}
 
 plugs:
   all-home:
@@ -41,10 +41,10 @@ apps:
     command: bin/launch-multipassd
     environment:
       LD_LIBRARY_PATH: &library-path
-        $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET
+        $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
       PATH: &path
         $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
-      QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/qt6/plugins
+      QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
       XDG_DATA_HOME: $SNAP_COMMON/data
       XDG_CACHE_HOME: $SNAP_COMMON/cache
       XDG_CONFIG_HOME: &daemon-config $SNAP_DATA/config
@@ -69,7 +69,7 @@ apps:
       <<: &client-environment
         LD_LIBRARY_PATH: *library-path
         PATH: *path
-        QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/qt6/plugins
+        QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
         XDG_DATA_HOME: $SNAP_USER_DATA/data
         XDG_DATA_DIRS: $SNAP/usr/share:$SNAP_DATA/data
         XDG_CACHE_HOME: $SNAP_USER_DATA/cache
@@ -194,7 +194,7 @@ parts:
     - --disable-vduse-blk-export
     - --firmwarepath=/snap/multipass/current/qemu/
     - --prefix=/usr
-    - --libdir=/usr/lib/$CRAFT_ARCH_TRIPLET
+    - --libdir=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
     - --libexecdir=/usr/lib/qemu
     - --enable-strip
     build-packages:
@@ -233,7 +233,7 @@ parts:
     - usr/bin/qemu-img*
     - usr/bin/virtfs-proxy-helper*
     - usr/bin/virtiofsd*
-    - usr/lib/$CRAFT_ARCH_TRIPLET/*
+    - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/*
     - lib/*/libpixman*so*
     - qemu/keymaps*
     - qemu/efi-virtio.rom*


### PR DESCRIPTION
This will quiet the errors and linter.  The only warning now is for libvirt.so which is still needed since it is dlopen()'d.  This reduces the Snap size by ~45%!