### PR TITLE
Fix detection of whether an instance is bridged, take2

### DIFF
--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -76,6 +76,7 @@ public:
     virtual QString default_driver() const;
     virtual QString default_privileged_mounts() const;
     virtual bool is_image_url_supported() const;
+    [[nodiscard]] virtual std::string bridge_nomenclature() const;
 };
 
 QString interpret_setting(const QString& key, const QString& val);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -99,15 +99,16 @@ bool valid_hostname(const std::string& name_string);
 std::string generate_mac_address();
 bool valid_mac_address(const std::string& mac);
 template <typename NetworkContainer>
-auto find_bridge_with(const NetworkContainer& networks,
-                      const std::string& member_network,
-                      const std::string& bridge_type)
+std::optional<NetworkInterfaceInfo> find_bridge_with(const NetworkContainer& networks,
+                                                     const std::string& member_network,
+                                                     const std::string& bridge_type)
 {
-    return std::find_if(std::cbegin(networks),
-                        std::cend(networks),
-                        [&member_network, &bridge_type](const NetworkInterfaceInfo& info) {
-                            return info.type == bridge_type && info.has_link(member_network);
-                        });
+    const auto it = std::find_if(std::cbegin(networks),
+                                 std::cend(networks),
+                                 [&member_network, &bridge_type](const NetworkInterfaceInfo& info) {
+                                     return info.type == bridge_type && info.has_link(member_network);
+                                 });
+    return it == std::cend(networks) ? std::nullopt : std::make_optional(*it);
 }
 
 // string helpers

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -100,13 +100,13 @@ std::string generate_mac_address();
 bool valid_mac_address(const std::string& mac);
 template <typename NetworkContainer>
 std::optional<NetworkInterfaceInfo> find_bridge_with(const NetworkContainer& networks,
-                                                     const std::string& member_network,
+                                                     const std::string& target_network,
                                                      const std::string& bridge_type)
 {
     const auto it = std::find_if(std::cbegin(networks),
                                  std::cend(networks),
-                                 [&member_network, &bridge_type](const NetworkInterfaceInfo& info) {
-                                     return info.type == bridge_type && info.has_link(member_network);
+                                 [&target_network, &bridge_type](const NetworkInterfaceInfo& info) {
+                                     return info.type == bridge_type && info.has_link(target_network);
                                  });
     return it == std::cend(networks) ? std::nullopt : std::make_optional(*it);
 }

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -19,6 +19,7 @@
 #define MULTIPASS_UTILS_H
 
 #include <multipass/logging/level.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/path.h>
 #include <multipass/singleton.h>
 #include <multipass/ssh/ssh_session.h>
@@ -97,6 +98,17 @@ void validate_server_address(const std::string& value);
 bool valid_hostname(const std::string& name_string);
 std::string generate_mac_address();
 bool valid_mac_address(const std::string& mac);
+template <typename NetworkContainer>
+auto find_bridge_with(const NetworkContainer& networks,
+                      const std::string& member_network,
+                      const std::string& bridge_type)
+{
+    return std::find_if(std::cbegin(networks),
+                        std::cend(networks),
+                        [&member_network, &bridge_type](const NetworkInterfaceInfo& info) {
+                            return info.type == bridge_type && info.has_link(member_network);
+                        });
+}
 
 // string helpers
 bool has_only_digits(const std::string& value);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -98,18 +98,10 @@ void validate_server_address(const std::string& value);
 bool valid_hostname(const std::string& name_string);
 std::string generate_mac_address();
 bool valid_mac_address(const std::string& mac);
-template <typename NetworkContainer>
-std::optional<NetworkInterfaceInfo> find_bridge_with(const NetworkContainer& networks,
+
+std::optional<NetworkInterfaceInfo> find_bridge_with(const std::vector<NetworkInterfaceInfo>& networks,
                                                      const std::string& target_network,
-                                                     const std::string& bridge_type)
-{
-    const auto it = std::find_if(std::cbegin(networks),
-                                 std::cend(networks),
-                                 [&target_network, &bridge_type](const NetworkInterfaceInfo& info) {
-                                     return info.type == bridge_type && info.has_link(target_network);
-                                 });
-    return it == std::cend(networks) ? std::nullopt : std::make_optional(*it);
-}
+                                                     const std::string& bridge_type);
 
 // string helpers
 bool has_only_digits(const std::string& value);

--- a/include/multipass/virtual_machine_factory.h
+++ b/include/multipass/virtual_machine_factory.h
@@ -73,7 +73,6 @@ public:
     virtual std::vector<NetworkInterfaceInfo> networks() const = 0;
     virtual void require_snapshots_support() const = 0;
     virtual void require_suspend_support() const = 0;
-    virtual std::string bridge_name_for(const std::string& iface_name) const = 0;
 
 protected:
     VirtualMachineFactory() = default;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3521,10 +3521,13 @@ bool mp::Daemon::is_bridged(const std::string& instance_name)
     const auto& spec = vm_instance_specs[instance_name];
     const auto& preferred_net = get_bridged_interface_name();
 
-    // TODO@ricab check also for bridge containing preferred net
+    const auto& host_nets = config->factory->networks(); // TODO@no-merge shouldn't keep calling this
+    const auto& matching_bridge = mpu::find_bridge_with(host_nets, preferred_net, MP_PLATFORM.bridge_nomenclature());
     return std::any_of(spec.extra_interfaces.cbegin(),
                        spec.extra_interfaces.cend(),
-                       [&preferred_net](const auto& network) -> bool { return network.id == preferred_net; });
+                       [&preferred_net, &matching_bridge](const auto& network) -> bool {
+                           return network.id == preferred_net || (matching_bridge && network.id == matching_bridge->id);
+                       });
 }
 
 void mp::Daemon::add_bridged_interface(const std::string& instance_name)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3519,13 +3519,13 @@ void mp::Daemon::populate_instance_info(VirtualMachine& vm,
 bool mp::Daemon::is_bridged(const std::string& instance_name)
 {
     const auto& spec = vm_instance_specs[instance_name];
-    const auto& br_interface = get_bridged_interface_name();
-    const auto& br_name = config->factory->bridge_name_for(br_interface);
+    const auto& preferred_net = get_bridged_interface_name();
+    const auto& br_name = config->factory->bridge_name_for(preferred_net);
 
     return std::any_of(spec.extra_interfaces.cbegin(),
                        spec.extra_interfaces.cend(),
-                       [&br_interface, &br_name](const auto& network) -> bool {
-                           return network.id == br_interface || network.id == br_name;
+                       [&preferred_net, &br_name](const auto& network) -> bool {
+                           return network.id == preferred_net || network.id == br_name;
                        });
 }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3537,9 +3537,8 @@ bool mp::Daemon::is_bridged(const std::string& instance_name) const
 
 void mp::Daemon::add_bridged_interface(const std::string& instance_name)
 {
-    // These two use operator[] to access elements because this function is called after existence was checked.
-    mp::VMSpecs& specs = vm_instance_specs[instance_name];
-    mp::VirtualMachine::ShPtr instance = operative_instances[instance_name];
+    mp::VMSpecs& specs = vm_instance_specs.at(instance_name);
+    mp::VirtualMachine::ShPtr instance = operative_instances.at(instance_name);
 
     const auto& host_nets = config->factory->networks(); // This will throw if not implemented on this backend.
     const auto& preferred_net = get_bridged_interface_name();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3520,13 +3520,11 @@ bool mp::Daemon::is_bridged(const std::string& instance_name)
 {
     const auto& spec = vm_instance_specs[instance_name];
     const auto& preferred_net = get_bridged_interface_name();
-    const auto& br_name = config->factory->bridge_name_for(preferred_net);
 
+    // TODO@ricab check also for bridge containing preferred net
     return std::any_of(spec.extra_interfaces.cbegin(),
                        spec.extra_interfaces.cend(),
-                       [&preferred_net, &br_name](const auto& network) -> bool {
-                           return network.id == preferred_net || network.id == br_name;
-                       });
+                       [&preferred_net](const auto& network) -> bool { return network.id == preferred_net; });
 }
 
 void mp::Daemon::add_bridged_interface(const std::string& instance_name)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3528,9 +3528,11 @@ void mp::Daemon::populate_instance_info(VirtualMachine& vm,
                                                          vm_specs.num_cores != 1);
 }
 
-bool mp::Daemon::is_bridged(const std::string& instance_name) // TODO@no-merge should be const?
+bool mp::Daemon::is_bridged(const std::string& instance_name) const
 {
-    return is_bridged_impl(vm_instance_specs[instance_name], config->factory->networks(), get_bridged_interface_name());
+    return is_bridged_impl(vm_instance_specs.at(instance_name),
+                           config->factory->networks(),
+                           get_bridged_interface_name());
 }
 
 void mp::Daemon::add_bridged_interface(const std::string& instance_name)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -209,7 +209,7 @@ protected:
     std::unordered_map<std::string, VMSpecs> vm_instance_specs;
     InstanceTable operative_instances;
 
-    bool is_bridged(const std::string& instance_name);
+    bool is_bridged(const std::string& instance_name) const;
     void add_bridged_interface(const std::string& instance_name);
 
 private:

--- a/src/daemon/instance_settings_handler.cpp
+++ b/src/daemon/instance_settings_handler.cpp
@@ -168,11 +168,11 @@ void update_bridged(const QString& key,
                     std::function<void(const std::string&)> add_interface)
 {
     // This is the user parameter, true or false.
-    auto bridged = mp::BoolSettingSpec{key, "false"}.interpret(val) == "true";
+    auto want_bridged = mp::BoolSettingSpec{key, "false"}.interpret(val) == "true";
 
     if (is_bridged(instance_name))
     {
-        if (bridged)
+        if (want_bridged)
         {
             mpl::log(mpl::Level::warning, category, fmt::format("{} is already bridged", instance_name));
         }
@@ -181,7 +181,7 @@ void update_bridged(const QString& key,
             throw mp::InvalidSettingException{key, val, "Bridged interface cannot be removed"};
         }
     }
-    else if (bridged)
+    else if (want_bridged)
     {
         add_interface(instance_name);
     }

--- a/src/daemon/instance_settings_handler.cpp
+++ b/src/daemon/instance_settings_handler.cpp
@@ -20,8 +20,6 @@
 #include <multipass/cli/prompters.h>
 #include <multipass/constants.h>
 #include <multipass/exceptions/invalid_memory_size_exception.h>
-#include <multipass/exceptions/not_implemented_on_this_backend_exception.h>
-#include <multipass/logging/log.h>
 #include <multipass/settings/bool_setting_spec.h>
 
 #include <QRegularExpression>
@@ -32,8 +30,6 @@ namespace mpl = multipass::logging;
 
 namespace
 {
-constexpr auto category = "instance settings";
-
 constexpr auto cpus_suffix = "cpus";
 constexpr auto mem_suffix = "memory";
 constexpr auto disk_suffix = "disk";

--- a/src/daemon/instance_settings_handler.cpp
+++ b/src/daemon/instance_settings_handler.cpp
@@ -167,24 +167,14 @@ void update_bridged(const QString& key,
                     std::function<bool(const std::string&)> is_bridged,
                     std::function<void(const std::string&)> add_interface)
 {
-    // This is the user parameter, true or false.
     auto want_bridged = mp::BoolSettingSpec{key, "false"}.interpret(val) == "true";
-
-    if (is_bridged(instance_name))
+    if (!want_bridged)
     {
-        if (want_bridged)
-        {
-            mpl::log(mpl::Level::warning, category, fmt::format("{} is already bridged", instance_name));
-        }
-        else
-        {
-            throw mp::InvalidSettingException{key, val, "Bridged interface cannot be removed"};
-        }
+        if (is_bridged(instance_name)) // inspects host networks once
+            throw mp::InvalidSettingException{key, val, "Bridged interface cannot be removed"}; // TODO@ricab better err
     }
-    else if (want_bridged)
-    {
-        add_interface(instance_name);
-    }
+    else
+        add_interface(instance_name); // if already bridged, this merely warns
 }
 } // namespace
 

--- a/src/daemon/instance_settings_handler.cpp
+++ b/src/daemon/instance_settings_handler.cpp
@@ -171,7 +171,7 @@ void update_bridged(const QString& key,
     if (!want_bridged)
     {
         if (is_bridged(instance_name)) // inspects host networks once
-            throw mp::InvalidSettingException{key, val, "Bridged interface cannot be removed"}; // TODO@ricab better err
+            throw mp::InvalidSettingException{key, val, "Removing the bridged network is currently not supported"};
     }
     else
         add_interface(instance_name); // if already bridged, this merely warns

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -239,7 +239,7 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
                 ret.push_back(std::move(network));
 
         for (auto& net : ret)
-            if (net.needs_authorization && mu::find_bridge_with(ret, net.id, br_nomenclature))
+            if (net.needs_authorization && mpu::find_bridge_with(ret, net.id, br_nomenclature))
                 net.needs_authorization = false;
     }
 

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -239,7 +239,7 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
                 ret.push_back(std::move(network));
 
         for (auto& net : ret)
-            if (net.needs_authorization && mu::find_bridge_with(ret, net.id, br_nomenclature) != ret.cend())
+            if (net.needs_authorization && mu::find_bridge_with(ret, net.id, br_nomenclature))
                 net.needs_authorization = false;
     }
 

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -246,11 +246,6 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
     return ret;
 }
 
