### PR TITLE
Fix `get local.instance.bridged`

### DIFF
--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -73,7 +73,6 @@ public:
     virtual std::vector<NetworkInterfaceInfo> networks() const = 0;
     virtual void require_snapshots_support() const = 0;
     virtual void require_suspend_support() const = 0;
-    virtual std::string bridge_name_for(const std::string& iface_name) const = 0;
 
     virtual std::vector<NetworkInterfaceInfo>::const_iterator
     find_bridge_with(const std::vector<NetworkInterfaceInfo>& networks, const std::string& member_network) const = 0;

--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -75,6 +75,9 @@ public:
     virtual void require_suspend_support() const = 0;
     virtual std::string bridge_name_for(const std::string& iface_name) const = 0;
 
+    virtual std::vector<NetworkInterfaceInfo>::const_iterator
+    find_bridge_with(const std::vector<NetworkInterfaceInfo>& networks, const std::string& member_network) const = 0;
+
 protected:
     VirtualMachineFactory() = default;
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3522,32 +3522,21 @@ bool mp::Daemon::is_bridged(const std::string& instance_name)
     const auto& br_interface = get_bridged_interface_name();
     const auto& host_nets = config->factory->networks();
 
-    // Return true if the bridged interface is already a bridge.
-    if (std::any_of(std::cbegin(host_nets),
-                    std::cend(host_nets),
-                    [&br_interface](const mp::NetworkInterfaceInfo& info) {
-                        return info.id == br_interface && info.type == "bridge";
-                    }))
-    {
-        return true;
-    }
-
     const auto& br_it = config->factory->find_bridge_with(host_nets, br_interface);
 
-    // Return false if there is no bridge containing br_interface.
+    // Return false if there is no bridge containing br_interface and br_interface is not a bridge itself. No need to
+    // check the specs.
     if (br_it == host_nets.cend())
     {
         return false;
     }
 
