### PR TITLE
[ssh] Reduce log level to avoid log spam with GUI

### DIFF
--- a/include/multipass/ssh/ssh_session.h
+++ b/include/multipass/ssh/ssh_session.h
@@ -49,7 +49,8 @@ public:
 
     ~SSHSession();
 
-    SSHProcess exec(const std::string& cmd); // locks the session until the process is destroyed or exit_code is called!
+    SSHProcess exec(const std::string& cmd, bool whisper = false); /* locks the session until the process is destroyed
+                                                                      or exit_code is called! */
     [[nodiscard]] bool is_connected() const;
 
     operator ssh_session(); // careful, not thread safe

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -223,7 +223,7 @@ public:
 
     // virtual machine helpers
     [[nodiscard]] virtual bool is_running(const VirtualMachine::State& state) const;
-    virtual std::string run_in_ssh_session(SSHSession& session, const std::string& cmd) const;
+    virtual std::string run_in_ssh_session(SSHSession& session, const std::string& cmd, bool whisper = false) const;
 
     // various
     virtual std::vector<uint8_t> random_bytes(size_t len);

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -76,7 +76,9 @@ public:
     virtual std::string management_ipv4() = 0;
     virtual std::vector<std::string> get_all_ipv4() = 0;
     virtual std::string ipv6() = 0;
-    virtual std::string ssh_exec(const std::string& cmd) = 0;
+
+    // careful: default param in virtual method; be sure to keep the same value in all descendants
+    virtual std::string ssh_exec(const std::string& cmd, bool whisper = false) = 0;
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;
     virtual void wait_for_cloud_init(std::chrono::milliseconds timeout) = 0;
     virtual void ensure_vm_is_running() = 0;

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -79,6 +79,7 @@ public:
 
     // careful: default param in virtual method; be sure to keep the same value in all descendants
     virtual std::string ssh_exec(const std::string& cmd, bool whisper = false) = 0;
+
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;
     virtual void wait_for_cloud_init(std::chrono::milliseconds timeout) = 0;
     virtual void ensure_vm_is_running() = 0;

--- a/src/daemon/runtime_instance_info_helper.cpp
+++ b/src/daemon/runtime_instance_info_helper.cpp
@@ -85,7 +85,7 @@ void mp::RuntimeInstanceInfoHelper::populate_runtime_info(mp::VirtualMachine& vm
                                                           bool parallelize)
 {
     const auto& cmd = parallelize ? Cmds::parallel_composite_cmd : Cmds::sequential_composite_cmd;
-    auto results = YAML::Load(vm.ssh_exec(cmd));
+    auto results = YAML::Load(vm.ssh_exec(cmd, /* whisper = */ true));
 
     instance_info->set_load(results[Keys::loadavg_key].as<std::string>());
     instance_info->set_memory_usage(results[Keys::mem_usage_key].as<std::string>());

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -190,7 +190,7 @@ std::string BaseVirtualMachine::get_instance_id_from_the_cloud_init() const
     return MP_CLOUD_INIT_FILE_OPS.get_instance_id_from_cloud_init(cloud_init_config_iso_file_path);
 }
 