-std::string mp::LXDVirtualMachineFactory::bridge_name_for(const std::string& iface_name) const
-{
-    return MP_BACKEND.bridge_name(iface_name);
-};
-
 void mp::LXDVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
 {
     prepare_networking_guts(extra_interfaces, MP_PLATFORM.bridge_nomenclature());

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -232,13 +232,14 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
 
     if (!networks.isEmpty())
     {
+        const auto& br_nomenclature = MP_PLATFORM.bridge_nomenclature();
         auto platform_networks = MP_PLATFORM.get_network_interfaces_info();
         for (const QJsonValueRef net_value : networks)
             if (auto network = munch_network(platform_networks, net_value.toObject()); !network.id.empty())
                 ret.push_back(std::move(network));
 
         for (auto& net : ret)
-            if (net.needs_authorization && mu::find_bridge_with(ret, net.id, "bridge") != ret.cend())
+            if (net.needs_authorization && mu::find_bridge_with(ret, net.id, br_nomenclature) != ret.cend())
                 net.needs_authorization = false;
     }
 
@@ -252,7 +253,7 @@ std::string mp::LXDVirtualMachineFactory::bridge_name_for(const std::string& ifa
 
 void mp::LXDVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
 {
-    prepare_networking_guts(extra_interfaces, "bridge");
+    prepare_networking_guts(extra_interfaces, MP_PLATFORM.bridge_nomenclature());
 }
 
 std::string mp::LXDVirtualMachineFactory::create_bridge_with(const NetworkInterfaceInfo& interface)

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -43,15 +43,6 @@ namespace
 constexpr auto category = "lxd factory";
 const QString multipass_bridge_name = "mpbr0";
 
-template <typename NetworkContainer>
-auto find_bridge_with(const NetworkContainer& networks, const std::string& member_network)
-{
-    return std::find_if(std::cbegin(networks), std::cend(networks),
-                        [&member_network](const mp::NetworkInterfaceInfo& info) {
-                            return info.type == "bridge" && info.has_link(member_network);
-                        });
-}
-
 mp::NetworkInterfaceInfo munch_network(std::map<std::string, mp::NetworkInterfaceInfo>& platform_networks,
                                        const QJsonObject& network)
 {
@@ -247,7 +238,7 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
                 ret.push_back(std::move(network));
 
         for (auto& net : ret)
-            if (net.needs_authorization && find_bridge_with(ret, net.id) != ret.cend())
+            if (net.needs_authorization && mu::find_bridge_with(ret, net.id, "bridge") != ret.cend())
                 net.needs_authorization = false;
     }
 

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.cpp
@@ -246,11 +246,6 @@ auto mp::LXDVirtualMachineFactory::networks() const -> std::vector<NetworkInterf
     return ret;
 }
 
-void mp::LXDVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
-{
-    prepare_networking_guts(extra_interfaces, MP_PLATFORM.bridge_nomenclature());
-}
-
 std::string mp::LXDVirtualMachineFactory::create_bridge_with(const NetworkInterfaceInfo& interface)
 {
     assert(interface.type == "ethernet");

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -34,7 +34,6 @@ public:
     explicit LXDVirtualMachineFactory(NetworkAccessManager::UPtr manager, const Path& data_dir,
                                       const QUrl& base_url = lxd_socket_url);
 
-    void prepare_networking(std::vector<NetworkInterface>& extra_interfaces) override;
     VirtualMachine::UPtr create_virtual_machine(const VirtualMachineDescription& desc,
                                                 const SSHKeyProvider& key_provider,
                                                 VMStatusMonitor& monitor) override;

--- a/src/platform/backends/lxd/lxd_virtual_machine_factory.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine_factory.h
@@ -53,8 +53,6 @@ public:
     std::vector<NetworkInterfaceInfo> networks() const override;
     void require_suspend_support() const override;
 
-    std::string bridge_name_for(const std::string& iface_name) const override;
-
 protected:
     void remove_resources_for_impl(const std::string& name) override;
     std::string create_bridge_with(const NetworkInterfaceInfo& interface) override;

--- a/src/platform/backends/qemu/linux/qemu_platform_detail.h
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail.h
@@ -42,6 +42,7 @@ public:
     void platform_health_check() override;
     QStringList vm_platform_args(const VirtualMachineDescription& vm_desc) override;
     void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& extra_interface) override;
+    void prepare_networking(std::vector<NetworkInterface>& extra_interfaces) const override;
 
 private:
     const QString bridge_name;

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -204,7 +204,7 @@ void mp::QemuPlatformDetail::add_network_interface(VirtualMachineDescription& de
     // desc.extra_interfaces.push_back(net);
 
     // For the time being, just complain:
-    throw NotImplementedOnThisBackendException("add interfaces");
+    throw NotImplementedOnThisBackendException("networks");
 }
 
 mp::QemuPlatform::UPtr mp::QemuPlatformFactory::make_qemu_platform(const Path& data_dir) const

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -211,3 +211,8 @@ mp::QemuPlatform::UPtr mp::QemuPlatformFactory::make_qemu_platform(const Path& d
 {
     return std::make_unique<mp::QemuPlatformDetail>(data_dir);
 }
+
+void mp::QemuPlatformDetail::prepare_networking(std::vector<NetworkInterface>& /*extra_interfaces*/) const
+{
+    throw NotImplementedOnThisBackendException("networks");
+}

--- a/src/platform/backends/qemu/qemu_platform.h
+++ b/src/platform/backends/qemu/qemu_platform.h
@@ -59,6 +59,7 @@ public:
         throw NotImplementedOnThisBackendException("networks");
     };
     virtual void add_network_interface(VirtualMachineDescription& desc, const NetworkInterface& extra_interface) = 0;
+    virtual void prepare_networking(std::vector<NetworkInterface>& extra_interfaces) const = 0;
 
 protected:
     explicit QemuPlatform() = default;

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -131,3 +131,8 @@ auto mp::QemuVirtualMachineFactory::networks() const -> std::vector<NetworkInter
 {
     return qemu_platform->networks();
 }
+
+void multipass::QemuVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
+{
+    return qemu_platform->prepare_networking(extra_interfaces);
+}

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.h
@@ -43,6 +43,7 @@ public:
     QString get_backend_directory_name() const override;
     std::vector<NetworkInterfaceInfo> networks() const override;
     void require_snapshots_support() const override;
+    void prepare_networking(std::vector<NetworkInterface>& extra_interfaces) override;
 
 protected:
     void remove_resources_for_impl(const std::string& name) override;

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -70,9 +70,9 @@ void mp::BaseVirtualMachineFactory::prepare_interface(NetworkInterface& net,
 
     if (net_it != host_nets.end() && net_it->type != bridge_type)
     {
-        if (auto bridge_it = mpu::find_bridge_with(host_nets, net.id, bridge_type); bridge_it != host_nets.cend())
+        if (auto bridge = mpu::find_bridge_with(host_nets, net.id, bridge_type))
         {
-            net.id = bridge_it->id;
+            net.id = bridge->id;
         }
         else
         {

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -26,19 +26,6 @@
 namespace mp = multipass;
 namespace mpu = multipass::utils;
 
-namespace
-{
-template <typename NetworkContainer>
-auto find_bridge_with(const NetworkContainer& networks, const std::string& member_network,
-                      const std::string& bridge_type)
-{
-    return std::find_if(std::cbegin(networks), std::cend(networks),
-                        [&member_network, &bridge_type](const mp::NetworkInterfaceInfo& info) {
-                            return info.type == bridge_type && info.has_link(member_network);
-                        });
-}
-} // namespace
-
 const mp::Path mp::BaseVirtualMachineFactory::instances_subdir = "vault/instances";
 
 mp::BaseVirtualMachineFactory::BaseVirtualMachineFactory(const Path& instances_dir) : instances_dir{instances_dir} {};
@@ -83,7 +70,7 @@ void mp::BaseVirtualMachineFactory::prepare_interface(NetworkInterface& net,
 
     if (net_it != host_nets.end() && net_it->type != bridge_type)
     {
-        if (auto bridge_it = find_bridge_with(host_nets, net.id, bridge_type); bridge_it != host_nets.cend())
+        if (auto bridge_it = mpu::find_bridge_with(host_nets, net.id, bridge_type); bridge_it != host_nets.cend())
         {
             net.id = bridge_it->id;
         }

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "base_virtual_machine_factory.h"
+#include "multipass/platform.h"
 
 #include <multipass/cloud_init_iso.h>
 #include <multipass/network_interface.h>
@@ -50,14 +51,13 @@ void mp::BaseVirtualMachineFactory::configure(VirtualMachineDescription& vm_desc
     vm_desc.cloud_init_iso = cloud_init_iso;
 }
 
-void mp::BaseVirtualMachineFactory::prepare_networking_guts(std::vector<NetworkInterface>& extra_interfaces,
-                                                            const std::string& bridge_type)
+void mp::BaseVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
 {
     if (!extra_interfaces.empty())
     {
         auto host_nets = networks(); // expensive
         for (auto& net : extra_interfaces)
-            prepare_interface(net, host_nets, bridge_type);
+            prepare_interface(net, host_nets, MP_PLATFORM.bridge_nomenclature());
     }
 }
 

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -57,14 +57,14 @@ void mp::BaseVirtualMachineFactory::prepare_networking(std::vector<NetworkInterf
     {
         auto host_nets = networks(); // expensive
         for (auto& net : extra_interfaces)
-            prepare_interface(net, host_nets, MP_PLATFORM.bridge_nomenclature());
+            prepare_interface(net, host_nets);
     }
 }
 
 void mp::BaseVirtualMachineFactory::prepare_interface(NetworkInterface& net,
-                                                      std::vector<NetworkInterfaceInfo>& host_nets,
-                                                      const std::string& bridge_type)
+                                                      std::vector<NetworkInterfaceInfo>& host_nets)
 {
+    const auto bridge_type = MP_PLATFORM.bridge_nomenclature();
     auto net_it = std::find_if(host_nets.cbegin(), host_nets.cend(),
                                [&net](const mp::NetworkInterfaceInfo& info) { return info.id == net.id; });
 

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -83,8 +83,7 @@ protected:
         throw NotImplementedOnThisBackendException{"bridge creation"};
     }
 
-    virtual void prepare_interface(NetworkInterface& net, std::vector<NetworkInterfaceInfo>& host_nets,
-                                   const std::string& bridge_type);
+    virtual void prepare_interface(NetworkInterface& net, std::vector<NetworkInterfaceInfo>& host_nets);
 
     virtual void remove_resources_for_impl(const std::string& name) = 0;
 

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -77,11 +77,6 @@ public:
 
     void require_suspend_support() const override;
 
-    std::string bridge_name_for(const std::string& iface_name) const override
-    {
-        return "";
-    };
-
 protected:
     static const Path instances_subdir;
 

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -53,7 +53,7 @@ public:
         return utils::backend_directory_path(instances_dir, QString::fromStdString(name));
     }
 
-    void prepare_networking(std::vector<NetworkInterface>& /*extra_interfaces*/) override;
+    void prepare_networking(std::vector<NetworkInterface>& extra_interfaces) override;
 
     VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                           const Path& cache_dir_path, const Path& data_dir_path,

--- a/src/platform/backends/shared/base_virtual_machine_factory.h
+++ b/src/platform/backends/shared/base_virtual_machine_factory.h
@@ -53,10 +53,7 @@ public:
         return utils::backend_directory_path(instances_dir, QString::fromStdString(name));
     }
 
-    void prepare_networking(std::vector<NetworkInterface>& /*extra_interfaces*/) override
-    {
-        // only certain backends need to do anything to prepare networking
-    }
+    void prepare_networking(std::vector<NetworkInterface>& /*extra_interfaces*/) override;
 
     VMImageVault::UPtr create_image_vault(std::vector<VMImageHost*> image_hosts, URLDownloader* downloader,
                                           const Path& cache_dir_path, const Path& data_dir_path,
@@ -85,9 +82,6 @@ protected:
     {
         throw NotImplementedOnThisBackendException{"bridge creation"};
     }
-
-    virtual void prepare_networking_guts(std::vector<NetworkInterface>& extra_interfaces,
-                                         const std::string& bridge_type);
 
     virtual void prepare_interface(NetworkInterface& net, std::vector<NetworkInterfaceInfo>& host_nets,
                                    const std::string& bridge_type);

--- a/src/platform/backends/shared/linux/backend_utils.h
+++ b/src/platform/backends/shared/linux/backend_utils.h
@@ -51,7 +51,6 @@ class Backend : public Singleton<Backend>
 public:
     using Singleton<Backend>::Singleton;
 
-    virtual std::string bridge_name(const std::string& interface) const;
     virtual std::string create_bridge_with(const std::string& interface);
     virtual std::string get_subnet(const Path& network_dir, const QString& bridge_name) const;
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -15,13 +15,14 @@
  *
  */
 
-#include "multipass/exceptions/ssh_exception.h"
 #include <multipass/constants.h>
 #include <multipass/exceptions/autostart_setup_exception.h>
 #include <multipass/exceptions/file_open_failed_exception.h>
+#include <multipass/exceptions/ssh_exception.h>
 #include <multipass/file_ops.h>
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/platform.h>
 #include <multipass/ssh/ssh_session.h>
 #include <multipass/standard_paths.h>
@@ -41,6 +42,7 @@
 #include <cassert>
 #include <cctype>
 #include <fstream>
+#include <optional>
 #include <random>
 #include <regex>
 #include <sstream>
@@ -572,4 +574,16 @@ bool mp::Utils::is_ipv4_valid(const std::string& ipv4) const
     }
 
     return true;
+}
+
+auto mp::utils::find_bridge_with(const std::vector<mp::NetworkInterfaceInfo>& networks,
+                                 const std::string& target_network,
+                                 const std::string& bridge_type) -> std::optional<mp::NetworkInterfaceInfo>
+{
+    const auto it = std::find_if(std::cbegin(networks),
+                                 std::cend(networks),
+                                 [&target_network, &bridge_type](const NetworkInterfaceInfo& info) {
+                                     return info.type == bridge_type && info.has_link(target_network);
+                                 });
+    return it == std::cend(networks) ? std::nullopt : std::make_optional(*it);
 }

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -2318,8 +2318,7 @@ public:
     using mp::LXDVirtualMachineFactory::create_bridge_with;
     using mp::LXDVirtualMachineFactory::LXDVirtualMachineFactory;
 
-    MOCK_METHOD(void, prepare_networking_guts,
-                (std::vector<mp::NetworkInterface> & extra_interfaces, const std::string& bridge_type), (override));
+    MOCK_METHOD(void, prepare_networking, (std::vector<mp::NetworkInterface>&), (override));
 };
 } // namespace
 