-    // br_name is the name of the bridge which contains br_interface.
+    // br_name equals the name of the bridge which contains br_interface, or equals br_interface if it is a bridge.
     const auto& br_name = br_it->id;
 
     return std::any_of(spec.extra_interfaces.cbegin(),
                        spec.extra_interfaces.cend(),
-                       [&br_interface, &br_name](const auto& network) -> bool {
-                           return network.id == br_interface || network.id == br_name;
-                       });
+                       [&br_name](const auto& network) -> bool { return network.id == br_name; });
 }
 
 void mp::Daemon::add_bridged_interface(const std::string& instance_name)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3520,7 +3520,28 @@ bool mp::Daemon::is_bridged(const std::string& instance_name)
 {
     const auto& spec = vm_instance_specs[instance_name];
     const auto& br_interface = get_bridged_interface_name();
-    const auto& br_name = config->factory->bridge_name_for(br_interface);
+    const auto& host_nets = config->factory->networks();
+
+    // Return true if the bridged interface is already a bridge.
+    if (std::any_of(std::cbegin(host_nets),
+                    std::cend(host_nets),
+                    [&br_interface](const mp::NetworkInterfaceInfo& info) {
+                        return info.id == br_interface && info.type == "bridge";
+                    }))
+    {
+        return true;
+    }
+
+    const auto& br_it = config->factory->find_bridge_with(host_nets, br_interface);
+
+    // Return false if there is no bridge containing br_interface.
+    if (br_it == host_nets.cend())
+    {
+        return false;
+    }
+
+    // br_name is the name of the bridge which contains br_interface.
+    const auto& br_name = br_it->id;
 
     return std::any_of(spec.extra_interfaces.cbegin(),
                        spec.extra_interfaces.cend(),

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -245,11 +245,6 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
     return ret;
 }
 
-std::string mp::LXDVirtualMachineFactory::bridge_name_for(const std::string& iface_name) const
-{
-    return MP_BACKEND.bridge_name(iface_name);
-};
-
 void mp::LXDVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
 {
     prepare_networking_guts(extra_interfaces, "bridge");

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -43,15 +43,6 @@ namespace
 constexpr auto category = "lxd factory";
 const QString multipass_bridge_name = "mpbr0";
 
-template <typename NetworkContainer>
-auto find_bridge_with(const NetworkContainer& networks, const std::string& member_network)
-{
-    return std::find_if(std::cbegin(networks), std::cend(networks),
-                        [&member_network](const mp::NetworkInterfaceInfo& info) {
-                            return info.type == "bridge" && info.has_link(member_network);
-                        });
-}
-
 mp::NetworkInterfaceInfo munch_network(std::map<std::string, mp::NetworkInterfaceInfo>& platform_networks,
                                        const QJsonObject& network)
 {

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -53,8 +53,6 @@ public:
     std::vector<NetworkInterfaceInfo> networks() const override;
     void require_suspend_support() const override;
 
-    std::string bridge_name_for(const std::string& iface_name) const override;
-
 protected:
     void remove_resources_for_impl(const std::string& name) override;
     std::string create_bridge_with(const NetworkInterfaceInfo& interface) override;

--- a/src/platform/backends/qemu/linux/qemu_platform_detail.h
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail.h
@@ -43,6 +43,10 @@ public:
     QStringList vm_platform_args(const VirtualMachineDescription& vm_desc) override;
     void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& extra_interface) override;
 
+    std::vector<NetworkInterfaceInfo>::const_iterator find_bridge_with(
+        const std::vector<NetworkInterfaceInfo>& networks,
+        const std::string& member_network) const override;
+
 private:
     const QString bridge_name;
     const Path network_dir;

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -207,6 +207,13 @@ void mp::QemuPlatformDetail::add_network_interface(VirtualMachineDescription& de
     throw NotImplementedOnThisBackendException("add interfaces");
 }
 
+std::vector<mp::NetworkInterfaceInfo>::const_iterator mp::QemuPlatformDetail::find_bridge_with(
+    const std::vector<mp::NetworkInterfaceInfo>& networks,
+    const std::string& member_network) const
+{
+    return networks.cend();
+}
+
 mp::QemuPlatform::UPtr mp::QemuPlatformFactory::make_qemu_platform(const Path& data_dir) const
 {
     return std::make_unique<mp::QemuPlatformDetail>(data_dir);

--- a/src/platform/backends/qemu/qemu_platform.h
+++ b/src/platform/backends/qemu/qemu_platform.h
@@ -60,6 +60,9 @@ public:
     };
     virtual void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& extra_interface) = 0;
 
+    virtual std::vector<NetworkInterfaceInfo>::const_iterator
+    find_bridge_with(const std::vector<NetworkInterfaceInfo>& networks, const std::string& member_network) const = 0;
+
 protected:
     explicit QemuPlatform() = default;
 };

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -131,3 +131,10 @@ auto mp::QemuVirtualMachineFactory::networks() const -> std::vector<NetworkInter
 {
     return qemu_platform->networks();
 }
+
+std::vector<mp::NetworkInterfaceInfo>::const_iterator mp::QemuVirtualMachineFactory::find_bridge_with(
+    const std::vector<mp::NetworkInterfaceInfo>& networks,
+    const std::string& member_network) const
+{
+    return qemu_platform->find_bridge_with(networks, member_network);
+}

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -44,6 +44,10 @@ public:
     std::vector<NetworkInterfaceInfo> networks() const override;
     void require_snapshots_support() const override;
 
+    std::vector<NetworkInterfaceInfo>::const_iterator find_bridge_with(
+        const std::vector<NetworkInterfaceInfo>& networks,
+        const std::string& member_network) const override;
+
 protected:
     void remove_resources_for_impl(const std::string& name) override;
 

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -97,6 +97,7 @@ std::vector<mp::NetworkInterfaceInfo>::const_iterator mp::BaseVirtualMachineFact
     return std::find_if(std::cbegin(networks),
                         std::cend(networks),
                         [&member_network, &bridge_type](const mp::NetworkInterfaceInfo& info) {
-                            return info.type == bridge_type && info.has_link(member_network);
+                            return info.type == bridge_type &&
+                                   (info.has_link(member_network) || info.id == member_network);
                         });
 }

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -77,11 +77,6 @@ public:
 
     void require_suspend_support() const override;
 
