### PR TITLE
Fix broken launch on QEMU

### DIFF
--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -214,5 +214,5 @@ mp::QemuPlatform::UPtr mp::QemuPlatformFactory::make_qemu_platform(const Path& d
 
 void mp::QemuPlatformDetail::prepare_networking(std::vector<NetworkInterface>& /*extra_interfaces*/) const
 {
-    throw NotImplementedOnThisBackendException("networks");
+    // Nothing to do here until we implement networking on this backend
 }

--- a/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine_factory.cpp
@@ -132,7 +132,7 @@ auto mp::QemuVirtualMachineFactory::networks() const -> std::vector<NetworkInter
     return qemu_platform->networks();
 }
 
-void multipass::QemuVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
+void mp::QemuVirtualMachineFactory::prepare_networking(std::vector<NetworkInterface>& extra_interfaces)
 {
     return qemu_platform->prepare_networking(extra_interfaces);
 }


### PR DESCRIPTION
On backends that do not implement networks, `prepare_networking()` should be a NOOP, rather than throw. We throw NotImplemented elsewhere.