@@ -2329,7 +2328,7 @@ TEST_F(LXDBackend, prepares_networking_via_base_factory)
     std::vector<mp::NetworkInterface> extra_networks{{"netid", "mac", false}};
 
     auto address = [](const auto& v) { return &v; }; // replace with Address matcher once available
-    EXPECT_CALL(backend, prepare_networking_guts(ResultOf(address, Eq(&extra_networks)), Eq("bridge")));
+    EXPECT_CALL(backend, prepare_networking(ResultOf(address, Eq(&extra_networks))));
     backend.prepare_networking(extra_networks);
 }
 

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -2403,21 +2403,3 @@ TEST_F(LXDBackend, addsNetworkInterface)
 
     EXPECT_EQ(patch_times_called, 1u);
 }
-
-struct LXDNetworkNameTestSuite : LXDBackend, WithParamInterface<std::pair<std::string, std::string>>
-{
-};
-
-TEST_P(LXDNetworkNameTestSuite, backendReturnsCorrectBridgeName)
-{
-    const auto [name, ret] = GetParam();
-
-    CustomLXDFactory factory{std::move(mock_network_access_manager), data_dir.path(), base_url};
-
-    EXPECT_EQ(factory.bridge_name_for(name), ret);
-}
-
-INSTANTIATE_TEST_SUITE_P(LXDBackend,
-                         LXDNetworkNameTestSuite,
-                         Values(std::make_pair("enp4s0", "br-enp4s0"),
-                                std::make_pair("enx586d8fd35b6c", "br-enx586d8fd35")));

