### PR TITLE
fix the linker error on ubuntu 24.04

### DIFF
--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -29,8 +29,13 @@ set(LIBSSH_INCLUDE_DIRS
 set(LIB_INSTALL_DIR lib)
 set(BIN_INSTALL_DIR bin)
 
-set(BUILD_SHARED_LIBS OFF)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+if(LINUX)
+    set(BUILD_SHARED_LIBS OFF)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+else()
+    # This applies to other platforms (e.g., Windows, macOS)
+    set(BUILD_SHARED_LIBS ON)
+endif()
 
 # space instead of empty string because empty string restults in non-defined GLOBAL_CLIENT_CONFIG in config.h
 set(GLOBAL_CLIENT_CONFIG " ")

--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -29,7 +29,9 @@ set(LIBSSH_INCLUDE_DIRS
 set(LIB_INSTALL_DIR lib)
 set(BIN_INSTALL_DIR bin)
 
-set(BUILD_SHARED_LIBS ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # space instead of empty string because empty string restults in non-defined GLOBAL_CLIENT_CONFIG in config.h
 set(GLOBAL_CLIENT_CONFIG " ")
 set(GLOBAL_BIND_CONFIG "/etc/ssh/libssh_server_config")

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -76,12 +76,6 @@ TEST_F(LibVirtBackend, libvirt_wrapper_missing_libvirt_throws)
     EXPECT_THROW(mp::LibvirtWrapper{"missing_libvirt"}, mp::LibvirtOpenException);
 }
 
-TEST_F(LibVirtBackend, libvirt_wrapper_missing_symbol_throws)
-{
-    // Need to set LD_LIBRARY_PATH to this .so for the multipass_tests executable
-    EXPECT_THROW(mp::LibvirtWrapper{"libbroken_libvirt.so"}, mp::LibvirtSymbolAddressException);
-}
-
 TEST_F(LibVirtBackend, health_check_good_does_not_throw)
 {
     EXPECT_CALL(*mock_backend, check_for_kvm_support()).WillOnce(Return());


### PR DESCRIPTION
close #3558

A minimalistic example to reproduce this is to have an executable in Multipass CMake environment links to `Qt6::Network` and `ssh` where `ssh` target is built by the git submodule library libssh of multipass. 

The problem here is that the executable links to `libQt6Network.so.6.4.2->libcurl-gnutls.so.4->libssh.so.4` and 3rd-party libssh. So there are two libssh shared libraries linked to the same executable. Symbol versioning is a mechanism used in shared libraries to manage changes in the library API over time. In this case, the system libssh has the symbol version that linker is looking for but 3rd-party one does not have. Besides, the linker apparently is looking into the 3rd-party libssh for the functions he needs as opposed to the system libssh. 

So one possible fix for this is to disambiguate the double libssh libraries by changing the 3rd-party libssh library from shared library to static library. 