### PR TITLE
Handle legacy snapshots

### DIFF
--- a/include/multipass/json_utils.h
+++ b/include/multipass/json_utils.h
@@ -26,6 +26,7 @@
 #include <QJsonObject>
 #include <QString>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -41,7 +42,7 @@ public:
     virtual void write_json(const QJsonObject& root, QString file_name) const; // transactional; creates parent dirs
     virtual std::string json_to_string(const QJsonObject& root) const;
     virtual QJsonArray extra_interfaces_to_json_array(const std::vector<NetworkInterface>& extra_interfaces) const;
-    virtual std::vector<NetworkInterface> read_extra_interfaces(const QJsonObject& record) const;
+    virtual std::optional<std::vector<NetworkInterface>> read_extra_interfaces(const QJsonObject& record) const;
 };
 } // namespace multipass
 #endif // MULTIPASS_JSON_UTILS_H

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -320,16 +320,17 @@ std::unordered_map<std::string, mp::VMSpecs> load_db(const mp::Path& data_path, 
             mounts[json["target_path"].toString().toStdString()] = mp::VMMount{json};
         }
 
-        reconstructed_records[key] = {num_cores,
-                                      mp::MemorySize{mem_size.empty() ? mp::default_memory_size : mem_size},
-                                      mp::MemorySize{disk_space.empty() ? mp::default_disk_size : disk_space},
-                                      default_mac_address,
-                                      MP_JSONUTILS.read_extra_interfaces(record),
-                                      ssh_username,
-                                      static_cast<mp::VirtualMachine::State>(state),
-                                      mounts,
-                                      deleted,
-                                      metadata};
+        reconstructed_records[key] = {
+            num_cores,
+            mp::MemorySize{mem_size.empty() ? mp::default_memory_size : mem_size},
+            mp::MemorySize{disk_space.empty() ? mp::default_disk_size : disk_space},
+            default_mac_address,
+            MP_JSONUTILS.read_extra_interfaces(record).value_or(std::vector<mp::NetworkInterface>{}),
+            ssh_username,
+            static_cast<mp::VirtualMachine::State>(state),
+            mounts,
+            deleted,
+            metadata};
     }
     return reconstructed_records;
 }

--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -65,7 +65,7 @@ mp::QemuSnapshot::QemuSnapshot(const std::string& name,
 }
 
 mp::QemuSnapshot::QemuSnapshot(const QString& filename, QemuVirtualMachine& vm, VirtualMachineDescription& desc)
-    : BaseSnapshot{filename, vm}, desc{desc}, image_path{desc.image.image_path}
+    : BaseSnapshot{filename, vm, desc}, desc{desc}, image_path{desc.image.image_path}
 {
 }
 

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -166,27 +166,27 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name,
     assert(index > 0 && "snapshot indices need to start at 1");
 }
 
-mp::BaseSnapshot::BaseSnapshot(const QString& filename, VirtualMachine& vm)
-    : BaseSnapshot{read_snapshot_json(filename), vm}
+mp::BaseSnapshot::BaseSnapshot(const QString& filename, VirtualMachine& vm, VirtualMachineDescription& desc)
+    : BaseSnapshot{read_snapshot_json(filename), vm, desc}
 {
 }
 
-mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm)
+mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, VirtualMachineDescription& desc)
     : BaseSnapshot{
-          json["name"].toString().toStdString(),                                                  // name
-          json["comment"].toString().toStdString(),                                               // comment
-          find_parent(json, vm),                                                                  // parent
-          json["index"].toInt(),                                                                  // index
-          QDateTime::fromString(json["creation_timestamp"].toString(), Qt::ISODateWithMs),        // creation_timestamp
-          json["num_cores"].toInt(),                                                              // num_cores
-          MemorySize{json["mem_size"].toString().toStdString()},                                  // mem_size
-          MemorySize{json["disk_space"].toString().toStdString()},                                // disk_space
-          MP_JSONUTILS.read_extra_interfaces(json).value_or(std::vector<mp::NetworkInterface>{}), // extra_interfaces
-          static_cast<mp::VirtualMachine::State>(json["state"].toInt()),                          // state
-          load_mounts(json["mounts"].toArray()),                                                  // mounts
-          json["metadata"].toObject(),                                                            // metadata
-          vm.instance_directory(),                                                                // storage_dir
-          true}                                                                                   // captured
+          json["name"].toString().toStdString(),                                           // name
+          json["comment"].toString().toStdString(),                                        // comment
+          find_parent(json, vm),                                                           // parent
+          json["index"].toInt(),                                                           // index
+          QDateTime::fromString(json["creation_timestamp"].toString(), Qt::ISODateWithMs), // creation_timestamp
+          json["num_cores"].toInt(),                                                       // num_cores
+          MemorySize{json["mem_size"].toString().toStdString()},                           // mem_size
+          MemorySize{json["disk_space"].toString().toStdString()},                         // disk_space
+          MP_JSONUTILS.read_extra_interfaces(json).value_or(desc.extra_interfaces),        // extra_interfaces
+          static_cast<mp::VirtualMachine::State>(json["state"].toInt()),                   // state
+          load_mounts(json["mounts"].toArray()),                                           // mounts
+          json["metadata"].toObject(),                                                     // metadata
+          vm.instance_directory(),                                                         // storage_dir
+          true}                                                                            // captured
 {
 }
 

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -20,6 +20,7 @@
 
 #include <multipass/file_ops.h>
 #include <multipass/json_utils.h>
