### PR TITLE
Snapshot restore applies cloud init change

### DIFF
--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -37,6 +37,7 @@ public:
     const std::string& at(const std::string& name) const;
     std::string& at(const std::string& name);
     std::string& operator[](const std::string& name);
+    bool erase(const std::string& name);
 
     void write_to(const Path& path);
     void read_from(const std::filesystem::path& path);

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -85,8 +85,8 @@ public:
     virtual void resize_memory(const MemorySize& new_size) = 0;
     virtual void resize_disk(const MemorySize& new_size) = 0;
     virtual void add_network_interface(int index, const NetworkInterface& net) = 0;
-    virtual void add_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                                    const std::vector<NetworkInterface>& extra_interfaces) = 0;
+    virtual void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
+                                                      const std::vector<NetworkInterface>& extra_interfaces) = 0;
     virtual std::unique_ptr<MountHandler> make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
                                                                     const std::string& target,
                                                                     const VMMount& mount) = 0;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3646,7 +3646,7 @@ void mp::Daemon::add_bridged_interface(const std::string& instance_name)
         // Configure the new interface via cloud-init (this won't throw).
         std::vector<mp::NetworkInterface> interfaces_to_add{new_if};
         mpl::log(mpl::Level::trace, category, "Adding new interface to cloud-init");
-        instance->add_extra_interfaces_to_cloud_init(spec.default_mac_address, interfaces_to_add);
+        instance->apply_extra_interfaces_to_cloud_init(spec.default_mac_address, interfaces_to_add);
         mpl::log(mpl::Level::trace, category, "Done adding");
     }
     catch (const std::exception& e)

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -706,8 +706,15 @@ void mp::cloudInitIsoUtils::update_cloud_init_with_new_extra_interfaces(
     std::string& meta_data_file_content = iso_file.at("meta-data");
     meta_data_file_content =
         mpu::emit_cloud_config(mpu::make_cloud_init_meta_config_with_id_tweak(meta_data_file_content));
-    // overwrite the whole network-config file content
-    iso_file["network-config"] =
-        mpu::emit_cloud_config(mpu::make_cloud_init_network_config(default_mac_addr, extra_interfaces));
+    if (extra_interfaces.empty())
+    {
+        iso_file.erase("network-config");
+    }
+    else
+    {
+        // overwrite the whole network-config file content
+        iso_file["network-config"] =
+            mpu::emit_cloud_config(mpu::make_cloud_init_network_config(default_mac_addr, extra_interfaces));
+    }
     iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
 }

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -515,6 +515,20 @@ std::string& mp::CloudInitIso::operator[](const std::string& name)
     }
 }
 
+bool mp::CloudInitIso::erase(const std::string& name)
+{
+    if (auto iter = std::find_if(files.cbegin(),
+                                 files.cend(),
+                                 [name](const FileEntry& file_entry) -> bool { return file_entry.name == name; });
+        iter != std::cend((files)))
+    {
+        files.erase(iter);
+        return true;
+    }
+
+    return false;
+}
+
 void mp::CloudInitIso::write_to(const Path& path)
 {
     QFile f{path};

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -492,8 +492,8 @@ void mp::LXDVirtualMachine::add_network_interface(int index, const mp::NetworkIn
     lxd_request(manager, "PATCH", url(), patch_json);
 }
 
-void mp::LXDVirtualMachine::add_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                                               const std::vector<NetworkInterface>& extra_interfaces)
+void mp::LXDVirtualMachine::apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
+                                                                 const std::vector<NetworkInterface>& extra_interfaces)
 {
     const QJsonObject instance_info = lxd_request(manager, "GET", url());
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -58,8 +58,8 @@ public:
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
     void add_network_interface(int index, const NetworkInterface& net) override;
-    void add_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                            const std::vector<NetworkInterface>& extra_interfaces) override;
+    void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
+                                              const std::vector<NetworkInterface>& extra_interfaces) override;
     std::unique_ptr<MountHandler> make_native_mount_handler(const SSHKeyProvider* ssh_key_provider,
                                                             const std::string& target, const VMMount& mount) override;
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -556,8 +556,7 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
 
     if (is_extra_interfaces_different)
     {
-        // change the name to apply_extra_interfaces_to_cloud_init, here we can use default_mac_address of the current
-        // state because it is an immutable variable.
+        // here we can use default_mac_address of the current state because it is an immutable variable.
         apply_extra_interfaces_to_cloud_init(specs.default_mac_address, snapshot->get_extra_interfaces());
     }
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -541,6 +541,7 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
     specs.num_cores = snapshot->get_num_cores();
     specs.mem_size = snapshot->get_mem_size();
     specs.disk_space = snapshot->get_disk_space();
