### PR TITLE
Make snapshot and restore track the instance id

### DIFF
--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -76,6 +76,7 @@ public:
     virtual void add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
                                                    const NetworkInterface& extra_interfaces,
                                                    const std::filesystem::path& cloud_init_path) const;
+    virtual std::string get_instance_id_from_cloud_init(const std::filesystem::path& cloud_init_path) const;
 };
 } // namespace multipass
 #endif // MULTIPASS_CLOUD_INIT_ISO_H

--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -70,9 +70,11 @@ class CloudInitFileOps : public Singleton<CloudInitFileOps>
 public:
     CloudInitFileOps(const Singleton<CloudInitFileOps>::PrivatePass&) noexcept;
 
-    virtual void update_cloud_init_with_new_extra_interfaces(const std::string& default_mac_addr,
-                                                             const std::vector<NetworkInterface>& extra_interfaces,
-                                                             const std::filesystem::path& cloud_init_path) const;
+    virtual void update_cloud_init_with_new_extra_interfaces_and_new_id(
+        const std::string& default_mac_addr,
+        const std::vector<NetworkInterface>& extra_interfaces,
+        const std::string& new_instance_id,
+        const std::filesystem::path& cloud_init_path) const;
     virtual void add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
                                                    const NetworkInterface& extra_interfaces,
                                                    const std::filesystem::path& cloud_init_path) const;

--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -79,8 +79,6 @@ public:
                                                    const NetworkInterface& extra_interfaces,
                                                    const std::filesystem::path& cloud_init_path) const;
     virtual std::string get_instance_id_from_cloud_init(const std::filesystem::path& cloud_init_path) const;
-    virtual void write_instance_id_to_cloud_init(const std::string& new_instance_id,
-                                                 const std::filesystem::path& cloud_init_path) const;
 };
 } // namespace multipass
 #endif // MULTIPASS_CLOUD_INIT_ISO_H

--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -72,10 +72,10 @@ public:
 
     virtual void update_cloud_init_with_new_extra_interfaces(const std::string& default_mac_addr,
                                                              const std::vector<NetworkInterface>& extra_interfaces,
-                                                             const std::filesystem::path& cloud_init_path);
+                                                             const std::filesystem::path& cloud_init_path) const;
     virtual void add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
                                                    const NetworkInterface& extra_interfaces,
-                                                   const std::filesystem::path& cloud_init_path);
+                                                   const std::filesystem::path& cloud_init_path) const;
 };
 } // namespace multipass
 #endif // MULTIPASS_CLOUD_INIT_ISO_H

--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -77,6 +77,8 @@ public:
                                                    const NetworkInterface& extra_interfaces,
                                                    const std::filesystem::path& cloud_init_path) const;
     virtual std::string get_instance_id_from_cloud_init(const std::filesystem::path& cloud_init_path) const;
+    virtual void write_instance_id_to_cloud_init(const std::string& new_instance_id,
+                                                 const std::filesystem::path& cloud_init_path) const;
 };
 } // namespace multipass
 #endif // MULTIPASS_CLOUD_INIT_ISO_H

--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -26,9 +26,12 @@
 #include <string>
 #include <vector>
 
+#include <multipass/singleton.h>
+
+#define MP_CLOUD_INIT_FILE_OPS multipass::CloudInitFileOps::instance()
+
 namespace multipass
 {
-struct NetworkInterface;
 class CloudInitIso
 {
 public:
@@ -61,14 +64,18 @@ private:
     std::vector<FileEntry> files;
 };
 
-namespace cloudInitIsoUtils
+struct NetworkInterface;
+class CloudInitFileOps : public Singleton<CloudInitFileOps>
 {
-void update_cloud_init_with_new_extra_interfaces(const std::string& default_mac_addr,
-                                                 const std::vector<NetworkInterface>& extra_interfaces,
-                                                 const std::filesystem::path& cloud_init_path);
-void add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
-                                       const NetworkInterface& extra_interfaces,
-                                       const std::filesystem::path& cloud_init_path);
-}
-}
+public:
+    CloudInitFileOps(const Singleton<CloudInitFileOps>::PrivatePass&) noexcept;
+
+    virtual void update_cloud_init_with_new_extra_interfaces(const std::string& default_mac_addr,
+                                                             const std::vector<NetworkInterface>& extra_interfaces,
+                                                             const std::filesystem::path& cloud_init_path);
+    virtual void add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
+                                                   const NetworkInterface& extra_interfaces,
+                                                   const std::filesystem::path& cloud_init_path);
+};
+} // namespace multipass
 #endif // MULTIPASS_CLOUD_INIT_ISO_H

--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -66,6 +66,9 @@ namespace cloudInitIsoUtils
 void update_cloud_init_with_new_extra_interfaces(const std::string& default_mac_addr,
                                                  const std::vector<NetworkInterface>& extra_interfaces,
                                                  const std::filesystem::path& cloud_init_path);
+void add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
+                                       const NetworkInterface& extra_interfaces,
+                                       const std::filesystem::path& cloud_init_path);
 }
 }
 #endif // MULTIPASS_CLOUD_INIT_ISO_H

--- a/include/multipass/snapshot.h
+++ b/include/multipass/snapshot.h
@@ -41,7 +41,7 @@ public:
     virtual int get_index() const noexcept = 0;
     virtual std::string get_name() const = 0;
     virtual std::string get_comment() const = 0;
-    virtual std::string get_instance_id() const noexcept = 0;
+    virtual std::string get_cloud_init_instance_id() const noexcept = 0;
     virtual QDateTime get_creation_timestamp() const noexcept = 0;
     virtual int get_num_cores() const noexcept = 0;
     virtual MemorySize get_mem_size() const noexcept = 0;

--- a/include/multipass/snapshot.h
+++ b/include/multipass/snapshot.h
@@ -41,6 +41,7 @@ public:
     virtual int get_index() const noexcept = 0;
     virtual std::string get_name() const = 0;
     virtual std::string get_comment() const = 0;
+    virtual std::string get_instance_id() const noexcept = 0;
     virtual QDateTime get_creation_timestamp() const noexcept = 0;
     virtual int get_num_cores() const noexcept = 0;
     virtual MemorySize get_mem_size() const noexcept = 0;

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -84,7 +84,7 @@ public:
     virtual void update_cpus(int num_cores) = 0;
     virtual void resize_memory(const MemorySize& new_size) = 0;
     virtual void resize_disk(const MemorySize& new_size) = 0;
-    virtual void add_network_interface(int index, const NetworkInterface& net) = 0;
+    virtual void add_network_interface(int index, const std::string& default_mac_addr, const NetworkInterface& net) = 0;
     virtual void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
                                                       const std::vector<NetworkInterface>& extra_interfaces) = 0;
     virtual std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target,

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -87,8 +87,6 @@ public:
     virtual void add_network_interface(int index,
                                        const std::string& default_mac_addr,
                                        const NetworkInterface& extra_interface) = 0;
-    virtual void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                                      const std::vector<NetworkInterface>& extra_interfaces) = 0;
     virtual std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target,
                                                                     const VMMount& mount) = 0;
 

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -84,7 +84,9 @@ public:
     virtual void update_cpus(int num_cores) = 0;
     virtual void resize_memory(const MemorySize& new_size) = 0;
     virtual void resize_disk(const MemorySize& new_size) = 0;
-    virtual void add_network_interface(int index, const std::string& default_mac_addr, const NetworkInterface& net) = 0;
+    virtual void add_network_interface(int index,
+                                       const std::string& default_mac_addr,
+                                       const NetworkInterface& extra_interface) = 0;
     virtual void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
                                                       const std::vector<NetworkInterface>& extra_interfaces) = 0;
     virtual std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target,

--- a/include/multipass/yaml_node_utils.h
+++ b/include/multipass/yaml_node_utils.h
@@ -34,9 +34,10 @@ std::string emit_cloud_config(const YAML::Node& node);
 // when file_content is non-empty, make_cloud_init_meta_config constructs the node based on the string and replaces
 // the original name occurrences with the input name
 YAML::Node make_cloud_init_meta_config(const std::string& name, const std::string& file_content = std::string{});