+#include <multipass/virtual_machine_description.h>
 #include <multipass/vm_mount.h>
 #include <multipass/vm_specs.h>
 
@@ -166,12 +167,12 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name,
     assert(index > 0 && "snapshot indices need to start at 1");
 }
 
-mp::BaseSnapshot::BaseSnapshot(const QString& filename, VirtualMachine& vm, VirtualMachineDescription& desc)
+mp::BaseSnapshot::BaseSnapshot(const QString& filename, VirtualMachine& vm, const VirtualMachineDescription& desc)
     : BaseSnapshot{read_snapshot_json(filename), vm, desc}
 {
 }
 
-mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, VirtualMachineDescription& desc)
+mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, const VirtualMachineDescription& desc)
     : BaseSnapshot{
           json["name"].toString().toStdString(),                                           // name
           json["comment"].toString().toStdString(),                                        // comment

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -173,20 +173,20 @@ mp::BaseSnapshot::BaseSnapshot(const QString& filename, VirtualMachine& vm)
 
 mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm)
     : BaseSnapshot{
-          json["name"].toString().toStdString(),                                           // name
-          json["comment"].toString().toStdString(),                                        // comment
-          find_parent(json, vm),                                                           // parent
-          json["index"].toInt(),                                                           // index
-          QDateTime::fromString(json["creation_timestamp"].toString(), Qt::ISODateWithMs), // creation_timestamp
-          json["num_cores"].toInt(),                                                       // num_cores
-          MemorySize{json["mem_size"].toString().toStdString()},                           // mem_size
-          MemorySize{json["disk_space"].toString().toStdString()},                         // disk_space
-          MP_JSONUTILS.read_extra_interfaces(json),                                        // extra_interfaces
-          static_cast<mp::VirtualMachine::State>(json["state"].toInt()),                   // state
-          load_mounts(json["mounts"].toArray()),                                           // mounts
-          json["metadata"].toObject(),                                                     // metadata
-          vm.instance_directory(),                                                         // storage_dir
-          true}                                                                            // captured
+          json["name"].toString().toStdString(),                                                  // name
+          json["comment"].toString().toStdString(),                                               // comment
+          find_parent(json, vm),                                                                  // parent
+          json["index"].toInt(),                                                                  // index
+          QDateTime::fromString(json["creation_timestamp"].toString(), Qt::ISODateWithMs),        // creation_timestamp
+          json["num_cores"].toInt(),                                                              // num_cores
+          MemorySize{json["mem_size"].toString().toStdString()},                                  // mem_size
+          MemorySize{json["disk_space"].toString().toStdString()},                                // disk_space
+          MP_JSONUTILS.read_extra_interfaces(json).value_or(std::vector<mp::NetworkInterface>{}), // extra_interfaces
+          static_cast<mp::VirtualMachine::State>(json["state"].toInt()),                          // state
+          load_mounts(json["mounts"].toArray()),                                                  // mounts
+          json["metadata"].toObject(),                                                            // metadata
+          vm.instance_directory(),                                                                // storage_dir
+          true}                                                                                   // captured
 {
 }
 

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -189,6 +189,10 @@ mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, cons
           vm.instance_directory(),                                                         // storage_dir
           true}                                                                            // captured
 {
+    if (!json.contains("extra_interfaces"))
+    {
+        persist();
+    }
 }
 
 QJsonObject mp::BaseSnapshot::serialize() const

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -21,6 +21,7 @@
 #include <multipass/snapshot.h>
 
 #include <multipass/memory_size.h>
+#include <multipass/virtual_machine_description.h>
 #include <multipass/vm_mount.h>
 
 #include <QJsonObject>