--- a/tests/mock_daemon.h
+++ b/tests/mock_daemon.h
@@ -138,9 +138,12 @@ struct MockDaemon : public Daemon
     }
 
     // The following functions are meant to test daemon's bridging functions.
-    // This tests bridged interface addition. The second parameter gives an instance to test on.
-    void test_add_bridged_interface(const std::string& instance_name, const VirtualMachine::ShPtr instance)
+    // This tests bridged interface addition.
+    void test_add_bridged_interface(const std::string& instance_name,
+                                    const VirtualMachine::ShPtr instance,
+                                    const VMSpecs& specs = {})
     {
+        vm_instance_specs.emplace(instance_name, specs);
         operative_instances.insert(std::make_pair(instance_name, instance));
 
         return add_bridged_interface(instance_name);

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -56,6 +56,7 @@ public:
     MOCK_METHOD(QString, default_privileged_mounts, (), (const, override));
     MOCK_METHOD(bool, is_image_url_supported, (), (const, override));
     MOCK_METHOD(QString, get_username, (), (const, override));
+    MOCK_METHOD(std::string, bridge_nomenclature, (), (const, override));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockPlatform, Platform);
 };

--- a/tests/mock_virtual_machine_factory.h
+++ b/tests/mock_virtual_machine_factory.h
@@ -51,7 +51,6 @@ struct MockVirtualMachineFactory : public VirtualMachineFactory
     MOCK_METHOD(std::vector<NetworkInterfaceInfo>, networks, (), (const, override));
     MOCK_METHOD(void, require_snapshots_support, (), (const, override));
     MOCK_METHOD(void, require_suspend_support, (), (const, override));
