### PR TITLE
[readme] added the special build instruction for forked repo developer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ cd build
 cmake ../
 make
 ```
-
+For those working on a forked repository. If you forked with the ```Copy the main branch only``` option, then the repository will not include the necessary git tags to determine the Multipass version during CMake configuration. Therefore, you need to manually fetch the tags from the upstream by running ```git fetch --tags https://github.com/canonical/multipass.git``` in the ```<multipass>``` source code directory. 
 ## Running Multipass daemon and client
 
 First, install multipass's runtime dependencies. On amd64 architecture, you can achieve that with:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ cd build
 cmake ../
 make
 ```
-For those working on a forked repository. If you forked with the "Copy the main branch only" option, then the repository will not include the necessary git tags to determine the Multipass version during CMake configuration. Therefore, you need to manually fetch the tags from the upstream by running ```git fetch --tags https://github.com/canonical/multipass.git``` in the ```<multipass>``` source code directory. 
+**Note:** if you're working on a forked repository that you created using the "Copy the main branch only" option, the repository will not include the necessary git tags to determine the Multipass version during CMake configuration. In this case, you need to manually fetch the tags from the upstream by running `git fetch --tags https://github.com/canonical/multipass.git` in the `<multipass>` source code directory. 
 ## Running Multipass daemon and client
 
 First, install multipass's runtime dependencies. On amd64 architecture, you can achieve that with:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ cd build
 cmake ../
 make
 ```
-For those working on a forked repository. If you forked with the ```Copy the main branch only``` option, then the repository will not include the necessary git tags to determine the Multipass version during CMake configuration. Therefore, you need to manually fetch the tags from the upstream by running ```git fetch --tags https://github.com/canonical/multipass.git``` in the ```<multipass>``` source code directory. 
+For those working on a forked repository. If you forked with the "Copy the main branch only" option, then the repository will not include the necessary git tags to determine the Multipass version during CMake configuration. Therefore, you need to manually fetch the tags from the upstream by running ```git fetch --tags https://github.com/canonical/multipass.git``` in the ```<multipass>``` source code directory. 
 ## Running Multipass daemon and client
 
 First, install multipass's runtime dependencies. On amd64 architecture, you can achieve that with:


### PR DESCRIPTION
close https://github.com/canonical/multipass/issues/3476

@ricab 
I did not add `MULTIPASS_UPSTREAM` approach because I can not get it to work. 
I also attempted to make a dummy version number in the `determine_version` function. But it turns out there are more things to change than just one if statement. So I did not go down that route. 

So eventually I went with just suggesting the user run `git fetch --tags https://github.com/canonical/multipass.git`. If that is fine with you. Then @giuliazanchi can start the linguistics review. 