### PR TITLE
Refine utilities to `make_file_with_content`

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -85,6 +85,7 @@ public:
     virtual qint64 size(QFile& file) const;
     virtual qint64 write(QFile& file, const char* data, qint64 maxSize) const;
     virtual qint64 write(QFileDevice& file, const QByteArray& data) const;
+    virtual bool flush(QFile& file) const;
 
     // QSaveFile operations
     virtual bool commit(QSaveFile& file) const;

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -165,6 +165,11 @@ qint64 mp::FileOps::write(QFileDevice& file, const QByteArray& data) const
     return file.write(data);
 }
 
+bool mp::FileOps::flush(QFile& file) const
+{
+    return file.flush();
+}
+
 bool mp::FileOps::commit(QSaveFile& file) const
 {
     return file.commit();

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -113,7 +113,10 @@ void mp::Utils::make_file_with_content(const std::string& file_name, const std::
     if (MP_FILEOPS.write(file, content.c_str(), content.size()) != (qint64)content.size())
         throw std::runtime_error(fmt::format("failed to write to file '{}': {}", file_name, file.errorString()));
 
-    return;
+    if (!MP_FILEOPS.flush(file)) // flush manually to check return (which QFile::close ignores)
+        throw std::runtime_error(fmt::format("failed to flush file '{}': {}", file_name, file.errorString()));
+
+    return; // file closed, flush called again with errors ignored
 }
 
 std::string mp::Utils::get_kernel_version() const

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -105,10 +105,13 @@ void mp::Utils::make_file_with_content(const std::string& file_name, const std::
         throw std::runtime_error(fmt::format("failed to create dir '{}'", parent_dir.path()));
 
     if (!MP_FILEOPS.open(file, QFile::WriteOnly))
-        throw std::runtime_error(fmt::format("failed to open file '{}' for writing", file_name));
+        throw std::runtime_error(
+            fmt::format("failed to open file '{}' for writing: {}", file_name, file.errorString()));
 
+    // TODO use a QTextStream instead. Theoretically, this may fail to write it all in one go but still succeed.
+    // In practice, that seems unlikely. See https://stackoverflow.com/a/70933650 for more.
     if (MP_FILEOPS.write(file, content.c_str(), content.size()) != (qint64)content.size())
-        throw std::runtime_error(fmt::format("failed to write to file '{}'", file_name));
+        throw std::runtime_error(fmt::format("failed to write to file '{}': {}", file_name, file.errorString()));
 
     return;
 }

--- a/tests/file_operations.cpp
+++ b/tests/file_operations.cpp
@@ -45,7 +45,7 @@ QByteArray mpt::load_test_file(const char* file_name)
     return multipass::test::load(file_path);
 }
 
-qint64 mpt::make_file_with_content(const QString& file_name, const std::string& content)
+void mpt::make_file_with_content(const QString& file_name, const std::string& content)
 {
     QFile file(file_name);
     if (file.exists())
@@ -63,5 +63,4 @@ qint64 mpt::make_file_with_content(const QString& file_name, const std::string& 
         throw std::runtime_error(fmt::format("failed to open test file: '{}'", file_name));
 
     file.write(content.data(), content.size());
-    return file.size();
 }

--- a/tests/file_operations.cpp
+++ b/tests/file_operations.cpp
@@ -21,6 +21,7 @@
 #include "path.h"
 
 #include <multipass/format.h>
+#include <multipass/utils.h>
 
 #include <QDir>
 #include <QFile>
@@ -47,20 +48,5 @@ QByteArray mpt::load_test_file(const char* file_name)
 
 void mpt::make_file_with_content(const QString& file_name, const std::string& content)
 {
-    QFile file(file_name);
-    if (file.exists())
-        throw std::runtime_error(fmt::format("test file already exists: '{}'", file_name));
-
-    QDir parent_dir{QFileInfo{file}.absoluteDir()};
-    if (!parent_dir.mkpath(".")) // true if directory already exists
-        throw std::runtime_error(fmt::format("failed to create test dir: '{}'", parent_dir.path()));
-
-    auto file_dir = QFileInfo(file).absoluteDir();
-    if (!file_dir.exists())
-        file_dir.mkpath(file_dir.absolutePath());
-
-    if (!file.open(QFile::WriteOnly))
-        throw std::runtime_error(fmt::format("failed to open test file: '{}'", file_name));
-
-    file.write(content.data(), content.size());
+    MP_UTILS.Utils::make_file_with_content(file_name.toStdString(), content); // call the base impl even if it is a mock
 }

--- a/tests/file_operations.h
+++ b/tests/file_operations.h
@@ -30,7 +30,7 @@ namespace test
 {
 QByteArray load(QString path);
 QByteArray load_test_file(const char* file_name);
-qint64 make_file_with_content(const QString& file_name, const std::string& content = "this is a test file");
+void make_file_with_content(const QString& file_name, const std::string& content = "this is a test file");
 }
 }
 #endif // MULTIPASS_FILE_READER_H

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -250,7 +250,7 @@ TEST_F(PlatformLinux, retrieves_empty_bridges)
 
     QDir fake_sys_class_net{tmp_dir.path()};
     QDir bridge_dir{fake_sys_class_net.filePath(fake_bridge)};
