### PR TITLE
Fix the bug where VirtualMachine::shutdown function throw affects multipass delete

### DIFF
--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -60,9 +60,10 @@ public:
 
     enum class ShutdownPolicy
     {
-        Powerdown,
-        Poweroff,
-        Halt
+        Powerdown, // gracefully shut down the vm
+        Poweroff,  // forcefully shut down the vm
+        Halt // halt the vm to non-running state. More specifically. suspended and stopped state will remain the same
+             // and running state will be shut down to stopped state
     };
 
     using UPtr = std::unique_ptr<VirtualMachine>;

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -58,12 +58,19 @@ public:
         unknown
     };
 
+    enum class ShutdownPolicy
+    {
+        Powerdown,
+        Poweroff,
+        Halt
+    };
+
     using UPtr = std::unique_ptr<VirtualMachine>;
     using ShPtr = std::shared_ptr<VirtualMachine>;
 
     virtual ~VirtualMachine() = default;
     virtual void start() = 0;
-    virtual void shutdown(bool force = false) = 0;
+    virtual void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) = 0;
     virtual void suspend() = 0;
     virtual State current_state() = 0;
     virtual int ssh_port() = 0;

--- a/src/client/cli/cmd/delete.cpp
+++ b/src/client/cli/cmd/delete.cpp
@@ -69,8 +69,8 @@ mp::ReturnCode cmd::Delete::run(mp::ArgParser* parser)
     };
 
     auto on_failure = [this](grpc::Status& status) {
-        // grpc::StatusCode::INVALID_ARGUMENT matches mp::VMStateInvalidException
-        return status.error_code() == grpc::StatusCode::INVALID_ARGUMENT
+        // grpc::StatusCode::FAILED_PRECONDITION matches mp::VMStateInvalidException
+        return status.error_code() == grpc::StatusCode::FAILED_PRECONDITION
                    ? standard_failure_handler_for(name(), cerr, status, "Use --purge to forcefully delete it.")
                    : standard_failure_handler_for(name(), cerr, status);
     };

--- a/src/client/cli/cmd/stop.cpp
+++ b/src/client/cli/cmd/stop.cpp
@@ -44,7 +44,11 @@ mp::ReturnCode cmd::Stop::run(mp::ArgParser* parser)
     AnimatedSpinner spinner{cout};
     auto on_failure = [this, &spinner](grpc::Status& status) {
         spinner.stop();
-        return standard_failure_handler_for(name(), cerr, status);
+
+        // grpc::StatusCode::INVALID_ARGUMENT matches mp::VMStateInvalidException
+        return status.error_code() == grpc::StatusCode::INVALID_ARGUMENT
+                   ? standard_failure_handler_for(name(), cerr, status, "Use --force to power it off.")
+                   : standard_failure_handler_for(name(), cerr, status);
     };
 
     spinner.start(instance_action_message_for(request.instance_names(), "Stopping "));

