### PR TITLE
[cli] Added -a flag to the stop command

### DIFF
--- a/src/client/cli/cmd/stop.cpp
+++ b/src/client/cli/cmd/stop.cpp
@@ -80,7 +80,7 @@ mp::ParseCode cmd::Stop::parse_args(mp::ArgParser* parser)
 
     parser->addPositionalArgument("name", description, syntax);
 
-    QCommandLineOption all_option(all_option_name, "Stop all instances");
+    QCommandLineOption all_option({"a", all_option_name}, "Stop all instances");
     QCommandLineOption time_option({"t", "time"}, "Time from now, in minutes, to delay shutdown of the instance",
                                    "time", "0");
     QCommandLineOption cancel_option({"c", "cancel"}, "Cancel a pending delayed shutdown");


### PR DESCRIPTION
Adds the _-a_ flag in addition to the already existing _--all_ flag to the sub command _stop_.

This provides a more consistent help output and it is handy for regular use:
```
Options:
  -h, --help         Displays help on commandline options
  -v, --verbose      Increase logging verbosity. Repeat the 'v' in the short
                     option for more detail. Maximum verbosity is obtained with
                     4 (or more) v's, i.e. -vvvv.
  -a, --all          Stop all instances
  -t, --time <time>  Time from now, in minutes, to delay shutdown of the
                     instance
  -c, --cancel       Cancel a pending delayed shutdown
```