-// load the file_content to construct the node and tweak the instance-id, this is a hack to make cloud-init-config.iso
-// re-run, it will no longer be needed once cloud-init-config.iso has proper re-run external controlled mechanism
-YAML::Node make_cloud_init_meta_config_with_id_tweak(const std::string& file_content);
+// load the file_content to construct the node and overwrite the instance-id, when the new_instance_id is provided, then
+// it is used, if not, then there will be a generated new instance id to be used
+YAML::Node make_cloud_init_meta_config_with_id_tweak(const std::string& file_content,
+                                                     const std::string& new_instance_id = std::string());
 // when file_content is non-empty, make_cloud_init_network_config constructs the node based on the string and replaces
 // the default mac address and extra interfaces
 YAML::Node make_cloud_init_network_config(const std::string& default_mac_addr,

--- a/include/multipass/yaml_node_utils.h
+++ b/include/multipass/yaml_node_utils.h
@@ -40,8 +40,13 @@ YAML::Node make_cloud_init_meta_config_with_id_tweak(const std::string& file_con
 // when file_content is non-empty, make_cloud_init_network_config constructs the node based on the string and replaces
 // the default mac address and extra interfaces
 YAML::Node make_cloud_init_network_config(const std::string& default_mac_addr,
-                                          const std::vector<multipass::NetworkInterface>& extra_interfaces,
+                                          const std::vector<NetworkInterface>& extra_interfaces,
                                           const std::string& file_content = std::string{});
+// adds one extra interface to the network_config_file_content baseline, it creats the default address node
+// together with the extra interface node when it is empty,
+YAML::Node add_extra_interface_to_network_config(const std::string& default_mac_addr,
+                                                 const NetworkInterface& extra_interface,
+                                                 const std::string& network_config_file_content);
 } // namespace utils
 } // namespace multipass
 #endif // MULTIPASS_YAML_NODE_UTILS_H

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3591,7 +3591,7 @@ void mp::Daemon::add_bridged_interface(const std::string& instance_name)
     mpl::log(mpl::Level::trace, category, "Adding new interface to instance");
     try
     {
-        instance->add_network_interface(spec.extra_interfaces.size() - 1, new_if);
+        instance->add_network_interface(spec.extra_interfaces.size() - 1, spec.default_mac_address, new_if);
         mpl::log(mpl::Level::trace, category, "Done adding");
 
         // Configure the new interface via cloud-init (this won't throw).

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3593,11 +3593,6 @@ void mp::Daemon::add_bridged_interface(const std::string& instance_name)
     {
         instance->add_network_interface(spec.extra_interfaces.size() - 1, spec.default_mac_address, new_if);
         mpl::log(mpl::Level::trace, category, "Done adding");
-
-        // Configure the new interface via cloud-init (this won't throw).
-        mpl::log(mpl::Level::trace, category, "Adding new interface to cloud-init");
-        instance->apply_extra_interfaces_to_cloud_init(spec.default_mac_address, spec.extra_interfaces);
-        mpl::log(mpl::Level::trace, category, "Done adding");
     }
     catch (const std::exception& e)
     {

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -735,3 +735,13 @@ void mp::CloudInitFileOps::add_extra_interface_to_cloud_init(const std::string& 
         mpu::add_extra_interface_to_network_config(default_mac_addr, extra_interface, iso_file["network-config"]));
     iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
 }
+
+std::string mp::CloudInitFileOps::get_instance_id_from_cloud_init(const std::filesystem::path& cloud_init_path) const
+{
+    CloudInitIso iso_file;
+    iso_file.read_from(cloud_init_path);
+    const std::string& meta_data_file_content = iso_file.at("meta-data");
+    const auto meta_data_node = YAML::Load(meta_data_file_content);
+
+    return meta_data_node["instance-id"].as<std::string>();
+}

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -751,16 +751,3 @@ std::string mp::CloudInitFileOps::get_instance_id_from_cloud_init(const std::fil
 
     return meta_data_node["instance-id"].as<std::string>();
 }
-
-void mp::CloudInitFileOps::write_instance_id_to_cloud_init(const std::string& new_instance_id,
-                                                           const std::filesystem::path& cloud_init_path) const
-{
-    CloudInitIso iso_file;
-    iso_file.read_from(cloud_init_path);
-    std::string& meta_data_file_content = iso_file.at("meta-data");
-    auto meta_data_node = YAML::Load(meta_data_file_content);
-    meta_data_node["instance-id"] = YAML::Node{new_instance_id};
-    meta_data_file_content = mpu::emit_cloud_config(meta_data_node);
-
-    iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
-}

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -704,7 +704,7 @@ mp::CloudInitFileOps::CloudInitFileOps(const Singleton<CloudInitFileOps>::Privat
 void mp::CloudInitFileOps::update_cloud_init_with_new_extra_interfaces(
     const std::string& default_mac_addr,
     const std::vector<NetworkInterface>& extra_interfaces,
-    const std::filesystem::path& cloud_init_path)
+    const std::filesystem::path& cloud_init_path) const
 {
     CloudInitIso iso_file;
     iso_file.read_from(cloud_init_path);
@@ -727,7 +727,7 @@ void mp::CloudInitFileOps::update_cloud_init_with_new_extra_interfaces(
 
 void mp::CloudInitFileOps::add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
                                                              const NetworkInterface& extra_interface,
-                                                             const std::filesystem::path& cloud_init_path)
+                                                             const std::filesystem::path& cloud_init_path) const
 {
     CloudInitIso iso_file;
     iso_file.read_from(cloud_init_path);

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -701,9 +701,10 @@ mp::CloudInitFileOps::CloudInitFileOps(const Singleton<CloudInitFileOps>::Privat
 {
 }
 
-void mp::CloudInitFileOps::update_cloud_init_with_new_extra_interfaces(
+void mp::CloudInitFileOps::update_cloud_init_with_new_extra_interfaces_and_new_id(
     const std::string& default_mac_addr,
     const std::vector<NetworkInterface>& extra_interfaces,
+    const std::string& new_instance_id,
     const std::filesystem::path& cloud_init_path) const
 {
     CloudInitIso iso_file;

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -703,6 +703,7 @@ void mp::cloudInitIsoUtils::update_cloud_init_with_new_extra_interfaces(
 {
     CloudInitIso iso_file;
     iso_file.read_from(cloud_init_path);
+    // do not tweak the meta instance id
     std::string& meta_data_file_content = iso_file.at("meta-data");
     meta_data_file_content =
         mpu::emit_cloud_config(mpu::make_cloud_init_meta_config_with_id_tweak(meta_data_file_content));
@@ -716,5 +717,20 @@ void mp::cloudInitIsoUtils::update_cloud_init_with_new_extra_interfaces(
         iso_file["network-config"] =
             mpu::emit_cloud_config(mpu::make_cloud_init_network_config(default_mac_addr, extra_interfaces));
     }
+    iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
+}
+
+void mp::cloudInitIsoUtils::add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
+                                                              const NetworkInterface& extra_interface,
+                                                              const std::filesystem::path& cloud_init_path)
+{
+    CloudInitIso iso_file;
+    iso_file.read_from(cloud_init_path);
+    std::string& meta_data_file_content = iso_file.at("meta-data");
+    meta_data_file_content =
+        mpu::emit_cloud_config(mpu::make_cloud_init_meta_config_with_id_tweak(meta_data_file_content));
+
+    iso_file["network-config"] = mpu::emit_cloud_config(
+        mpu::add_extra_interface_to_network_config(default_mac_addr, extra_interface, iso_file["network-config"]));
     iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
 }

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -709,6 +709,11 @@ void mp::CloudInitFileOps::update_cloud_init_with_new_extra_interfaces_and_new_i
 {
     CloudInitIso iso_file;
     iso_file.read_from(cloud_init_path);
+
+    std::string& meta_data_file_content = iso_file.at("meta-data");
+    meta_data_file_content =
+        mpu::emit_cloud_config(mpu::make_cloud_init_meta_config_with_id_tweak(meta_data_file_content, new_instance_id));
+
     if (extra_interfaces.empty())
     {
         iso_file.erase("network-config");

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -696,7 +696,12 @@ void mp::CloudInitIso::read_from(const std::filesystem::path& fs_path)
     }
 }
 
-void mp::cloudInitIsoUtils::update_cloud_init_with_new_extra_interfaces(
+mp::CloudInitFileOps::CloudInitFileOps(const Singleton<CloudInitFileOps>::PrivatePass& pass) noexcept
+    : Singleton<CloudInitFileOps>::Singleton{pass}
+{
+}
+
+void mp::CloudInitFileOps::update_cloud_init_with_new_extra_interfaces(
     const std::string& default_mac_addr,
     const std::vector<NetworkInterface>& extra_interfaces,
     const std::filesystem::path& cloud_init_path)
@@ -720,9 +725,9 @@ void mp::cloudInitIsoUtils::update_cloud_init_with_new_extra_interfaces(
     iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
 }
 
-void mp::cloudInitIsoUtils::add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
-                                                              const NetworkInterface& extra_interface,
-                                                              const std::filesystem::path& cloud_init_path)
+void mp::CloudInitFileOps::add_extra_interface_to_cloud_init(const std::string& default_mac_addr,
+                                                             const NetworkInterface& extra_interface,
+                                                             const std::filesystem::path& cloud_init_path)
 {
     CloudInitIso iso_file;
     iso_file.read_from(cloud_init_path);

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -708,10 +708,6 @@ void mp::CloudInitFileOps::update_cloud_init_with_new_extra_interfaces(
 {
     CloudInitIso iso_file;
     iso_file.read_from(cloud_init_path);
-    // do not tweak the meta instance id
-    std::string& meta_data_file_content = iso_file.at("meta-data");
-    meta_data_file_content =
-        mpu::emit_cloud_config(mpu::make_cloud_init_meta_config_with_id_tweak(meta_data_file_content));
     if (extra_interfaces.empty())
     {
         iso_file.erase("network-config");

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -745,3 +745,16 @@ std::string mp::CloudInitFileOps::get_instance_id_from_cloud_init(const std::fil
 
     return meta_data_node["instance-id"].as<std::string>();
 }
+
+void mp::CloudInitFileOps::write_instance_id_to_cloud_init(const std::string& new_instance_id,
+                                                           const std::filesystem::path& cloud_init_path) const
+{
+    CloudInitIso iso_file;
+    iso_file.read_from(cloud_init_path);
+    std::string& meta_data_file_content = iso_file.at("meta-data");
+    auto meta_data_node = YAML::Load(meta_data_file_content);
+    meta_data_node["instance-id"] = YAML::Node{new_instance_id};
+    meta_data_file_content = mpu::emit_cloud_config(meta_data_node);
+
+    iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
+}

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -474,14 +474,14 @@ void mp::LXDVirtualMachine::resize_disk(const MemorySize& new_size)
 
 void mp::LXDVirtualMachine::add_network_interface(int index,
                                                   const std::string& default_mac_addr,
-                                                  const mp::NetworkInterface& net)
+                                                  const mp::NetworkInterface& extra_interface)
 {
     assert(manager);
 
     auto net_name = QStringLiteral("eth%1").arg(index + 1);
     auto net_config = create_bridged_interface_json(net_name,
-                                                    QString::fromStdString(net.id),
-                                                    QString::fromStdString(net.mac_address));
+                                                    QString::fromStdString(extra_interface.id),
+                                                    QString::fromStdString(extra_interface.mac_address));
 
     QJsonObject patch_json{{"devices", QJsonObject{{net_name, net_config}}}};
 

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -391,7 +391,7 @@ std::string mp::LXDVirtualMachine::ipv6()
     return {};
 }
 
-const QUrl mp::LXDVirtualMachine::url()
+const QUrl mp::LXDVirtualMachine::url() const
 {
     return QString("%1/virtual-machines/%2").arg(base_url.toString()).arg(name);
 }
@@ -489,8 +489,9 @@ void mp::LXDVirtualMachine::add_network_interface(int index,
     add_extra_interface_to_instance_cloud_init(default_mac_addr, extra_interface);
 }
 
-void mp::LXDVirtualMachine::apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                                                 const std::vector<NetworkInterface>& extra_interfaces)
+void mp::LXDVirtualMachine::apply_extra_interfaces_to_cloud_init(
+    const std::string& default_mac_addr,
+    const std::vector<NetworkInterface>& extra_interfaces) const
 {
     const QJsonObject instance_info = lxd_request(manager, "GET", url());
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
@@ -523,7 +524,7 @@ std::unique_ptr<mp::MountHandler> mp::LXDVirtualMachine::make_native_mount_handl
 }
 
 void mp::LXDVirtualMachine::add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
-                                                                       const NetworkInterface& extra_interface)
+                                                                       const NetworkInterface& extra_interface) const
 {
     const QJsonObject instance_info = lxd_request(manager, "GET", url());
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -489,30 +489,6 @@ void mp::LXDVirtualMachine::add_network_interface(int index,
     add_extra_interface_to_instance_cloud_init(default_mac_addr, extra_interface);
 }
 
-void mp::LXDVirtualMachine::apply_extra_interfaces_and_instance_id_to_cloud_init(
-    const std::string& default_mac_addr,
-    const std::vector<NetworkInterface>& extra_interfaces,
-    const std::string&) const
-{
-    const QJsonObject instance_info = lxd_request(manager, "GET", url());
-    QJsonObject instance_info_metadata = instance_info["metadata"].toObject();
-    QJsonObject config_section = instance_info_metadata["config"].toObject();
-
-    QJsonValueRef meta_data = config_section["user.meta-data"];
-    assert(!meta_data.isNull());
-
-    meta_data = QString::fromStdString(
-        mpu::emit_cloud_config(mpu::make_cloud_init_meta_config_with_id_tweak(meta_data.toString().toStdString())));
-
-    config_section["user.network-config"] = QString::fromStdString(
-        mpu::emit_cloud_config(mpu::make_cloud_init_network_config(default_mac_addr, extra_interfaces)));
-
-    instance_info_metadata["config"] = config_section;
-
-    const QJsonObject json_reply = lxd_request(manager, "PUT", url(), instance_info_metadata);
-    lxd_wait(manager, base_url, json_reply, timeout_milliseconds);
-}
-
 std::unique_ptr<mp::MountHandler> mp::LXDVirtualMachine::make_native_mount_handler(const std::string& target,
                                                                                    const VMMount& mount)
 {

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -489,9 +489,10 @@ void mp::LXDVirtualMachine::add_network_interface(int index,
     add_extra_interface_to_instance_cloud_init(default_mac_addr, extra_interface);
 }
 
-void mp::LXDVirtualMachine::apply_extra_interfaces_to_cloud_init(
+void mp::LXDVirtualMachine::apply_extra_interfaces_and_instance_id_to_cloud_init(
     const std::string& default_mac_addr,
-    const std::vector<NetworkInterface>& extra_interfaces) const
+    const std::vector<NetworkInterface>& extra_interfaces,
+    const std::string&) const
 {
     const QJsonObject instance_info = lxd_request(manager, "GET", url());
     QJsonObject instance_info_metadata = instance_info["metadata"].toObject();

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -486,6 +486,7 @@ void mp::LXDVirtualMachine::add_network_interface(int index,
     QJsonObject patch_json{{"devices", QJsonObject{{net_name, net_config}}}};
 
     lxd_request(manager, "PATCH", url(), patch_json);
+    add_extra_interface_to_instance_cloud_init(default_mac_addr, extra_interface);
 }
 
 void mp::LXDVirtualMachine::apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -472,7 +472,9 @@ void mp::LXDVirtualMachine::resize_disk(const MemorySize& new_size)
     lxd_request(manager, "PATCH", url(), patch_json);
 }
 
-void mp::LXDVirtualMachine::add_network_interface(int index, const mp::NetworkInterface& net)
+void mp::LXDVirtualMachine::add_network_interface(int index,
+                                                  const std::string& default_mac_addr,
+                                                  const mp::NetworkInterface& net)
 {
     assert(manager);
 

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -66,7 +66,11 @@ private:
                                                     const NetworkInterface& extra_interface) const override;
     void apply_extra_interfaces_and_instance_id_to_cloud_init(const std::string& default_mac_addr,
                                                               const std::vector<NetworkInterface>& extra_interfaces,
-                                                              const std::string& new_instance_id) const override;
+                                                              const std::string& new_instance_id) const override
+    {
+        throw std::runtime_error(
+            "This should be only called by restore_snapshot, currently LXD does not support that yet.");
+    }
 
     const QString name;
     const std::string username;

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -64,8 +64,9 @@ public:
 private:
     void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
                                                     const NetworkInterface& extra_interface) const override;
-    void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                              const std::vector<NetworkInterface>& extra_interfaces) const override;
+    void apply_extra_interfaces_and_instance_id_to_cloud_init(const std::string& default_mac_addr,
+                                                              const std::vector<NetworkInterface>& extra_interfaces,
+                                                              const std::string& new_instance_id) const override;
 
     const QString name;
     const std::string username;

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -59,13 +59,14 @@ public:
     void add_network_interface(int index,
                                const std::string& default_mac_addr,
                                const NetworkInterface& extra_interface) override;
-    void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                              const std::vector<NetworkInterface>& extra_interfaces) override;
     std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target, const VMMount& mount) override;
 
 private:
     void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
-                                                    const NetworkInterface& extra_interface);
+                                                    const NetworkInterface& extra_interface) override;
+    void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
+                                              const std::vector<NetworkInterface>& extra_interfaces) override;
+
     const QString name;
     const std::string username;
     std::optional<int> port;

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -64,13 +64,6 @@ public:
 private:
     void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
                                                     const NetworkInterface& extra_interface) const override;
-    void apply_extra_interfaces_and_instance_id_to_cloud_init(const std::string& default_mac_addr,
-                                                              const std::vector<NetworkInterface>& extra_interfaces,
-                                                              const std::string& new_instance_id) const override
-    {
-        throw std::runtime_error(
-            "This should be only called by restore_snapshot, currently LXD does not support that yet.");
-    }
 
     const QString name;
     const std::string username;

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -62,6 +62,8 @@ public:
     std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target, const VMMount& mount) override;
 
 private:
+    void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
+                                                    const NetworkInterface& extra_interface);
     const QString name;
     const std::string username;
     std::optional<int> port;

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -63,9 +63,9 @@ public:
 
 private:
     void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
-                                                    const NetworkInterface& extra_interface) override;
+                                                    const NetworkInterface& extra_interface) const override;
     void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                              const std::vector<NetworkInterface>& extra_interfaces) override;
+                                              const std::vector<NetworkInterface>& extra_interfaces) const override;
 
     const QString name;
     const std::string username;
@@ -78,7 +78,7 @@ private:
     const QString mac_addr;
     const QString storage_pool;
 
-    const QUrl url();
+    const QUrl url() const;
     const QUrl state_url();
     const QUrl network_leases_url();
     void request_state(const QString& new_state);

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -64,6 +64,12 @@ public:
 private:
     void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
                                                     const NetworkInterface& extra_interface) const override;
+    void apply_extra_interfaces_and_instance_id_to_cloud_init(const std::string& default_mac_addr,
+                                                              const std::vector<NetworkInterface>& extra_interfaces,
+                                                              const std::string& new_instance_id) const override
+    {
+        throw NotImplementedOnThisBackendException("apply_extra_interfaces_and_instance_id_to_cloud_init");
+    }
 
     const QString name;
     const std::string username;

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -56,7 +56,7 @@ public:
     void update_cpus(int num_cores) override;
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
-    void add_network_interface(int index, const NetworkInterface& net) override;
+    void add_network_interface(int index, const std::string& default_mac_addr, const NetworkInterface& net) override;
     void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
                                               const std::vector<NetworkInterface>& extra_interfaces) override;
     std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target, const VMMount& mount) override;

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -56,7 +56,9 @@ public:
     void update_cpus(int num_cores) override;
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
-    void add_network_interface(int index, const std::string& default_mac_addr, const NetworkInterface& net) override;
+    void add_network_interface(int index,
+                               const std::string& default_mac_addr,
+                               const NetworkInterface& extra_interface) override;
     void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
                                               const std::vector<NetworkInterface>& extra_interfaces) override;
     std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target, const VMMount& mount) override;

--- a/src/platform/backends/qemu/linux/qemu_platform_detail.h
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail.h
@@ -41,7 +41,7 @@ public:
     void remove_resources_for(const std::string& name) override;
     void platform_health_check() override;
     QStringList vm_platform_args(const VirtualMachineDescription& vm_desc) override;
-    void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& net) override;
+    void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& extra_interface) override;
 
 private:
     const QString bridge_name;

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -195,7 +195,8 @@ QStringList mp::QemuPlatformDetail::vm_platform_args(const VirtualMachineDescrip
     return opts;
 }
 
-void mp::QemuPlatformDetail::add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& net)
+void mp::QemuPlatformDetail::add_network_interface(VirtualMachineDescription& desc,
+                                                   const NetworkInterface& extra_interface)
 {
     // TODO: Do not uncomment the following line when implementing bridging in Linux QEMU. Since implementing it would
     // yield the same exact implementation than in macOS, we need to move the code out of here, and put it only once

--- a/src/platform/backends/qemu/qemu_platform.h
+++ b/src/platform/backends/qemu/qemu_platform.h
@@ -58,7 +58,7 @@ public:
     {
         throw NotImplementedOnThisBackendException("networks");
     };
-    virtual void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& net) = 0;
+    virtual void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& extra_interface) = 0;
 
 protected:
     explicit QemuPlatform() = default;

