### PR TITLE
Retry on download failure

### DIFF
--- a/include/multipass/async_periodic_download_task.h
+++ b/include/multipass/async_periodic_download_task.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef MULTIPASS_ASYNC_PERIODIC_TASK_H
-#define MULTIPASS_ASYNC_PERIODIC_TASK_H
+#ifndef MULTIPASS_ASYNC_PERIODIC_DOWNLOAD_TASK_H
+#define MULTIPASS_ASYNC_PERIODIC_DOWNLOAD_TASK_H
 
 #include <multipass/exceptions/download_exception.h>
 #include <multipass/logging/log.h>
@@ -125,4 +125,4 @@ private:
 };
 } // namespace multipass::utils
 
-#endif // MULTIPASS_TIMER_H
+#endif

--- a/include/multipass/async_periodic_task.h
+++ b/include/multipass/async_periodic_task.h
@@ -31,31 +31,31 @@ namespace mpl = multipass::logging;
 
 namespace multipass::utils
 {
-// Because AsyncPeriodicTask needs to be instantiated as data member of a class to function properly, and Class template
-// argument deduction (CTAD) does not work for data member, so that means we can not deduced type data member from the
-// below code snippet.
+// Because AsyncPeriodicDownloadTask needs to be instantiated as data member of a class to function properly, and Class
+// template argument deduction (CTAD) does not work for data member, so that means we can not deduced type data member
+// from the below code snippet.
 
 // template <typename Callable, typename...Args>
-// class AsyncPeriodicTask
+// class AsyncPeriodicDownloadTask
 // {
 // public:
 //     using ReturnType = std::invoke_result_t<std::decay_t<Callable>, std::decay_t<Args>...>;
-//     AsyncPeriodicTask(Callable&& func, Args&&... args);
+//     AsyncPeriodicDownloadTask(Callable&& func, Args&&... args);
 //     ...
 // };
 
 // Therefore, the user has to specify the ReturnType as template argument while constructing it.
 
 template <typename ReturnType = void>
-class AsyncPeriodicTask
+class AsyncPeriodicDownloadTask
 {
 public:
     template <typename Callable, typename... Args>
-    AsyncPeriodicTask(std::string_view launch_msg,
-                      std::chrono::milliseconds normal_delay_time,
-                      std::chrono::milliseconds retry_start_delay_time,
-                      Callable&& func,
-                      Args&&... args)
+    AsyncPeriodicDownloadTask(std::string_view launch_msg,
+                              std::chrono::milliseconds normal_delay_time,
+                              std::chrono::milliseconds retry_start_delay_time,
+                              Callable&& func,
+                              Args&&... args)
         : default_delay_time{normal_delay_time}, retry_current_delay_time{retry_start_delay_time}
     {
         // Log in a side thread will cause some unit tests (like launch_warns_when_overcommitting_disk) to have data

--- a/include/multipass/async_periodic_task.h
+++ b/include/multipass/async_periodic_task.h
@@ -18,7 +18,7 @@
 #ifndef MULTIPASS_ASYNC_PERIODIC_TASK_H
 #define MULTIPASS_ASYNC_PERIODIC_TASK_H
 
-#include <fmt/format.h>
+#include <multipass/exceptions/download_exception.h>
 #include <multipass/logging/log.h>
 
 #include <chrono>
@@ -78,9 +78,7 @@ public:
                 timer.start(default_delay_time);
                 retry_current_delay_time = retry_start_delay_time;
             }
-            catch (const std::exception& e) // note that a more specific exception like
-                                            // multipass::DownloadException or std::runtime_error will make us catch
-                                            // nothing because Qt internally transformed that.
+            catch (const multipass::DownloadException& e)
             {
                 mpl::log(mpl::Level::info,
                          "async task",

--- a/include/multipass/async_periodic_task.h
+++ b/include/multipass/async_periodic_task.h
@@ -73,7 +73,6 @@ public:
             {
                 // rethrow exception
                 future.waitForFinished();
-                mpl::log(mpl::Level::debug, "async task", "The download succeeded.");
                 // success case, we reset the time interval for timer and the reset the retry delay time value
                 timer.start(default_delay_time);
                 retry_current_delay_time = retry_start_delay_time;

--- a/include/multipass/exceptions/aborted_download_exception.h
+++ b/include/multipass/exceptions/aborted_download_exception.h
@@ -18,34 +18,14 @@
 #ifndef MULTIPASS_ABORTED_DOWNLOAD_EXCEPTION
 #define MULTIPASS_ABORTED_DOWNLOAD_EXCEPTION
 
-#include <QException>
-
-#include <string>
+#include "base_qexception.h"
 
 namespace multipass
 {
-class AbortedDownloadException : public QException
+class AbortedDownloadException : public BaseQException<AbortedDownloadException>
 {
 public:
-    AbortedDownloadException(const std::string& err) : error_string{err}
-    {
-    }
-
-    void raise() const override
-    {
-        throw *this;
-    }
-    AbortedDownloadException* clone() const override
-    {
-        return new AbortedDownloadException(*this);
-    }
-    const char* what() const noexcept override
-    {
-        return error_string.c_str();
-    }
-
-private:
-    std::string error_string;
+    using BaseQException::BaseQException;
 };
 } // namespace multipass
 #endif // MULTIPASS_ABORTED_DOWNLOAD_EXCEPTION

--- a/include/multipass/exceptions/aborted_download_exception.h
+++ b/include/multipass/exceptions/aborted_download_exception.h
@@ -22,7 +22,7 @@
 
 namespace multipass
 {
-class AbortedDownloadException : public BaseQException<AbortedDownloadException>
+class AbortedDownloadException final : public BaseQException<AbortedDownloadException>
 {
 public:
     using BaseQException::BaseQException;

--- a/include/multipass/exceptions/base_qexception.h
+++ b/include/multipass/exceptions/base_qexception.h
@@ -25,7 +25,7 @@
 namespace multipass
 {
 // CRTP template base class that is the boilerplate code of QException derived classes
-// The usage of it should be CRTP derive class, that is inheriting the base calass and label itself final.
+// Derived classes should either be final or be themselves templated with the ultimate leaf type.
 template <typename DerivedException>
 class BaseQException : public QException
 {

--- a/include/multipass/exceptions/base_qexception.h
+++ b/include/multipass/exceptions/base_qexception.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_BASE_QEXCEPTION
+#define MULTIPASS_BASE_QEXCEPTION
+
+#include <QException>
+
+#include <string>
+
+namespace multipass
+{
+// CRTP template base class that is the boilerplate code of QException derived classes
+template <typename DerivedException>
+class BaseQException : public QException
+{
+public:
+    BaseQException(const std::string& err) : error_string{err}
+    {
+        // use concepts instead of static_assert or enable_if to apply the contraint once C++ 20 arrives.
+        static_assert(std::is_base_of_v<BaseQException, DerivedException>,
+                      "DerivedException must be derived from BaseQException");
+    }
+
+    void raise() const override
+    {
+        throw static_cast<const DerivedException&>(*this);
+    }
+
+    BaseQException* clone() const override
+    {
+        return new DerivedException(static_cast<const DerivedException&>(*this));
+    }
+
+    const char* what() const noexcept override
+    {
+        return error_string.c_str();
+    }
+
+private:
+    std::string error_string;
+};
+} // namespace multipass
+#endif // MULTIPASS_BASE_QEXCEPTION

--- a/include/multipass/exceptions/base_qexception.h
+++ b/include/multipass/exceptions/base_qexception.h
@@ -32,13 +32,13 @@ class BaseQException : public QException
 public:
     BaseQException(const std::string& err) : error_string{err}
     {
-        // use concepts instead of static_assert to apply the contraint once C++ 20 arrives.
+        // TODO@C++20, use concepts instead of static_assert + type traits to apply the constraint.
         static_assert(std::is_base_of_v<BaseQException, DerivedException>,
                       "DerivedException must be derived from BaseQException");
     }
 
-    // use explicit object parameters once we have C++23, see
-    // https://devblogs.microsoft.com/cppblog/cpp23-deducing-this/ for details
+    // TODO@C++23, use explicit object parameters instead of static_cast conversion to derive class, see
+    // https://devblogs.microsoft.com/cppblog/cpp23-deducing-this/ for more details
     void raise() const override
     {
         throw static_cast<const DerivedException&>(*this);

--- a/include/multipass/exceptions/base_qexception.h
+++ b/include/multipass/exceptions/base_qexception.h
@@ -37,6 +37,8 @@ public:
                       "DerivedException must be derived from BaseQException");
     }
 
+    // use explicit object parameters once we have C++23, see
+    // https://devblogs.microsoft.com/cppblog/cpp23-deducing-this/ for details
     void raise() const override
     {
         throw static_cast<const DerivedException&>(*this);

--- a/include/multipass/exceptions/base_qexception.h
+++ b/include/multipass/exceptions/base_qexception.h
@@ -25,13 +25,14 @@
 namespace multipass
 {
 // CRTP template base class that is the boilerplate code of QException derived classes
+// The usage of it should be CRTP derive class, that is inheriting the base calass and label itself final.
 template <typename DerivedException>
 class BaseQException : public QException
 {
 public:
     BaseQException(const std::string& err) : error_string{err}
     {
-        // use concepts instead of static_assert or enable_if to apply the contraint once C++ 20 arrives.
+        // use concepts instead of static_assert to apply the contraint once C++ 20 arrives.
         static_assert(std::is_base_of_v<BaseQException, DerivedException>,
                       "DerivedException must be derived from BaseQException");
     }

--- a/include/multipass/exceptions/create_image_exception.h
+++ b/include/multipass/exceptions/create_image_exception.h
@@ -22,7 +22,7 @@
 
 namespace multipass
 {
-class CreateImageException : public BaseQException<CreateImageException>
+class CreateImageException final : public BaseQException<CreateImageException>
 {
 public:
     using BaseQException::BaseQException;

--- a/include/multipass/exceptions/create_image_exception.h
+++ b/include/multipass/exceptions/create_image_exception.h
@@ -18,34 +18,14 @@
 #ifndef MULTIPASS_CREATE_IMAGE_EXCEPTION
 #define MULTIPASS_CREATE_IMAGE_EXCEPTION
 
-#include <QException>
-
-#include <string>
+#include "base_qexception.h"
 
 namespace multipass
 {
-class CreateImageException : public QException
+class CreateImageException : public BaseQException<CreateImageException>
 {
 public:
-    CreateImageException(const std::string& err) : error_string{err}
-    {
-    }
-
-    void raise() const override
-    {
-        throw *this;
-    }
-    CreateImageException* clone() const override
-    {
-        return new CreateImageException(*this);
-    }
-    const char* what() const noexcept override
-    {
-        return error_string.c_str();
-    }
-
-private:
-    std::string error_string;
+    using BaseQException::BaseQException;
 };
 } // namespace multipass
 #endif // MULTIPASS_CREATE_IMAGE_EXCEPTION

--- a/include/multipass/exceptions/download_exception.h
+++ b/include/multipass/exceptions/download_exception.h
@@ -20,33 +20,17 @@
 
 #include <fmt/format.h>
 
-#include <QException>
-#include <string>
+#include "base_qexception.h"
 
 namespace multipass
 {
-class DownloadException : public QException
+class DownloadException : public BaseQException<DownloadException>
 {
 public:
     DownloadException(const std::string& url, const std::string& cause)
-        : error_string{fmt::format("failed to download from '{}': {}", url, cause)}
+        : BaseQException{fmt::format("failed to download from '{}': {}", url, cause)}
     {
     }
-    void raise() const override
-    {
-        throw *this;
-    }
-    DownloadException* clone() const override
-    {
-        return new DownloadException(*this);
-    }
-    const char* what() const noexcept override
-    {
-        return error_string.c_str();
-    }
-
-private:
-    std::string error_string;
 };
 } // namespace multipass
 #endif // MULTIPASS_DOWNLOAD_H

--- a/include/multipass/exceptions/download_exception.h
+++ b/include/multipass/exceptions/download_exception.h
@@ -24,7 +24,7 @@
 
 namespace multipass
 {
-class DownloadException : public BaseQException<DownloadException>
+class DownloadException final : public BaseQException<DownloadException>
 {
 public:
     DownloadException(const std::string& url, const std::string& cause)

--- a/include/multipass/exceptions/download_exception.h
+++ b/include/multipass/exceptions/download_exception.h
@@ -20,18 +20,33 @@
 
 #include <fmt/format.h>
 
-#include <stdexcept>
+#include <QException>
 #include <string>
 
 namespace multipass
 {
-class DownloadException : public std::runtime_error
+class DownloadException : public QException
 {
 public:
     DownloadException(const std::string& url, const std::string& cause)
-        : runtime_error(fmt::format("failed to download from '{}': {}", url, cause))
+        : error_string{fmt::format("failed to download from '{}': {}", url, cause)}
     {
     }
+    void raise() const override
+    {
+        throw *this;
+    }
+    DownloadException* clone() const override
+    {
+        return new DownloadException(*this);
+    }
+    const char* what() const noexcept override
+    {
+        return error_string.c_str();
+    }
+
+private:
+    std::string error_string;
 };
 } // namespace multipass
 #endif // MULTIPASS_DOWNLOAD_H

--- a/src/daemon/custom_image_host.cpp
+++ b/src/daemon/custom_image_host.cpp
@@ -237,11 +237,7 @@ void mp::CustomVMImageHost::fetch_manifests(const bool is_force_update_from_netw
         }
         catch (mp::DownloadException& e)
         {
-            if (is_force_update_from_network)
-            {
-                throw e;
-            }
-            on_manifest_update_failure(e.what());
+            throw e;
         }
         catch (const mp::UnsupportedRemoteException&)
         {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3425,33 +3425,7 @@ void mp::Daemon::update_manifests_all(const bool is_force_update_from_network)
         [is_force_update_from_network](const std::unique_ptr<VMImageHost>& vm_image_host_ptr) -> void {
         vm_image_host_ptr->update_manifests(is_force_update_from_network);
     };
-
-    if (is_force_update_from_network)
-    {
-        utils::parallel_for_each(config->image_hosts, launch_update_manifests_from_vm_image_host);
-    }
-    else
-    {
-        const std::chrono::seconds max_delay_s = 20s; // 20 seconds maximum delay
-        std::chrono::seconds delay = 5s;              // 5 secondes initial delay
-        while (true)
-        {
-            try
-            {
-                utils::parallel_for_each(config->image_hosts, launch_update_manifests_from_vm_image_host);
-                return;
-            }
-            catch (const mp::DownloadException& e)
-            {
-                mpl::log(
-                    mpl::Level::warning,
-                    "daemon",
-                    fmt::format("Download attempt failed: {}, try it again in {} seconds", e.what(), delay.count()));
-                std::this_thread::sleep_for(delay);
-                delay = std::min(2 * delay, max_delay_s);
-            }
-        }
-    }
+    utils::parallel_for_each(config->image_hosts, launch_update_manifests_from_vm_image_host);
 }
 
 void mp::Daemon::wait_update_manifests_all_and_optionally_applied_force(const bool force_manifest_network_download)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3425,6 +3425,7 @@ void mp::Daemon::update_manifests_all(const bool is_force_update_from_network)
         [is_force_update_from_network](const std::unique_ptr<VMImageHost>& vm_image_host_ptr) -> void {
         vm_image_host_ptr->update_manifests(is_force_update_from_network);
     };
+
     utils::parallel_for_each(config->image_hosts, launch_update_manifests_from_vm_image_host);
 }
 
@@ -3433,8 +3434,10 @@ void mp::Daemon::wait_update_manifests_all_and_optionally_applied_force(const bo
     update_manifests_all_task.wait_ongoing_task_finish();
     if (force_manifest_network_download)
     {
+        update_manifests_all_task.stop_timer();
         mpl::log(mpl::Level::debug, "async task", "fetch manifest from the internet");
         update_manifests_all(true);
+        update_manifests_all_task.start_timer();
     }
 }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3432,10 +3432,8 @@ void mp::Daemon::update_manifests_all(const bool is_force_update_from_network)
     }
     else
     {
-        int initial_delay_s = 5; // 5 secondes initial delay
-        // int max_delay_ms = 900000; // 15 minutes maximum delay
-        int max_delay_s = 20; // 20 seconds maximum delay
-        int delay = initial_delay_s;
+        const std::chrono::seconds max_delay_s = 20s; // 20 seconds maximum delay
+        std::chrono::seconds delay = 5s;              // 5 secondes initial delay
         while (true)
         {
             try
@@ -3445,10 +3443,11 @@ void mp::Daemon::update_manifests_all(const bool is_force_update_from_network)
             }
             catch (const mp::DownloadException& e)
             {
-                mpl::log(mpl::Level::warning,
-                         "daemon",
-                         fmt::format("Download attempt failed: {}, try it again in {} seconds", e.what(), delay));
-                std::this_thread::sleep_for(std::chrono::seconds{delay});
+                mpl::log(
+                    mpl::Level::warning,
+                    "daemon",
+                    fmt::format("Download attempt failed: {}, try it again in {} seconds", e.what(), delay.count()));
+                std::this_thread::sleep_for(delay);
                 delay = std::min(2 * delay, max_delay_s);
             }
         }
@@ -3460,10 +3459,8 @@ void mp::Daemon::wait_update_manifests_all_and_optionally_applied_force(const bo
     update_manifests_all_task.wait_ongoing_task_finish();
     if (force_manifest_network_download)
     {
-        update_manifests_all_task.stop_timer();
         mpl::log(mpl::Level::debug, "async task", "fetch manifest from the internet");
         update_manifests_all(true);
-        update_manifests_all_task.start_timer();
     }
 }
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -218,12 +218,12 @@ private:
     std::unordered_set<std::string> allocated_mac_addrs;
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
-    multipass::utils::AsyncPeriodicTask<void> update_manifests_all_task{"fetch manifest periodically",
-                                                                        std::chrono::minutes(15),
-                                                                        std::chrono::seconds(5),
-                                                                        &Daemon::update_manifests_all,
-                                                                        this,
-                                                                        false};
+    multipass::utils::AsyncPeriodicDownloadTask<void> update_manifests_all_task{"fetch manifest periodically",
+                                                                                std::chrono::minutes(15),
+                                                                                std::chrono::seconds(5),
+                                                                                &Daemon::update_manifests_all,
+                                                                                this,
+                                                                                false};
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -218,8 +218,12 @@ private:
     std::unordered_set<std::string> allocated_mac_addrs;
     DaemonRpc daemon_rpc;
     QTimer source_images_maintenance_task;
-    multipass::utils::AsyncPeriodicTask<void> update_manifests_all_task{
-        "fetch manifest periodically", std::chrono::minutes(15), &Daemon::update_manifests_all, this, false};
+    multipass::utils::AsyncPeriodicTask<void> update_manifests_all_task{"fetch manifest periodically",
+                                                                        std::chrono::minutes(15),
+                                                                        std::chrono::seconds(5),
+                                                                        &Daemon::update_manifests_all,
+                                                                        this,
+                                                                        false};
     std::unordered_map<std::string, std::unique_ptr<QFutureWatcher<AsyncOperationStatus>>> async_future_watchers;
     std::unordered_map<std::string, QFuture<std::string>> async_running_futures;
     std::mutex start_mutex;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -21,7 +21,7 @@
 #include "daemon_config.h"
 #include "daemon_rpc.h"
 
-#include <multipass/async_periodic_task.h>
+#include <multipass/async_periodic_download_task.h>
 #include <multipass/delayed_shutdown_timer.h>
 #include <multipass/format.h>
 #include <multipass/mount_handler.h>

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -269,11 +269,7 @@ void mp::UbuntuVMImageHost::fetch_manifests(const bool is_force_update_from_netw
         }
         catch (mp::DownloadException& e)
         {
-            if (is_force_update_from_network)
-            {
-                throw e;
-            }
-            on_manifest_update_failure(e.what());
+            throw e;
         }
         catch (const mp::UnsupportedRemoteException&)
         {

--- a/tests/test_custom_image_host.cpp
+++ b/tests/test_custom_image_host.cpp
@@ -241,7 +241,7 @@ TEST_F(CustomImageHost, handles_and_recovers_from_initial_network_failure)
     mp::CustomVMImageHost host{"x86_64", &mock_url_downloader};
 
     const auto query = make_query("core20", "");
-    host.update_manifests(false);
+    EXPECT_THROW(host.update_manifests(false), mp::DownloadException);
     EXPECT_THROW(host.info_for(query), std::runtime_error);
 
     host.update_manifests(false);
@@ -259,8 +259,7 @@ TEST_F(CustomImageHost, handles_and_recovers_from_later_network_failure)
     EXPECT_CALL(mock_url_downloader, last_modified(_))
         .WillOnce(Throw(mp::DownloadException{"", ""}))
         .WillRepeatedly(DoDefault());
-
-    host.update_manifests(false);
+    EXPECT_THROW(host.update_manifests(false), mp::DownloadException);
     EXPECT_THROW(host.info_for(query), std::runtime_error);
 
     host.update_manifests(false);

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -265,7 +265,7 @@ TEST_F(DaemonFind, findWithoutForceUpdateCheckUpdateManifestsCall)
     send_command({"find"});
 }
 
-TEST_F(DaemonFind, UpdateManifestsThrowTriggersTheFailedCaseEventHanlderOfAsyncPeriodicTask)
+TEST_F(DaemonFind, UpdateManifestsThrowTriggersTheFailedCaseEventHanlderOfAsyncPeriodicDownloadTask)
 {
     auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
 

--- a/tests/test_daemon_find.cpp
+++ b/tests/test_daemon_find.cpp
@@ -26,6 +26,7 @@
 #include <src/daemon/daemon.h>
 
 #include <multipass/constants.h>
+#include <multipass/exceptions/download_exception.h>
 #include <multipass/format.h>
 
 namespace mp = multipass;
@@ -261,6 +262,24 @@ TEST_F(DaemonFind, findWithoutForceUpdateCheckUpdateManifestsCall)
     config_builder.image_hosts[0] = std::move(mock_image_host);
     const mp::Daemon daemon{config_builder.build()};
 
+    send_command({"find"});
+}
+
+TEST_F(DaemonFind, UpdateManifestsThrowTriggersTheFailedCaseEventHanlderOfAsyncPeriodicTask)
+{
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+
+    // daemon constructor which constructs update_manifests_all_task calls this.
+    EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1).WillOnce([]() {
+        throw mp::DownloadException{"dummy_url", "dummy_cause"};
+    });
+
+    // overwrite the default emplaced StubVMImageHost
+    config_builder.image_hosts[0] = std::move(mock_image_host);
+    const mp::Daemon daemon{config_builder.build()};
+
+    // need it because mp::Daemon destructor which destructs qfuture and qfuturewatcher does not wait the async task to
+    // finish. As a consquence, the event handler is not guaranteed to be called without send_command({"find"});
     send_command({"find"});
 }
 


### PR DESCRIPTION
fix #3464 

This PR adds [binary exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) based retry mechanism to async periodic download tasks, the checking exception (download failure an exception) in the main thread is done in a non-blocking fashion via `QFutureWatcher`. 

1. Changed `std::async` + `std::future` pair to `QtConcurrent::run` + `QFuture` in order to use some QFuture specific features.
2. Added  `QFutureWatcher` to watch `QFuture` and react correspondingly in the successful and failed cases when QFuture is finished. 
3. Changed `DownloadException` to a QException-based class so it can cross the qt thread boundary. 
4. Made the CRTP `BaseQException` class to reuse the boilerplate code for all the QException derived classes. 

To test the behavior, you can modify the default delay time in `daemon.h` line 222 to a small number, so the download will run more frequently. After that, the wifi network can be manually turned off in ubuntu settings, which in a way causes download failure. 