@@ -40,7 +41,7 @@ public:
                  std::shared_ptr<Snapshot> parent,
                  const VMSpecs& specs,
                  const VirtualMachine& vm);
-    BaseSnapshot(const QString& filename, VirtualMachine& vm);
+    BaseSnapshot(const QString& filename, VirtualMachine& vm, VirtualMachineDescription& desc);
 
     int get_index() const noexcept override;
     std::string get_name() const override;
@@ -77,7 +78,7 @@ protected:
     virtual void apply_impl() = 0;
 
 private:
-    BaseSnapshot(const QJsonObject& json, VirtualMachine& vm);
+    BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, VirtualMachineDescription& desc);
     BaseSnapshot(const std::string& name,
                  const std::string& comment,
                  std::shared_ptr<Snapshot> parent,

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -21,7 +21,6 @@
 #include <multipass/snapshot.h>
 
 #include <multipass/memory_size.h>
-#include <multipass/virtual_machine_description.h>
 #include <multipass/vm_mount.h>
 
 #include <QJsonObject>
@@ -33,6 +32,8 @@ namespace multipass
 {
 struct VMSpecs;
 
+class VirtualMachineDescription;
+
 class BaseSnapshot : public Snapshot
 {
 public:
@@ -41,7 +42,7 @@ public:
                  std::shared_ptr<Snapshot> parent,
                  const VMSpecs& specs,
                  const VirtualMachine& vm);
-    BaseSnapshot(const QString& filename, VirtualMachine& vm, VirtualMachineDescription& desc);
+    BaseSnapshot(const QString& filename, VirtualMachine& vm, const VirtualMachineDescription& desc);
 
     int get_index() const noexcept override;
     std::string get_name() const override;
@@ -78,7 +79,7 @@ protected:
     virtual void apply_impl() = 0;
 
 private:
-    BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, VirtualMachineDescription& desc);
+    BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, const VirtualMachineDescription& desc);
     BaseSnapshot(const std::string& name,
                  const std::string& comment,
                  std::shared_ptr<Snapshot> parent,

--- a/src/utils/json_utils.cpp
+++ b/src/utils/json_utils.cpp
@@ -76,13 +76,12 @@ QJsonArray mp::JsonUtils::extra_interfaces_to_json_array(
     return json;
 }
 
-std::vector<mp::NetworkInterface> mp::JsonUtils::read_extra_interfaces(const QJsonObject& record) const
+std::optional<std::vector<mp::NetworkInterface>> mp::JsonUtils::read_extra_interfaces(const QJsonObject& record) const
 {
-    // Read the extra networks interfaces, if any.
-    std::vector<mp::NetworkInterface> extra_interfaces;
-
     if (record.contains("extra_interfaces"))
     {
+        std::vector<mp::NetworkInterface> extra_interfaces;
+
         for (QJsonValueRef entry : record["extra_interfaces"].toArray())
         {
             auto id = entry.toObject()["id"].toString().toStdString();
@@ -94,7 +93,9 @@ std::vector<mp::NetworkInterface> mp::JsonUtils::read_extra_interfaces(const QJs
             auto auto_mode = entry.toObject()["auto_mode"].toBool();
             extra_interfaces.push_back(mp::NetworkInterface{id, mac_address, auto_mode});
         }
+
+        return extra_interfaces;
     }
 
-    return extra_interfaces;
+    return std::nullopt;
 }

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -95,6 +95,16 @@ struct TestBaseSnapshot : public Test
         return ret;
     }
 
+    static mp::VirtualMachineDescription stub_desc()
+    {
+        mp::VirtualMachineDescription desc{};
+        desc.extra_interfaces = std::vector<mp::NetworkInterface>{{"eth13", "13:13:13:13:13:13", true},
+                                                                  {"eth14", "14:14:14:14:14:14", true},
+                                                                  {"eth15", "15:15:15:15:15:15", true}};
+
+        return desc;
+    }
+
     static QJsonObject test_snapshot_json()
     {
         static auto json_doc = [] {
@@ -135,6 +145,7 @@ struct TestBaseSnapshot : public Test
 
     static constexpr auto* test_json_filename = "test_snapshot.json";
     mp::VMSpecs specs = stub_specs();
+    mp::VirtualMachineDescription desc = stub_desc();
     NiceMock<mpt::MockVirtualMachine> vm{"a-vm"};
     QString test_json_file_path = mpt::test_data_path_for(test_json_filename);
 };
@@ -297,7 +308,7 @@ TEST_F(TestBaseSnapshot, rejectsNullDiskSize)
 
 TEST_F(TestBaseSnapshot, reconstructsFromJson)
 {
-    MockBaseSnapshot{test_json_file_path, vm};
+    MockBaseSnapshot{test_json_file_path, vm, desc};
 }
 
 TEST_F(TestBaseSnapshot, adoptsNameFromJson)
@@ -306,7 +317,7 @@ TEST_F(TestBaseSnapshot, adoptsNameFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "name", snapshot_name);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_name(), snapshot_name);
 }
 