-    MOCK_METHOD(std::string, bridge_name_for, (const std::string&), (const, override));
 
     // originally protected:
     MOCK_METHOD(std::string, create_bridge_with, (const NetworkInterfaceInfo&), (override));

--- a/tests/qemu/mock_qemu_platform.h
+++ b/tests/qemu/mock_qemu_platform.h
@@ -43,6 +43,7 @@ struct MockQemuPlatform : public QemuPlatform
     MOCK_METHOD(QStringList, vm_platform_args, (const VirtualMachineDescription&), (override));
     MOCK_METHOD(QString, get_directory_name, (), (const, override));
     MOCK_METHOD(void, add_network_interface, (VirtualMachineDescription&, const NetworkInterface&), (override));
+    MOCK_METHOD(void, prepare_networking, (std::vector<NetworkInterface>&), (const, override));
 };
 
 struct MockQemuPlatformFactory : public QemuPlatformFactory

--- a/tests/test_base_virtual_machine_factory.cpp
+++ b/tests/test_base_virtual_machine_factory.cpp
@@ -56,18 +56,12 @@ struct MockBaseFactory : mp::BaseVirtualMachineFactory
     MOCK_METHOD(QString, get_backend_version_string, (), (const, override));
     MOCK_METHOD(void, prepare_networking, (std::vector<mp::NetworkInterface>&), (override));
     MOCK_METHOD(std::vector<mp::NetworkInterfaceInfo>, networks, (), (const, override));