--- a/src/client/cli/cmd/stop.cpp
+++ b/src/client/cli/cmd/stop.cpp
@@ -45,8 +45,8 @@ mp::ReturnCode cmd::Stop::run(mp::ArgParser* parser)
     auto on_failure = [this, &spinner](grpc::Status& status) {
         spinner.stop();
 
-        // grpc::StatusCode::INVALID_ARGUMENT matches mp::VMStateInvalidException
-        return status.error_code() == grpc::StatusCode::INVALID_ARGUMENT
+        // grpc::StatusCode::FAILED_PRECONDITION matches mp::VMStateInvalidException
+        return status.error_code() == grpc::StatusCode::FAILED_PRECONDITION
                    ? standard_failure_handler_for(name(), cerr, status, "Use --force to power it off.")
                    : standard_failure_handler_for(name(), cerr, status);
     };

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3089,7 +3089,8 @@ bool mp::Daemon::delete_vm(InstanceTable::iterator vm_it, bool purge, DeleteRepl
         // TODO, move this check into check_state_for_shutdown
         if (!(instance->current_state() == VirtualMachine::State::suspended) || purge)
         {
-            instance->shutdown(purge);
+            instance->shutdown(purge == true ? VirtualMachine::ShutdownPolicy::Poweroff
+                                             : VirtualMachine::ShutdownPolicy::Halt);
         }
 
         if (!purge)
@@ -3155,7 +3156,7 @@ grpc::Status mp::Daemon::switch_off_vm(VirtualMachine& vm)
     const auto& name = vm.vm_name;
     delayed_shutdown_instances.erase(name);
 
-    vm.shutdown(true);
+    vm.shutdown(VirtualMachine::ShutdownPolicy::Poweroff);
 
     return grpc::Status::OK;
 }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3085,14 +3085,8 @@ bool mp::Daemon::delete_vm(InstanceTable::iterator vm_it, bool purge, DeleteRepl
 
         mounts[name].clear();
 
-        // Temporary solution to make multipass delete behave right.
-        // TODO, move this check into check_state_for_shutdown
-        if (!(instance->current_state() == VirtualMachine::State::suspended) || purge)
-        {
-            instance->shutdown(purge == true ? VirtualMachine::ShutdownPolicy::Poweroff
-                                             : VirtualMachine::ShutdownPolicy::Halt);
-        }
-
+        instance->shutdown(purge == true ? VirtualMachine::ShutdownPolicy::Poweroff
+                                         : VirtualMachine::ShutdownPolicy::Halt);
         if (!purge)
         {
             vm_instance_specs[name].deleted = true;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2147,6 +2147,10 @@ try // clang-format on
 
     status_promise->set_value(status);
 }
+catch (const mp::VMStateInvalidException& e)
+{
+    status_promise->set_value(grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, e.what()});
+}
 catch (const std::exception& e)
 {
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2149,11 +2149,11 @@ try // clang-format on
 }
 catch (const mp::VMStateInvalidException& e)
 {
-    status_promise->set_value(grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, e.what()});
+    status_promise->set_value(grpc::Status{grpc::StatusCode::FAILED_PRECONDITION, e.what()});
 }
 catch (const std::exception& e)
 {
-    status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
+    status_promise->set_value(grpc::Status(grpc::StatusCode::INTERNAL, e.what()));
 }
 
 void mp::Daemon::suspend(const SuspendRequest* request,
@@ -2302,11 +2302,11 @@ try // clang-format on
 }
 catch (const mp::VMStateInvalidException& e)
 {
-    status_promise->set_value(grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, e.what()});
+    status_promise->set_value(grpc::Status{grpc::StatusCode::FAILED_PRECONDITION, e.what()});
 }
 catch (const std::exception& e)
 {
-    status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
+    status_promise->set_value(grpc::Status(grpc::StatusCode::INTERNAL, e.what()));
 }
 
 void mp::Daemon::umount(const UmountRequest* request,

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -32,6 +32,7 @@
 #include <multipass/exceptions/snapshot_exceptions.h>
 #include <multipass/exceptions/sshfs_missing_error.h>
 #include <multipass/exceptions/start_exception.h>
+#include <multipass/exceptions/virtual_machine_state_exceptions.h>
 #include <multipass/ip_address.h>
 #include <multipass/json_utils.h>
 #include <multipass/logging/client_logger.h>
@@ -3075,7 +3076,15 @@ bool mp::Daemon::delete_vm(InstanceTable::iterator vm_it, bool purge, DeleteRepl
             delayed_shutdown_instances.erase(name);
 
         mounts[name].clear();
-        instance->shutdown(purge);
+
+        try
+        {
+            instance->shutdown(purge);
+        }
+        catch (const VMStateInvalidException& exception)
+        {
+            // in the case of VMStateInvalidException, we simply just skip shutdown call
+        }
 
         if (!purge)
         {

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
@@ -346,7 +346,7 @@ void mp::LibVirtVirtualMachine::start()
     monitor->on_resume();
 }
 
-void mp::LibVirtVirtualMachine::shutdown(bool force)
+void mp::LibVirtVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 {
     std::unique_lock<std::mutex> lock{state_mutex};
     auto domain = checked_vm_domain();
@@ -355,7 +355,7 @@ void mp::LibVirtVirtualMachine::shutdown(bool force)
 
     try
     {
-        check_state_for_shutdown(force);
+        check_state_for_shutdown(shutdown_policy);
     }
     catch (const VMStateIdempotentException& e)
     {
@@ -363,7 +363,7 @@ void mp::LibVirtVirtualMachine::shutdown(bool force)
         return;
     }
 
-    if (force) // TODO delete suspension state if it exists
+    if (shutdown_policy == ShutdownPolicy::Poweroff) // TODO delete suspension state if it exists
     {
         mpl::log(mpl::Level::info, vm_name, "Forcing shutdown");
 

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.h
@@ -44,7 +44,7 @@ public:
     ~LibVirtVirtualMachine();
 
     void start() override;
-    void shutdown(bool force = false) override;
+    void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;
     void suspend() override;
     State current_state() override;
     int ssh_port() override;

--- a/src/platform/backends/lxd/lxd_virtual_machine.cpp
+++ b/src/platform/backends/lxd/lxd_virtual_machine.cpp
@@ -262,7 +262,7 @@ void mp::LXDVirtualMachine::start()
     update_state();
 }
 
-void mp::LXDVirtualMachine::shutdown(bool force)
+void mp::LXDVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 {
     std::unique_lock<std::mutex> lock{state_mutex};
 
@@ -270,7 +270,7 @@ void mp::LXDVirtualMachine::shutdown(bool force)
 
     try
     {
-        check_state_for_shutdown(force);
+        check_state_for_shutdown(shutdown_policy);
     }
     catch (const VMStateIdempotentException& e)
     {
@@ -278,7 +278,8 @@ void mp::LXDVirtualMachine::shutdown(bool force)
         return;
     }
 
-    request_state("stop", {{"force", force}});
+    // ShutdownPolicy::Poweroff is force and the other two values are non-force
+    request_state("stop", {{"force", shutdown_policy == ShutdownPolicy::Poweroff}});
 
     state = State::off;
 

--- a/src/platform/backends/lxd/lxd_virtual_machine.h
+++ b/src/platform/backends/lxd/lxd_virtual_machine.h
@@ -43,7 +43,7 @@ public:
     ~LXDVirtualMachine() override;
 
     void start() override;
-    void shutdown(bool force = false) override;
+    void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;
     void suspend() override;
     State current_state() override;
     int ssh_port() override;

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -349,7 +349,7 @@ void mp::QemuVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 {
     std::unique_lock<std::mutex> lock{state_mutex};
 
-    force_shutdown = force;
+    force_shutdown = (shutdown_policy == ShutdownPolicy::Poweroff);
 
     try
     {

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -345,7 +345,7 @@ void mp::QemuVirtualMachine::start()
     vm_process->write(qmp_execute_json("qmp_capabilities"));
 }
 
-void mp::QemuVirtualMachine::shutdown(bool force)
+void mp::QemuVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 {
     std::unique_lock<std::mutex> lock{state_mutex};
 
@@ -353,7 +353,7 @@ void mp::QemuVirtualMachine::shutdown(bool force)
 
     try
     {
-        check_state_for_shutdown(force);
+        check_state_for_shutdown(shutdown_policy);
     }
     catch (const VMStateIdempotentException& e)
     {
@@ -361,7 +361,7 @@ void mp::QemuVirtualMachine::shutdown(bool force)
         return;
     }
 
-    if (force)
+    if (shutdown_policy == ShutdownPolicy::Poweroff)
     {
         mpl::log(mpl::Level::info, vm_name, "Forcing shutdown");
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -349,8 +349,6 @@ void mp::QemuVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 {
     std::unique_lock<std::mutex> lock{state_mutex};
 
-    force_shutdown = (shutdown_policy == ShutdownPolicy::Poweroff);
-
     try
     {
         check_state_for_shutdown(shutdown_policy);
@@ -368,6 +366,7 @@ void mp::QemuVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
         if (vm_process)
         {
             mpl::log(mpl::Level::info, vm_name, "Killing process");
+            force_shutdown = true;
             lock.unlock();
             vm_process->kill();
             if (vm_process != nullptr && !vm_process->wait_for_finished(kill_process_timeout))

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -50,7 +50,7 @@ public:
     ~QemuVirtualMachine();
 
     void start() override;
-    void shutdown(bool force = false) override;
+    void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;
     void suspend() override;
     State current_state() override;
     int ssh_port() override;

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -190,8 +190,6 @@ std::string mp::BaseVirtualMachine::get_instance_id_from_the_cloud_init() const
 
 void mp::BaseVirtualMachine::check_state_for_shutdown(bool force)
 {
-    const std::string force_statement{"Use --force to override."};
-
     // A mutex should already be locked by the caller here
     if (state == State::off || state == State::stopped)
     {
@@ -205,17 +203,17 @@ void mp::BaseVirtualMachine::check_state_for_shutdown(bool force)
 
     if (state == State::suspending)
     {
-        throw VMStateInvalidException{fmt::format("Cannot stop instance while suspending. {}", force_statement)};
+        throw VMStateInvalidException{"Cannot stop instance while suspending."};
     }
 
     if (state == State::suspended)
     {
-        throw VMStateInvalidException{fmt::format("Cannot stop suspended instance. {}", force_statement)};
+        throw VMStateInvalidException{"Cannot stop suspended instance."};
     }
 
     if (state == State::starting || state == State::restarting)
     {
-        throw VMStateInvalidException{fmt::format("Cannot stop instance while starting. {}", force_statement)};
+        throw VMStateInvalidException{"Cannot stop instance while starting."};
     }
 }
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -203,17 +203,17 @@ void mp::BaseVirtualMachine::check_state_for_shutdown(bool force)
 
     if (state == State::suspending)
     {
-        throw VMStateInvalidException{"Cannot stop instance while suspending."};
+        throw VMStateInvalidException{fmt::format("Cannot shut down instance {} while suspending.", vm_name)};
     }
 
     if (state == State::suspended)
     {
-        throw VMStateInvalidException{"Cannot stop suspended instance."};
+        throw VMStateInvalidException{fmt::format("Cannot shut down suspended instance {}.", vm_name)};
     }
 
     if (state == State::starting || state == State::restarting)
     {
-        throw VMStateInvalidException{"Cannot stop instance while starting."};
+        throw VMStateInvalidException{fmt::format("Cannot shut down instance {} while starting.", vm_name)};
     }
 }
 

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -201,15 +201,21 @@ void mp::BaseVirtualMachine::check_state_for_shutdown(ShutdownPolicy shutdown_po
         return;
     }
 
+    if (state == State::suspended)
+    {
+        if (shutdown_policy == ShutdownPolicy::Halt)
+        {
+            throw VMStateIdempotentException{"Ignoring shutdown since instance is already suspended."};
+        }
+        else // else only can be ShutdownPolicy::Powerdown since ShutdownPolicy::Poweroff check was preemptively done.
+        {
+            throw VMStateInvalidException{fmt::format("Cannot shut down suspended instance {}.", vm_name)};
+        }
+    }
+
     if (state == State::suspending)
     {
         throw VMStateInvalidException{fmt::format("Cannot shut down instance {} while suspending.", vm_name)};
-    }
-
-    // add branching here for the halt shutdown policy
-    if (state == State::suspended)
-    {
-        throw VMStateInvalidException{fmt::format("Cannot shut down suspended instance {}.", vm_name)};
     }
 
     if (state == State::starting || state == State::restarting)

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -188,7 +188,7 @@ std::string mp::BaseVirtualMachine::get_instance_id_from_the_cloud_init() const
     return MP_CLOUD_INIT_FILE_OPS.get_instance_id_from_cloud_init(cloud_init_config_iso_file_path);
 }
 
-void mp::BaseVirtualMachine::check_state_for_shutdown(bool force)
+void mp::BaseVirtualMachine::check_state_for_shutdown(ShutdownPolicy shutdown_policy)
 {
     // A mutex should already be locked by the caller here
     if (state == State::off || state == State::stopped)
@@ -196,7 +196,7 @@ void mp::BaseVirtualMachine::check_state_for_shutdown(bool force)
         throw VMStateIdempotentException{"Ignoring shutdown since instance is already stopped."};
     }
 
-    if (force)
+    if (shutdown_policy == ShutdownPolicy::Poweroff)
     {
         return;
     }
@@ -206,6 +206,7 @@ void mp::BaseVirtualMachine::check_state_for_shutdown(bool force)
         throw VMStateInvalidException{fmt::format("Cannot shut down instance {} while suspending.", vm_name)};
     }
 
+    // add branching here for the halt shutdown policy 
     if (state == State::suspended)
     {
         throw VMStateInvalidException{fmt::format("Cannot shut down suspended instance {}.", vm_name)};

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -206,7 +206,7 @@ void mp::BaseVirtualMachine::check_state_for_shutdown(ShutdownPolicy shutdown_po
         throw VMStateInvalidException{fmt::format("Cannot shut down instance {} while suspending.", vm_name)};
     }
 
-    // add branching here for the halt shutdown policy 
+    // add branching here for the halt shutdown policy
     if (state == State::suspended)
     {
         throw VMStateInvalidException{fmt::format("Cannot shut down suspended instance {}.", vm_name)};

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -104,7 +104,7 @@ protected:
         const std::string& new_instance_id) const;
     virtual std::string get_instance_id_from_the_cloud_init() const;
 
-    virtual void check_state_for_shutdown(bool force);
+    virtual void check_state_for_shutdown(ShutdownPolicy shutdown_policy);
 
 private:
     using SnapshotMap = std::unordered_map<std::string, std::shared_ptr<Snapshot>>;

--- a/tests/libvirt/test_libvirt_backend.cpp
+++ b/tests/libvirt/test_libvirt_backend.cpp
@@ -448,7 +448,7 @@ TEST_F(LibVirtBackend, shutdown_while_starting_throws_and_sets_correct_state)
 
     ASSERT_EQ(machine->state, mp::VirtualMachine::State::starting);
 
-    mp::AutoJoinThread thread = [&machine] { machine->shutdown(true); };
+    mp::AutoJoinThread thread = [&machine] { machine->shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff); };
 
     using namespace std::chrono_literals;
     while (!destroy_called)

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1702,7 +1702,7 @@ TEST_F(LXDBackend, shutdown_while_stopped_does_nothing_and_logs_debug)
 
 TEST_F(LXDBackend, shutdown_while_frozen_throws_and_logs_info)
 {
-    const std::string error_msg{"Cannot stop suspended instance. Use --force to override."};
+    const std::string error_msg{"Cannot stop suspended instance."};
     mpt::MockVMStatusMonitor mock_monitor;
 
     EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillRepeatedly([](auto, auto request, auto) {

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1702,7 +1702,7 @@ TEST_F(LXDBackend, shutdown_while_stopped_does_nothing_and_logs_debug)
 
 TEST_F(LXDBackend, shutdown_while_frozen_throws_and_logs_info)
 {
-    const std::string error_msg{"Cannot stop suspended instance."};
+    const std::string sub_error_msg{"Cannot shut down suspended instance"};
     mpt::MockVMStatusMonitor mock_monitor;
 
     EXPECT_CALL(*mock_network_access_manager, createRequest(_, _, _)).WillRepeatedly([](auto, auto request, auto) {
@@ -1730,7 +1730,7 @@ TEST_F(LXDBackend, shutdown_while_frozen_throws_and_logs_info)
 
     EXPECT_CALL(mock_monitor, persist_state_for(_, _));
 
-    MP_EXPECT_THROW_THAT(machine.shutdown(), mp::VMStateInvalidException, mpt::match_what(StrEq(error_msg)));
+    MP_EXPECT_THROW_THAT(machine.shutdown(), mp::VMStateInvalidException, mpt::match_what(HasSubstr(sub_error_msg)));
 
     EXPECT_EQ(machine.current_state(), mp::VirtualMachine::State::suspended);
 }

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -1843,7 +1843,9 @@ TEST_F(LXDBackend, shutdown_while_starting_throws_and_sets_correct_state)
 
     ASSERT_EQ(machine.state, mp::VirtualMachine::State::starting);
 
-    mp::AutoJoinThread thread = [&machine] { machine.shutdown(true); }; // force shutdown
+    mp::AutoJoinThread thread = [&machine] {
+        machine.shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff);
+    }; // force shutdown
 
     while (machine.state != mp::VirtualMachine::State::off)
         std::this_thread::sleep_for(1ms);

--- a/tests/mock_virtual_machine.h
+++ b/tests/mock_virtual_machine.h
@@ -56,7 +56,7 @@ struct MockVirtualMachineT : public T
     }
 
     MOCK_METHOD(void, start, (), (override));
-    MOCK_METHOD(void, shutdown, (bool), (override));
+    MOCK_METHOD(void, shutdown, (VirtualMachine::ShutdownPolicy), (override));
     MOCK_METHOD(void, suspend, (), (override));
     MOCK_METHOD(multipass::VirtualMachine::State, current_state, (), (override));
     MOCK_METHOD(int, ssh_port, (), (override));

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -375,7 +375,7 @@ TEST_F(QemuBackend, machine_unknown_state_properly_shuts_down)
 
 TEST_F(QemuBackend, suspendedStateNoForceShutdownThrows)
 {
-    const std::string error_msg{"Cannot stop suspended instance."};
+    const std::string sub_error_msg{"Cannot shut down suspended instance"};
 
     EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_)).WillOnce([this](auto...) {
         return std::move(mock_qemu_platform);
@@ -388,14 +388,15 @@ TEST_F(QemuBackend, suspendedStateNoForceShutdownThrows)
 
     machine->state = mp::VirtualMachine::State::suspended;
 
-    MP_EXPECT_THROW_THAT(machine->shutdown(), mp::VMStateInvalidException, mpt::match_what(StrEq(error_msg)));
+    MP_EXPECT_THROW_THAT(machine->shutdown(), mp::VMStateInvalidException, mpt::match_what(HasSubstr(sub_error_msg)));
 
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::suspended);
 }
 
 TEST_F(QemuBackend, suspendingStateNoForceShutdownThrows)
 {
-    const std::string error_msg{"Cannot stop instance while suspending."};
+    const std::string sub_error_msg1{"Cannot shut down instance"};
+    const std::string sub_error_msg2{"while suspending."};
 
     EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_)).WillOnce([this](auto...) {
         return std::move(mock_qemu_platform);
@@ -408,14 +409,17 @@ TEST_F(QemuBackend, suspendingStateNoForceShutdownThrows)
 
     machine->state = mp::VirtualMachine::State::suspending;
 
-    MP_EXPECT_THROW_THAT(machine->shutdown(), mp::VMStateInvalidException, mpt::match_what(StrEq(error_msg)));
+    MP_EXPECT_THROW_THAT(machine->shutdown(),
+                         mp::VMStateInvalidException,
+                         mpt::match_what(AllOf(HasSubstr(sub_error_msg1), HasSubstr(sub_error_msg2))));
 
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::suspending);
 }
 
 TEST_F(QemuBackend, startingStateNoForceShutdownThrows)
 {
-    const std::string error_msg{"Cannot stop instance while starting."};
+    const std::string sub_error_msg1{"Cannot shut down instance"};
+    const std::string sub_error_msg2{"while starting."};
 
     EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_)).WillOnce([this](auto...) {
         return std::move(mock_qemu_platform);
@@ -428,7 +432,9 @@ TEST_F(QemuBackend, startingStateNoForceShutdownThrows)
 
     machine->state = mp::VirtualMachine::State::starting;
 
-    MP_EXPECT_THROW_THAT(machine->shutdown(), mp::VMStateInvalidException, mpt::match_what(StrEq(error_msg)));
+    MP_EXPECT_THROW_THAT(machine->shutdown(),
+                         mp::VMStateInvalidException,
+                         mpt::match_what(AllOf(HasSubstr(sub_error_msg1), HasSubstr(sub_error_msg2))));
 
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::starting);
 }

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -288,7 +288,7 @@ TEST_F(QemuBackend, throws_when_shutdown_while_starting)
 
     mp::AutoJoinThread thread{[&machine, vmproc] {
         ON_CALL(*vmproc, running()).WillByDefault(Return(false));
-        machine->shutdown(true);
+        machine->shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff);
     }};
 
     using namespace std::chrono_literals;
@@ -481,7 +481,7 @@ TEST_F(QemuBackend, forceShutdownKillsProcessAndLogs)
 
     machine->state = mp::VirtualMachine::State::running;
 
-    machine->shutdown(true); // force shutdown
+    machine->shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff); // force shutdown
 
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::off);
 }
@@ -503,7 +503,7 @@ TEST_F(QemuBackend, forceShutdownNoProcessLogs)
 
     machine->state = mp::VirtualMachine::State::unknown;
 
-    machine->shutdown(true); // force shutdown
+    machine->shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff); // force shutdown
 
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::off);
 }
@@ -559,8 +559,8 @@ TEST_F(QemuBackend, forceShutdownSuspendedStateButNoSuspensionSnapshotInImage)
 
     const auto machine = backend.create_virtual_machine(default_description, key_provider, stub_monitor);
     machine->state = mp::VirtualMachine::State::suspended;
-    machine->shutdown(true);
-
+    machine->shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff);
+    
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::off);
 }
 