+    const bool is_extra_interfaces_different = specs.extra_interfaces != snapshot->get_extra_interfaces();
     specs.extra_interfaces = snapshot->get_extra_interfaces();
     specs.mounts = snapshot->get_mounts();
     specs.metadata = snapshot->get_metadata();
@@ -552,6 +553,14 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
     }
 
     snapshot->apply();
+
+    if (is_extra_interfaces_different)
+    {
+        // change the name to apply_extra_interfaces_to_cloud_init, here we can use default_mac_address of the current
+        // state because it is an immutable variable.
+        add_extra_interfaces_to_cloud_init(specs.default_mac_address, snapshot->get_extra_interfaces());
+    }
+
     rollback.dismiss();
 }
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -541,7 +541,7 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
     specs.num_cores = snapshot->get_num_cores();
     specs.mem_size = snapshot->get_mem_size();
     specs.disk_space = snapshot->get_disk_space();
-    const bool is_extra_interfaces_different = specs.extra_interfaces != snapshot->get_extra_interfaces();
+    const bool are_extra_interfaces_different = specs.extra_interfaces != snapshot->get_extra_interfaces();
     specs.extra_interfaces = snapshot->get_extra_interfaces();
     specs.mounts = snapshot->get_mounts();
     specs.metadata = snapshot->get_metadata();
@@ -554,7 +554,7 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
 
     snapshot->apply();
 
-    if (is_extra_interfaces_different)
+    if (are_extra_interfaces_different)
     {
         // here we can use default_mac_address of the current state because it is an immutable variable.
         apply_extra_interfaces_to_cloud_init(specs.default_mac_address, snapshot->get_extra_interfaces());

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -77,8 +77,8 @@ BaseVirtualMachine::BaseVirtualMachine(VirtualMachine::State state,
 BaseVirtualMachine::BaseVirtualMachine(const std::string& vm_name, const mp::Path& instance_dir)
     : VirtualMachine(vm_name, instance_dir){};
 
-void BaseVirtualMachine::add_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                                            const std::vector<NetworkInterface>& extra_interfaces)
+void BaseVirtualMachine::apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
+                                                              const std::vector<NetworkInterface>& extra_interfaces)
 {
     const std::filesystem::path cloud_init_config_iso_file_path =
         std::filesystem::path{instance_dir.absolutePath().toStdString()} / "cloud-init-config.iso";
@@ -558,7 +558,7 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
     {
         // change the name to apply_extra_interfaces_to_cloud_init, here we can use default_mac_address of the current
         // state because it is an immutable variable.
-        add_extra_interfaces_to_cloud_init(specs.default_mac_address, snapshot->get_extra_interfaces());
+        apply_extra_interfaces_to_cloud_init(specs.default_mac_address, snapshot->get_extra_interfaces());
     }
 
     rollback.dismiss();

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -53,8 +53,8 @@ public:
     {
         throw NotImplementedOnThisBackendException("native mounts");
     };
-    void add_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                            const std::vector<NetworkInterface>& extra_interfaces) override;
+    void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
+                                              const std::vector<NetworkInterface>& extra_interfaces) override;
 
     SnapshotVista view_snapshots() const override;
     int get_num_snapshots() const override;

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -2411,7 +2411,7 @@ TEST_F(LXDBackend, addsNetworkInterfaceToCloudInit)
     const std::string default_mac_addr = "52:54:00:56:78:90";
     const std::vector<mp::NetworkInterface> extra_interfaces = {{"id", "52:54:00:56:78:91", true},
                                                                 {"id", "52:54:00:56:78:92", true}};
-    EXPECT_NO_THROW(machine.add_extra_interfaces_to_cloud_init(default_mac_addr, extra_interfaces));
+    EXPECT_NO_THROW(machine.apply_extra_interfaces_to_cloud_init(default_mac_addr, extra_interfaces));
 }
 
 struct LXDNetworkNameTestSuite : LXDBackend, WithParamInterface<std::pair<std::string, std::string>>

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -75,7 +75,7 @@ struct MockVirtualMachineT : public T
     MOCK_METHOD(void, resize_disk, (const MemorySize&), (override));
     MOCK_METHOD(void, add_network_interface, (int, const NetworkInterface&), (override));
     MOCK_METHOD(void,
-                add_extra_interfaces_to_cloud_init,
+                apply_extra_interfaces_to_cloud_init,
                 (const std::string&, const std::vector<NetworkInterface>&),
                 (override));
     MOCK_METHOD(std::unique_ptr<MountHandler>,

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -123,8 +123,8 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
     {
     }
 
-    void add_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                            const std::vector<NetworkInterface>& extra_interfaces) override
+    void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
+                                              const std::vector<NetworkInterface>& extra_interfaces) override
     {
     }
 

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -756,6 +756,36 @@ TEST_F(BaseVM, restoresSnapshots)
     EXPECT_EQ(original_specs, changed_specs);
 }
 
