### PR TITLE
[utils] Use a consistent namespace alias for utils

### DIFF
--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -36,7 +36,7 @@
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 namespace
 {
@@ -146,7 +146,7 @@ void mp::LXDVirtualMachineFactory::hypervisor_health_check()
     catch (const LocalSocketConnectionException& e)
     {
         std::string snap_msg;
-        if (mu::in_multipass_snap())
+        if (mpu::in_multipass_snap())
             snap_msg = " Also make sure\n the LXD interface is connected via `snap connect multipass:lxd lxd`.";
 
         throw std::runtime_error(

--- a/src/platform/backends/qemu/linux/dnsmasq_process_spec.cpp
+++ b/src/platform/backends/qemu/linux/dnsmasq_process_spec.cpp
@@ -22,7 +22,7 @@
 #include <multipass/snap_utils.h>
 
 namespace mp = multipass;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 mp::DNSMasqProcessSpec::DNSMasqProcessSpec(const mp::Path& data_dir, const QString& bridge_name,
                                            const std::string& subnet, const QString& conf_file_path)
@@ -112,7 +112,7 @@ profile %1 flags=(attach_disconnected) {
     try
     {
         // if snap confined, specify only multipassd can kill dnsmasq
-        root_dir = mu::snap_dir();
+        root_dir = mpu::snap_dir();
         signal_peer = "snap.multipass.multipassd";
     }
     catch (const mp::SnapEnvironmentException&)

--- a/src/platform/backends/qemu/qemu_base_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_base_process_spec.cpp
@@ -21,7 +21,7 @@
 #include <multipass/snap_utils.h>
 
 namespace mp = multipass;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 QString mp::QemuBaseProcessSpec::program() const
 {
@@ -32,7 +32,7 @@ QString mp::QemuBaseProcessSpec::working_directory() const
 {
     try
     {
-        return mu::snap_dir().append("/qemu");
+        return mpu::snap_dir().append("/qemu");
     }
     catch (const mp::SnapEnvironmentException&)
     {

--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -25,7 +25,7 @@
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 mp::QemuVMProcessSpec::QemuVMProcessSpec(const mp::VirtualMachineDescription& desc, const QStringList& platform_args,
                                          const mp::QemuVirtualMachine::MountArgs& mount_args,
@@ -196,7 +196,7 @@ profile %1 flags=(attach_disconnected) {
 
     try
     {
-        root_dir = mu::snap_dir();
+        root_dir = mpu::snap_dir();
         signal_peer = "snap.multipass.multipassd"; // only multipassd can send qemu signals
         firmware = root_dir + "/qemu/*";           // if snap confined, firmware in $SNAP/qemu
     }

--- a/src/platform/backends/shared/sshfs_server_process_spec.cpp
+++ b/src/platform/backends/shared/sshfs_server_process_spec.cpp
@@ -27,7 +27,7 @@
 #include <QDir>
 
 namespace mp = multipass;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 namespace
 {
@@ -129,7 +129,7 @@ profile %1 flags=(attach_disconnected) {
 
     try
     {
-        root_dir = mu::snap_dir();
+        root_dir = mpu::snap_dir();
         signal_peer = "snap.multipass.multipassd";
     }
     catch (const mp::SnapEnvironmentException&)

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -67,7 +67,7 @@
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 namespace
 {
@@ -87,7 +87,7 @@ int get_net_type(const QDir& net_dir) // types defined in if_arp.h
         return ok ? got : default_ret;
     }
 
-    auto snap_hint = mu::in_multipass_snap() ? " Is the 'network-observe' snap interface connected?" : "";
+    auto snap_hint = mpu::in_multipass_snap() ? " Is the 'network-observe' snap interface connected?" : "";
     mpl::log(mpl::Level::warning, category, fmt::format("Could not read {}.{}", type_file.fileName(), snap_hint));
 
     return default_ret;
@@ -282,9 +282,9 @@ QDir mp::platform::Platform::get_alias_scripts_folder() const
 {
     QDir aliases_folder;
 
-    if (mu::in_multipass_snap())
+    if (mpu::in_multipass_snap())
     {
-        aliases_folder = QDir(QString(mu::snap_user_common_dir()) + "/bin");
+        aliases_folder = QDir(QString(mpu::snap_user_common_dir()) + "/bin");
     }
     else
     {
@@ -299,7 +299,7 @@ void mp::platform::Platform::create_alias_script(const std::string& alias, const
 {
     std::string file_path = get_alias_script_path(alias);
 
-    std::string multipass_exec = mu::in_multipass_snap()
+    std::string multipass_exec = mpu::in_multipass_snap()
                                      ? "exec /usr/bin/snap run multipass"
                                      : fmt::format("\"{}\"", QCoreApplication::applicationFilePath());
 
@@ -397,7 +397,7 @@ std::string mp::platform::default_server_address()
     try
     {
         // if Snap, client and daemon can both access $SNAP_COMMON so can put socket there
-        base_dir = mu::snap_common_dir().toStdString();
+        base_dir = mpu::snap_common_dir().toStdString();
     }
     catch (const mp::SnapEnvironmentException&)
     {
@@ -454,6 +454,6 @@ std::string mp::platform::reinterpret_interface_id(const std::string& ux_id)
 
 std::string multipass::platform::host_version()
 {
-    return mu::in_multipass_snap() ? multipass::platform::detail::read_os_release()
-                                   : fmt::format("{}-{}", QSysInfo::productType(), QSysInfo::productVersion());
+    return mpu::in_multipass_snap() ? multipass::platform::detail::read_os_release()
+                                    : fmt::format("{}-{}", QSysInfo::productType(), QSysInfo::productVersion());
 }

--- a/src/process/qemuimg_process_spec.cpp
+++ b/src/process/qemuimg_process_spec.cpp
@@ -20,7 +20,7 @@
 #include <multipass/snap_utils.h>
 
 namespace mp = multipass;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 mp::QemuImgProcessSpec::QemuImgProcessSpec(const QStringList& args, const QString& source_image,
                                            const QString& target_image)
@@ -72,7 +72,7 @@ profile %1 flags=(attach_disconnected) {
 
     try
     {
-        root_dir = mu::snap_dir();
+        root_dir = mpu::snap_dir();
         signal_peer = "snap.multipass.multipassd"; // only multipassd can send qemu-img signals
     }
     catch (mp::SnapEnvironmentException&)

--- a/src/utils/snap_utils.cpp
+++ b/src/utils/snap_utils.cpp
@@ -22,7 +22,7 @@
 #include <QString>
 
 namespace mp = multipass;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 namespace
 {
@@ -30,7 +30,7 @@ const QString snap_name{"multipass"};
 
 void verify_snap_name()
 {
-    if (!mu::in_multipass_snap())
+    if (!mpu::in_multipass_snap())
         throw mp::SnapEnvironmentException("SNAP_NAME", snap_name.toStdString());
 }
 
@@ -51,27 +51,27 @@ QByteArray checked_snap_dir(const char* dir)
 }
 } // namespace
 
-bool mu::in_multipass_snap()
+bool mpu::in_multipass_snap()
 {
     return qgetenv("SNAP_NAME") == snap_name;
 }
 
-QByteArray mu::snap_dir()
+QByteArray mpu::snap_dir()
 {
     return checked_snap_dir("SNAP");
 }
 
-QByteArray mu::snap_common_dir()
+QByteArray mpu::snap_common_dir()
 {
     return checked_snap_dir("SNAP_COMMON");
 }
 
-QByteArray mu::snap_real_home_dir()
+QByteArray mpu::snap_real_home_dir()
 {
     return checked_snap_dir("SNAP_REAL_HOME");
 }
 
-QByteArray mu::snap_user_common_dir()
+QByteArray mpu::snap_user_common_dir()
 {
     return checked_snap_dir("SNAP_USER_COMMON");
 }

--- a/tests/linux/test_snap_utils.cpp
+++ b/tests/linux/test_snap_utils.cpp
@@ -28,7 +28,7 @@
 
 namespace mp = multipass;
 namespace mpt = multipass::test;
-namespace mu = multipass::utils;
+namespace mpu = multipass::utils;
 
 using namespace testing;
 
@@ -40,19 +40,19 @@ const QByteArray snap_name{"multipass"};
 TEST(Snap, recognizes_in_snap_when_snap_name_is_multipass)
 {
     mpt::SetEnvScope env{"SNAP_NAME", "multipass"};
-    EXPECT_TRUE(mu::in_multipass_snap());
+    EXPECT_TRUE(mpu::in_multipass_snap());
 }
 
 TEST(Snap, recognizes_not_in_snap_when_snap_name_is_empty)
 {
     mpt::UnsetEnvScope env{"SNAP_NAME"};
-    EXPECT_FALSE(mu::in_multipass_snap());
+    EXPECT_FALSE(mpu::in_multipass_snap());
 }
 
 TEST(Snap, recognizes_not_in_snap_when_snap_name_is_otherwise)
 {
     mpt::SetEnvScope env{"SNAP_NAME", "otherwise"};
-    EXPECT_FALSE(mu::in_multipass_snap());
+    EXPECT_FALSE(mpu::in_multipass_snap());
 }
 
 struct SnapDirs : public TestWithParam<std::pair<const char*, std::function<QByteArray()>>>
@@ -120,7 +120,8 @@ TEST_P(SnapDirs, test_snap_dir_resolves_links)
     EXPECT_EQ(snap_dir.path(), getter());
 }
 
-INSTANTIATE_TEST_SUITE_P(SnapUtils, SnapDirs,
-                         testing::Values(std::make_pair("SNAP", &mu::snap_dir),
-                                         std::make_pair("SNAP_COMMON", &mu::snap_common_dir),
-                                         std::make_pair("SNAP_REAL_HOME", &mu::snap_real_home_dir)));
+INSTANTIATE_TEST_SUITE_P(SnapUtils,
+                         SnapDirs,
+                         testing::Values(std::make_pair("SNAP", &mpu::snap_dir),
+                                         std::make_pair("SNAP_COMMON", &mpu::snap_common_dir),
+                                         std::make_pair("SNAP_REAL_HOME", &mpu::snap_real_home_dir)));


### PR DESCRIPTION
Normalize uses of `mu` to `mpu`, which was already in use and is more in line with the three-letter norm for multipass namespace aliases.