-    std::string bridge_name_for(const std::string& iface_name) const override
-    {
-        return "";
-    };
-
     std::vector<NetworkInterfaceInfo>::const_iterator find_bridge_with(
         const std::vector<NetworkInterfaceInfo>& networks,
         const std::string& member_network) const override;

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -82,6 +82,10 @@ public:
         return "";
     };
 
+    std::vector<NetworkInterfaceInfo>::const_iterator find_bridge_with(
+        const std::vector<NetworkInterfaceInfo>& networks,
+        const std::string& member_network) const override;
+
 protected:
     static const Path instances_subdir;
 
@@ -98,6 +102,11 @@ protected:
                                    const std::string& bridge_type);
 
     virtual void remove_resources_for_impl(const std::string& name) = 0;
+
+    std::vector<NetworkInterfaceInfo>::const_iterator find_bridge_with_type(
+        const std::vector<NetworkInterfaceInfo>& networks,
+        const std::string& member_network,
+        const std::string& bridge_type) const;
 
 private:
     Path instances_dir;

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -2403,21 +2403,3 @@ TEST_F(LXDBackend, addsNetworkInterface)
 
     EXPECT_EQ(patch_times_called, 1u);
 }
-
-struct LXDNetworkNameTestSuite : LXDBackend, WithParamInterface<std::pair<std::string, std::string>>
-{
-};
-
-TEST_P(LXDNetworkNameTestSuite, backendReturnsCorrectBridgeName)
-{
-    const auto [name, ret] = GetParam();
-
-    CustomLXDFactory factory{std::move(mock_network_access_manager), data_dir.path(), base_url};
-
-    EXPECT_EQ(factory.bridge_name_for(name), ret);
-}
-
-INSTANTIATE_TEST_SUITE_P(LXDBackend,
-                         LXDNetworkNameTestSuite,
-                         Values(std::make_pair("enp4s0", "br-enp4s0"),
-                                std::make_pair("enx586d8fd35b6c", "br-enx586d8fd35")));

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -52,6 +52,10 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD(void, require_snapshots_support, (), (const, override));
     MOCK_METHOD(void, require_suspend_support, (), (const, override));
     MOCK_METHOD(std::string, bridge_name_for, (const std::string&), (const, override));
+    MOCK_METHOD(std::vector<NetworkInterfaceInfo>::const_iterator,
+                find_bridge_with,
+                (const std::vector<NetworkInterfaceInfo>&, const std::string&, const std::string&),
+                (const, override));
 
     // originally protected:
     MOCK_METHOD(std::string, create_bridge_with, (const NetworkInterfaceInfo&), (override));

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -54,7 +54,7 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD(std::string, bridge_name_for, (const std::string&), (const, override));
     MOCK_METHOD(std::vector<NetworkInterfaceInfo>::const_iterator,
                 find_bridge_with,
-                (const std::vector<NetworkInterfaceInfo>&, const std::string&, const std::string&),
+                (const std::vector<NetworkInterfaceInfo>&, const std::string&),
                 (const, override));
 
     // originally protected:

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -51,7 +51,6 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD(std::vector<NetworkInterfaceInfo>, networks, (), (const, override));
     MOCK_METHOD(void, require_snapshots_support, (), (const, override));
     MOCK_METHOD(void, require_suspend_support, (), (const, override));
-    MOCK_METHOD(std::string, bridge_name_for, (const std::string&), (const, override));
     MOCK_METHOD(std::vector<NetworkInterfaceInfo>::const_iterator,
                 find_bridge_with,
                 (const std::vector<NetworkInterfaceInfo>&, const std::string&),

--- a/tests/qemu/linux/test_qemu_platform_detail.cpp
+++ b/tests/qemu/linux/test_qemu_platform_detail.cpp
@@ -217,3 +217,25 @@ TEST_F(QemuPlatformDetail, add_network_interface_throws)
     mp::NetworkInterface net{"id", "52:54:00:98:76:54", true};
     EXPECT_THROW(qemu_platform_detail.add_network_interface(desc, net), mp::NotImplementedOnThisBackendException);
 }