--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -56,12 +56,12 @@ std::unique_ptr<mp::QemuImgProcessSpec> make_delete_spec(const QString& tag, con
 
 mp::QemuSnapshot::QemuSnapshot(const std::string& name,
                                const std::string& comment,
-                               const std::string& instance_id,
+                               const std::string& cloud_init_instance_id,
                                std::shared_ptr<Snapshot> parent,
                                const VMSpecs& specs,
                                QemuVirtualMachine& vm,
                                VirtualMachineDescription& desc)
-    : BaseSnapshot{name, comment, instance_id, std::move(parent), specs, vm},
+    : BaseSnapshot{name, comment, cloud_init_instance_id, std::move(parent), specs, vm},
       desc{desc},
       image_path{desc.image.image_path}
 {

--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -61,7 +61,9 @@ mp::QemuSnapshot::QemuSnapshot(const std::string& name,
                                const VMSpecs& specs,
                                QemuVirtualMachine& vm,
                                VirtualMachineDescription& desc)
-    : BaseSnapshot{name, comment, std::move(parent), specs, vm}, desc{desc}, image_path{desc.image.image_path}
+    : BaseSnapshot{name, comment, instance_id, std::move(parent), specs, vm},
+      desc{desc},
+      image_path{desc.image.image_path}
 {
 }
 

--- a/src/platform/backends/qemu/qemu_snapshot.cpp
+++ b/src/platform/backends/qemu/qemu_snapshot.cpp
@@ -56,6 +56,7 @@ std::unique_ptr<mp::QemuImgProcessSpec> make_delete_spec(const QString& tag, con
 
 mp::QemuSnapshot::QemuSnapshot(const std::string& name,
                                const std::string& comment,
+                               const std::string& instance_id,
                                std::shared_ptr<Snapshot> parent,
                                const VMSpecs& specs,
                                QemuVirtualMachine& vm,

--- a/src/platform/backends/qemu/qemu_snapshot.h
+++ b/src/platform/backends/qemu/qemu_snapshot.h
@@ -34,7 +34,7 @@ class QemuSnapshot : public BaseSnapshot
 public:
     QemuSnapshot(const std::string& name,
                  const std::string& comment,
-                 const std::string& instance_id,
+                 const std::string& cloud_init_instance_id,
                  std::shared_ptr<Snapshot> parent,
                  const VMSpecs& specs,
                  QemuVirtualMachine& vm,

--- a/src/platform/backends/qemu/qemu_snapshot.h
+++ b/src/platform/backends/qemu/qemu_snapshot.h
@@ -34,6 +34,7 @@ class QemuSnapshot : public BaseSnapshot
 public:
     QemuSnapshot(const std::string& name,
                  const std::string& comment,
+                 const std::string& instance_id,
                  std::shared_ptr<Snapshot> parent,
                  const VMSpecs& specs,
                  QemuVirtualMachine& vm,

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -671,7 +671,7 @@ auto mp::QemuVirtualMachine::make_specific_snapshot(const std::string& snapshot_
                                                     std::shared_ptr<Snapshot> parent) -> std::shared_ptr<Snapshot>
 {
     assert(state == VirtualMachine::State::off || state == VirtualMachine::State::stopped); // would need QMP otherwise
-    return std::make_shared<QemuSnapshot>(snapshot_name, comment, std::move(parent), specs, *this, desc);
+    return std::make_shared<QemuSnapshot>(snapshot_name, comment, instance_id, std::move(parent), specs, *this, desc);
 }
 
 auto mp::QemuVirtualMachine::make_specific_snapshot(const QString& filename) -> std::shared_ptr<Snapshot>

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -666,6 +666,7 @@ mp::QemuVirtualMachine::MountArgs& mp::QemuVirtualMachine::modifiable_mount_args
 
 auto mp::QemuVirtualMachine::make_specific_snapshot(const std::string& snapshot_name,
                                                     const std::string& comment,
+                                                    const std::string& instance_id,
                                                     const VMSpecs& specs,
                                                     std::shared_ptr<Snapshot> parent) -> std::shared_ptr<Snapshot>
 {

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -645,9 +645,11 @@ void mp::QemuVirtualMachine::resize_disk(const MemorySize& new_size)
     desc.disk_space = new_size;
 }
 
-void mp::QemuVirtualMachine::add_network_interface(int /* not used on this backend */, const NetworkInterface& net)
+void mp::QemuVirtualMachine::add_network_interface(int /* not used on this backend */,
+                                                   const std::string& default_mac_addr,
+                                                   const NetworkInterface& net)
 {
-    return qemu_platform->add_network_interface(desc, net);
+    qemu_platform->add_network_interface(desc, net);
 }
 
 mp::MountHandler::UPtr mp::QemuVirtualMachine::make_native_mount_handler(const std::string& target,

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -647,9 +647,9 @@ void mp::QemuVirtualMachine::resize_disk(const MemorySize& new_size)
 
 void mp::QemuVirtualMachine::add_network_interface(int /* not used on this backend */,
                                                    const std::string& default_mac_addr,
-                                                   const NetworkInterface& net)
+                                                   const NetworkInterface& extra_interface)
 {
-    qemu_platform->add_network_interface(desc, net);
+    qemu_platform->add_network_interface(desc, extra_interface);
 }
 
 mp::MountHandler::UPtr mp::QemuVirtualMachine::make_native_mount_handler(const std::string& target,

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -650,6 +650,7 @@ void mp::QemuVirtualMachine::add_network_interface(int /* not used on this backe
                                                    const NetworkInterface& extra_interface)
 {
     qemu_platform->add_network_interface(desc, extra_interface);
+    add_extra_interface_to_instance_cloud_init(default_mac_addr, extra_interface);
 }
 
 mp::MountHandler::UPtr mp::QemuVirtualMachine::make_native_mount_handler(const std::string& target,

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -66,7 +66,7 @@ public:
     void resize_disk(const MemorySize& new_size) override;
     virtual void add_network_interface(int index,
                                        const std::string& default_mac_addr,
-                                       const NetworkInterface& net) override;
+                                       const NetworkInterface& extra_interface) override;
     virtual MountArgs& modifiable_mount_args();
     std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target, const VMMount& mount) override;
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -64,7 +64,9 @@ public:
     void update_cpus(int num_cores) override;
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
-    virtual void add_network_interface(int index, const NetworkInterface& net) override;
+    virtual void add_network_interface(int index,
+                                       const std::string& default_mac_addr,
+                                       const NetworkInterface& net) override;
     virtual MountArgs& modifiable_mount_args();
     std::unique_ptr<MountHandler> make_native_mount_handler(const std::string& target, const VMMount& mount) override;
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -86,6 +86,7 @@ protected:
     std::shared_ptr<Snapshot> make_specific_snapshot(const QString& filename) override;
     std::shared_ptr<Snapshot> make_specific_snapshot(const std::string& snapshot_name,
                                                      const std::string& comment,
+                                                     const std::string& instance_id,
                                                      const VMSpecs& specs,
                                                      std::shared_ptr<Snapshot> parent) override;
 

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -99,6 +99,7 @@ std::shared_ptr<mp::Snapshot> find_parent(const QJsonObject& json, mp::VirtualMa
 
 mp::BaseSnapshot::BaseSnapshot(const std::string& name,    // NOLINT(modernize-pass-by-value)
                                const std::string& comment, // NOLINT(modernize-pass-by-value)
+                               const std::string& instance_id,
                                std::shared_ptr<Snapshot> parent,
                                int index,
                                QDateTime&& creation_timestamp,
@@ -146,11 +147,13 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name,    // NOLINT(modernize-p
 
 mp::BaseSnapshot::BaseSnapshot(const std::string& name,
                                const std::string& comment,
+                               const std::string& instance_id,
                                std::shared_ptr<Snapshot> parent,
                                const VMSpecs& specs,
                                const VirtualMachine& vm)
     : BaseSnapshot{name,
                    comment,
+                   instance_id,
                    std::move(parent),
                    vm.get_snapshot_count() + 1,
                    QDateTime::currentDateTimeUtc(),
@@ -174,10 +177,11 @@ mp::BaseSnapshot::BaseSnapshot(const QString& filename, VirtualMachine& vm, cons
 
 mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, const VirtualMachineDescription& desc)
     : BaseSnapshot{
-          json["name"].toString().toStdString(),                                           // name
-          json["comment"].toString().toStdString(),                                        // comment
-          find_parent(json, vm),                                                           // parent
-          json["index"].toInt(),                                                           // index
+          json["name"].toString().toStdString(),    // name
+          json["comment"].toString().toStdString(), // comment
+          "",                                       // instance id from cloud init
+          find_parent(json, vm),                    // parent
+          json["index"].toInt(),                    // index
           QDateTime::fromString(json["creation_timestamp"].toString(), Qt::ISODateWithMs), // creation_timestamp
           json["num_cores"].toInt(),                                                       // num_cores
           MemorySize{json["mem_size"].toString().toStdString()},                           // mem_size

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -114,8 +114,8 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name,    // NOLINT(modernize-p
                                bool captured)
     : name{name},
       comment{comment},
-      instance_id{instance_id},
       parent{std::move(parent)},
+      instance_id{instance_id},
       index{index},
       id{snapshot_template.arg(index)},
       creation_timestamp{std::move(creation_timestamp)},

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -114,6 +114,7 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name,    // NOLINT(modernize-p
                                bool captured)
     : name{name},
       comment{comment},
+      instance_id{instance_id},
       parent{std::move(parent)},
       index{index},
       id{snapshot_template.arg(index)},

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<mp::Snapshot> find_parent(const QJsonObject& json, mp::VirtualMa
 
 mp::BaseSnapshot::BaseSnapshot(const std::string& name,    // NOLINT(modernize-pass-by-value)
                                const std::string& comment, // NOLINT(modernize-pass-by-value)
-                               const std::string& instance_id,
+                               const std::string& cloud_init_instance_id,
                                std::shared_ptr<Snapshot> parent,
                                int index,
                                QDateTime&& creation_timestamp,
@@ -115,7 +115,7 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name,    // NOLINT(modernize-p
     : name{name},
       comment{comment},
       parent{std::move(parent)},
-      instance_id{instance_id},
+      cloud_init_instance_id{cloud_init_instance_id},
       index{index},
       id{snapshot_template.arg(index)},
       creation_timestamp{std::move(creation_timestamp)},
@@ -148,13 +148,13 @@ mp::BaseSnapshot::BaseSnapshot(const std::string& name,    // NOLINT(modernize-p
 
 mp::BaseSnapshot::BaseSnapshot(const std::string& name,
                                const std::string& comment,
-                               const std::string& instance_id,
+                               const std::string& cloud_init_instance_id,
                                std::shared_ptr<Snapshot> parent,
                                const VMSpecs& specs,
                                const VirtualMachine& vm)
     : BaseSnapshot{name,
                    comment,
-                   instance_id,
+                   cloud_init_instance_id,
                    std::move(parent),
                    vm.get_snapshot_count() + 1,
                    QDateTime::currentDateTimeUtc(),
@@ -178,11 +178,11 @@ mp::BaseSnapshot::BaseSnapshot(const QString& filename, VirtualMachine& vm, cons
 
 mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, const VirtualMachineDescription& desc)
     : BaseSnapshot{
-          json["name"].toString().toStdString(),        // name
-          json["comment"].toString().toStdString(),     // comment
-          json["instance_id"].toString().toStdString(), // instance id from cloud init
-          find_parent(json, vm),                        // parent
-          json["index"].toInt(),                        // index
+          json["name"].toString().toStdString(),                   // name
+          json["comment"].toString().toStdString(),                // comment
+          json["cloud_init_instance_id"].toString().toStdString(), // instance id from cloud init
+          find_parent(json, vm),                                   // parent
+          json["index"].toInt(),                                   // index
           QDateTime::fromString(json["creation_timestamp"].toString(), Qt::ISODateWithMs), // creation_timestamp
           json["num_cores"].toInt(),                                                       // num_cores
           MemorySize{json["mem_size"].toString().toStdString()},                           // mem_size
@@ -208,7 +208,7 @@ QJsonObject mp::BaseSnapshot::serialize() const
 
     snapshot.insert("name", QString::fromStdString(name));
     snapshot.insert("comment", QString::fromStdString(comment));
-    snapshot.insert("instance_id", QString::fromStdString(instance_id));
+    snapshot.insert("cloud_init_instance_id", QString::fromStdString(cloud_init_instance_id));
     snapshot.insert("parent", get_parents_index());
     snapshot.insert("index", index);
     snapshot.insert("creation_timestamp", creation_timestamp.toString(Qt::ISODateWithMs));

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -178,11 +178,11 @@ mp::BaseSnapshot::BaseSnapshot(const QString& filename, VirtualMachine& vm, cons
 
 mp::BaseSnapshot::BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, const VirtualMachineDescription& desc)
     : BaseSnapshot{
-          json["name"].toString().toStdString(),    // name
-          json["comment"].toString().toStdString(), // comment
-          "",                                       // instance id from cloud init
-          find_parent(json, vm),                    // parent
-          json["index"].toInt(),                    // index
+          json["name"].toString().toStdString(),        // name
+          json["comment"].toString().toStdString(),     // comment
+          json["instance_id"].toString().toStdString(), // instance id from cloud init
+          find_parent(json, vm),                        // parent
+          json["index"].toInt(),                        // index
           QDateTime::fromString(json["creation_timestamp"].toString(), Qt::ISODateWithMs), // creation_timestamp
           json["num_cores"].toInt(),                                                       // num_cores
           MemorySize{json["mem_size"].toString().toStdString()},                           // mem_size
@@ -208,6 +208,7 @@ QJsonObject mp::BaseSnapshot::serialize() const
 
     snapshot.insert("name", QString::fromStdString(name));
     snapshot.insert("comment", QString::fromStdString(comment));
+    snapshot.insert("instance_id", QString::fromStdString(instance_id));
     snapshot.insert("parent", get_parents_index());
     snapshot.insert("index", index);
     snapshot.insert("creation_timestamp", creation_timestamp.toString(Qt::ISODateWithMs));

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -106,6 +106,7 @@ private:
 private:
     std::string name;
     std::string comment;
+    std::string instance_id;
     std::shared_ptr<Snapshot> parent;
 
     // This class is non-copyable and having these const simplifies thread safety
@@ -145,8 +146,7 @@ inline int multipass::BaseSnapshot::get_index() const noexcept
 
 inline std::string multipass::BaseSnapshot::get_instance_id() const noexcept
 {
-    // return the actual id later
-    return std::string();
+    return instance_id;
 }
 
 inline QDateTime multipass::BaseSnapshot::get_creation_timestamp() const noexcept

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -106,10 +106,10 @@ private:
 private:
     std::string name;
     std::string comment;
-    std::string instance_id;
     std::shared_ptr<Snapshot> parent;
 
     // This class is non-copyable and having these const simplifies thread safety
+    const std::string instance_id;                         // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const int index;                                       // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const QString id;                                      // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const QDateTime creation_timestamp;                    // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
@@ -139,14 +139,14 @@ inline std::string multipass::BaseSnapshot::get_comment() const
     return comment;
 }
 
-inline int multipass::BaseSnapshot::get_index() const noexcept
-{
-    return index;
-}
-
 inline std::string multipass::BaseSnapshot::get_instance_id() const noexcept
 {
     return instance_id;
+}
+
+inline int multipass::BaseSnapshot::get_index() const noexcept
+{
+    return index;
 }
 
 inline QDateTime multipass::BaseSnapshot::get_creation_timestamp() const noexcept

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -39,6 +39,7 @@ class BaseSnapshot : public Snapshot
 public:
     BaseSnapshot(const std::string& name,
                  const std::string& comment,
+                 const std::string& instance_id,
                  std::shared_ptr<Snapshot> parent,
                  const VMSpecs& specs,
                  const VirtualMachine& vm);
@@ -83,6 +84,7 @@ private:
     BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, const VirtualMachineDescription& desc);
     BaseSnapshot(const std::string& name,
                  const std::string& comment,
+                 const std::string& instance_id,
                  std::shared_ptr<Snapshot> parent,
                  int index,
                  QDateTime&& creation_timestamp,

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -47,6 +47,7 @@ public:
     int get_index() const noexcept override;
     std::string get_name() const override;
     std::string get_comment() const override;
+    std::string get_instance_id() const noexcept override;
     QDateTime get_creation_timestamp() const noexcept override;
     int get_num_cores() const noexcept override;
     MemorySize get_mem_size() const noexcept override;
@@ -138,6 +139,12 @@ inline std::string multipass::BaseSnapshot::get_comment() const
 inline int multipass::BaseSnapshot::get_index() const noexcept
 {
     return index;
+}
+
+inline std::string multipass::BaseSnapshot::get_instance_id() const noexcept
+{
+    // return the actual id later
+    return std::string();
 }
 
 inline QDateTime multipass::BaseSnapshot::get_creation_timestamp() const noexcept

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -39,7 +39,7 @@ class BaseSnapshot : public Snapshot
 public:
     BaseSnapshot(const std::string& name,
                  const std::string& comment,
-                 const std::string& instance_id,
+                 const std::string& cloud_init_instance_id,
                  std::shared_ptr<Snapshot> parent,
                  const VMSpecs& specs,
                  const VirtualMachine& vm);
@@ -48,7 +48,7 @@ public:
     int get_index() const noexcept override;
     std::string get_name() const override;
     std::string get_comment() const override;
-    std::string get_instance_id() const noexcept override;
+    std::string get_cloud_init_instance_id() const noexcept override;
     QDateTime get_creation_timestamp() const noexcept override;
     int get_num_cores() const noexcept override;
     MemorySize get_mem_size() const noexcept override;
@@ -84,7 +84,7 @@ private:
     BaseSnapshot(const QJsonObject& json, VirtualMachine& vm, const VirtualMachineDescription& desc);
     BaseSnapshot(const std::string& name,
                  const std::string& comment,
-                 const std::string& instance_id,
+                 const std::string& cloud_init_instance_id,
                  std::shared_ptr<Snapshot> parent,
                  int index,
                  QDateTime&& creation_timestamp,
@@ -109,7 +109,7 @@ private:
     std::shared_ptr<Snapshot> parent;
 
     // This class is non-copyable and having these const simplifies thread safety
-    const std::string instance_id;                         // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    const std::string cloud_init_instance_id;              // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const int index;                                       // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const QString id;                                      // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     const QDateTime creation_timestamp;                    // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
@@ -139,9 +139,9 @@ inline std::string multipass::BaseSnapshot::get_comment() const
     return comment;
 }
 
-inline std::string multipass::BaseSnapshot::get_instance_id() const noexcept
+inline std::string multipass::BaseSnapshot::get_cloud_init_instance_id() const noexcept
 {
-    return instance_id;
+    return cloud_init_instance_id;
 }
 
 inline int multipass::BaseSnapshot::get_index() const noexcept

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -168,6 +168,17 @@ void BaseVirtualMachine::apply_extra_interfaces_to_cloud_init(const std::string&
                                                                        cloud_init_config_iso_file_path);
 }
 
+void BaseVirtualMachine::add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
+                                                                    const NetworkInterface& extra_interface)
+{
+    const std::filesystem::path cloud_init_config_iso_file_path =
+        std::filesystem::path{instance_dir.absolutePath().toStdString()} / "cloud-init-config.iso";
+
+    MP_CLOUD_INIT_FILE_OPS.add_extra_interface_to_cloud_init(default_mac_addr,
+                                                             extra_interface,
+                                                             cloud_init_config_iso_file_path);
+}
+
 std::string BaseVirtualMachine::ssh_exec(const std::string& cmd)
 {
     const std::unique_lock lock{state_mutex};

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -157,16 +157,18 @@ BaseVirtualMachine::BaseVirtualMachine(const std::string& vm_name,
 {
 }
 
-void BaseVirtualMachine::apply_extra_interfaces_to_cloud_init(
+void BaseVirtualMachine::apply_extra_interfaces_and_instance_id_to_cloud_init(
     const std::string& default_mac_addr,
-    const std::vector<NetworkInterface>& extra_interfaces) const
+    const std::vector<NetworkInterface>& extra_interfaces,
+    const std::string& new_instance_id) const
 {
     const std::filesystem::path cloud_init_config_iso_file_path =
         std::filesystem::path{instance_dir.absolutePath().toStdString()} / "cloud-init-config.iso";
 
-    MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces(default_mac_addr,
-                                                                       extra_interfaces,
-                                                                       cloud_init_config_iso_file_path);
+    MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces_and_new_id(default_mac_addr,
+                                                                                  extra_interfaces,
+                                                                                  new_instance_id,
+                                                                                  cloud_init_config_iso_file_path);
 }
 
 void BaseVirtualMachine::add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
@@ -734,7 +736,9 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
     if (are_extra_interfaces_different)
     {
         // here we can use default_mac_address of the current state because it is an immutable variable.
-        apply_extra_interfaces_to_cloud_init(specs.default_mac_address, snapshot->get_extra_interfaces());
+        apply_extra_interfaces_and_instance_id_to_cloud_init(specs.default_mac_address,
+                                                             snapshot->get_extra_interfaces(),
+                                                             snapshot->get_instance_id());
     }
 
     rollback.dismiss();

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -180,6 +180,14 @@ void BaseVirtualMachine::add_extra_interface_to_instance_cloud_init(const std::s
                                                              cloud_init_config_iso_file_path);
 }
 
+std::string BaseVirtualMachine::get_instance_id_from_the_cloud_init() const
+{
+    const std::filesystem::path cloud_init_config_iso_file_path =
+        std::filesystem::path{instance_dir.absolutePath().toStdString()} / "cloud-init-config.iso";
+
+    return MP_CLOUD_INIT_FILE_OPS.get_instance_id_from_cloud_init(cloud_init_config_iso_file_path);
+}
+
 std::string BaseVirtualMachine::ssh_exec(const std::string& cmd)
 {
     const std::unique_lock lock{state_mutex};

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -163,7 +163,7 @@ void BaseVirtualMachine::apply_extra_interfaces_to_cloud_init(const std::string&
     const std::filesystem::path cloud_init_config_iso_file_path =
         std::filesystem::path{instance_dir.absolutePath().toStdString()} / "cloud-init-config.iso";
 
-    mp::cloudInitIsoUtils::update_cloud_init_with_new_extra_interfaces(default_mac_addr,
+    MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces(default_mac_addr,
                                                                        extra_interfaces,
                                                                        cloud_init_config_iso_file_path);
 }

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -391,6 +391,7 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs&
 
     auto rollback_on_failure = make_take_snapshot_rollback(it);
 
+    // get instance id from cloud-init file or lxd cloud init config and pass to make_specific_snapshot
     auto ret = head_snapshot = it->second = make_specific_snapshot(sname, comment, specs, head_snapshot);
     ret->capture();
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -738,7 +738,7 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
         // here we can use default_mac_address of the current state because it is an immutable variable.
         apply_extra_interfaces_and_instance_id_to_cloud_init(specs.default_mac_address,
                                                              snapshot->get_extra_interfaces(),
-                                                             snapshot->get_instance_id());
+                                                             snapshot->get_cloud_init_instance_id());
     }
 
     rollback.dismiss();

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -401,7 +401,8 @@ std::shared_ptr<const Snapshot> BaseVirtualMachine::take_snapshot(const VMSpecs&
     auto rollback_on_failure = make_take_snapshot_rollback(it);
 
     // get instance id from cloud-init file or lxd cloud init config and pass to make_specific_snapshot
-    auto ret = head_snapshot = it->second = make_specific_snapshot(sname, comment, specs, head_snapshot);
+    auto ret = head_snapshot = it->second =
+        make_specific_snapshot(sname, comment, get_instance_id_from_the_cloud_init(), specs, head_snapshot);
     ret->capture();
 
     ++snapshot_count;
@@ -741,6 +742,7 @@ void BaseVirtualMachine::restore_snapshot(const std::string& name, VMSpecs& spec
 
 std::shared_ptr<Snapshot> BaseVirtualMachine::make_specific_snapshot(const std::string& /*snapshot_name*/,
                                                                      const std::string& /*comment*/,
+                                                                     const std::string& /*instance_id*/,
                                                                      const VMSpecs& /*specs*/,
                                                                      std::shared_ptr<Snapshot> /*parent*/)
 {

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -157,8 +157,9 @@ BaseVirtualMachine::BaseVirtualMachine(const std::string& vm_name,
 {
 }
 
-void BaseVirtualMachine::apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                                              const std::vector<NetworkInterface>& extra_interfaces)
+void BaseVirtualMachine::apply_extra_interfaces_to_cloud_init(
+    const std::string& default_mac_addr,
+    const std::vector<NetworkInterface>& extra_interfaces) const
 {
     const std::filesystem::path cloud_init_config_iso_file_path =
         std::filesystem::path{instance_dir.absolutePath().toStdString()} / "cloud-init-config.iso";
@@ -169,7 +170,7 @@ void BaseVirtualMachine::apply_extra_interfaces_to_cloud_init(const std::string&
 }
 
 void BaseVirtualMachine::add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
-                                                                    const NetworkInterface& extra_interface)
+                                                                    const NetworkInterface& extra_interface) const
 {
     const std::filesystem::path cloud_init_config_iso_file_path =
         std::filesystem::path{instance_dir.absolutePath().toStdString()} / "cloud-init-config.iso";

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -94,6 +94,8 @@ protected:
                                                              std::shared_ptr<Snapshot> parent);
     virtual void drop_ssh_session(); // virtual to allow mocking
     void renew_ssh_session();
+    void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
+                                                    const NetworkInterface& extra_interface);
 
 private:
     using SnapshotMap = std::unordered_map<std::string, std::shared_ptr<Snapshot>>;

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -96,9 +96,9 @@ protected:
     void renew_ssh_session();
 
     virtual void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
-                                                            const NetworkInterface& extra_interface);
+                                                            const NetworkInterface& extra_interface) const;
     virtual void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                                      const std::vector<NetworkInterface>& extra_interfaces);
+                                                      const std::vector<NetworkInterface>& extra_interfaces) const;
 
 private:
     using SnapshotMap = std::unordered_map<std::string, std::shared_ptr<Snapshot>>;

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -98,8 +98,10 @@ protected:
 
     virtual void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
                                                             const NetworkInterface& extra_interface) const;
-    virtual void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                                      const std::vector<NetworkInterface>& extra_interfaces) const;
+    virtual void apply_extra_interfaces_and_instance_id_to_cloud_init(
+        const std::string& default_mac_addr,
+        const std::vector<NetworkInterface>& extra_interfaces,
+        const std::string& new_instance_id) const;
     virtual std::string get_instance_id_from_the_cloud_init() const;
 
 private:

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -64,8 +64,6 @@ public:
     {
         throw NotImplementedOnThisBackendException("native mounts");
     };
