### PR TITLE
[qemu] Make logging code terser

### DIFF
--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -380,24 +380,16 @@ void mp::QemuVirtualMachine::shutdown(bool force)
             mpl::log(mpl::Level::debug, vm_name, "No process to kill");
         }
 
-        if (mp::backend::instance_image_has_snapshot(desc.image.image_path, suspend_tag))
-        {
-            if (state != State::suspended)
-            {
-                mpl::log(
-                    mpl::Level::warning,
-                    vm_name,
-                    fmt::format("{} has the image suspension snapshot, but it is not in the suspended state", vm_name));
-            }
+        const auto has_suspend_snapshot = mp::backend::instance_image_has_snapshot(desc.image.image_path, suspend_tag);
+        if (has_suspend_snapshot != (state == State::suspended)) // clang-format off
+            mpl::log(mpl::Level::warning, vm_name, fmt::format("Image has {} suspension snapshot, but the state is {}",
+                                                               has_suspend_snapshot ? "a" : "no",
+                                                               static_cast<short>(state))); // clang-format on
 
+        if (has_suspend_snapshot)
+        {
             mpl::log(mpl::Level::info, vm_name, "Deleting suspend image");
             mp::backend::delete_instance_suspend_image(desc.image.image_path, suspend_tag);
-        }
-        else if (state == State::suspended)
-        {
-            mpl::log(mpl::Level::warning,
-                     vm_name,
-                     fmt::format("{} is suspended, but the image does not have the suspension snapshot", vm_name));
         }
 
         state = State::off;

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -545,8 +545,7 @@ TEST_F(QemuBackend, forceShutdownSuspendedStateButNoSuspensionSnapshotInImage)
     logger_scope.mock_logger->screen_logs(mpl::Level::debug);
     logger_scope.mock_logger->expect_log(mpl::Level::info, "Forcing shutdown");
     logger_scope.mock_logger->expect_log(mpl::Level::debug, "No process to kill");
-    logger_scope.mock_logger->expect_log(mpl::Level::warning,
-                                         "is suspended, but the image does not have the suspension snapshot");
+    logger_scope.mock_logger->expect_log(mpl::Level::warning, "Image has no suspension snapshot, but the state is 7");
 
     mpt::StubVMStatusMonitor stub_monitor;
     mp::QemuVirtualMachineFactory backend{data_dir.path()};
@@ -577,8 +576,7 @@ TEST_F(QemuBackend, forceShutdownRunningStateButWithSuspensionSnapshotInImage)
     logger_scope.mock_logger->expect_log(mpl::Level::info, "Forcing shutdown");
     logger_scope.mock_logger->expect_log(mpl::Level::debug, "No process to kill");
     logger_scope.mock_logger->expect_log(mpl::Level::info, "Deleting suspend image");
-    logger_scope.mock_logger->expect_log(mpl::Level::warning,
-                                         "has the image suspension snapshot, but it is not in the suspended state");
+    logger_scope.mock_logger->expect_log(mpl::Level::warning, "Image has a suspension snapshot, but the state is 4");
 
     mpt::StubVMStatusMonitor stub_monitor;
     mp::QemuVirtualMachineFactory backend{data_dir.path()};


### PR DESCRIPTION
Condense code to log mismatches between suspension snapshot and VM state. Just trying to reduce the space that is taken by logging code, which dilutes actual logic for the reader.

This could be further improved by adding a formatter for the State enum to `multipass/format.h`. That would be useful in other places too, but we should then probably also move the corresponding logic from the CLI formatters, so leaving that for now.
