### PR TITLE
[actions] Continue on Coverage build errors

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -178,6 +178,7 @@ jobs:
 
     - name: Measure coverage
       if: ${{ matrix.build-type == 'Coverage' }}
+      id: measure-coverage
       continue-on-error: true
       timeout-minutes: 5
       run: |
@@ -204,6 +205,13 @@ jobs:
           env CTEST_OUTPUT_ON_FAILURE=1 \
             cmake --build /root/parts/multipass/build --target covreport
         bash <(curl -s https://codecov.io/bash) -Z -s ${{ steps.coverage-setup.outputs.build }}
+
+    - name: Continue on Error comment
+      uses: mainmatter/continue-on-error-comment@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        outcome: ${{ steps.measure-coverage.outcome }}
+        test-id: Error with measuring coverage in ${{ matrix.build-type }} build
 
     - name: Build and verify the snap
       id: build-snap

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -178,6 +178,7 @@ jobs:
 
     - name: Measure coverage
       if: ${{ matrix.build-type == 'Coverage' }}
+      continue-on-error: true
       timeout-minutes: 5
       run: |
         instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`


### PR DESCRIPTION
This will help allow builds to continue while the issue of tokenless uploads to Codecov is worked out.

See https://github.com/codecov/codecov-action/issues/1359 for more details.