-    void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                              const std::vector<NetworkInterface>& extra_interfaces) override;
 
     SnapshotVista view_snapshots() const override;
     int get_num_snapshots() const override;
@@ -96,8 +94,11 @@ protected:
                                                              std::shared_ptr<Snapshot> parent);
     virtual void drop_ssh_session(); // virtual to allow mocking
     void renew_ssh_session();
-    void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
-                                                    const NetworkInterface& extra_interface);
+
+    virtual void add_extra_interface_to_instance_cloud_init(const std::string& default_mac_addr,
+                                                            const NetworkInterface& extra_interface);
+    virtual void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
+                                                      const std::vector<NetworkInterface>& extra_interfaces);
 
 private:
     using SnapshotMap = std::unordered_map<std::string, std::shared_ptr<Snapshot>>;

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -54,7 +54,9 @@ public:
     void wait_for_cloud_init(std::chrono::milliseconds timeout) override;
 
     std::vector<std::string> get_all_ipv4() override;
-    void add_network_interface(int index, const std::string& default_mac_addr, const NetworkInterface& net) override
+    void add_network_interface(int index,
+                               const std::string& default_mac_addr,
+                               const NetworkInterface& extra_interface) override
     {
         throw NotImplementedOnThisBackendException("networks");
     }

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -99,6 +99,7 @@ protected:
                                                             const NetworkInterface& extra_interface) const;
     virtual void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
                                                       const std::vector<NetworkInterface>& extra_interfaces) const;
+    virtual std::string get_instance_id_from_the_cloud_init() const;
 
 private:
     using SnapshotMap = std::unordered_map<std::string, std::shared_ptr<Snapshot>>;

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -54,7 +54,7 @@ public:
     void wait_for_cloud_init(std::chrono::milliseconds timeout) override;
 
     std::vector<std::string> get_all_ipv4() override;
-    void add_network_interface(int index, const NetworkInterface& net) override
+    void add_network_interface(int index, const std::string& default_mac_addr, const NetworkInterface& net) override
     {
         throw NotImplementedOnThisBackendException("networks");
     }

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -90,6 +90,7 @@ protected:
     virtual std::shared_ptr<Snapshot> make_specific_snapshot(const QString& filename);
     virtual std::shared_ptr<Snapshot> make_specific_snapshot(const std::string& snapshot_name,
                                                              const std::string& comment,
+                                                             const std::string& instance_id,
                                                              const VMSpecs& specs,
                                                              std::shared_ptr<Snapshot> parent);
     virtual void drop_ssh_session(); // virtual to allow mocking

--- a/src/utils/yaml_node_utils.cpp
+++ b/src/utils/yaml_node_utils.cpp
@@ -66,11 +66,19 @@ YAML::Node mp::utils::make_cloud_init_meta_config(const std::string& name, const
     return meta_data;
 }
 
-YAML::Node mp::utils::make_cloud_init_meta_config_with_id_tweak(const std::string& file_content)
+YAML::Node mp::utils::make_cloud_init_meta_config_with_id_tweak(const std::string& file_content,
+                                                                const std::string& new_instance_id)
 {
     YAML::Node meta_data = YAML::Load(file_content);
 
-    meta_data["instance-id"] = YAML::Node{meta_data["instance-id"].as<std::string>() + "_e"};
+    if (new_instance_id.empty())
+    {
+        meta_data["instance-id"] = YAML::Node{meta_data["instance-id"].as<std::string>() + "_e"};
+    }
+    else
+    {
+        meta_data["instance-id"] = YAML::Node{new_instance_id};
+    }
 
     return meta_data;
 }