+
+struct FindBridgeWithTestSuite : public QemuPlatformDetail,
+                                 public WithParamInterface<std::vector<mp::NetworkInterfaceInfo>>
+{
+};
+
+TEST_P(FindBridgeWithTestSuite, find_bridge_with_always_returns_cend)
+{
+    const auto& networks = GetParam();
+
+    mp::QemuPlatformDetail qemu_platform_detail{data_dir.path()};
+
+    EXPECT_EQ(qemu_platform_detail.find_bridge_with(networks, "eth8"), networks.cend());
+}
+
+INSTANTIATE_TEST_SUITE_P(QemuPlatformDetail,
+                         FindBridgeWithTestSuite,
+                         Values(std::vector<mp::NetworkInterfaceInfo>{},
+                                std::vector<mp::NetworkInterfaceInfo>{{"eth8", "ethernet", "Ethernet interface"}},
+                                std::vector<mp::NetworkInterfaceInfo>{{"eth9", "ethernet", "Ethernet interface"}},
+                                std::vector<mp::NetworkInterfaceInfo>{
+                                    {"br-eth8", "bridge", "Network bridge", {"eth8"}}}));

--- a/tests/qemu/mock_qemu_platform.h
+++ b/tests/qemu/mock_qemu_platform.h
@@ -43,6 +43,10 @@ struct MockQemuPlatform : public QemuPlatform
     MOCK_METHOD(QStringList, vm_platform_args, (const VirtualMachineDescription&), (override));
     MOCK_METHOD(QString, get_directory_name, (), (const, override));
     MOCK_METHOD(void, add_network_interface, (VirtualMachineDescription&, const NetworkInterface&), (override));
+    MOCK_METHOD(std::vector<NetworkInterfaceInfo>::const_iterator,
+                find_bridge_with,
+                (const std::vector<NetworkInterfaceInfo>&, const std::string&),
+                (const, override));
 };
 
 struct MockQemuPlatformFactory : public QemuPlatformFactory

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -56,18 +56,12 @@ struct MockBaseFactory : mp::BaseVirtualMachineFactory
     MOCK_METHOD(QString, get_backend_version_string, (), (const, override));
     MOCK_METHOD(void, prepare_networking, (std::vector<mp::NetworkInterface>&), (override));
     MOCK_METHOD(std::vector<mp::NetworkInterfaceInfo>, networks, (), (const, override));
-    MOCK_METHOD(std::string, bridge_name_for, (const std::string&), (const, override));
     MOCK_METHOD(std::string, create_bridge_with, (const mp::NetworkInterfaceInfo&), (override));
     MOCK_METHOD(void, prepare_interface,
                 (mp::NetworkInterface & net, std::vector<mp::NetworkInterfaceInfo>& host_nets,
                  const std::string& bridge_type),
                 (override));
     MOCK_METHOD(void, remove_resources_for_impl, (const std::string&), (override));
-
-    std::string base_bridge_name_for(const std::string& iface_name) const
-    {
-        return mp::BaseVirtualMachineFactory::bridge_name_for(iface_name);
-    }
 
     std::string base_create_bridge_with(const mp::NetworkInterfaceInfo& interface)
     {
@@ -161,13 +155,6 @@ TEST_F(BaseFactory, creates_cloud_init_iso_image)
 
     EXPECT_EQ(vm_desc.cloud_init_iso, QString("%1/cloud-init-config.iso").arg(factory.tmp_dir->path()));
     EXPECT_TRUE(QFile::exists(vm_desc.cloud_init_iso));
-}
-
-TEST_F(BaseFactory, baseBridgeNameForReturnsEmpty)
-{
-    StrictMock<MockBaseFactory> factory;
-
-    ASSERT_EQ(factory.base_bridge_name_for("any_interface"), "");
 }
 
 TEST_F(BaseFactory, create_bridge_not_implemented)


### PR DESCRIPTION
The answer was wrong in some backends. This PR uses a more reliable mechanism, inspecting the contents of the platform networks data structure.

Fixes #3489.