### PR TITLE
Inconsistent error message with vm in an unknown state

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2070,7 +2070,9 @@ try // clang-format on
         {
         case VirtualMachine::State::unknown:
         {
-            auto error_string = fmt::format("Instance \'{}\' is already running, but in an unknown state", name);
+            auto error_string = fmt::format("Instance \'{0}\' is already running, but in an unknown state\n"
+                                            "Try 'multipass stop {0}'",
+                                            name);
             mpl::log(mpl::Level::warning, category, error_string);
             fmt::format_to(std::back_inserter(start_errors), error_string);
             continue;
@@ -3110,7 +3112,10 @@ grpc::Status mp::Daemon::reboot_vm(VirtualMachine& vm)
 
     if (!MP_UTILS.is_running(vm.current_state()))
         return grpc::Status{grpc::StatusCode::INVALID_ARGUMENT,
-                            fmt::format("instance \"{}\" is not running", vm.vm_name), ""};
+                            fmt::format("Instance \"{0}\" is already running, but in an unknown state\n"
+                                        "Try 'multipass stop {0}'",
+                                        vm.vm_name),
+                            ""};
 
     mpl::log(mpl::Level::debug, category, fmt::format("Rebooting {}", vm.vm_name));
     return ssh_reboot(vm);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2070,15 +2070,15 @@ try // clang-format on
         {
         case VirtualMachine::State::unknown:
         {
-            auto error_string = fmt::format("Instance '{0}' is already running, but in an unknown state\n"
-                                            "Try 'multipass stop {0}'",
+            auto error_string = fmt::format("Instance '{0}' is already running, but in an unknown state.\n"
+                                            "Try to stop it first.",
                                             name);
             mpl::log(mpl::Level::warning, category, error_string);
             fmt::format_to(std::back_inserter(start_errors), error_string);
             continue;
         }
         case VirtualMachine::State::suspending:
-            fmt::format_to(std::back_inserter(start_errors), "Cannot start the instance '{}' while suspending", name);
+            fmt::format_to(std::back_inserter(start_errors), "Cannot start the instance '{}' while suspending.", name);
             continue;
         case VirtualMachine::State::delayed_shutdown:
             delayed_shutdown_instances.erase(name);
@@ -3112,8 +3112,8 @@ grpc::Status mp::Daemon::reboot_vm(VirtualMachine& vm)
 
     if (!MP_UTILS.is_running(vm.current_state()))
         return grpc::Status{grpc::StatusCode::INVALID_ARGUMENT,
-                            fmt::format("Instance '{0}' is already running, but in an unknown state\n"
-                                        "Try 'multipass stop {0}'",
+                            fmt::format("Instance '{0}' is already running, but in an unknown state.\n"
+                                        "Try to stop and start it instead.",
                                         vm.vm_name),
                             ""};
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2070,7 +2070,7 @@ try // clang-format on
         {
         case VirtualMachine::State::unknown:
         {
-            auto error_string = fmt::format("Instance \'{0}\' is already running, but in an unknown state\n"
+            auto error_string = fmt::format("Instance '{0}' is already running, but in an unknown state\n"
                                             "Try 'multipass stop {0}'",
                                             name);
             mpl::log(mpl::Level::warning, category, error_string);
@@ -2078,7 +2078,7 @@ try // clang-format on
             continue;
         }
         case VirtualMachine::State::suspending:
-            fmt::format_to(std::back_inserter(start_errors), "Cannot start the instance \'{}\' while suspending", name);
+            fmt::format_to(std::back_inserter(start_errors), "Cannot start the instance '{}' while suspending", name);
             continue;
         case VirtualMachine::State::delayed_shutdown:
             delayed_shutdown_instances.erase(name);
@@ -3112,7 +3112,7 @@ grpc::Status mp::Daemon::reboot_vm(VirtualMachine& vm)
 
     if (!MP_UTILS.is_running(vm.current_state()))
         return grpc::Status{grpc::StatusCode::INVALID_ARGUMENT,
-                            fmt::format("Instance \"{0}\" is already running, but in an unknown state\n"
+                            fmt::format("Instance '{0}' is already running, but in an unknown state\n"
                                         "Try 'multipass stop {0}'",
                                         vm.vm_name),
                             ""};


### PR DESCRIPTION
Issue #3659
Earlier when vm was in unknown state it was providing different error messages between 'restart' and 'start'
Earlier
~~~
$ multipass restart charm-dev
restart failed: instance "charm-dev" is not running

$ multipass start charm-dev
start failed: The following errors occurred:
Instance 'charm-dev' is already running, but in an unknown state
~~~
Now
~~~

$ multipass restart charm-dev
restart failed: Instance 'Charm-dev' is already running, but in an unknown state
Use `multipass stop charm-dev`

$ multipass start charm-dev
start failed: The following errors occurred:
Instance 'Charm-dev' is already running, but in an unknown state
Use `multipass stop charm-dev`
~~~