-    ASSERT_EQ(mpt::make_file_with_content(bridge_dir.filePath("type"), "1"), 1);
+    mpt::make_file_with_content(bridge_dir.filePath("type"), "1");
     ASSERT_TRUE(bridge_dir.mkpath("bridge"));
 
     auto net_map = mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path());
@@ -269,7 +269,7 @@ TEST_F(PlatformLinux, retrieves_ethernet_devices)
     const auto fake_eth = "someth";
 
     QDir fake_sys_class_net{tmp_dir.path()};
-    ASSERT_EQ(mpt::make_file_with_content(fake_sys_class_net.filePath(fake_eth) + "/type", "1"), 1);
+    mpt::make_file_with_content(fake_sys_class_net.filePath(fake_eth) + "/type", "1");
 
     auto net_map = mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path());
 
@@ -300,7 +300,7 @@ TEST_F(PlatformLinux, does_not_retrieve_other_virtual)
     const auto fake_virt = "somevirt";
 
     QDir fake_sys_class_net{tmp_dir.path() + "/virtual"};
-    ASSERT_EQ(mpt::make_file_with_content(fake_sys_class_net.filePath(fake_virt) + "/type", "1"), 1);
+    mpt::make_file_with_content(fake_sys_class_net.filePath(fake_virt) + "/type", "1");
 
     EXPECT_THAT(mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path()), IsEmpty());
 }
@@ -312,7 +312,7 @@ TEST_F(PlatformLinux, does_not_retrieve_wireless)
 
     QDir fake_sys_class_net{tmp_dir.path()};
     QDir wifi_dir{fake_sys_class_net.filePath(fake_wifi)};
-    ASSERT_EQ(mpt::make_file_with_content(wifi_dir.filePath("type"), "1"), 1);
+    mpt::make_file_with_content(wifi_dir.filePath("type"), "1");
     ASSERT_TRUE(wifi_dir.mkpath("wireless"));
 
     EXPECT_THAT(mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path()), IsEmpty());
@@ -324,7 +324,7 @@ TEST_F(PlatformLinux, does_not_retrieve_protocols)
     const auto fake_net = "somenet";
 
     QDir fake_sys_class_net{tmp_dir.path()};
-    ASSERT_EQ(mpt::make_file_with_content(fake_sys_class_net.filePath(fake_net) + "/type", "32"), 2);
+    mpt::make_file_with_content(fake_sys_class_net.filePath(fake_net) + "/type", "32");
 
     EXPECT_THAT(mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path()), IsEmpty());
 }
@@ -337,9 +337,8 @@ TEST_F(PlatformLinux, does_not_retrieve_other_specified_device_types)
 
     QDir fake_sys_class_net{tmp_dir.path()};
     QDir net_dir{fake_sys_class_net.filePath(fake_net)};
-    ASSERT_EQ(mpt::make_file_with_content(net_dir.filePath("type"), "1"), 1);
-    ASSERT_EQ(mpt::make_file_with_content(net_dir.filePath("uevent"), uevent_contents),
-              static_cast<int64_t>(uevent_contents.size()));
+    mpt::make_file_with_content(net_dir.filePath("type"), "1");
+    mpt::make_file_with_content(net_dir.filePath("uevent"), uevent_contents);
 
     auto net_map = mp::platform::detail::get_network_interfaces_from(fake_sys_class_net.path());
 
@@ -359,7 +358,7 @@ TEST_P(BridgeMemberTest, retrieves_bridges_with_members)
     QDir interface_dir{fake_sys_class_net.filePath(fake_bridge)};
     QDir members_dir{interface_dir.filePath("brif")};
 
-    ASSERT_EQ(mpt::make_file_with_content(interface_dir.filePath("type"), "1"), 1);
+    mpt::make_file_with_content(interface_dir.filePath("type"), "1");
     ASSERT_TRUE(interface_dir.mkpath("bridge"));
     ASSERT_TRUE(members_dir.mkpath("."));
 