-std::string BaseVirtualMachine::ssh_exec(const std::string& cmd)
+std::string BaseVirtualMachine::ssh_exec(const std::string& cmd, bool whisper)
 {
     const std::unique_lock lock{state_mutex};
 
@@ -211,7 +211,7 @@ std::string BaseVirtualMachine::ssh_exec(const std::string& cmd)
 
         try
         {
-            return MP_UTILS.run_in_ssh_session(*ssh_session, cmd);
+            return MP_UTILS.run_in_ssh_session(*ssh_session, cmd, whisper);
         }
         catch (const SSHException& e)
         {

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -278,7 +278,8 @@ std::vector<std::string> BaseVirtualMachine::get_all_ipv4()
     {
         try
         {
-            auto ip_a_output = QString::fromStdString(ssh_exec("ip -brief -family inet address show scope global"));
+            auto ip_a_output = QString::fromStdString(
+                ssh_exec("ip -brief -family inet address show scope global", /* whisper = */ true));
 
             QRegularExpression ipv4_re{QStringLiteral("([\\d\\.]+)\\/\\d+\\s*(metric \\d+)?\\s*$"),
                                        QRegularExpression::MultilineOption};

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -48,7 +48,7 @@ public:
                        const Path& instance_dir);
     BaseVirtualMachine(const std::string& vm_name, const SSHKeyProvider& key_provider, const Path& instance_dir);
 
-    virtual std::string ssh_exec(const std::string& cmd) override;
+    virtual std::string ssh_exec(const std::string& cmd, bool whisper = false) override;
 
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
     void wait_for_cloud_init(std::chrono::milliseconds timeout) override;

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -90,9 +90,11 @@ multipass::SSHSession::~SSHSession()
     force_shutdown(); // do we really need this?
 }
 
-mp::SSHProcess mp::SSHSession::exec(const std::string& cmd)
+mp::SSHProcess mp::SSHSession::exec(const std::string& cmd, bool whisper)
 {
-    mpl::log(mpl::Level::trace, "ssh session", fmt::format("Executing '{}'", cmd));
+    auto lvl = whisper ? mpl::Level::trace : mpl::Level::debug;
+    mpl::log(lvl, "ssh session", fmt::format("Executing '{}'", cmd));
+
     return {session.get(), cmd, std::unique_lock{mut}};
 }
 

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -92,7 +92,7 @@ multipass::SSHSession::~SSHSession()
 
 mp::SSHProcess mp::SSHSession::exec(const std::string& cmd)
 {
-    mpl::log(mpl::Level::debug, "ssh session", fmt::format("Executing '{}'", cmd));
+    mpl::log(mpl::Level::trace, "ssh session", fmt::format("Executing '{}'", cmd));
     return {session.get(), cmd, std::unique_lock{mut}};
 }
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -257,9 +257,9 @@ bool mp::utils::valid_mac_address(const std::string& mac)
 }
 
 // Executes a given command on the given session. Returns the output of the command, with spaces and feeds trimmed.
-std::string mp::Utils::run_in_ssh_session(mp::SSHSession& session, const std::string& cmd) const
+std::string mp::Utils::run_in_ssh_session(mp::SSHSession& session, const std::string& cmd, bool whisper) const
 {
-    auto proc = session.exec(cmd);
+    auto proc = session.exec(cmd, whisper);
 
     if (auto ec = proc.exit_code() != 0)
     {

--- a/tests/mock_utils.h
+++ b/tests/mock_utils.h
@@ -46,13 +46,9 @@ public:
     MOCK_METHOD(void, copy_client_certs_to_common_dir, (const QString&, const QString&), (const));
     MOCK_METHOD(bool, is_running, (const VirtualMachine::State& state), (const, override));
     MOCK_METHOD(std::string,
-                run_in_ssh_session_mock,
+                run_in_ssh_session,
                 (SSHSession & session, const std::string& cmd, bool whisper),
-                (const));
-    std::string run_in_ssh_session(SSHSession& session, const std::string& cmd, bool whisper = false) const override
-    {
-        return run_in_ssh_session_mock(session, cmd, whisper);
-    }
+                (const, override));
     MOCK_METHOD(QString, make_uuid, (const std::optional<std::string>&), (const, override));
     MOCK_METHOD(void, sleep_for, (const std::chrono::milliseconds&), (const, override));
     MOCK_METHOD(bool, is_ipv4_valid, (const std::string& ipv4), (const, override));

--- a/tests/mock_utils.h
+++ b/tests/mock_utils.h
@@ -45,7 +45,14 @@ public:
     MOCK_METHOD(bool, client_certs_exist, (const QString&), (const));
     MOCK_METHOD(void, copy_client_certs_to_common_dir, (const QString&, const QString&), (const));
     MOCK_METHOD(bool, is_running, (const VirtualMachine::State& state), (const, override));
-    MOCK_METHOD(std::string, run_in_ssh_session, (SSHSession & session, const std::string& cmd), (const, override));
+    MOCK_METHOD(std::string,
+                run_in_ssh_session_mock,
+                (SSHSession & session, const std::string& cmd, bool whisper),
+                (const));
+    std::string run_in_ssh_session(SSHSession& session, const std::string& cmd, bool whisper = false) const override
+    {
+        return run_in_ssh_session_mock(session, cmd, whisper);
+    }
     MOCK_METHOD(QString, make_uuid, (const std::optional<std::string>&), (const, override));
     MOCK_METHOD(void, sleep_for, (const std::chrono::milliseconds&), (const, override));
     MOCK_METHOD(bool, is_ipv4_valid, (const std::string& ipv4), (const, override));

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -66,7 +66,13 @@ struct MockVirtualMachineT : public T
     MOCK_METHOD(std::string, management_ipv4, (), (override));
     MOCK_METHOD(std::vector<std::string>, get_all_ipv4, (), (override));
     MOCK_METHOD(std::string, ipv6, (), (override));
-    MOCK_METHOD(std::string, ssh_exec, (const std::string& cmd), (override));
+
+    MOCK_METHOD(std::string, ssh_exec_mock, (const std::string& cmd, bool whisper));
+    std::string ssh_exec(const std::string& cmd, bool whisper = false) override
+    {
+        return ssh_exec_mock(cmd, whisper);
+    }
+
     MOCK_METHOD(void, ensure_vm_is_running, (), (override));
     MOCK_METHOD(void, wait_until_ssh_up, (std::chrono::milliseconds), (override));
     MOCK_METHOD(void, wait_for_cloud_init, (std::chrono::milliseconds), (override));

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -67,10 +67,10 @@ struct MockVirtualMachineT : public T
     MOCK_METHOD(std::vector<std::string>, get_all_ipv4, (), (override));
     MOCK_METHOD(std::string, ipv6, (), (override));
 
-    MOCK_METHOD(std::string, ssh_exec_mock, (const std::string& cmd, bool whisper));
-    std::string ssh_exec(const std::string& cmd, bool whisper = false) override
+    MOCK_METHOD(std::string, ssh_exec, (const std::string& cmd, bool whisper), (override));
+    std::string ssh_exec(const std::string& cmd)
     {
-        return ssh_exec_mock(cmd, whisper);
+        return ssh_exec(cmd, false);
     }
 
     MOCK_METHOD(void, ensure_vm_is_running, (), (override));

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -90,7 +90,7 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
         return {};
     }
 
-    std::string ssh_exec(const std::string& cmd) override
+    std::string ssh_exec(const std::string& cmd, bool whisper = false) override
     {
         return {};
     }

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -98,7 +98,9 @@ struct MockBaseVirtualMachine : public mpt::MockVirtualMachineT<mp::BaseVirtualM
 
     void simulate_ssh_exec() // use if premocking libssh stuff
     {
-        MP_DELEGATE_MOCK_CALLS_ON_BASE(*this, ssh_exec, mp::BaseVirtualMachine);
+        ON_CALL(*this, ssh_exec_mock).WillByDefault([this](auto&&... args) {
+            return this->BaseVirtualMachine::ssh_exec(std::forward<decltype(args)>(args)...);
+        });
     }
 
     void simulate_waiting_for_ssh() // use if premocking libssh stuff
@@ -1234,7 +1236,7 @@ TEST_F(BaseVM, waitForCloudInitNoErrorsAndDoneDoesNotThrow)
 {
     vm.simulate_cloud_init();
     EXPECT_CALL(vm, ensure_vm_is_running()).WillRepeatedly(Return());
-    EXPECT_CALL(vm, ssh_exec).WillOnce(DoDefault());
+    EXPECT_CALL(vm, ssh_exec_mock).WillOnce(DoDefault());
 
     std::chrono::milliseconds timeout(1);
     EXPECT_NO_THROW(vm.wait_for_cloud_init(timeout));
@@ -1244,7 +1246,7 @@ TEST_F(BaseVM, waitForCloudInitErrorTimesOutThrows)
 {
     vm.simulate_cloud_init();
     EXPECT_CALL(vm, ensure_vm_is_running()).WillRepeatedly(Return());
-    EXPECT_CALL(vm, ssh_exec).WillOnce(Throw(mp::SSHExecFailure{"no worky", 1}));
+    EXPECT_CALL(vm, ssh_exec_mock).WillOnce(Throw(mp::SSHExecFailure{"no worky", 1}));
 
     std::chrono::milliseconds timeout(1);
     MP_EXPECT_THROW_THAT(vm.wait_for_cloud_init(timeout),
@@ -1305,7 +1307,7 @@ TEST_F(BaseVM, sshExecRefusesToExecuteIfVMIsNotRunning)
 {
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
     EXPECT_CALL(*mock_utils_ptr, is_running).WillRepeatedly(Return(false));
-    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session).Times(0);
+    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session_mock).Times(0);
 
     vm.simulate_ssh_exec();
     MP_EXPECT_THROW_THAT(vm.ssh_exec("echo"), mp::SSHException, mpt::match_what(HasSubstr("not running")));
@@ -1317,7 +1319,7 @@ TEST_F(BaseVM, sshExecRunsDirectlyIfConnected)
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
     EXPECT_CALL(*mock_utils_ptr, is_running).WillOnce(Return(true));
-    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session(_, cmd)).Times(1);
+    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session_mock(_, cmd, _)).Times(1);
 
     vm.simulate_ssh_exec();
     vm.renew_ssh_session();
@@ -1331,7 +1333,7 @@ TEST_F(BaseVM, sshExecReconnectsIfDisconnected)
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
     EXPECT_CALL(*mock_utils_ptr, is_running).WillOnce(Return(true));
-    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session(_, cmd)).Times(1);
+    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session_mock(_, cmd, _)).Times(1);
 
     vm.simulate_ssh_exec();
 
