### PR TITLE
[qemu] silence force stop logs

### DIFF
--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -626,7 +626,7 @@ void mp::QemuVirtualMachine::initialize_vm_process()
             // out any scary error messages for this state
             if (update_shutdown_status)
             {
-                auto log_level = force_shutdown ? mpl::Level::info : mpl::Level::error;
+                const auto log_level = force_shutdown ? mpl::Level::info : mpl::Level::error;
                 mpl::log(log_level,
                          vm_name,
                          fmt::format("process error occurred {} {}", utils::qenum_to_string(error), error_string));
@@ -650,7 +650,7 @@ void mp::QemuVirtualMachine::initialize_vm_process()
             }
             else
             {
-                auto log_level = force_shutdown ? mpl::Level::info : mpl::Level::error;
+                const auto log_level = force_shutdown ? mpl::Level::info : mpl::Level::error;
                 mpl::log(log_level, vm_name, fmt::format("error: {}", process_state.error->message));
             }
         }

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -349,6 +349,8 @@ void mp::QemuVirtualMachine::shutdown(bool force)
 {
     std::unique_lock<std::mutex> lock{state_mutex};
 
+    force_shutdown = force;
+
     try
     {
         check_state_for_shutdown(force);
@@ -624,7 +626,9 @@ void mp::QemuVirtualMachine::initialize_vm_process()
             // out any scary error messages for this state
             if (update_shutdown_status)
             {
-                mpl::log(mpl::Level::error, vm_name,
+                auto log_level = force_shutdown ? mpl::Level::info : mpl::Level::error;
+                mpl::log(log_level,
+                         vm_name,
                          fmt::format("process error occurred {} {}", utils::qenum_to_string(error), error_string));
                 on_error();
             }
@@ -646,7 +650,8 @@ void mp::QemuVirtualMachine::initialize_vm_process()
             }
             else
             {
-                mpl::log(mpl::Level::error, vm_name, fmt::format("error: {}", process_state.error->message));
+                auto log_level = force_shutdown ? mpl::Level::info : mpl::Level::error;
+                mpl::log(log_level, vm_name, fmt::format("error: {}", process_state.error->message));
             }
         }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -652,6 +652,9 @@ void mp::QemuVirtualMachine::initialize_vm_process()
             {
                 const auto log_level = force_shutdown ? mpl::Level::info : mpl::Level::error;
                 mpl::log(log_level, vm_name, fmt::format("error: {}", process_state.error->message));
+
+                // reset force_shutdown so that subsequent errors can be accurately reported
+                force_shutdown = false;
             }
         }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -108,6 +108,7 @@ private:
     std::string saved_error_msg;
     bool update_shutdown_status{true};
     bool is_starting_from_suspend{false};
+    bool force_shutdown{false};
     std::chrono::steady_clock::time_point network_deadline;
 };
 } // namespace multipass

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -460,8 +460,8 @@ TEST_F(QemuBackend, forceShutdownKillsProcessAndLogs)
     logger_scope.mock_logger->expect_log(mpl::Level::info, "process started");
     logger_scope.mock_logger->expect_log(mpl::Level::info, "Forcing shutdown");
     logger_scope.mock_logger->expect_log(mpl::Level::info, "Killing process");
-    logger_scope.mock_logger->expect_log(mpl::Level::error, "Killed");
-    logger_scope.mock_logger->expect_log(mpl::Level::error, "Force stopped");
+    logger_scope.mock_logger->expect_log(mpl::Level::info, "Killed");
+    logger_scope.mock_logger->expect_log(mpl::Level::info, "Force stopped");
 
     mpt::StubVMStatusMonitor stub_monitor;
     mp::QemuVirtualMachineFactory backend{data_dir.path()};


### PR DESCRIPTION
Downgrades log levels when forcing a shutdown. This way we still get logs from the vm process, but they are not shown to the user through the CLI.

Fixes #3591 