### PR TITLE
Fix coverage on Mantic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,14 +218,20 @@ if(cmake_build_type_lower MATCHES "coverage")
     message(STATUS
       "Coverage enabled, use the 'covreport' target."
     )
+    execute_process(COMMAND ${LCOV} --version
+                    OUTPUT_VARIABLE LCOV_VERSION_RAW)
+    string(REGEX REPLACE "lcov: LCOV version " "" LCOV_VERSION_STR "${LCOV_VERSION_RAW}")
+    string(REGEX REPLACE "\\..*" "" LCOV_VERSION_MAJOR "${LCOV_VERSION_STR}")
+    if(${LCOV_VERSION_MAJOR} GREATER_EQUAL 2)
+      set(LCOV_IGNORE_ERRORS --ignore-errors mismatch --ignore-errors negative)
+    endif()
+
     add_custom_target(covreport
       DEPENDS multipass_tests
       WORKING_DIRECTORY ${CMAKE_BUILD_DIR}
       COMMAND ${LCOV} --directory . --zerocounters
       COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target test
-      COMMAND ${LCOV} --directory . --capture --output-file coverage.info
-        --ignore-errors mismatch
-        --ignore-errors negative
+      COMMAND ${LCOV} --directory . --capture --output-file coverage.info ${LCOV_IGNORE_ERRORS}
       COMMAND ${LCOV}
         --remove coverage.info
         '/usr/*'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,8 @@ if(cmake_build_type_lower MATCHES "coverage")
       COMMAND ${LCOV} --directory . --zerocounters
       COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target test
       COMMAND ${LCOV} --directory . --capture --output-file coverage.info
+        --ignore-errors mismatch
+        --ignore-errors negative
       COMMAND ${LCOV}
         --remove coverage.info
         '/usr/*'


### PR DESCRIPTION
The `covreport` target is not working (this target is obtained by using the CMake flag `-DCMAKE_BUILD_TYPE=Coverage`) with Mantic. The reason is that the `lcov` package in Mantic is broken; this is fixed by installing the package from Noble. But this newer package produce some warnings which become fatal. This PR makes newer versions of `lcov` ignore those warnings, producing the desired output.