### PR TITLE
[snap] Use a more general approach for paths in gui part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -351,42 +351,42 @@ parts:
     plugin: nil
     source: ./src/client/gui
     stage-packages:
-      - libgdk-pixbuf2.0-bin
-      - libglib2.0-0
-      - libgtk-3-0
-      - libkeybinder-3.0-dev
+    - libgdk-pixbuf2.0-bin
+    - libglib2.0-0
+    - libgtk-3-0
+    - libkeybinder-3.0-dev
     build-packages:
-      - libkeybinder-3.0-dev
-      - build-essential
-      - clang
-      - ninja-build
-      - unzip
+    - libkeybinder-3.0-dev
+    - build-essential
+    - clang
+    - ninja-build
+    - unzip
     stage:
-      - -**/X11
-      - -usr/include
-      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libcolordprivate.so.*
-      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libdconf.so.*
-      - -usr/lib/*/libgirepository-1.0.so.*
-      - -usr/lib/*/libgthread-2.0.so*
-      - -usr/lib/*/libicuio.so.*
-      - -usr/lib/*/libicutest.so.*
-      - -usr/lib/*/libicutu.so.*
-      - -usr/share/apport
-      - -usr/share/bug
-      - -usr/share/*doc*
-      - -usr/share/gettext
-      - -usr/share/icons/Adwaita
-      - -usr/share/icons/DMZ-Black
-      - -usr/share/icons/Humanity*
-      - -usr/share/icons/LoginIcons
-      - -usr/share/icons/hicolor
-      - -usr/share/icons/ubuntu-*
-      - -usr/share/libthai
-      - -usr/share/lintian
-      - -usr/share/man
-      - -usr/share/mime
-      - -usr/share/pkgconfig
-      - -usr/share/thumbnailers
+    - -**/X11
+    - -usr/include
+    - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libcolordprivate.so.*
+    - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libdconf.so.*
+    - -usr/lib/*/libgirepository-1.0.so.*
+    - -usr/lib/*/libgthread-2.0.so*
+    - -usr/lib/*/libicuio.so.*
+    - -usr/lib/*/libicutest.so.*
+    - -usr/lib/*/libicutu.so.*
+    - -usr/share/apport
+    - -usr/share/bug
+    - -usr/share/*doc*
+    - -usr/share/gettext
+    - -usr/share/icons/Adwaita
+    - -usr/share/icons/DMZ-Black
+    - -usr/share/icons/Humanity*
+    - -usr/share/icons/LoginIcons
+    - -usr/share/icons/hicolor
+    - -usr/share/icons/ubuntu-*
+    - -usr/share/libthai
+    - -usr/share/lintian
+    - -usr/share/man
+    - -usr/share/mime
+    - -usr/share/pkgconfig
+    - -usr/share/thumbnailers
     override-build: |
       craftctl default
       export PATH="${CRAFT_PART_BUILD}/flutter-distro/bin:$HOME/.pub-cache/bin:$PATH"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -191,6 +191,8 @@ parts:
     - -usr/share/lintian
     - -usr/share/man
     - -usr/share/pkgconfig
+    prime:
+    - -protobuf
     source: .
     cmake-parameters:
     - -DCMAKE_BUILD_TYPE=Release
@@ -211,6 +213,13 @@ parts:
 
       cd ${CRAFT_PART_SRC}/3rd-party
       find . -name 'LICENSE*' -print0 | xargs -0 -I FILE install --mode=644 -D --no-target-directory FILE ${CRAFT_PART_INSTALL}/licenses/FILE
+
+      # Stage protoc and protobuf files for use in the gui part
+      PROTOBUF_INSTALL_DIR=${CRAFT_PART_INSTALL}/protobuf
+      mkdir -p ${PROTOBUF_INSTALL_DIR}/google/protobuf
+      cp -a ${CRAFT_PART_BUILD}/vcpkg_installed/*/tools/protobuf/protoc* ${PROTOBUF_INSTALL_DIR}
+      cp -a ${CRAFT_PART_BUILD}/vcpkg_installed/*/include/google ${PROTOBUF_INSTALL_DIR}
+      cp -a ${CRAFT_PART_SRC}/src/rpc/multipass.proto ${PROTOBUF_INSTALL_DIR}
 
   qemu:
     build-environment:
@@ -380,19 +389,18 @@ parts:
       - -usr/share/thumbnailers
     override-build: |
       craftctl default
-      export PATH="/root/parts/gui/build/flutter-distro/bin:$HOME/.pub-cache/bin:$PATH"
-      rm -rf /root/parts/gui/build/flutter-distro
-      git clone --depth 1 --branch 3.16.9 https://github.com/flutter/flutter.git /root/parts/gui/build/flutter-distro
+      export PATH="${CRAFT_PART_BUILD}/flutter-distro/bin:$HOME/.pub-cache/bin:$PATH"
+      rm -rf ${CRAFT_PART_BUILD}/flutter-distro
+      git clone --depth 1 --branch 3.16.9 https://github.com/flutter/flutter.git ${CRAFT_PART_BUILD}/flutter-distro
       flutter config --suppress-analytics --no-enable-web --enable-linux-desktop --no-enable-macos-desktop --no-enable-windows-desktop --no-enable-android --no-enable-ios --no-enable-fuchsia --no-enable-custom-devices
       flutter precache --linux
 
       dart pub global activate protoc_plugin
-      export MP_PROTO_FILE_DIR=$HOME/parts/multipass/src/src/rpc
 
+      PROTOBUF_DIR=${CRAFT_STAGE}/protobuf
       mkdir -p lib/generated
-      /root/parts/multipass/build/vcpkg_installed/x64-linux-release/tools/protobuf/protoc --dart_out=grpc:lib/generated -I $MP_PROTO_FILE_DIR -I /root/parts/multipass/build/_deps/grpc-src/third_party/protobuf/src $MP_PROTO_FILE_DIR/multipass.proto google/protobuf/timestamp.proto
+      ${PROTOBUF_DIR}/protoc --dart_out=grpc:lib/generated -I ${PROTOBUF_DIR} ${PROTOBUF_DIR}/multipass.proto ${PROTOBUF_DIR}/google/protobuf/timestamp.proto
 
       flutter pub get
       flutter build linux --release --verbose --target lib/main.dart
-    organize:
-      /root/parts/gui/build/build/linux/x64/release/bundle: bin/
+      cp -a ${CRAFT_PART_BUILD}/build/linux/*/release/bundle ${CRAFT_PART_INSTALL}/bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,8 +16,6 @@ base: core22
 architectures:
   - build-on: amd64
   - build-on: arm64
-  - build-on: ppc64el
-  - build-on: s390x
 
 layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu:


### PR DESCRIPTION
Paths in the gui part were hardcoded to the multipass part, but this breaks on Launchpad due to how snapcraft is invoked (--destructive-mode).