-    MOCK_METHOD(std::string, bridge_name_for, (const std::string&), (const, override));
     MOCK_METHOD(std::string, create_bridge_with, (const mp::NetworkInterfaceInfo&), (override));
     MOCK_METHOD(void, prepare_interface,
                 (mp::NetworkInterface & net, std::vector<mp::NetworkInterfaceInfo>& host_nets,
                  const std::string& bridge_type),
                 (override));
     MOCK_METHOD(void, remove_resources_for_impl, (const std::string&), (override));
-
-    std::string base_bridge_name_for(const std::string& iface_name) const
-    {
-        return mp::BaseVirtualMachineFactory::bridge_name_for(iface_name);
-    }
 
     std::string base_create_bridge_with(const mp::NetworkInterfaceInfo& interface)
     {
@@ -161,13 +155,6 @@ TEST_F(BaseFactory, creates_cloud_init_iso_image)
 
     EXPECT_EQ(vm_desc.cloud_init_iso, QString("%1/cloud-init-config.iso").arg(factory.tmp_dir->path()));
     EXPECT_TRUE(QFile::exists(vm_desc.cloud_init_iso));
-}
-
-TEST_F(BaseFactory, baseBridgeNameForReturnsEmpty)
-{
-    StrictMock<MockBaseFactory> factory;
-
-    ASSERT_EQ(factory.base_bridge_name_for("any_interface"), "");
 }
 
 TEST_F(BaseFactory, create_bridge_not_implemented)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -2324,19 +2324,23 @@ TEST_F(Daemon, add_bridged_interface_throws_if_needs_authorization)
                          mpt::match_what(msg));
 }
 