--- a/src/utils/yaml_node_utils.cpp
+++ b/src/utils/yaml_node_utils.cpp
@@ -23,37 +23,6 @@ namespace mp = multipass;
 
 namespace
 {
-// remove this utility function once C++20 std::string::ends_with is available
-bool ends_with(const std::string_view search_str, const std::string_view sub_str)
-{
-    if (sub_str.size() > search_str.size())
-    {
-        return false;
-    }
-
-    return std::equal(sub_str.crbegin(), sub_str.crend(), search_str.crbegin());
-}
-
-std::string toggle_instance_id(const std::string& original_instance_id)
-{
-    std::string result_instance_id{original_instance_id};
-    const std::string tweak = "_e";
-
-    // Check if the instance_id already ends with the tweak.
-    if (ends_with(original_instance_id, tweak))
-    {
-        // Tweak found at the string end, remove it.
-        result_instance_id.erase(result_instance_id.size() - tweak.size(), tweak.size());
-    }
-    else
-    {
-        // Tweak not found, append it.
-        result_instance_id += tweak;
-    }
-
-    return result_instance_id;
-}
-
 YAML::Node create_extra_interface_node(const std::string& extra_interface_name,
                                        const std::string& extra_interface_mac_address)
 {
@@ -101,7 +70,7 @@ YAML::Node mp::utils::make_cloud_init_meta_config_with_id_tweak(const std::strin
 {
     YAML::Node meta_data = YAML::Load(file_content);
 
-    meta_data["instance-id"] = YAML::Node{toggle_instance_id(meta_data["instance-id"].as<std::string>())};
+    meta_data["instance-id"] = YAML::Node{meta_data["instance-id"].as<std::string>() + "_e"};
 
     return meta_data;
 }

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -2404,56 +2404,6 @@ TEST_F(LXDBackend, addsNetworkInterface)
     EXPECT_EQ(patch_times_called, 1u);
 }
 
-TEST_F(LXDBackend, addsNetworkInterfaceToCloudInit)
-{
-    mpt::StubVMStatusMonitor stub_monitor;
-
-    EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _))
-        .Times(5)
-        .WillRepeatedly([](auto, auto request, auto) {
-            auto op = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
-            auto url = request.url().toString();
-
-            if (op == "GET")
-            {
-                if (url.contains("1.0/virtual-machines/pied-piper-valley/state"))
-                {
-                    return new mpt::MockLocalSocketReply(mpt::vm_state_stopped_data);
-                }
-
-                if (url.contains("1.0/virtual-machines/pied-piper-valley"))
-                {
-                    return new mpt::MockLocalSocketReply(mpt::vm_info_data);
-                }
-
-                return new mpt::MockLocalSocketReply(mpt::not_found_data, QNetworkReply::ContentNotFoundError);
-            }
-
-            if (op == "PUT" && url.contains("1.0/virtual-machines"))
-            {
-                return new mpt::MockLocalSocketReply(mpt::delete_vm_wait_task_data);
-            }
-
-            return new mpt::MockLocalSocketReply(mpt::not_found_data, QNetworkReply::ContentNotFoundError);
-        });
-
-    mp::LXDVirtualMachine machine{default_description,
-                                  stub_monitor,
-                                  mock_network_access_manager.get(),
-                                  base_url,
-                                  bridge_name,
-                                  default_storage_pool,
-                                  key_provider,
-                                  instance_dir.path()};
-
-    EXPECT_EQ(machine.current_state(), mp::VirtualMachine::State::stopped);
-
-    const std::string default_mac_addr = "52:54:00:56:78:90";
-    const std::vector<mp::NetworkInterface> extra_interfaces = {{"id", "52:54:00:56:78:91", true},
-                                                                {"id", "52:54:00:56:78:92", true}};
-    EXPECT_NO_THROW(machine.apply_extra_interfaces_to_cloud_init(default_mac_addr, extra_interfaces));
-}
-
 struct LXDNetworkNameTestSuite : LXDBackend, WithParamInterface<std::pair<std::string, std::string>>
 {
 };

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -2386,7 +2386,7 @@ TEST_F(LXDBackend, addsNetworkInterface)
 
     machine->shutdown();
 
-    machine->add_network_interface(1, {"id", "52:54:00:56:78:90", true});
+    machine->add_network_interface(1, "", {"id", "52:54:00:56:78:90", true});
 
     EXPECT_EQ(times_called, 1u);
 }

--- a/tests/mock_cloud_init_file_ops.h
+++ b/tests/mock_cloud_init_file_ops.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_CLOUD_INIT_FILE_OPS_H
+#define MULTIPASS_MOCK_CLOUD_INIT_FILE_OPS_H
+
+#include "mock_singleton_helpers.h"
+
+#include <multipass/cloud_init_iso.h>
+
+namespace multipass::test
+{
+class MockCloudInitFileOps : public CloudInitFileOps
+{
+public:
+    using CloudInitFileOps::CloudInitFileOps;
+
+    MOCK_METHOD(void,
+                update_cloud_init_with_new_extra_interfaces,
+                (const std::string&, const std::vector<NetworkInterface>&, const std::filesystem::path&),
+                (const, override));
+    MOCK_METHOD(void,
+                add_extra_interface_to_cloud_init,
+                (const std::string&, const NetworkInterface&, const std::filesystem::path&),
+                (const, override));
+
+    MP_MOCK_SINGLETON_BOILERPLATE(MockCloudInitFileOps, CloudInitFileOps);
+};
+} // namespace multipass::test
+
+#endif // MULTIPASS_MOCK_CLOUD_INIT_FILE_OPS_H

--- a/tests/mock_cloud_init_file_ops.h
+++ b/tests/mock_cloud_init_file_ops.h
@@ -37,6 +37,7 @@ public:
                 add_extra_interface_to_cloud_init,
                 (const std::string&, const NetworkInterface&, const std::filesystem::path&),
                 (const, override));
+    MOCK_METHOD(std::string, get_instance_id_from_cloud_init, (const std::filesystem::path&), (const, override));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockCloudInitFileOps, CloudInitFileOps);
 };

--- a/tests/mock_cloud_init_file_ops.h
+++ b/tests/mock_cloud_init_file_ops.h
@@ -29,10 +29,11 @@ class MockCloudInitFileOps : public CloudInitFileOps
 public:
     using CloudInitFileOps::CloudInitFileOps;
 
-    MOCK_METHOD(void,
-                update_cloud_init_with_new_extra_interfaces,
-                (const std::string&, const std::vector<NetworkInterface>&, const std::filesystem::path&),
-                (const, override));
+    MOCK_METHOD(
+        void,
+        update_cloud_init_with_new_extra_interfaces_and_new_id,
+        (const std::string&, const std::vector<NetworkInterface>&, const std::string&, const std::filesystem::path&),
+        (const, override));
     MOCK_METHOD(void,
                 add_extra_interface_to_cloud_init,
                 (const std::string&, const NetworkInterface&, const std::filesystem::path&),

--- a/tests/mock_snapshot.h
+++ b/tests/mock_snapshot.h
@@ -33,7 +33,7 @@ struct MockSnapshot : public mp::Snapshot
     MOCK_METHOD(int, get_index, (), (const, noexcept, override));
     MOCK_METHOD(std::string, get_name, (), (const, override));
     MOCK_METHOD(std::string, get_comment, (), (const, override));
-    MOCK_METHOD(std::string, get_instance_id, (), (const, noexcept, override));
+    MOCK_METHOD(std::string, get_cloud_init_instance_id, (), (const, noexcept, override));
     MOCK_METHOD(QDateTime, get_creation_timestamp, (), (const, noexcept, override));
     MOCK_METHOD(int, get_num_cores, (), (const, noexcept, override));
     MOCK_METHOD(mp::MemorySize, get_mem_size, (), (const, noexcept, override));

--- a/tests/mock_snapshot.h
+++ b/tests/mock_snapshot.h
@@ -33,6 +33,7 @@ struct MockSnapshot : public mp::Snapshot
     MOCK_METHOD(int, get_index, (), (const, noexcept, override));
     MOCK_METHOD(std::string, get_name, (), (const, override));
     MOCK_METHOD(std::string, get_comment, (), (const, override));
+    MOCK_METHOD(std::string, get_instance_id, (), (const, noexcept, override));
     MOCK_METHOD(QDateTime, get_creation_timestamp, (), (const, noexcept, override));
     MOCK_METHOD(int, get_num_cores, (), (const, noexcept, override));
     MOCK_METHOD(mp::MemorySize, get_mem_size, (), (const, noexcept, override));

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -74,7 +74,7 @@ struct MockVirtualMachineT : public T
     MOCK_METHOD(void, update_cpus, (int), (override));
     MOCK_METHOD(void, resize_memory, (const MemorySize&), (override));
     MOCK_METHOD(void, resize_disk, (const MemorySize&), (override));
-    MOCK_METHOD(void, add_network_interface, (int, const NetworkInterface&), (override));
+    MOCK_METHOD(void, add_network_interface, (int, const std::string&, const NetworkInterface&), (override));
     MOCK_METHOD(void,
                 apply_extra_interfaces_to_cloud_init,
                 (const std::string&, const std::vector<NetworkInterface>&),

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -75,10 +75,6 @@ struct MockVirtualMachineT : public T
     MOCK_METHOD(void, resize_memory, (const MemorySize&), (override));
     MOCK_METHOD(void, resize_disk, (const MemorySize&), (override));
     MOCK_METHOD(void, add_network_interface, (int, const std::string&, const NetworkInterface&), (override));
-    MOCK_METHOD(void,
-                apply_extra_interfaces_to_cloud_init,
-                (const std::string&, const std::vector<NetworkInterface>&),
-                (override));
     MOCK_METHOD(std::unique_ptr<MountHandler>,
                 make_native_mount_handler,
                 (const std::string&, const VMMount&),

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -891,7 +891,7 @@ TEST_F(QemuBackend, addNetworkInterface)
     mpt::StubVMStatusMonitor stub_monitor;
     mp::QemuVirtualMachineFactory backend{data_dir.path()};
 
-    auto machine = backend.create_virtual_machine(default_description, stub_monitor);
+    auto machine = backend.create_virtual_machine(default_description, key_provider, stub_monitor);
     EXPECT_NO_THROW(machine->add_network_interface(0, "", {"", "", true}));
 }
 

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -757,6 +757,8 @@ TEST_F(QemuBackend, createsQemuSnapshotsFromSpecs)
 
     auto snapshot_name = "elvis";
     auto snapshot_comment = "has left the building";
+    auto instance_id = "vm1";
+
     const mp::VMSpecs specs{2,
                             mp::MemorySize{"3.21G"},
                             mp::MemorySize{"4.32M"},
@@ -767,7 +769,7 @@ TEST_F(QemuBackend, createsQemuSnapshotsFromSpecs)
                             {},
                             false,
                             {}};
-    auto snapshot = machine.make_specific_snapshot(snapshot_name, snapshot_comment, specs, nullptr);
+    auto snapshot = machine.make_specific_snapshot(snapshot_name, snapshot_comment, instance_id, specs, nullptr);
     EXPECT_EQ(snapshot->get_name(), snapshot_name);
     EXPECT_EQ(snapshot->get_comment(), snapshot_comment);
     EXPECT_EQ(snapshot->get_num_cores(), specs.num_cores);

--- a/tests/qemu/test_qemu_snapshot.cpp
+++ b/tests/qemu/test_qemu_snapshot.cpp
@@ -58,7 +58,7 @@ struct TestQemuSnapshot : public Test
 
     mp::QemuSnapshot quick_snapshot(const std::string& name = "asdf")
     {
-        return mp::QemuSnapshot{name, "", nullptr, specs, vm, desc};
+        return mp::QemuSnapshot{name, "", "", nullptr, specs, vm, desc};
     }
 
     mp::QemuSnapshot loaded_snapshot()
@@ -117,12 +117,14 @@ TEST_F(TestQemuSnapshot, initializesBaseProperties)
 {
     const auto name = "name";
     const auto comment = "comment";
+    const auto instance_id = "vm2";
+
     const auto parent = std::make_shared<mpt::MockSnapshot>();
 
     auto desc = mp::VirtualMachineDescription{};
     auto vm = NiceMock<mpt::MockVirtualMachineT<mp::QemuVirtualMachine>>{"qemu-vm", key_provider};
 
-    const auto snapshot = mp::QemuSnapshot{name, comment, parent, specs, vm, desc};
+    const auto snapshot = mp::QemuSnapshot{name, comment, instance_id, parent, specs, vm, desc};
     EXPECT_EQ(snapshot.get_name(), name);
     EXPECT_EQ(snapshot.get_comment(), comment);
     EXPECT_EQ(snapshot.get_parent(), parent);

--- a/tests/stub_snapshot.h
+++ b/tests/stub_snapshot.h
@@ -37,6 +37,11 @@ struct StubSnapshot : public Snapshot
         return {};
     }
 
+    std::string get_instance_id() const noexcept override
+    {
+        return {};
+    }
+
     QDateTime get_creation_timestamp() const noexcept override
     {
         return QDateTime{};

--- a/tests/stub_snapshot.h
+++ b/tests/stub_snapshot.h
@@ -37,7 +37,7 @@ struct StubSnapshot : public Snapshot
         return {};
     }
 
-    std::string get_instance_id() const noexcept override
+    std::string get_cloud_init_instance_id() const noexcept override
     {
         return {};
     }

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -124,7 +124,7 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
     {
     }
 
-    void add_network_interface(int, const NetworkInterface&) override
+    void add_network_interface(int, const std::string&, const NetworkInterface&) override
     {
     }
 

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -128,11 +128,6 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
     {
     }
 
-    void apply_extra_interfaces_to_cloud_init(const std::string& default_mac_addr,
-                                              const std::vector<NetworkInterface>& extra_interfaces) override
-    {
-    }
-
     std::unique_ptr<MountHandler> make_native_mount_handler(const std::string&, const VMMount&) override
     {
         return std::make_unique<StubMountHandler>();

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -166,14 +166,14 @@ struct TestBaseSnapshot : public Test
 TEST_F(TestBaseSnapshot, adoptsGivenValidName)
 {
     constexpr auto name = "a-name";
-    auto snapshot = MockBaseSnapshot{name, "", nullptr, specs, vm};
+    auto snapshot = MockBaseSnapshot{name, "", "", nullptr, specs, vm};
     EXPECT_EQ(snapshot.get_name(), name);
 }
 
 TEST_F(TestBaseSnapshot, rejectsEmptyName)
 {
     const std::string empty{};
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{empty, "asdf", nullptr, specs, vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{empty, "asdf", "", nullptr, specs, vm}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("empty")));
 }
@@ -181,26 +181,26 @@ TEST_F(TestBaseSnapshot, rejectsEmptyName)
 TEST_F(TestBaseSnapshot, adoptsGivenComment)
 {
     constexpr auto comment = "some comment";
-    auto snapshot = MockBaseSnapshot{"whatever", comment, nullptr, specs, vm};
+    auto snapshot = MockBaseSnapshot{"whatever", comment, "", nullptr, specs, vm};
     EXPECT_EQ(snapshot.get_comment(), comment);
 }
 
 TEST_F(TestBaseSnapshot, adoptsGivenParent)
 {
-    const auto parent = std::make_shared<MockBaseSnapshot>("root", "asdf", nullptr, specs, vm);
-    auto snapshot = MockBaseSnapshot{"descendant", "descends", parent, specs, vm};
+    const auto parent = std::make_shared<MockBaseSnapshot>("root", "asdf", "", nullptr, specs, vm);
+    auto snapshot = MockBaseSnapshot{"descendant", "descends", "", parent, specs, vm};
     EXPECT_EQ(snapshot.get_parent(), parent);
 }
 
 TEST_F(TestBaseSnapshot, adoptsNullParent)
 {
-    auto snapshot = MockBaseSnapshot{"descendant", "descends", nullptr, specs, vm};
+    auto snapshot = MockBaseSnapshot{"descendant", "descends", "", nullptr, specs, vm};
     EXPECT_EQ(snapshot.get_parent(), nullptr);
 }
 
 TEST_F(TestBaseSnapshot, adoptsGivenSpecs)
 {
-    auto snapshot = MockBaseSnapshot{"snapshot", "", nullptr, specs, vm};
+    auto snapshot = MockBaseSnapshot{"snapshot", "", "", nullptr, specs, vm};
     EXPECT_EQ(snapshot.get_num_cores(), specs.num_cores);
     EXPECT_EQ(snapshot.get_mem_size(), specs.mem_size);
     EXPECT_EQ(snapshot.get_disk_space(), specs.disk_space);
@@ -217,7 +217,7 @@ TEST_F(TestBaseSnapshot, adoptsCustomMounts)
     specs.mounts["tata"] =
         mp::VMMount{"fountain", {{234, 123}}, {{81, 18}, {9, 10}}, multipass::VMMount::MountType::Native};
 
-    auto snapshot = MockBaseSnapshot{"snapshot", "", nullptr, specs, vm};
+    auto snapshot = MockBaseSnapshot{"snapshot", "", "", nullptr, specs, vm};
     EXPECT_EQ(snapshot.get_mounts(), specs.mounts);
 }
 
@@ -230,7 +230,7 @@ TEST_F(TestBaseSnapshot, adoptsCustomMetadata)
     json.insert("meta", data);
     specs.metadata = json;
 
-    auto snapshot = MockBaseSnapshot{"snapshot", "", nullptr, specs, vm};
+    auto snapshot = MockBaseSnapshot{"snapshot", "", "", nullptr, specs, vm};
     EXPECT_EQ(snapshot.get_metadata(), specs.metadata);
 }
 
@@ -239,7 +239,7 @@ TEST_F(TestBaseSnapshot, adoptsNextIndex)
     const int count = 123;
     EXPECT_CALL(vm, get_snapshot_count).WillOnce(Return(count));
 
-    auto snapshot = MockBaseSnapshot{"tau", "ceti", nullptr, specs, vm};
+    auto snapshot = MockBaseSnapshot{"tau", "ceti", "", nullptr, specs, vm};
     EXPECT_EQ(snapshot.get_index(), count + 1);
 }
 