+TEST_F(BaseVM, restoresSnapshotsWithExtraInterfaceDiff)
+{
+    mock_snapshotting();
+
+    // default value of VMSpecs::state is off, so restore_snapshot will pass the assert_vm_stopped check, the other
+    // fields do not matter, and VMSpecs::extra_interfaces is defaulted to be empty, which is we want.
+    const mp::VMSpecs original_specs{};
+    const auto* snapshot_name = "snapshot1";
+    vm.take_snapshot(original_specs, snapshot_name, "");
+
+    ASSERT_EQ(snapshot_album.size(), 1);
+    const auto& snapshot = *snapshot_album[0];
+
+    mp::VMSpecs new_specs = original_specs;
+    new_specs.extra_interfaces =
+        std::vector<mp::NetworkInterface>{{"id", "52:54:00:56:78:91", true}, {"id", "52:54:00:56:78:92", true}};
+
+    // the ref return functions can not use the default mock behavior, so they need to be specified
+    EXPECT_CALL(snapshot, get_mounts).WillOnce(ReturnRef(original_specs.mounts));
+    EXPECT_CALL(snapshot, get_metadata).WillOnce(ReturnRef(original_specs.metadata));
+
+    // set the behavior of get_extra_interfaces to cause the difference to the new spece extra interfaces
+    EXPECT_CALL(snapshot, get_extra_interfaces).Times(3).WillRepeatedly(Return(original_specs.extra_interfaces));
+    // Expect to getinto the if (is_extra_interfaces_different) branch
+    EXPECT_CALL(vm, apply_extra_interfaces_to_cloud_init).Times(1);
+
+    vm.restore_snapshot(snapshot_name, new_specs);
+    EXPECT_EQ(original_specs, new_specs);
+}
+
 TEST_F(BaseVM, usesRestoredSnapshotAsParentForNewSnapshots)
 {
     mock_snapshotting();

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -1179,7 +1179,7 @@ TEST(BaseVMStub, addExtraInterfacesToCloudInit)
     const std::vector<mp::NetworkInterface> extra_interfaces = {{"id", "52:54:00:56:78:91", true},
                                                                 {"id", "52:54:00:56:78:92", true}};
     // use internal instance dir, in this unit test case, it will not find the cloud-init file, so it should throw
-    EXPECT_THROW(base_vm.add_extra_interfaces_to_cloud_init(default_mac_addr, extra_interfaces), std::runtime_error);
+    EXPECT_THROW(base_vm.apply_extra_interfaces_to_cloud_init(default_mac_addr, extra_interfaces), std::runtime_error);
 }
 
 } // namespace

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -64,6 +64,21 @@ TEST_F(CloudInitIso, check_contains_true)
     EXPECT_TRUE(iso.contains("test"));
 }
 
