### PR TITLE
change window minimumSize to 750x450, and default size based on screen resolution 

### DIFF
--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:window_size/window_size.dart';
 
 import 'before_quit_dialog.dart';
 import 'catalogue/catalogue.dart';
@@ -21,15 +22,24 @@ import 'vm_table/vm_table_screen.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await setupLogger();
+  // Get the current screen size
+  final screen = await getCurrentScreen();
+  Size windowSize;
 
-  await windowManager.ensureInitialized();
-  const windowOptions = WindowOptions(
+  if (screen != null && screen.frame.size.width >= 1600
+      && screen.frame.size.height >= 900) {
+    windowSize = const Size(1400, 822);  // For screens larger than 1600x900
+  } else {
+    windowSize = const Size(750, 450);   // Default window size
+  }
+
+  final windowOptions = WindowOptions(
     center: true,
-    minimumSize: Size(1000, 600),
-    size: Size(1400, 822),
+    minimumSize: const Size(750, 450),
+    size: windowSize,
     title: 'Multipass',
   );
+
   await windowManager.waitUntilReadyToShow(windowOptions, () async {
     await windowManager.show();
     await windowManager.focus();

--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -22,16 +22,19 @@ import 'vm_table/vm_table_screen.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Get the current screen size
-  final screen = await getCurrentScreen();
-  Size windowSize;
+  await setupLogger();
 
-  if (screen != null && screen.frame.size.width >= 1600
-      && screen.frame.size.height >= 900) {
-    windowSize = const Size(1400, 822);  // For screens larger than 1600x900
-  } else {
-    windowSize = const Size(750, 450);   // Default window size
-  }
+  // Get the current screen size
+  final screenSize = await getCurrentScreen().then((screen) {
+    return screen?.frame.size;
+  });
+
+  final windowSize = (screenSize != null && screenSize.width >= 1600
+      && screenSize.height >= 900)
+      ? const Size(1400, 822) // For screens 1600x900 or larger
+      : const Size(750, 450); // Default window size
+
+  await windowManager.ensureInitialized();
 
   final windowOptions = WindowOptions(
     center: true,

--- a/src/client/gui/linux/flutter/generated_plugin_registrant.cc
+++ b/src/client/gui/linux/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <tray_menu/tray_menu_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
+#include <window_size/window_size_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) hotkey_manager_linux_registrar =
@@ -28,4 +29,7 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) window_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
   window_manager_plugin_register_with_registrar(window_manager_registrar);
+  g_autoptr(FlPluginRegistrar) window_size_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowSizePlugin");
+  window_size_plugin_register_with_registrar(window_size_registrar);
 }

--- a/src/client/gui/linux/flutter/generated_plugins.cmake
+++ b/src/client/gui/linux/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   tray_menu
   url_launcher_linux
   window_manager
+  window_size
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/src/client/gui/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/src/client/gui/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import shared_preferences_foundation
 import tray_menu
 import url_launcher_macos
 import window_manager
+import window_size
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   HotkeyManagerMacosPlugin.register(with: registry.registrar(forPlugin: "HotkeyManagerMacosPlugin"))
@@ -21,4 +22,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   TrayMenuPlugin.register(with: registry.registrar(forPlugin: "TrayMenuPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
+  WindowSizePlugin.register(with: registry.registrar(forPlugin: "WindowSizePlugin"))
 }

--- a/src/client/gui/pubspec.lock
+++ b/src/client/gui/pubspec.lock
@@ -787,6 +787,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.9"
+  window_size:
+    dependency: "direct main"
+    description:
+      path: "plugins/window_size"
+      ref: "6c66ad2"
+      resolved-ref: "6c66ad23ee79749f30a8eece542cf54eaf157ed8"
+      url: "https://github.com/google/flutter-desktop-embedding.git"
+    source: git
+    version: "0.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/src/client/gui/pubspec.yaml
+++ b/src/client/gui/pubspec.yaml
@@ -40,6 +40,11 @@ dependencies:
   url_launcher: ^6.3.0
   win32: ^5.2.0
   window_manager: ^0.3.9
+  window_size:
+    git:
+      url: https://github.com/google/flutter-desktop-embedding.git
+      path: plugins/window_size
+      ref: 6c66ad2
   xterm: ^3.6.0
 
 dependency_overrides:

--- a/src/client/gui/windows/flutter/generated_plugin_registrant.cc
+++ b/src/client/gui/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <tray_menu/tray_menu_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
+#include <window_size/window_size_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   HotkeyManagerWindowsPluginCApiRegisterWithRegistrar(
@@ -23,4 +24,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowManagerPlugin"));
+  WindowSizePluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowSizePlugin"));
 }

--- a/src/client/gui/windows/flutter/generated_plugins.cmake
+++ b/src/client/gui/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   tray_menu
   url_launcher_windows
   window_manager
+  window_size
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
close #3590 

We can use the window_size flutter plugin from google's flutter desktop embeddings repository https://github.com/google/flutter-desktop-embedding/tree/main/plugins/window_size
to check the size of the screen, and 
- if the size of the screen is below 1600x900, open a small 750x450 window
- if the size of the screen is larger then open the 1400x822 window that multipass is currently set to by default. We can also think of more reactive functionality than this but I don't think it's necessary. 

We'll need to add this plugin to pubspec.yaml, but it's ~an official plugin from Google~ the closest-to-official Flutter plugin that handles screen size and it seems that the only reason that this plugin needs to be added at all is because Google has not yet added this functionality to the Flutter framework itself