@@ -1344,7 +1346,7 @@ TEST_F(BaseVM, sshExecTriesToReconnectAfterLateDetectionOfDisconnection)
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
     EXPECT_CALL(*mock_utils_ptr, is_running).WillRepeatedly(Return(true));
-    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session(_, cmd))
+    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session_mock(_, cmd, _))
         .WillOnce(Throw(mp::SSHException{"intentional"}))
         .WillOnce(DoDefault());
 
@@ -1362,7 +1364,7 @@ TEST_F(BaseVM, sshExecRethrowsOtherExceptions)
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
     EXPECT_CALL(*mock_utils_ptr, is_running).WillOnce(Return(true));
-    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session(_, cmd)).WillOnce(Throw(std::runtime_error{"intentional"}));
+    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session_mock(_, cmd, _)).WillOnce(Throw(std::runtime_error{"intentional"}));
 
     vm.simulate_ssh_exec();
     vm.renew_ssh_session();
@@ -1376,7 +1378,7 @@ TEST_F(BaseVM, sshExecRethrowsSSHExceptionsWhenConnected)
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
     EXPECT_CALL(*mock_utils_ptr, is_running).WillOnce(Return(true));
-    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session(_, cmd)).WillOnce(Throw(mp::SSHException{"intentional"}));
+    EXPECT_CALL(*mock_utils_ptr, run_in_ssh_session_mock(_, cmd, _)).WillOnce(Throw(mp::SSHException{"intentional"}));
 
     vm.simulate_ssh_exec();
     vm.renew_ssh_session();

