### PR TITLE
[workflows] reduce retention time of snap packages

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -235,6 +235,7 @@ jobs:
         name: ${{ steps.build-snap.outputs.snap-file }}
         path: ${{ steps.build-snap.outputs.snap-file }}
         if-no-files-found: error
+        retention-days: 30
 
   # Publish the snap to the store if a channel was determined and we have access to secrets.
   Publish-Snap:


### PR DESCRIPTION
Multipass is currently using a lot of storage in GitHub workflows. This can easily be addressed by reducing the number of days that artifacts are retained.

Additionally, built packages are also uploaded to the snapcraft store which persist for a period of 30 days from the point of the last update to the channel.

https://snapcraft.io/docs/channels