+TEST_F(CloudInitIso, check_erase_false)
+{
+    mp::CloudInitIso iso;
+    EXPECT_FALSE(iso.erase("non_exist_file"));
+}
+
+TEST_F(CloudInitIso, check_erase_true)
+{
+    mp::CloudInitIso iso;
+    iso.add_file("test", "test data");
+    EXPECT_TRUE(iso.contains("test"));
+    EXPECT_TRUE(iso.erase("test"));
+    EXPECT_FALSE(iso.contains("test"));
+}
+
 TEST_F(CloudInitIso, check_at_operator_throw)
 {
     mp::CloudInitIso iso;

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -28,6 +28,11 @@ using namespace testing;
 
 namespace
 {
+constexpr std::string_view meta_data_content = R"(#cloud-config
+instance-id: vm1
+local-hostname: vm1
+cloud-name: multipass)";
+
 auto read_returns_failed_ifstream = [](std::ifstream& file, char*, std::streamsize) -> std::ifstream& {
     file.setstate(std::ios::failbit);
     return file;
@@ -324,10 +329,6 @@ TEST_F(CloudInitIso, reads_iso_file_with_random_string_data)
 
 TEST_F(CloudInitIso, reads_iso_file_with_mocked_real_file_data)
 {
-    constexpr std::string_view meta_data_content = R"(#cloud-config
-instance-id: vm1
-local-hostname: vm1
-cloud-name: multipass)";
     constexpr std::string_view user_data_content = R"(#cloud-config
 {})";
     constexpr std::string_view vendor_data_content = R"(#cloud-config
@@ -363,11 +364,6 @@ write_files:
 
 TEST_F(CloudInitIso, updateCloudInitWithNewNonEmptyExtraInterfaces)
 {
-    constexpr std::string_view meta_data_content = R"(#cloud-config
-instance-id: vm1
-local-hostname: vm1
-cloud-name: multipass)";
-
     mp::CloudInitIso original_iso;
 
     original_iso.add_file("meta-data", std::string(meta_data_content));
@@ -410,11 +406,6 @@ ethernets:
 
 TEST_F(CloudInitIso, updateCloudInitWithNewEmptyExtraInterfaces)
 {
-    constexpr std::string_view meta_data_content = R"(#cloud-config
-instance-id: vm1
-local-hostname: vm1
-cloud-name: multipass)";
-
     mp::CloudInitIso original_iso;
     original_iso.add_file("meta-data", std::string(meta_data_content));
     original_iso.add_file("network-data", "");

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -2230,7 +2230,7 @@ TEST_F(Daemon, add_bridged_interface_works)
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(1);
     EXPECT_CALL(*instance_ptr, add_network_interface(0, _)).Times(1);
-    EXPECT_CALL(*instance_ptr, add_extra_interfaces_to_cloud_init(_, _)).Times(1);
+    EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(1);
 
     EXPECT_NO_THROW(daemon.test_add_bridged_interface(instance_name, instance_ptr));
 }
@@ -2251,7 +2251,7 @@ TEST_F(Daemon, add_bridged_interface_throws_if_backend_throws)
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(1);
     EXPECT_CALL(*instance_ptr, add_network_interface(0, _)).WillOnce(Throw(std::runtime_error("something bad")));
-    EXPECT_CALL(*instance_ptr, add_extra_interfaces_to_cloud_init(_, _)).Times(0);
+    EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{"Cannot update instance settings; instance: " + instance_name + "; reason: Failure to bridge eth8"};
     MP_EXPECT_THROW_THAT(daemon.test_add_bridged_interface(instance_name, instance_ptr),
@@ -2271,7 +2271,7 @@ TEST_F(Daemon, add_bridged_interface_throws_on_bad_bridged_network_setting)
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(0);
     EXPECT_CALL(*instance_ptr, add_network_interface(_, _)).Times(0);
-    EXPECT_CALL(*instance_ptr, add_extra_interfaces_to_cloud_init(_, _)).Times(0);
+    EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{"Invalid network 'eth8' set as bridged interface, use `multipass set local.bridged-network=<name>` "
                     "to correct. See `multipass networks` for valid names."};
@@ -2292,7 +2292,7 @@ TEST_F(Daemon, add_bridged_interface_throws_if_needs_authorization)
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(0);
     EXPECT_CALL(*instance_ptr, add_network_interface(_, _)).Times(0);
-    EXPECT_CALL(*instance_ptr, add_extra_interfaces_to_cloud_init(_, _)).Times(0);
+    EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{
         "Cannot update instance settings; instance: glass-elevator; reason: Need user authorization to bridge eth8"};

--- a/tests/test_instance_settings_handler.cpp
+++ b/tests/test_instance_settings_handler.cpp
@@ -536,6 +536,57 @@ TEST_F(TestInstanceSettingsHandler, setAddsInterface)
     EXPECT_TRUE(mpu::valid_mac_address(specs[target_instance_name].extra_interfaces[1].mac_address));
 }
 