-struct DaemonIsBridged : public Daemon, public WithParamInterface<std::pair<std::vector<mp::NetworkInterface>, bool>>
+struct DaemonIsBridged : public Daemon,
+                         public WithParamInterface<
+                             std::tuple<std::vector<mp::NetworkInterfaceInfo>, std::vector<mp::NetworkInterface>, bool>>
 {
 };
 
 TEST_P(DaemonIsBridged, is_bridged_works)
 {
-    const auto [extra_interfaces, result] = GetParam();
+    const auto [host_nets, extra_interfaces, result] = GetParam();
 
     std::string instance_name{"charlie"};
 
     mp::VMSpecs specs;
     specs.extra_interfaces = extra_interfaces;
 
+    auto mock_factory = use_a_mock_vm_factory();
+    EXPECT_CALL(*mock_factory, networks).WillOnce(Return(host_nets));
     mpt::MockDaemon daemon{config_builder.build()};
     auto instance_ptr = std::make_shared<NiceMock<mpt::MockVirtualMachine>>(instance_name);
 
@@ -2346,10 +2350,18 @@ TEST_P(DaemonIsBridged, is_bridged_works)
 INSTANTIATE_TEST_SUITE_P(
     Daemon,
     DaemonIsBridged,
-    Values(std::make_pair(std::vector<mp::NetworkInterface>{{"eth8", "52:54:00:09:10:11", true}}, true),
-           std::make_pair(std::vector<mp::NetworkInterface>{{"br-eth8", "52:54:00:12:13:14", true}}, true),
-           std::make_pair(std::vector<mp::NetworkInterface>{{"eth9", "52:54:00:15:16:17", true}}, false),
-           std::make_pair(std::vector<mp::NetworkInterface>{{"br-eth9", "52:54:00:18:19:20", true}}, false)));
+    Values(std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{},
+                           std::vector<mp::NetworkInterface>{{"eth8", "52:54:00:09:10:11", true}},
+                           true),
+           std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{{"somebr", "bridge", "some bridge", {"eth8"}, false}},
+                           std::vector<mp::NetworkInterface>{{"somebr", "52:54:00:12:13:14", true}},
+                           true),
+           std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{},
+                           std::vector<mp::NetworkInterface>{{"eth9", "52:54:00:15:16:17", true}},
+                           false),
+           std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{{"somebr", "bridge", "some bridge", {"eth9"}, false}},
+                           std::vector<mp::NetworkInterface>{{"somebr", "52:54:00:18:19:20", true}},
+                           false)));
 
 TEST_F(Daemon, requests_networks)
 {

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -2379,8 +2379,11 @@ TEST_P(DaemonIsBridged, is_bridged_works)
 
     std::string instance_name{"charlie"};
 
-    mp::VMSpecs specs;
+    mp::VMSpecs specs{};
     specs.extra_interfaces = extra_interfaces;
+
+    auto [mock_platform, platform_guard] = mpt::MockPlatform::inject();
+    EXPECT_CALL(*mock_platform, bridge_nomenclature).WillRepeatedly(Return("generic"));
 
     auto mock_factory = use_a_mock_vm_factory();
     EXPECT_CALL(*mock_factory, networks).WillOnce(Return(host_nets));
@@ -2396,13 +2399,13 @@ INSTANTIATE_TEST_SUITE_P(
     Values(std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{},
                            std::vector<mp::NetworkInterface>{{"eth8", "52:54:00:09:10:11", true}},
                            true),
-           std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{{"somebr", "bridge", "some bridge", {"eth8"}, false}},
+           std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{{"somebr", "generic", "some bridge", {"eth8"}, false}},
                            std::vector<mp::NetworkInterface>{{"somebr", "52:54:00:12:13:14", true}},
                            true),
            std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{},
                            std::vector<mp::NetworkInterface>{{"eth9", "52:54:00:15:16:17", true}},
                            false),