@@ -974,7 +974,7 @@ TEST_F(QemuBackend, dropsSSHSessionWhenStopping)
     EXPECT_CALL(machine, drop_ssh_session());
 
     MP_DELEGATE_MOCK_CALLS_ON_BASE(machine, shutdown, mp::QemuVirtualMachine);
-    machine.shutdown(false);
+    machine.shutdown(mp::VirtualMachine::ShutdownPolicy::Powerdown);
 }
 
 TEST_F(QemuBackend, supportsSnapshots)

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -375,7 +375,7 @@ TEST_F(QemuBackend, machine_unknown_state_properly_shuts_down)
 
 TEST_F(QemuBackend, suspendedStateNoForceShutdownThrows)
 {
-    const std::string error_msg{"Cannot stop suspended instance. Use --force to override."};
+    const std::string error_msg{"Cannot stop suspended instance."};
 
     EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_)).WillOnce([this](auto...) {
         return std::move(mock_qemu_platform);
@@ -395,7 +395,7 @@ TEST_F(QemuBackend, suspendedStateNoForceShutdownThrows)
 
 TEST_F(QemuBackend, suspendingStateNoForceShutdownThrows)
 {
-    const std::string error_msg{"Cannot stop instance while suspending. Use --force to override."};
+    const std::string error_msg{"Cannot stop instance while suspending."};
 
     EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_)).WillOnce([this](auto...) {
         return std::move(mock_qemu_platform);
@@ -415,7 +415,7 @@ TEST_F(QemuBackend, suspendingStateNoForceShutdownThrows)
 
 TEST_F(QemuBackend, startingStateNoForceShutdownThrows)
 {
-    const std::string error_msg{"Cannot stop instance while starting. Use --force to override."};
+    const std::string error_msg{"Cannot stop instance while starting."};
 
     EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_)).WillOnce([this](auto...) {
         return std::move(mock_qemu_platform);

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -533,7 +533,7 @@ TEST_F(QemuBackend, forceShutdownSuspendDeletesSuspendImageAndOffState)
 
     const auto machine = backend.create_virtual_machine(default_description, key_provider, stub_monitor);
     machine->state = mp::VirtualMachine::State::suspended;
-    machine->shutdown(true);
+    machine->shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff);
 
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::off);
 
@@ -560,7 +560,7 @@ TEST_F(QemuBackend, forceShutdownSuspendedStateButNoSuspensionSnapshotInImage)
     const auto machine = backend.create_virtual_machine(default_description, key_provider, stub_monitor);
     machine->state = mp::VirtualMachine::State::suspended;
     machine->shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff);
-    
+
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::off);
 }
 