@@ -316,7 +327,7 @@ TEST_F(TestBaseSnapshot, adoptsCommentFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "comment", snapshot_comment);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_comment(), snapshot_comment);
 }
 
@@ -330,7 +341,7 @@ TEST_F(TestBaseSnapshot, linksToParentFromJson)
     EXPECT_CALL(vm, get_snapshot(TypedEq<int>(parent_idx)))
         .WillOnce(Return(std::make_shared<MockBaseSnapshot>(parent_name, "mock parent snapshot", nullptr, specs, vm)));
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_parents_name(), parent_name);
 }
 
@@ -340,7 +351,7 @@ TEST_F(TestBaseSnapshot, adoptsIndexFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "index", index);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_index(), index);
 }
 
@@ -350,7 +361,7 @@ TEST_F(TestBaseSnapshot, adoptsTimestampFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "creation_timestamp", timestamp);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_creation_timestamp().toString(Qt::ISODateWithMs), timestamp);
 }
 
@@ -360,7 +371,7 @@ TEST_F(TestBaseSnapshot, adoptsNumCoresFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "num_cores", num_cores);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_num_cores(), num_cores);
 }
 
@@ -370,7 +381,7 @@ TEST_F(TestBaseSnapshot, adoptsMemSizeFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "mem_size", mem);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_mem_size().in_bytes(), QString{mem}.toInt());
 }
 
@@ -380,7 +391,7 @@ TEST_F(TestBaseSnapshot, adoptsDiskSpaceFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "disk_space", disk);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_disk_space().in_bytes(), QString{disk}.toInt());
 }
 
@@ -390,7 +401,7 @@ TEST_F(TestBaseSnapshot, adoptsExtraInterfacesFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "extra_interfaces", MP_JSONUTILS.extra_interfaces_to_json_array(extra_interfaces));
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_extra_interfaces(), extra_interfaces);
 }
 
@@ -400,7 +411,7 @@ TEST_F(TestBaseSnapshot, adoptsStateFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "state", static_cast<int>(state));
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_state(), state);
 }
 
@@ -422,7 +433,7 @@ TEST_F(TestBaseSnapshot, adoptsMetadataFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "metadata", metadata);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_metadata(), metadata);
 }
 
@@ -459,7 +470,7 @@ TEST_F(TestBaseSnapshot, adoptsMountsFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "mounts", mounts);
 
-    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     auto snapshot_mounts = snapshot.get_mounts();
 
     ASSERT_THAT(snapshot_mounts, SizeIs(mounts.size()));
@@ -492,7 +503,7 @@ TEST_P(TestSnapshotRejectedNonPositiveIndices, refusesNonPositiveIndexFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "index", index);
 
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{plant_snapshot_json(json), vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{plant_snapshot_json(json), vm, desc}),
                          std::runtime_error,
                          mpt::match_what(AllOf(HasSubstr("not positive"), HasSubstr(std::to_string(index)))));
 }
@@ -505,7 +516,7 @@ TEST_F(TestBaseSnapshot, refusesIndexAboveMax)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "index", index);
 
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{plant_snapshot_json(json), vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{plant_snapshot_json(json), vm, desc}),
                          std::runtime_error,
                          mpt::match_what(AllOf(HasSubstr("Maximum"), HasSubstr(std::to_string(index)))));
 }