@@ -374,7 +373,7 @@ TEST_P(BridgeMemberTest, retrieves_bridges_with_members)
 
         if (recognized)
         {
-            ASSERT_EQ(mpt::make_file_with_content(member_dir.filePath("type"), "1"), 1);
+            mpt::make_file_with_content(member_dir.filePath("type"), "1");
 
             substrs_matchers.push_back(HasSubstr(member));
             network_matchers.push_back(Field(&net_value_type::first, member));

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -60,6 +60,7 @@ public:
     MOCK_METHOD(qint64, size, (QFile&), (const, override));
     MOCK_METHOD(qint64, write, (QFile&, const char*, qint64), (const, override));
     MOCK_METHOD(qint64, write, (QFileDevice&, const QByteArray&), (const, override));
+    MOCK_METHOD(bool, flush, (QFile & file), (const, override));
 
     // QSaveFile mock methods
     MOCK_METHOD(bool, commit, (QSaveFile&), (const, override));

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -1342,10 +1342,9 @@ TEST_F(SftpServer, open_in_truncate_mode_truncates_file)
 {
     mpt::TempDir temp_dir;
     auto file_name = temp_dir.path() + "/test-file";
-    auto size = mpt::make_file_with_content(file_name);
+    mpt::make_file_with_content(file_name);
 
     ASSERT_TRUE(QFile::exists(file_name));
-    ASSERT_GT(size, 0);
 
     auto sftp = make_sftpserver(temp_dir.path().toStdString());
     auto msg = make_msg(SFTP_OPEN);
@@ -1372,10 +1371,9 @@ TEST_F(SftpServer, open_unable_to_open_fails)
 {
     mpt::TempDir temp_dir;
     auto file_name = temp_dir.path() + "/test-file";
-    auto size = mpt::make_file_with_content(file_name);
+    mpt::make_file_with_content(file_name);
 
     ASSERT_TRUE(QFile::exists(file_name));
-    ASSERT_GT(size, 0);
 
     auto sftp = make_sftpserver(temp_dir.path().toStdString());
     sftp_attributes_struct attr{};
@@ -1418,10 +1416,9 @@ TEST_F(SftpServer, open_unable_to_get_status_fails)
 {
     mpt::TempDir temp_dir;
     auto file_name = temp_dir.path() + "/test-file";
-    auto size = mpt::make_file_with_content(file_name);
+    mpt::make_file_with_content(file_name);
 
     ASSERT_TRUE(QFile::exists(file_name));
-    ASSERT_GT(size, 0);
 
     auto sftp = make_sftpserver(temp_dir.path().toStdString());
     sftp_attributes_struct attr{};
@@ -1722,8 +1719,9 @@ TEST_F(SftpServer, handles_close)
 TEST_F(SftpServer, handles_fstat)
 {
     mpt::TempDir temp_dir;
+    const auto content = std::string{"whatever just some content bla bla"};
     auto file_name = temp_dir.path() + "/test-file";
-    uint64_t expected_size = mpt::make_file_with_content(file_name);
+    mpt::make_file_with_content(file_name, content);
 
     auto sftp = make_sftpserver(temp_dir.path().toStdString());
     auto open_msg = make_msg(SFTP_OPEN);
@@ -1740,7 +1738,8 @@ TEST_F(SftpServer, handles_fstat)
     };
 
     int num_calls{0};
-    auto reply_attr = [&num_calls, &fstat_msg, expected_size](sftp_client_message reply_msg, sftp_attributes attr) {
+    auto reply_attr = [&num_calls, &fstat_msg, expected_size = content.size()](sftp_client_message reply_msg,
+                                                                               sftp_attributes attr) {
         EXPECT_THAT(reply_msg, Eq(fstat_msg.get()));
         EXPECT_THAT(attr->size, Eq(expected_size));
         ++num_calls;

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -340,6 +340,23 @@ TEST(Utils, make_file_with_content_throws_on_write_error)
                          mpt::match_what(HasSubstr("failed to write to file")));
 }
 
+TEST(Utils, make_file_with_content_throws_on_failure_to_flush)
+{
+    std::string file_name{"some_dir/test-file"};
+
+    auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
+
+    EXPECT_CALL(*mock_file_ops, exists(A<const QFile&>())).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, mkpath(_, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, open(_, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, write(A<QFile&>(), _, _)).WillOnce(Return(file_contents.size()));
+    EXPECT_CALL(*mock_file_ops, flush(A<QFile&>())).WillOnce(Return(false));
+
+    MP_EXPECT_THROW_THAT(MP_UTILS.make_file_with_content(file_name, file_contents),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr("failed to flush file")));
+}
+
 TEST(Utils, expectedScryptHashReturned)
 {
     const auto passphrase = MP_UTILS.generate_scrypt_hash_for("passphrase");


### PR DESCRIPTION
This PR improves error handling around writing files via `make_file_with_content()`.

There are actually two versions of `make_file_with_content()` before this PR: one in utils, one in tests. One started as a copy-paste of the other, then they drifter apart. Entropy always increases... That is fixed here (not entropy increasing unfortunately).

But what prompted this was [this failure](https://github.com/canonical/multipass/actions/runs/9587796659/job/26438549050#step:15:262). That might arise if the test file is not properly flushed when closed, as that error would [go undetected](https://doc.qt.io/qt-6/qfiledevice.html#close). This refines the implementation of `make_file_with_content` by calling `QFile::flush()` directly and checking the return. It also adds more details when `QFile` detects an error.

One further improvement is [left for another occasion](https://github.com/canonical/multipass/blob/37ed0c7a43209fb5460b795a95613876bd806cda/src/utils/utils.cpp#L111-L112).