@@ -250,9 +250,9 @@ TEST_F(TestBaseSnapshot, retrievesParentsProperties)
 
     EXPECT_CALL(vm, get_snapshot_count).WillOnce(Return(parent_index - 1)).WillOnce(Return(31));
 
-    auto parent = std::make_shared<MockBaseSnapshot>(parent_name, "", nullptr, specs, vm);
+    auto parent = std::make_shared<MockBaseSnapshot>(parent_name, "", "", nullptr, specs, vm);
 
-    auto child = MockBaseSnapshot{"child", "", parent, specs, vm};
+    auto child = MockBaseSnapshot{"child", "", "", parent, specs, vm};
     EXPECT_EQ(child.get_parents_index(), parent_index);
     EXPECT_EQ(child.get_parents_name(), parent_name);
 }
@@ -260,7 +260,7 @@ TEST_F(TestBaseSnapshot, retrievesParentsProperties)
 TEST_F(TestBaseSnapshot, adoptsCurrentTimestamp)
 {
     auto before = QDateTime::currentDateTimeUtc();
-    auto snapshot = MockBaseSnapshot{"foo", "", nullptr, specs, vm};
+    auto snapshot = MockBaseSnapshot{"foo", "", "", nullptr, specs, vm};
     auto after = QDateTime::currentDateTimeUtc();
 
     EXPECT_GE(snapshot.get_creation_timestamp(), before);
@@ -274,7 +274,7 @@ class TestSnapshotRejectedStates : public TestBaseSnapshot, public WithParamInte
 TEST_P(TestSnapshotRejectedStates, rejectsActiveState)
 {
     specs.state = GetParam();
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{"snapshot", "comment", nullptr, specs, vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{"snapshot", "comment", "", nullptr, specs, vm}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Unsupported VM state")));
 }
@@ -296,7 +296,7 @@ class TestSnapshotInvalidCores : public TestBaseSnapshot, public WithParamInterf
 TEST_P(TestSnapshotInvalidCores, rejectsInvalidNumberOfCores)
 {
     specs.num_cores = GetParam();
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{"snapshot", "comment", nullptr, specs, vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{"snapshot", "comment", "", nullptr, specs, vm}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Invalid number of cores")));
 }
@@ -306,7 +306,7 @@ INSTANTIATE_TEST_SUITE_P(TestBaseSnapshot, TestSnapshotInvalidCores, Values(0, -
 TEST_F(TestBaseSnapshot, rejectsNullMemorySize)
 {
     specs.mem_size = mp::MemorySize{"0B"};
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{"snapshot", "comment", nullptr, specs, vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{"snapshot", "comment", "", nullptr, specs, vm}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Invalid memory size")));
 }
@@ -314,7 +314,7 @@ TEST_F(TestBaseSnapshot, rejectsNullMemorySize)
 TEST_F(TestBaseSnapshot, rejectsNullDiskSize)
 {
     specs.disk_space = mp::MemorySize{"0B"};
-    MP_EXPECT_THROW_THAT((MockBaseSnapshot{"snapshot", "comment", nullptr, specs, vm}),
+    MP_EXPECT_THROW_THAT((MockBaseSnapshot{"snapshot", "comment", "", nullptr, specs, vm}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Invalid disk size")));
 }
@@ -352,7 +352,8 @@ TEST_F(TestBaseSnapshot, linksToParentFromJson)
     mod_snapshot_json(json, "parent", parent_idx);
 
     EXPECT_CALL(vm, get_snapshot(TypedEq<int>(parent_idx)))
-        .WillOnce(Return(std::make_shared<MockBaseSnapshot>(parent_name, "mock parent snapshot", nullptr, specs, vm)));
+        .WillOnce(
+            Return(std::make_shared<MockBaseSnapshot>(parent_name, "mock parent snapshot", "", nullptr, specs, vm)));
 
     auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_parents_name(), parent_name);
@@ -564,7 +565,7 @@ TEST_F(TestBaseSnapshot, setsComment)
 TEST_F(TestBaseSnapshot, setsParent)
 {
     auto child = MockBaseSnapshot{test_json_file_path, vm, desc};
-    auto parent = std::make_shared<MockBaseSnapshot>("parent", "", nullptr, specs, vm);
+    auto parent = std::make_shared<MockBaseSnapshot>("parent", "", "", nullptr, specs, vm);
 
     child.set_parent(parent);
     EXPECT_EQ(child.get_parent(), parent);
@@ -599,7 +600,7 @@ INSTANTIATE_TEST_SUITE_P(TestBaseSnapshot,
 
 TEST_F(TestBaseSnapshot, capturePersists)
 {
-    NiceMock<MockBaseSnapshot> snapshot{"Big Whoop", "treasure", nullptr, specs, vm};
+    NiceMock<MockBaseSnapshot> snapshot{"Big Whoop", "treasure", "", nullptr, specs, vm};
     snapshot.capture();
 
     const auto expected_file = QFileInfo{derive_persisted_snapshot_file_path(snapshot.get_index())};
@@ -609,7 +610,7 @@ TEST_F(TestBaseSnapshot, capturePersists)
 
 TEST_F(TestBaseSnapshot, captureCallsImpl)
 {
-    MockBaseSnapshot snapshot{"LeChuck", "'s Revenge", nullptr, specs, vm};
+    MockBaseSnapshot snapshot{"LeChuck", "'s Revenge", "", nullptr, specs, vm};
     EXPECT_CALL(snapshot, capture_impl).Times(1);
 
     snapshot.capture();
@@ -617,7 +618,7 @@ TEST_F(TestBaseSnapshot, captureCallsImpl)
 
 TEST_F(TestBaseSnapshot, applyCallsImpl)
 {
-    MockBaseSnapshot snapshot{"Guybrush", "fears porcelain", nullptr, specs, vm};
+    MockBaseSnapshot snapshot{"Guybrush", "fears porcelain", "", nullptr, specs, vm};
     EXPECT_CALL(snapshot, apply_impl).Times(1);
 
     snapshot.apply();
@@ -625,7 +626,7 @@ TEST_F(TestBaseSnapshot, applyCallsImpl)
 
 TEST_F(TestBaseSnapshot, eraseCallsImpl)
 {
-    NiceMock<MockBaseSnapshot> snapshot{"House of Mojo", "voodoo", nullptr, specs, vm};
+    NiceMock<MockBaseSnapshot> snapshot{"House of Mojo", "voodoo", "", nullptr, specs, vm};
     snapshot.capture();
 
     EXPECT_CALL(snapshot, erase_impl).Times(1);
@@ -634,7 +635,7 @@ TEST_F(TestBaseSnapshot, eraseCallsImpl)
 
 TEST_F(TestBaseSnapshot, eraseRemovesFile)
 {
-    NiceMock<MockBaseSnapshot> snapshot{"House of Mojo", "voodoo", nullptr, specs, vm};
+    NiceMock<MockBaseSnapshot> snapshot{"House of Mojo", "voodoo", "", nullptr, specs, vm};
     snapshot.capture();
 
     const auto expected_file_path = derive_persisted_snapshot_file_path(snapshot.get_index());
@@ -646,7 +647,7 @@ TEST_F(TestBaseSnapshot, eraseRemovesFile)
 
 TEST_F(TestBaseSnapshot, eraseThrowsIfUnableToRenameFile)
 {
-    NiceMock<MockBaseSnapshot> snapshot{"voodoo-sword", "Cursed Cutlass of Kaflu", nullptr, specs, vm};
+    NiceMock<MockBaseSnapshot> snapshot{"voodoo-sword", "Cursed Cutlass of Kaflu", "", nullptr, specs, vm};
     snapshot.capture();
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
@@ -662,6 +663,7 @@ TEST_F(TestBaseSnapshot, restoresFileOnFailureToErase)
 {
     NiceMock<MockBaseSnapshot> snapshot{"ultimate-insult",
                                         "A powerful weapon capable of crippling even the toughest pirate's ego.",
+                                        "",
                                         nullptr,
                                         specs,
                                         vm};

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -374,7 +374,7 @@ TEST_F(TestBaseSnapshot, adoptsInstanceIdFromJson)
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "cloud_init_instance_id", QJsonValue{new_instance_id.data()});
 
-    const auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    const auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_cloud_init_instance_id(), new_instance_id);
 }
 

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -57,7 +57,7 @@ bool operator==(const MockBaseSnapshot& a, const MockBaseSnapshot& b)
     return std::tuple(a.get_index(),
                       a.get_name(),
                       a.get_comment(),
-                      a.get_instance_id(),
+                      a.get_cloud_init_instance_id(),
                       a.get_creation_timestamp(),
                       a.get_num_cores(),
                       a.get_mem_size(),
@@ -70,7 +70,7 @@ bool operator==(const MockBaseSnapshot& a, const MockBaseSnapshot& b)
                       a.get_id()) == std::tuple(b.get_index(),
                                                 b.get_name(),
                                                 b.get_comment(),
-                                                a.get_instance_id(),
+                                                a.get_cloud_init_instance_id(),
                                                 b.get_creation_timestamp(),
                                                 b.get_num_cores(),
                                                 b.get_mem_size(),
@@ -191,7 +191,7 @@ TEST_F(TestBaseSnapshot, adoptsGivenInstanceId)
 {
     constexpr std::string_view instance_id{"vm2"};
     const auto snapshot = MockBaseSnapshot{"whatever", "some comment", std::string{instance_id}, nullptr, specs, vm};
-    EXPECT_EQ(snapshot.get_instance_id(), instance_id);
+    EXPECT_EQ(snapshot.get_cloud_init_instance_id(), instance_id);
 }
 
 TEST_F(TestBaseSnapshot, adoptsGivenParent)
@@ -372,10 +372,10 @@ TEST_F(TestBaseSnapshot, adoptsInstanceIdFromJson)
 {
     constexpr std::string_view new_instance_id{"vm2"};
     auto json = test_snapshot_json();
-    mod_snapshot_json(json, "instance_id", QJsonValue{new_instance_id.data()});
+    mod_snapshot_json(json, "cloud_init_instance_id", QJsonValue{new_instance_id.data()});
 
     const auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
-    EXPECT_EQ(snapshot.get_instance_id(), new_instance_id);
+    EXPECT_EQ(snapshot.get_cloud_init_instance_id(), new_instance_id);
 }
 
 TEST_F(TestBaseSnapshot, adoptsIndexFromJson)

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -57,6 +57,7 @@ bool operator==(const MockBaseSnapshot& a, const MockBaseSnapshot& b)
     return std::tuple(a.get_index(),
                       a.get_name(),
                       a.get_comment(),
+                      a.get_instance_id(),
                       a.get_creation_timestamp(),
                       a.get_num_cores(),
                       a.get_mem_size(),
@@ -69,6 +70,7 @@ bool operator==(const MockBaseSnapshot& a, const MockBaseSnapshot& b)
                       a.get_id()) == std::tuple(b.get_index(),
                                                 b.get_name(),
                                                 b.get_comment(),
+                                                a.get_instance_id(),
                                                 b.get_creation_timestamp(),
                                                 b.get_num_cores(),
                                                 b.get_mem_size(),
@@ -183,6 +185,13 @@ TEST_F(TestBaseSnapshot, adoptsGivenComment)
     constexpr auto comment = "some comment";
     auto snapshot = MockBaseSnapshot{"whatever", comment, "", nullptr, specs, vm};
     EXPECT_EQ(snapshot.get_comment(), comment);
+}
+
+TEST_F(TestBaseSnapshot, adoptsGivenInstanceId)
+{
+    constexpr std::string_view instance_id{"vm2"};
+    const auto snapshot = MockBaseSnapshot{"whatever", "some comment", std::string{instance_id}, nullptr, specs, vm};
+    EXPECT_EQ(snapshot.get_instance_id(), instance_id);
 }
 
 TEST_F(TestBaseSnapshot, adoptsGivenParent)
@@ -357,6 +366,16 @@ TEST_F(TestBaseSnapshot, linksToParentFromJson)
 
     auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_parents_name(), parent_name);
+}
+
+TEST_F(TestBaseSnapshot, adoptsInstanceIdFromJson)
+{
+    constexpr std::string_view new_instance_id{"vm2"};
+    auto json = test_snapshot_json();
+    mod_snapshot_json(json, "instance_id", QJsonValue{new_instance_id.data()});
+
+    const auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm};
+    EXPECT_EQ(snapshot.get_instance_id(), new_instance_id);
 }
 
 TEST_F(TestBaseSnapshot, adoptsIndexFromJson)

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -23,7 +23,6 @@
 #include "mock_snapshot.h"
 #include "mock_ssh_test_fixture.h"
 #include "mock_utils.h"
-
 #include "mock_virtual_machine.h"
 #include "temp_dir.h"
 

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -19,7 +19,6 @@
 #include "dummy_ssh_key_provider.h"
 #include "file_operations.h"
 #include "mock_cloud_init_file_ops.h"
-#include "mock_file_ops.h"
 #include "mock_logger.h"
 #include "mock_snapshot.h"
 #include "mock_ssh_test_fixture.h"

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -777,35 +777,35 @@ TEST_F(BaseVM, restoresSnapshots)
     EXPECT_EQ(original_specs, changed_specs);
 }
 
-TEST_F(BaseVM, restoresSnapshotsWithExtraInterfaceDiff)
-{
-    mock_snapshotting();
+// temporary comment out until we mock MP_CLOUD_INIT_FILE_OPS
+// TEST_F(BaseVM, restoresSnapshotsWithExtraInterfaceDiff)
+// {
+//     mock_snapshotting();
 
-    // default value of VMSpecs::state is off, so restore_snapshot will pass the assert_vm_stopped check, the other
-    // fields do not matter, and VMSpecs::extra_interfaces is defaulted to be empty, which is we want.
-    const mp::VMSpecs original_specs{};
-    const auto* snapshot_name = "snapshot1";
-    vm.take_snapshot(original_specs, snapshot_name, "");
+//     // default value of VMSpecs::state is off, so restore_snapshot will pass the assert_vm_stopped check, the other
+//     // fields do not matter, and VMSpecs::extra_interfaces is defaulted to be empty, which is we want.
+//     const mp::VMSpecs original_specs{};
+//     const auto* snapshot_name = "snapshot1";
+//     vm.take_snapshot(original_specs, snapshot_name, "");
 
-    ASSERT_EQ(snapshot_album.size(), 1);
-    const auto& snapshot = *snapshot_album[0];
+//     ASSERT_EQ(snapshot_album.size(), 1);
+//     const auto& snapshot = *snapshot_album[0];
 
-    mp::VMSpecs new_specs = original_specs;
-    new_specs.extra_interfaces =
-        std::vector<mp::NetworkInterface>{{"id", "52:54:00:56:78:91", true}, {"id", "52:54:00:56:78:92", true}};
+//     mp::VMSpecs new_specs = original_specs;
+//     new_specs.extra_interfaces =
+//         std::vector<mp::NetworkInterface>{{"id", "52:54:00:56:78:91", true}, {"id", "52:54:00:56:78:92", true}};
 
-    // the ref return functions can not use the default mock behavior, so they need to be specified
-    EXPECT_CALL(snapshot, get_mounts).WillOnce(ReturnRef(original_specs.mounts));
-    EXPECT_CALL(snapshot, get_metadata).WillOnce(ReturnRef(original_specs.metadata));
+//     // the ref return functions can not use the default mock behavior, so they need to be specified
+//     EXPECT_CALL(snapshot, get_mounts).WillOnce(ReturnRef(original_specs.mounts));
+//     EXPECT_CALL(snapshot, get_metadata).WillOnce(ReturnRef(original_specs.metadata));
 
-    // set the behavior of get_extra_interfaces to cause the difference to the new spece extra interfaces
-    EXPECT_CALL(snapshot, get_extra_interfaces).Times(3).WillRepeatedly(Return(original_specs.extra_interfaces));
-    // Expect to getinto the if (is_extra_interfaces_different) branch
-    EXPECT_CALL(vm, apply_extra_interfaces_to_cloud_init).Times(1);
+//     // set the behavior of get_extra_interfaces to cause the difference to the new spece extra interfaces
+//     EXPECT_CALL(snapshot, get_extra_interfaces).Times(3).WillRepeatedly(Return(original_specs.extra_interfaces));
 
-    vm.restore_snapshot(snapshot_name, new_specs);
-    EXPECT_EQ(original_specs, new_specs);
-}
+//     // add mock update_cloud_init_with_new_extra_interfaces
+//     vm.restore_snapshot(snapshot_name, new_specs);
+//     EXPECT_EQ(original_specs, new_specs);
+// }
 
 TEST_F(BaseVM, usesRestoredSnapshotAsParentForNewSnapshots)
 {
@@ -1221,16 +1221,6 @@ TEST_F(BaseVM, rollsbackFailedRestore)
     EXPECT_THAT(mpt::load(head_path).toStdString(), regex_matcher);
 
     EXPECT_EQ(vm.take_snapshot(current_specs, "", "")->get_parent().get(), &last_snapshot);
-}
-
-TEST(BaseVMStub, addExtraInterfacesToCloudInit)
-{
-    StubBaseVirtualMachine base_vm(mp::VirtualMachine::State::off);
-    const std::string default_mac_addr = "52:54:00:56:78:90";
-    const std::vector<mp::NetworkInterface> extra_interfaces = {{"id", "52:54:00:56:78:91", true},
-                                                                {"id", "52:54:00:56:78:92", true}};
-    // use internal instance dir, in this unit test case, it will not find the cloud-init file, so it should throw
-    EXPECT_THROW(base_vm.apply_extra_interfaces_to_cloud_init(default_mac_addr, extra_interfaces), std::runtime_error);
 }
 
 TEST_F(BaseVM, waitForCloudInitNoErrorsAndDoneDoesNotThrow)

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -805,7 +805,8 @@ TEST_F(BaseVM, restoresSnapshotsWithExtraInterfaceDiff)
     // set the behavior of get_extra_interfaces to cause the difference to the new spece extra interfaces
     EXPECT_CALL(snapshot, get_extra_interfaces).Times(3).WillRepeatedly(Return(original_specs.extra_interfaces));
 
-    EXPECT_CALL(*mock_cloud_init_file_ops_injection.first, update_cloud_init_with_new_extra_interfaces_and_new_id)
+    EXPECT_CALL(*mock_cloud_init_file_ops_injection.first,
+                update_cloud_init_with_new_extra_interfaces_and_new_id(_, _, _, _))
         .Times(1);
 
     vm.restore_snapshot(snapshot_name, new_specs);

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -805,11 +805,7 @@ TEST_F(BaseVM, restoresSnapshotsWithExtraInterfaceDiff)
     EXPECT_CALL(snapshot, get_extra_interfaces).Times(3).WillRepeatedly(Return(original_specs.extra_interfaces));
 
     const auto [mock_cloud_init_file_ops, _] = mpt::MockCloudInitFileOps::inject();
-    EXPECT_CALL(*mock_cloud_init_file_ops,
-                update_cloud_init_with_new_extra_interfaces(A<const std::string&>(),
-                                                            A<const std::vector<mp::NetworkInterface>&>(),
-                                                            A<const std::filesystem::path&>()))
-        .Times(1);
+    EXPECT_CALL(*mock_cloud_init_file_ops, update_cloud_init_with_new_extra_interfaces_and_new_id).Times(1);
 
     vm.restore_snapshot(snapshot_name, new_specs);
     EXPECT_EQ(original_specs, new_specs);

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -298,7 +298,7 @@ TEST_F(BaseVM, add_network_interface_throws)
 {
     StubBaseVirtualMachine base_vm(St::off);
 
-    MP_EXPECT_THROW_THAT(base_vm.add_network_interface(1, {"eth1", "52:54:00:00:00:00", true}),
+    MP_EXPECT_THROW_THAT(base_vm.add_network_interface(1, "", {"eth1", "52:54:00:00:00:00", true}),
                          mp::NotImplementedOnThisBackendException,
                          mpt::match_what(HasSubstr("networks")));
 }

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -19,10 +19,12 @@
 #include "dummy_ssh_key_provider.h"
 #include "file_operations.h"
 #include "mock_cloud_init_file_ops.h"
+#include "mock_file_ops.h"
 #include "mock_logger.h"
 #include "mock_snapshot.h"
 #include "mock_ssh_test_fixture.h"
 #include "mock_utils.h"
+
 #include "mock_virtual_machine.h"
 #include "temp_dir.h"
 
@@ -254,7 +256,7 @@ struct BaseVM : public Test
     std::vector<std::shared_ptr<mpt::MockSnapshot>> snapshot_album;
     QString head_path = vm.tmp_dir->filePath(head_filename);
     QString count_path = vm.tmp_dir->filePath(count_filename);
-
+    mpt::MockCloudInitFileOps::GuardedMock mock_cloud_init_file_ops_injection = mpt::MockCloudInitFileOps::inject();
     static constexpr bool on_windows =
 #ifdef MULTIPASS_PLATFORM_WINDOWS
         true;

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -804,8 +804,8 @@ TEST_F(BaseVM, restoresSnapshotsWithExtraInterfaceDiff)
     // set the behavior of get_extra_interfaces to cause the difference to the new spece extra interfaces
     EXPECT_CALL(snapshot, get_extra_interfaces).Times(3).WillRepeatedly(Return(original_specs.extra_interfaces));
 
-    const auto [mock_cloud_init_file_ops, _] = mpt::MockCloudInitFileOps::inject();
-    EXPECT_CALL(*mock_cloud_init_file_ops, update_cloud_init_with_new_extra_interfaces_and_new_id).Times(1);
+    EXPECT_CALL(*mock_cloud_init_file_ops_injection.first, update_cloud_init_with_new_extra_interfaces_and_new_id)
+        .Times(1);
 
     vm.restore_snapshot(snapshot_name, new_specs);
     EXPECT_EQ(original_specs, new_specs);

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -255,7 +255,8 @@ struct BaseVM : public Test
     std::vector<std::shared_ptr<mpt::MockSnapshot>> snapshot_album;
     QString head_path = vm.tmp_dir->filePath(head_filename);
     QString count_path = vm.tmp_dir->filePath(count_filename);
-    mpt::MockCloudInitFileOps::GuardedMock mock_cloud_init_file_ops_injection = mpt::MockCloudInitFileOps::inject();
+    mpt::MockCloudInitFileOps::GuardedMock mock_cloud_init_file_ops_injection =
+        mpt::MockCloudInitFileOps::inject<NiceMock>();
     static constexpr bool on_windows =
 #ifdef MULTIPASS_PLATFORM_WINDOWS
         true;

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -16,8 +16,8 @@
  */
 
 #include "common.h"
+#include "mock_file_ops.h"
 #include "temp_dir.h"
-#include "tests/mock_file_ops.h"
 
 #include <multipass/cloud_init_iso.h>
 #include <multipass/network_interface.h>

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -372,9 +372,11 @@ TEST_F(CloudInitIso, updateCloudInitWithNewNonEmptyExtraInterfaces)
 
     const std::string default_mac_addr = "52:54:00:56:78:90";
     const std::vector<mp::NetworkInterface> extra_interfaces = {{"id", "52:54:00:56:78:91", true}};
-    EXPECT_NO_THROW(MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces(default_mac_addr,
-                                                                                       extra_interfaces,
-                                                                                       iso_path.toStdString()));
+    EXPECT_NO_THROW(
+        MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces_and_new_id(default_mac_addr,
+                                                                                      extra_interfaces,
+                                                                                      "vm2",
+                                                                                      iso_path.toStdString()));
 
     constexpr std::string_view expected_modified_meta_data_content = R"(#cloud-config
 instance-id: vm1
@@ -411,9 +413,11 @@ TEST_F(CloudInitIso, updateCloudInitWithNewEmptyExtraInterfaces)
 
     const std::string& default_mac_addr = "52:54:00:56:78:90";
     const std::vector<mp::NetworkInterface> empty_extra_interfaces{};
-    EXPECT_NO_THROW(MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces(default_mac_addr,
-                                                                                       empty_extra_interfaces,
-                                                                                       iso_path.toStdString()));
+    EXPECT_NO_THROW(
+        MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces_and_new_id(default_mac_addr,
+                                                                                      empty_extra_interfaces,
+                                                                                      std::string(),
+                                                                                      iso_path.toStdString()));
     mp::CloudInitIso new_iso;
     new_iso.read_from(iso_path.toStdString());
     EXPECT_FALSE(new_iso.contains("network-config"));

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -372,7 +372,7 @@ TEST_F(CloudInitIso, updateCloudInitWithNewNonEmptyExtraInterfaces)
 
     const std::string default_mac_addr = "52:54:00:56:78:90";
     const std::vector<mp::NetworkInterface> extra_interfaces = {{"id", "52:54:00:56:78:91", true}};
-    EXPECT_NO_THROW(mp::cloudInitIsoUtils::update_cloud_init_with_new_extra_interfaces(default_mac_addr,
+    EXPECT_NO_THROW(MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces(default_mac_addr,
                                                                                        extra_interfaces,
                                                                                        iso_path.toStdString()));
 
@@ -413,7 +413,7 @@ TEST_F(CloudInitIso, updateCloudInitWithNewEmptyExtraInterfaces)
 
     const std::string& default_mac_addr = "52:54:00:56:78:90";
     const std::vector<mp::NetworkInterface> empty_extra_interfaces{};
-    EXPECT_NO_THROW(mp::cloudInitIsoUtils::update_cloud_init_with_new_extra_interfaces(default_mac_addr,
+    EXPECT_NO_THROW(MP_CLOUD_INIT_FILE_OPS.update_cloud_init_with_new_extra_interfaces(default_mac_addr,
                                                                                        empty_extra_interfaces,
                                                                                        iso_path.toStdString()));
     mp::CloudInitIso new_iso;
@@ -429,5 +429,5 @@ TEST_F(CloudInitIso, addExtraInterfaceToCloudInit)
 
     const mp::NetworkInterface dummy_extra_interface{};
     EXPECT_NO_THROW(
-        mp::cloudInitIsoUtils::add_extra_interface_to_cloud_init("", dummy_extra_interface, iso_path.toStdString()));
+        MP_CLOUD_INIT_FILE_OPS.add_extra_interface_to_cloud_init("", dummy_extra_interface, iso_path.toStdString()));
 }

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -420,3 +420,14 @@ TEST_F(CloudInitIso, updateCloudInitWithNewEmptyExtraInterfaces)
     new_iso.read_from(iso_path.toStdString());
     EXPECT_FALSE(new_iso.contains("network-config"));
 }
+
+TEST_F(CloudInitIso, addExtraInterfaceToCloudInit)
+{
+    mp::CloudInitIso original_iso;
+    original_iso.add_file("meta-data", std::string(meta_data_content));
+    original_iso.write_to(iso_path);
+
+    const mp::NetworkInterface dummy_extra_interface{};
+    EXPECT_NO_THROW(
+        mp::cloudInitIsoUtils::add_extra_interface_to_cloud_init("", dummy_extra_interface, iso_path.toStdString()));
+}

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -376,7 +376,6 @@ TEST_F(CloudInitIso, updateCloudInitWithNewNonEmptyExtraInterfaces)
                                                                                        extra_interfaces,
                                                                                        iso_path.toStdString()));
 
-    // extra new line due to emit_cloud_config appending /n
     constexpr std::string_view expected_modified_meta_data_content = R"(#cloud-config
 instance-id: vm1
 local-hostname: vm1
@@ -438,4 +437,22 @@ TEST_F(CloudInitIso, getInstanceIdFromCloudInit)
     original_iso.write_to(iso_path);
 
     EXPECT_EQ(MP_CLOUD_INIT_FILE_OPS.get_instance_id_from_cloud_init(iso_path.toStdString()), "vm1");
+}
+
+TEST_F(CloudInitIso, writeInstanceIdToCloudInit)
+{
+    mp::CloudInitIso original_iso;
+    original_iso.add_file("meta-data", std::string(meta_data_content));
+    original_iso.write_to(iso_path);
+
+    MP_CLOUD_INIT_FILE_OPS.write_instance_id_to_cloud_init("vm2", iso_path.toStdString());
+    mp::CloudInitIso new_iso;
+    new_iso.read_from(iso_path.toStdString());
+
+    constexpr std::string_view expected_modified_meta_data_content = R"(#cloud-config
+instance-id: vm2
+local-hostname: vm1
+cloud-name: multipass
+)";
+    EXPECT_EQ(new_iso.at("meta-data"), expected_modified_meta_data_content);
 }

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -430,3 +430,12 @@ TEST_F(CloudInitIso, addExtraInterfaceToCloudInit)
     EXPECT_NO_THROW(
         MP_CLOUD_INIT_FILE_OPS.add_extra_interface_to_cloud_init("", dummy_extra_interface, iso_path.toStdString()));
 }
+
+TEST_F(CloudInitIso, getInstanceIdFromCloudInit)
+{
+    mp::CloudInitIso original_iso;
+    original_iso.add_file("meta-data", std::string(meta_data_content));
+    original_iso.write_to(iso_path);
+
+    EXPECT_EQ(MP_CLOUD_INIT_FILE_OPS.get_instance_id_from_cloud_init(iso_path.toStdString()), "vm1");
+}

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -379,9 +379,10 @@ TEST_F(CloudInitIso, updateCloudInitWithNewNonEmptyExtraInterfaces)
                                                                                       iso_path.toStdString()));
 
     constexpr std::string_view expected_modified_meta_data_content = R"(#cloud-config
-instance-id: vm1
+instance-id: vm2
 local-hostname: vm1
-cloud-name: multipass)";
+cloud-name: multipass
+)";
     constexpr std::string_view expected_generated_network_config_data_content = R"(#cloud-config
 version: 2
 ethernets:

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -443,21 +443,3 @@ TEST_F(CloudInitIso, getInstanceIdFromCloudInit)
 
     EXPECT_EQ(MP_CLOUD_INIT_FILE_OPS.get_instance_id_from_cloud_init(iso_path.toStdString()), "vm1");
 }
-
-TEST_F(CloudInitIso, writeInstanceIdToCloudInit)
-{
-    mp::CloudInitIso original_iso;
-    original_iso.add_file("meta-data", std::string(meta_data_content));
-    original_iso.write_to(iso_path);
-
-    MP_CLOUD_INIT_FILE_OPS.write_instance_id_to_cloud_init("vm2", iso_path.toStdString());
-    mp::CloudInitIso new_iso;
-    new_iso.read_from(iso_path.toStdString());
-
-    constexpr std::string_view expected_modified_meta_data_content = R"(#cloud-config
-instance-id: vm2
-local-hostname: vm1
-cloud-name: multipass
-)";
-    EXPECT_EQ(new_iso.at("meta-data"), expected_modified_meta_data_content);
-}

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -378,10 +378,9 @@ TEST_F(CloudInitIso, updateCloudInitWithNewNonEmptyExtraInterfaces)
 
     // extra new line due to emit_cloud_config appending /n
     constexpr std::string_view expected_modified_meta_data_content = R"(#cloud-config
-instance-id: vm1_e
+instance-id: vm1
 local-hostname: vm1
-cloud-name: multipass
-)";
+cloud-name: multipass)";
     constexpr std::string_view expected_generated_network_config_data_content = R"(#cloud-config
 version: 2
 ethernets:

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -2257,7 +2257,6 @@ TEST_F(Daemon, add_bridged_interface_works)
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(1);
     EXPECT_CALL(*instance_ptr, add_network_interface(0, _, _)).Times(1);