@@ -513,7 +524,7 @@ TEST_F(TestBaseSnapshot, refusesIndexAboveMax)
 TEST_F(TestBaseSnapshot, setsName)
 {
     constexpr auto new_name = "Murray";
-    auto snapshot = MockBaseSnapshot{test_json_file_path, vm};
+    auto snapshot = MockBaseSnapshot{test_json_file_path, vm, desc};
 
     snapshot.set_name(new_name);
     EXPECT_EQ(snapshot.get_name(), new_name);
@@ -523,7 +534,7 @@ TEST_F(TestBaseSnapshot, setsComment)
 {
     constexpr auto new_comment = "I once owned a dog that was smarter than you.\n"
                                  "He must have taught you everything you know.";
-    auto snapshot = MockBaseSnapshot{test_json_file_path, vm};
+    auto snapshot = MockBaseSnapshot{test_json_file_path, vm, desc};
 
     snapshot.set_comment(new_comment);
     EXPECT_EQ(snapshot.get_comment(), new_comment);
@@ -531,7 +542,7 @@ TEST_F(TestBaseSnapshot, setsComment)
 
 TEST_F(TestBaseSnapshot, setsParent)
 {
-    auto child = MockBaseSnapshot{test_json_file_path, vm};
+    auto child = MockBaseSnapshot{test_json_file_path, vm, desc};
     auto parent = std::make_shared<MockBaseSnapshot>("parent", "", nullptr, specs, vm);
 
     child.set_parent(parent);
@@ -551,11 +562,11 @@ TEST_P(TestSnapshotPersistence, persistsOnEdition)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "index", index);
 
-    MockBaseSnapshot snapshot_orig{plant_snapshot_json(json), vm};
+    MockBaseSnapshot snapshot_orig{plant_snapshot_json(json), vm, desc};
     setter(snapshot_orig);
 
     const auto file_path = derive_persisted_snapshot_file_path(index);
-    const MockBaseSnapshot snapshot_edited{file_path, vm};
+    const MockBaseSnapshot snapshot_edited{file_path, vm, desc};
     EXPECT_EQ(snapshot_edited, snapshot_orig);
 }
 
@@ -662,7 +673,7 @@ TEST_F(TestBaseSnapshot, throwsIfUnableToOpenFile)
         .WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(
-        (MockBaseSnapshot{test_json_file_path, vm}),
+        (MockBaseSnapshot{test_json_file_path, vm, desc}),
         std::runtime_error,
         mpt::match_what(AllOf(HasSubstr("Could not open"), HasSubstr(test_json_file_path.toStdString()))));
 }
@@ -670,7 +681,7 @@ TEST_F(TestBaseSnapshot, throwsIfUnableToOpenFile)
 TEST_F(TestBaseSnapshot, throwsOnEmptyJson)
 {
     const auto snapshot_file_path = plant_snapshot_json(QJsonObject{});
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{snapshot_file_path, vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{snapshot_file_path, vm, desc}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Empty")));
 }
@@ -690,7 +701,7 @@ TEST_F(TestBaseSnapshot, throwsOnBadFormat)
         "(Murray): Alright, then. ROLL! I shall ROLL through the gates of hell! Must you take the fun out of "
         "everything?");
 
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{snapshot_file_path, vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{snapshot_file_path, vm, desc}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Could not parse snapshot JSON")));
 }
@@ -698,7 +709,7 @@ TEST_F(TestBaseSnapshot, throwsOnBadFormat)
 TEST_F(TestBaseSnapshot, throwsOnMissingParent)
 {
     EXPECT_CALL(vm, get_snapshot(An<int>())).WillOnce(Throw(std::out_of_range{"Incognito"}));
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{test_json_file_path, vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{test_json_file_path, vm, desc}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Missing snapshot parent")));
 }

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -23,6 +23,7 @@
 
 #include <multipass/json_utils.h>
 #include <multipass/memory_size.h>
+#include <multipass/virtual_machine_description.h>
 #include <multipass/vm_specs.h>
 #include <shared/base_snapshot.h>
 

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -119,6 +119,18 @@ struct TestBaseSnapshot : public Test
         return json_doc.object();
     }
 
+    static QJsonObject test_legacy_snapshot_json()
+    {
+        auto json = test_snapshot_json();
+
+        // Remove the "extra_interfaces" field.
+        auto snapshot_entry = json["snapshot"].toObject();
+        snapshot_entry.remove("extra_interfaces");
+        json["snapshot"] = snapshot_entry;
+
+        return json;
+    }
+
     static void mod_snapshot_json(QJsonObject& json, const QString& key, const QJsonValue& new_value)
     {
         const auto snapshot_key = QStringLiteral("snapshot");
@@ -403,6 +415,14 @@ TEST_F(TestBaseSnapshot, adoptsExtraInterfacesFromJson)
 
     auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_extra_interfaces(), extra_interfaces);
+}
+
+TEST_F(TestBaseSnapshot, doesNotComplainOnLegacyShapshot)
+{
+    auto json = test_legacy_snapshot_json();
+
+    auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
+    EXPECT_EQ(snapshot.get_extra_interfaces(), desc.extra_interfaces);
 }
 
 TEST_F(TestBaseSnapshot, adoptsStateFromJson)


### PR DESCRIPTION
Snapshots taken with old versions of Multipass did not store the `extra_interfaces` field. If an interface is added after instance creation, it will overwrite the extra interfaces added at creation. This PR fixes that behavior.