@@ -590,7 +590,7 @@ TEST_F(QemuBackend, forceShutdownRunningStateButWithSuspensionSnapshotInImage)
 
     const auto machine = backend.create_virtual_machine(default_description, key_provider, stub_monitor);
     machine->state = mp::VirtualMachine::State::running;
-    machine->shutdown(true);
+    machine->shutdown(mp::VirtualMachine::ShutdownPolicy::Poweroff);
 
     EXPECT_EQ(machine->current_state(), mp::VirtualMachine::State::off);
 

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -47,7 +47,7 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
     {
     }
 
-    void shutdown(bool force = false) override
+    void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override
     {
     }
 

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -133,7 +133,7 @@ struct StubBaseVirtualMachine : public mp::BaseVirtualMachine
         state = St::running;
     }
 
-    void shutdown(bool force = false) override
+    void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override
     {
         state = St::off;
     }

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -2538,6 +2538,13 @@ TEST_F(Client, stop_cmd_force_conflicts_with_cancel_option)
     EXPECT_THAT(send_command({"stop", "foo", "--force", "--cancel"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
+TEST_F(Client, stopCmdWrongVmState)
+{
+    const auto invalid_vm_state_failure = grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, "msg"};
+    EXPECT_CALL(mock_daemon, stop(_, _)).WillOnce(Return(invalid_vm_state_failure));
+    EXPECT_THAT(send_command({"stop", "foo"}), Eq(mp::ReturnCode::CommandFail));
+}
+
 // suspend cli tests
 TEST_F(Client, suspend_cmd_ok_with_one_arg)
 {
@@ -2831,6 +2838,13 @@ TEST_F(Client, delete_cmd_accepts_purge_option)
     EXPECT_CALL(mock_daemon, delet(_, _)).Times(2);
     EXPECT_THAT(send_command({"delete", "--purge", "foo"}), Eq(mp::ReturnCode::Ok));
     EXPECT_THAT(send_command({"delete", "-p", "bar"}), Eq(mp::ReturnCode::Ok));
+}
+
+TEST_F(Client, deleteCmdWrongVmState)
+{
+    const auto invalid_vm_state_failure = grpc::Status{grpc::StatusCode::INVALID_ARGUMENT, "msg"};
+    EXPECT_CALL(mock_daemon, delet(_, _)).WillOnce(Return(invalid_vm_state_failure));
+    EXPECT_THAT(send_command({"delete", "foo"}), Eq(mp::ReturnCode::CommandFail));
 }
 
 // find cli tests


### PR DESCRIPTION
close #3624
close #3606

A few things were done based on our team discussion

1. skip_states check in `daemon.cpp` was removed because it is the responsibility of `VirtualMachine::shutdown` function to check the state. 
2. delegate the cmd suggestion part of the error message to CLI client. The daemon maps `VMStateInvalidException` exception to `grpc::StatusCode::FAILED_PRECONDITION`, and the CLI side interprets this code respectively. 
3. The force boolean input parameter of function `VirtualMachine::shutdown` is replaced by a 3 values enum `ShutdownPolicy`, corresponding refactor was performed as well.

Functional testing:
Please at least cover the following scenarios:

1. `multipass stop` on a deleted or non-existing VM does not trigger the `--force` suggestion
2. `multipass stop` on a VM with invalid states does trigger the `--force` suggestion. Invalid states include suspended, suspending, starting and restarting, the transtioning states require running `multipass stop` in 2nd cmd panel. 
3. `multipass delete` on a deleted or non-existing VM does not trigger the `--purge` suggestion
4. `multipass delete` on a suspended and stopped vm can retain the state meaning the recovered vm should have the same state. 
5. `multipass delete` on arunning vm will shutdown the vm gracefully and recover it to the stopped state.  
6. `multipass delete` on a VM with invalid states does trigger the `--purge` suggestion. Invalid states are only transtioning states like suspending, starting and restarting, they all require the 2nd cmd panel to run. 
7. Run these two commands in bulk with mixed state of the vms and see if they behave right. 
8. Check whether GUI encounters these exceptions. 

Note:
1. The private side is not done yet, but it will be a simple adaptation due to the `shutdown` and `check_state_for_shutdown` interface change. I would rather waiting the public PR review finish and change that later.
2. The unit tests on daemon::stop daemon::delete are lacking due to lacking frameworks which are similar to `test_daemon_snapshot_restore.cpp`. It is not a big problem to create the `stop` and `delete` version of this, but it might take more time. 