-           std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{{"somebr", "bridge", "some bridge", {"eth9"}, false}},
+           std::make_tuple(std::vector<mp::NetworkInterfaceInfo>{{"somebr", "generic", "some bridge", {"eth9"}, false}},
                            std::vector<mp::NetworkInterface>{{"somebr", "52:54:00:18:19:20", true}},
                            false)));
 

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -2337,11 +2337,8 @@ TEST_P(DaemonIsBridged, is_bridged_works)
     mp::VMSpecs specs;
     specs.extra_interfaces = extra_interfaces;
 
-    auto mock_factory = use_a_mock_vm_factory();
     mpt::MockDaemon daemon{config_builder.build()};
     auto instance_ptr = std::make_shared<NiceMock<mpt::MockVirtualMachine>>(instance_name);
-
-    EXPECT_CALL(*mock_factory, bridge_name_for(_)).WillOnce(Return("br-eth8"));
 
     EXPECT_EQ(daemon.test_is_bridged(instance_name, specs), result);
 }

--- a/tests/test_instance_settings_handler.cpp
+++ b/tests/test_instance_settings_handler.cpp
@@ -115,7 +115,8 @@ struct TestInstanceSettingsHandler : public Test
     std::function<void(const std::string&)> make_fake_add()
     {
         return [this](const std::string& n) {
-            specs[n].extra_interfaces.push_back(mp::NetworkInterface{"eth8", mpu::generate_mac_address(), true});
+            if (!make_fake_is_bridged()(n))
+                specs[n].extra_interfaces.push_back(mp::NetworkInterface{"eth8", mpu::generate_mac_address(), true});
         };
     }
 

--- a/tests/test_instance_settings_handler.cpp
+++ b/tests/test_instance_settings_handler.cpp
@@ -520,7 +520,7 @@ TEST_F(TestInstanceSettingsHandler, setRefusesToUnbridge)
 
     MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, "bridged"), "false"),
                          mp::InvalidSettingException,
-                         mpt::match_what(HasSubstr("Bridged interface cannot be removed")));
+                         mpt::match_what(HasSubstr("not supported")));
 }
 
 TEST_F(TestInstanceSettingsHandler, setAddsInterface)


### PR DESCRIPTION
An instance is considered bridged, at any point in time, *iff* the configured preferred network at that time is:
  - part of the corresponding `VMSpecs::extra_networks`, or
  - linked to a bridge/switch (depending on the platform) which is part of the instance's `extra_networks`.

This PR implements that predicate in `mp::Daemon::is_bridged` (and `is_bridged_impl`), removing any previous logic relying on bridge names to relate bridges with other interfaces, and instead using readily available `NetworkInterfaceInfo::links`. To achieve this, the predicate calls `find_bridge_with`, which was refactored into a backend-agnostic utility.

Because Windows uses "switches" instead of "bridges", a platform function is added to obtain the correct nomenclature, replacing hard-coded uses in backend factories. Since the factories no longer need to call a base `prepare_networking_guts` with the correct nomenclature, that method is removed and its implementation moved to `BaseVirtualMachine::prepare_networking`, which is overridden to do nothing in VirtualBox.

The separation between `mp::Daemon::is_bridged` (and `is_bridged_impl`) is meant to avoid inspecting host networks or the preferred bridge setting twice when adding a bridge. To that end, the responsibility of checking whether and instance is already bridged, when attempting to bridge it, is split from the `InstanceSettingsHandler` to the `Daemon`, depending on the use case. 

This scheme of having different entities checking if the instance is bridged is a compromise that avoids passing yet more lambdas to the settings handler, which would otherwise be required to obtain networks or settings only once from that level. A better implementation would instead extract all required functionality (all "lambdas") into a separate class that could be passed to the settings handler instead of disconnected callables. But that would require more time.

Finally, existing tests were adapted, removed where obsolete, and a couple of tests were added to cover everything. Codecov seems to be unhappy that I've removed previously covered, but wrong/unnecessary, code.