-    EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(1);
 
     EXPECT_NO_THROW(daemon.test_add_bridged_interface(instance_name, instance_ptr));
 }

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -2256,7 +2256,7 @@ TEST_F(Daemon, add_bridged_interface_works)
     std::vector<mp::NetworkInterfaceInfo> net_info{{"eth8", "Ethernet", "A network adapter", {}, false}};
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(1);
-    EXPECT_CALL(*instance_ptr, add_network_interface(0, _)).Times(1);
+    EXPECT_CALL(*instance_ptr, add_network_interface(0, _, _)).Times(1);
     EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(1);
 
     EXPECT_NO_THROW(daemon.test_add_bridged_interface(instance_name, instance_ptr));
@@ -2277,7 +2277,7 @@ TEST_F(Daemon, add_bridged_interface_throws_if_backend_throws)
     std::vector<mp::NetworkInterfaceInfo> net_info{{"eth8", "Ethernet", "A network adapter", {}, false}};
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(1);
-    EXPECT_CALL(*instance_ptr, add_network_interface(0, _)).WillOnce(Throw(std::runtime_error("something bad")));
+    EXPECT_CALL(*instance_ptr, add_network_interface(0, _, _)).WillOnce(Throw(std::runtime_error("something bad")));
     EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{"Cannot update instance settings; instance: " + instance_name + "; reason: Failure to bridge eth8"};
