### PR TITLE
[unit test] use nicemock to remove the excessive gmock warnings. 

### DIFF
--- a/tests/daemon_test_fixture.cpp
+++ b/tests/daemon_test_fixture.cpp
@@ -316,7 +316,7 @@ mpt::DaemonTestFixture::DaemonTestFixture()
     config_builder.factory = std::make_unique<StubVirtualMachineFactory>();
     config_builder.image_hosts.push_back(std::make_unique<StubVMImageHost>());
     config_builder.ssh_key_provider = std::make_unique<StubSSHKeyProvider>();
-    config_builder.cert_provider = std::make_unique<MockCertProvider>();
+    config_builder.cert_provider = std::make_unique<NiceMock<MockCertProvider>>();
     config_builder.client_cert_store = std::make_unique<StubCertStore>();
     config_builder.logger = std::make_unique<StubLogger>();
     config_builder.update_prompt = std::make_unique<DisabledUpdatePrompt>();
@@ -373,7 +373,7 @@ void mpt::DaemonTestFixture::send_commands(std::vector<std::vector<std::string>>
         StubTerminal term(cout, cerr, cin);
 
         std::unique_ptr<CertProvider> cert_provider;
-        cert_provider = std::make_unique<MockCertProvider>();
+        cert_provider = std::make_unique<NiceMock<MockCertProvider>>();
 
         ClientConfig client_config{server_address, std::move(cert_provider), &term};
         TestClient client{client_config};

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -369,11 +369,12 @@ struct Client : public Test
 #else
     std::string server_address{"unix:/tmp/test-multipassd.socket"};
 #endif
-    static std::unique_ptr<mpt::MockCertProvider> get_client_cert_provider()
+    static std::unique_ptr<NiceMock<mpt::MockCertProvider>> get_client_cert_provider()
     {
-        return std::make_unique<mpt::MockCertProvider>();
+        return std::make_unique<NiceMock<mpt::MockCertProvider>>();
     };
-    std::unique_ptr<mpt::MockCertProvider> daemon_cert_provider{std::make_unique<mpt::MockCertProvider>()};
+    std::unique_ptr<NiceMock<mpt::MockCertProvider>> daemon_cert_provider{
+        std::make_unique<NiceMock<mpt::MockCertProvider>>()};
     mpt::MockPlatform::GuardedMock attr{mpt::MockPlatform::inject<NiceMock>()};
     mpt::MockPlatform* mock_platform = attr.first;
     mpt::StubCertStore cert_store;

--- a/tests/test_client_common.cpp
+++ b/tests/test_client_common.cpp
@@ -56,7 +56,8 @@ struct TestClientCommon : public mpt::DaemonTestFixture
         return mpt::MockDaemon(config_builder.build());
     }
 
-    std::unique_ptr<mpt::MockCertProvider> mock_cert_provider{std::make_unique<mpt::MockCertProvider>()};
+    std::unique_ptr<NiceMock<mpt::MockCertProvider>> mock_cert_provider{
+        std::make_unique<NiceMock<mpt::MockCertProvider>>()};
     std::unique_ptr<mpt::MockCertStore> mock_cert_store{std::make_unique<mpt::MockCertStore>()};
 
     const std::string server_address{"localhost:50052"};

--- a/tests/unix/test_daemon_rpc.cpp
+++ b/tests/unix/test_daemon_rpc.cpp
@@ -89,7 +89,8 @@ struct TestDaemonRpc : public mpt::DaemonTestFixture
         });
     }
 
-    std::unique_ptr<mpt::MockCertProvider> mock_cert_provider{std::make_unique<mpt::MockCertProvider>()};
+    std::unique_ptr<NiceMock<mpt::MockCertProvider>> mock_cert_provider{
+        std::make_unique<NiceMock<mpt::MockCertProvider>>()};
     std::unique_ptr<mpt::MockCertStore> mock_cert_store{std::make_unique<mpt::MockCertStore>()};
 
     mpt::MockPlatform::GuardedMock platform_attr{mpt::MockPlatform::inject()};


### PR DESCRIPTION
Remove the excessive gmock warnings from unit tests.