### PR TITLE
[snap] Add curl build dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -135,6 +135,7 @@ parts:
     - qt6-base-dev-tools
     - zip
     - unzip
+    - curl
     stage-packages:
     - apparmor
     - libpng16-16


### PR DESCRIPTION
This is needed for vcpkg support and the Launchpad builders don't have it installed by default.

Fixes #3480