+/*TEST_F(TestInstanceSettingsHandler, setThrowsIfBridgingWrongInterface)
+{
+    bridged_interface = "wrong";
+
+    constexpr auto target_instance_name = "pappo";
+    specs.insert({{"blues", {}}, {"local", {}}, {target_instance_name, {}}});
+
+    mock_vm(target_instance_name); // TODO: make this an expectation.
+
+    std::string failure{"Invalid network 'wrong' set as bridged interface"};
+    MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, "bridged"), "true"),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr(failure)));
+}
+
+TEST_F(TestInstanceSettingsHandler, setWithoutAuthorizationThrows)
+{
+    user_authorized = false;
+    constexpr auto target_instance_name = "pappo";
+    specs.insert({{"blues", {}}, {"local", {}}, {target_instance_name, {}}});
+
+    mock_vm(target_instance_name); // TODO: make this an expectation.
+
+    std::string failure{
+        "Cannot update instance settings; instance: pappo; reason: Need user authorization to bridge eth8"};
+    MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, "bridged"), "true"),
+                         mp::NonAuthorizedBridgeSettingsException,
+                         mpt::match_what(HasSubstr(failure)));
+
+    EXPECT_EQ(specs[target_instance_name].extra_interfaces.size(), 0u);
+}
+
+TEST_F(TestInstanceSettingsHandler, setThrowsWhenAddingInterfaceThrows)
+{
+    user_authorized = true;
+    constexpr auto target_instance_name = "riff";
+    specs.insert({{"lily", {}}, {"malone", {}}, {target_instance_name, {}}});
+
+    mpt::MockVirtualMachine& instance = mock_vm(target_instance_name);
+
+    EXPECT_CALL(instance, add_network_interface(_, _)).WillOnce(Throw(std::runtime_error("panic show")));
+
+    std::string failure{"Cannot update instance settings; instance: riff; reason: Failure to bridge eth8"};
+
+    MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, "bridged"), "true"),
+                         mp::BridgeFailureException,
+                         mpt::match_what(HasSubstr(failure)));
+
+    EXPECT_EQ(specs[target_instance_name].extra_interfaces.size(), 0u);
+}*/
+
 using VMSt = mp::VirtualMachine::State;
 using Property = const char*;
 using PropertyAndState = std::tuple<Property, VMSt>; // no subliminal political msg intended :)

--- a/tests/test_instance_settings_handler.cpp
+++ b/tests/test_instance_settings_handler.cpp
@@ -536,57 +536,6 @@ TEST_F(TestInstanceSettingsHandler, setAddsInterface)
     EXPECT_TRUE(mpu::valid_mac_address(specs[target_instance_name].extra_interfaces[1].mac_address));
 }
 
-/*TEST_F(TestInstanceSettingsHandler, setThrowsIfBridgingWrongInterface)
-{
-    bridged_interface = "wrong";
-
-    constexpr auto target_instance_name = "pappo";
-    specs.insert({{"blues", {}}, {"local", {}}, {target_instance_name, {}}});
-
-    mock_vm(target_instance_name); // TODO: make this an expectation.
-
-    std::string failure{"Invalid network 'wrong' set as bridged interface"};
-    MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, "bridged"), "true"),
-                         std::runtime_error,
-                         mpt::match_what(HasSubstr(failure)));
-}
-
-TEST_F(TestInstanceSettingsHandler, setWithoutAuthorizationThrows)
-{
-    user_authorized = false;
-    constexpr auto target_instance_name = "pappo";
-    specs.insert({{"blues", {}}, {"local", {}}, {target_instance_name, {}}});
-
-    mock_vm(target_instance_name); // TODO: make this an expectation.
-
-    std::string failure{
-        "Cannot update instance settings; instance: pappo; reason: Need user authorization to bridge eth8"};
-    MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, "bridged"), "true"),
-                         mp::NonAuthorizedBridgeSettingsException,
-                         mpt::match_what(HasSubstr(failure)));
-
-    EXPECT_EQ(specs[target_instance_name].extra_interfaces.size(), 0u);
-}
-
-TEST_F(TestInstanceSettingsHandler, setThrowsWhenAddingInterfaceThrows)
-{
-    user_authorized = true;
-    constexpr auto target_instance_name = "riff";
-    specs.insert({{"lily", {}}, {"malone", {}}, {target_instance_name, {}}});
-
-    mpt::MockVirtualMachine& instance = mock_vm(target_instance_name);
-
-    EXPECT_CALL(instance, add_network_interface(_, _)).WillOnce(Throw(std::runtime_error("panic show")));
-
-    std::string failure{"Cannot update instance settings; instance: riff; reason: Failure to bridge eth8"};
-
-    MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, "bridged"), "true"),
-                         mp::BridgeFailureException,
-                         mpt::match_what(HasSubstr(failure)));
-
-    EXPECT_EQ(specs[target_instance_name].extra_interfaces.size(), 0u);
-}*/
-
 using VMSt = mp::VirtualMachine::State;
 using Property = const char*;
 using PropertyAndState = std::tuple<Property, VMSt>; // no subliminal political msg intended :)


### PR DESCRIPTION
This PR is about applying the extra interface changes to cloud-init-config.iso file when the snapshot retore command is called. 