@@ -2297,7 +2297,7 @@ TEST_F(Daemon, add_bridged_interface_throws_on_bad_bridged_network_setting)
     std::vector<mp::NetworkInterfaceInfo> net_info{{"eth9", "Ethernet", "An invalid network adapter", {}, false}};
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(0);
-    EXPECT_CALL(*instance_ptr, add_network_interface(_, _)).Times(0);
+    EXPECT_CALL(*instance_ptr, add_network_interface(_, _, _)).Times(0);
     EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{"Invalid network 'eth8' set as bridged interface, use `multipass set local.bridged-network=<name>` "
@@ -2318,7 +2318,7 @@ TEST_F(Daemon, add_bridged_interface_throws_if_needs_authorization)
     std::vector<mp::NetworkInterfaceInfo> net_info{{"eth8", "Ethernet", "A network adapter", {}, true}};
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(0);
-    EXPECT_CALL(*instance_ptr, add_network_interface(_, _)).Times(0);
+    EXPECT_CALL(*instance_ptr, add_network_interface(_, _, _)).Times(0);
     EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -2277,7 +2277,6 @@ TEST_F(Daemon, add_bridged_interface_throws_if_backend_throws)
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(1);
     EXPECT_CALL(*instance_ptr, add_network_interface(0, _, _)).WillOnce(Throw(std::runtime_error("something bad")));
-    EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{"Cannot update instance settings; instance: " + instance_name + "; reason: Failure to bridge eth8"};
     MP_EXPECT_THROW_THAT(daemon.test_add_bridged_interface(instance_name, instance_ptr),
@@ -2297,7 +2296,6 @@ TEST_F(Daemon, add_bridged_interface_throws_on_bad_bridged_network_setting)
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(0);
     EXPECT_CALL(*instance_ptr, add_network_interface(_, _, _)).Times(0);
-    EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{"Invalid network 'eth8' set as bridged interface, use `multipass set local.bridged-network=<name>` "
                     "to correct. See `multipass networks` for valid names."};
@@ -2318,7 +2316,6 @@ TEST_F(Daemon, add_bridged_interface_throws_if_needs_authorization)
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(net_info));
     EXPECT_CALL(*mock_factory, prepare_networking).Times(0);
     EXPECT_CALL(*instance_ptr, add_network_interface(_, _, _)).Times(0);
-    EXPECT_CALL(*instance_ptr, apply_extra_interfaces_to_cloud_init(_, _)).Times(0);
 
     std::string msg{
         "Cannot update instance settings; instance: glass-elevator; reason: Need user authorization to bridge eth8"};

--- a/tests/test_daemon_start.cpp
+++ b/tests/test_daemon_start.cpp
@@ -102,7 +102,7 @@ TEST_F(TestDaemonStart, exitlessSshProcessExceptionDoesNotShowMessage)
     EXPECT_CALL(*instance_ptr, current_state()).WillRepeatedly(Return(mp::VirtualMachine::State::off));
     EXPECT_CALL(*instance_ptr, start()).Times(1);
     // New networks configuration was moved to the instance settings handler, add_network_interface mustn't be called.
-    EXPECT_CALL(*instance_ptr, add_network_interface(_, _)).Times(0);
+    EXPECT_CALL(*instance_ptr, add_network_interface(_, _, _)).Times(0);
 
     config_builder.data_directory = temp_dir->path();
     config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();

--- a/tests/test_yaml_node_utils.cpp
+++ b/tests/test_yaml_node_utils.cpp
@@ -15,6 +15,7 @@
  *
  */
 
+#include <multipass/network_interface.h>
 #include <multipass/yaml_node_utils.h>
 
 #include <gtest/gtest.h>
@@ -40,4 +41,81 @@ cloud-name: multipass)";
     EXPECT_EQ(meta_data_node["instance-id"].as<std::string>(), "vm1");
     EXPECT_EQ(meta_data_node["local-hostname"].as<std::string>(), "vm1");
     EXPECT_EQ(meta_data_node["cloud-name"].as<std::string>(), "multipass");
+}
+
+TEST(UtilsTests, addOneExtraInterfaceNonEmptyNetworkFileContent)
+{
+    constexpr std::string_view original_network_config_file_content = R"(#cloud-config
+version: 2
+ethernets:
+  default:
+    match:
+      macaddress: "52:54:00:51:84:0c"
+    dhcp4: true
+  extra0:
+    match:
+      macaddress: "52:54:00:d8:12:9b"
+    dhcp4: true
+    dhcp4-overrides:
+      route-metric: 200
+    optional: true)";
+
+    constexpr std::string_view expected_new_network_config_file_content = R"(#cloud-config
+version: 2
+ethernets:
+  default:
+    match:
+      macaddress: "52:54:00:51:84:0c"
+    dhcp4: true
+  extra0:
+    match:
+      macaddress: "52:54:00:d8:12:9b"
+    dhcp4: true
+    dhcp4-overrides:
+      route-metric: 200
+    optional: true
+  extra1:
+    match:
+      macaddress: "52:54:00:d8:12:9c"
+    dhcp4: true
+    dhcp4-overrides:
+      route-metric: 200
+    optional: true
+)";
+
+    const mp::NetworkInterface extra_interface{"id", "52:54:00:d8:12:9c", true};
+    const std::string& default_mac_addr = "52:54:00:56:78:90";
+
+    const auto new_network_node =
+        mpu::add_extra_interface_to_network_config(default_mac_addr,
+                                                   extra_interface,
+                                                   std::string(original_network_config_file_content));
+
+    EXPECT_EQ(mpu::emit_cloud_config(new_network_node), expected_new_network_config_file_content);
+}
+
+TEST(UtilsTests, addOneExtraInterfaceEmptyNetworkFileContent)
+{
+    constexpr std::string_view expected_new_network_config_file_content = R"(#cloud-config
+version: 2
+ethernets:
+  default:
+    match:
+      macaddress: "52:54:00:56:78:90"
+    dhcp4: true
+  extra0:
+    match:
+      macaddress: "52:54:00:d8:12:9c"
+    dhcp4: true
+    dhcp4-overrides:
+      route-metric: 200
+    optional: true
+)";
+
+    const mp::NetworkInterface extra_interface{"id", "52:54:00:d8:12:9c", true};
+    const std::string default_mac_addr = "52:54:00:56:78:90";
+
+    const auto new_network_node = mpu::add_extra_interface_to_network_config(default_mac_addr, extra_interface, "");
+
+    EXPECT_EQ(mpu::emit_cloud_config(new_network_node), expected_new_network_config_file_content);
 }

--- a/tests/test_yaml_node_utils.cpp
+++ b/tests/test_yaml_node_utils.cpp
@@ -126,3 +126,30 @@ TEST(UtilsTests, addOneExtraInterfaceFalseExtraInterface)
     const auto new_network_node = mpu::add_extra_interface_to_network_config("", extra_interface, "");
     EXPECT_TRUE(new_network_node.IsNull());
 }
+
+TEST(UtilsTests, makeCloudInitMetaConfigWithIdTweakGeneratedId)
+{
+    constexpr std::string_view meta_data_content = R"(#cloud-config
+instance-id: vm1
+local-hostname: vm1
+cloud-name: multipass)";
+
+    const YAML::Node meta_data_node = mpu::make_cloud_init_meta_config_with_id_tweak(std::string{meta_data_content});
+    EXPECT_EQ(meta_data_node["instance-id"].as<std::string>(), "vm1_e");
+    EXPECT_EQ(meta_data_node["local-hostname"].as<std::string>(), "vm1");
+    EXPECT_EQ(meta_data_node["cloud-name"].as<std::string>(), "multipass");
+}
+
+TEST(UtilsTests, makeCloudInitMetaConfigWithIdTweakNewId)
+{
+    constexpr std::string_view meta_data_content = R"(#cloud-config
+instance-id: vm1
+local-hostname: vm1
+cloud-name: multipass)";
+
+    const YAML::Node meta_data_node =
+        mpu::make_cloud_init_meta_config_with_id_tweak(std::string{meta_data_content}, "vm2");
+    EXPECT_EQ(meta_data_node["instance-id"].as<std::string>(), "vm2");
+    EXPECT_EQ(meta_data_node["local-hostname"].as<std::string>(), "vm1");
+    EXPECT_EQ(meta_data_node["cloud-name"].as<std::string>(), "multipass");
+}

--- a/tests/test_yaml_node_utils.cpp
+++ b/tests/test_yaml_node_utils.cpp
@@ -84,7 +84,7 @@ ethernets:
 )";
 
     const mp::NetworkInterface extra_interface{"id", "52:54:00:d8:12:9c", true};
-    const std::string& default_mac_addr = "52:54:00:56:78:90";
+    const std::string default_mac_addr = "52:54:00:56:78:90";
 
     const auto new_network_node =
         mpu::add_extra_interface_to_network_config(default_mac_addr,

--- a/tests/test_yaml_node_utils.cpp
+++ b/tests/test_yaml_node_utils.cpp
@@ -119,3 +119,10 @@ ethernets:
 
     EXPECT_EQ(mpu::emit_cloud_config(new_network_node), expected_new_network_config_file_content);
 }
+
+TEST(UtilsTests, addOneExtraInterfaceFalseExtraInterface)
+{
+    const mp::NetworkInterface extra_interface{"id", "52:54:00:d8:12:9c", false};
+    const auto new_network_node = mpu::add_extra_interface_to_network_config("", extra_interface, "");
+    EXPECT_TRUE(new_network_node.IsNull());
+}


### PR DESCRIPTION
A few things are done in this PR. 
1. Removed `make_cloud_init_meta_config` and `make_cloud_init_network_config` in daemon.cpp which is the rebase fix forgotten to apply before. 
2. Made all the cloudinit free functions into singleton and established the unit test mocking framework for that. 
3. Toggle instance-id scheme was changed back to the simple appending "_e" since `snapshot_restore` will restore the instance-id so we will not have the long appending "_e" chain. 
4. Added `add_extra_interface_to_cloud_init` utility function into `CloudInitFileOps`, so it can be used by `base_virtual_machine::add_network_interface` and be mocked easily. 
5. `apply_extra_interfaces_to_cloud_init` function lxd part was removed for now because this utility function is only used in `restore_snapshot` and lxd does not support that yet. 
6. `apply_extra_interfaces_to_cloud_init` call from daemon is removed and each backend `add_network_interface` implementation is appended with a `add_extra_interface_to_instance_cloud_init` call. 
7. At last and the most important, the tracking instance id code in `basesnapshot` is added, including data member and `get_instance_id` function. 