--- a/tests/test_delayed_shutdown.cpp
+++ b/tests/test_delayed_shutdown.cpp
@@ -74,8 +74,8 @@ TEST_F(DelayedShutdown, wallsImpendingShutdown)
     mpt::MockVirtualMachine vm{mp::VirtualMachine::State::running, "mock"};
     mp::DelayedShutdownTimer delayed_shutdown_timer{&vm, [](const std::string&) {}};
 
-    EXPECT_CALL(vm, ssh_exec(upcoming_cmd_matcher)).Times(1); // as we start
-    EXPECT_CALL(vm, ssh_exec(now_cmd_matcher)).Times(1);      // as we finish
+    EXPECT_CALL(vm, ssh_exec_mock(upcoming_cmd_matcher, _)).Times(1); // as we start
+    EXPECT_CALL(vm, ssh_exec_mock(now_cmd_matcher, _)).Times(1);      // as we finish
 
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [this] { loop.quit(); });
 
@@ -88,7 +88,7 @@ TEST_F(DelayedShutdown, handlesExceptionWhenAttemptingToWall)
     mpt::MockVirtualMachine vm{mp::VirtualMachine::State::running, "mock"};
     mp::DelayedShutdownTimer delayed_shutdown_timer{&vm, [](const std::string&) {}};
 
-    EXPECT_CALL(vm, ssh_exec(HasSubstr("wall"))).Times(2).WillRepeatedly(Throw(mp::SSHException("nope")));
+    EXPECT_CALL(vm, ssh_exec_mock(HasSubstr("wall"), _)).Times(2).WillRepeatedly(Throw(mp::SSHException("nope")));
 
     mpt::Signal finished;
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [this, &finished] {

--- a/tests/test_delayed_shutdown.cpp
+++ b/tests/test_delayed_shutdown.cpp
@@ -74,8 +74,8 @@ TEST_F(DelayedShutdown, wallsImpendingShutdown)
     mpt::MockVirtualMachine vm{mp::VirtualMachine::State::running, "mock"};
     mp::DelayedShutdownTimer delayed_shutdown_timer{&vm, [](const std::string&) {}};
 
-    EXPECT_CALL(vm, ssh_exec_mock(upcoming_cmd_matcher, _)).Times(1); // as we start
-    EXPECT_CALL(vm, ssh_exec_mock(now_cmd_matcher, _)).Times(1);      // as we finish
+    EXPECT_CALL(vm, ssh_exec(upcoming_cmd_matcher, _)).Times(1); // as we start
+    EXPECT_CALL(vm, ssh_exec(now_cmd_matcher, _)).Times(1);      // as we finish
 
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [this] { loop.quit(); });
 
@@ -88,7 +88,7 @@ TEST_F(DelayedShutdown, handlesExceptionWhenAttemptingToWall)
     mpt::MockVirtualMachine vm{mp::VirtualMachine::State::running, "mock"};
     mp::DelayedShutdownTimer delayed_shutdown_timer{&vm, [](const std::string&) {}};
 
-    EXPECT_CALL(vm, ssh_exec_mock(HasSubstr("wall"), _)).Times(2).WillRepeatedly(Throw(mp::SSHException("nope")));
+    EXPECT_CALL(vm, ssh_exec(HasSubstr("wall"), _)).Times(2).WillRepeatedly(Throw(mp::SSHException("nope")));
 
     mpt::Signal finished;
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [this, &finished] {


### PR DESCRIPTION
Reduce logging of ssh executions inside instances for `list` and `info` to trace level, while keeping the rest at debug.