### PR TITLE
call windowManager.show() and windowManager.restore() together as an extension

### DIFF
--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -129,7 +129,7 @@ class _AppState extends ConsumerState<App> with WindowListener {
     final primary = ref.read(clientSettingProvider(primaryNameKey));
     if (vms.contains(primary)) {
       ref.read(sidebarKeyProvider.notifier).set('vm-$primary');
-      windowManager.show();
+      windowManager.showAndRestore();
     }
   }
 

--- a/src/client/gui/lib/tray_menu.dart
+++ b/src/client/gui/lib/tray_menu.dart
@@ -19,6 +19,13 @@ import 'vm_action.dart';
 import 'vm_details/terminal_tabs.dart';
 import 'vm_details/vm_details.dart';
 
+extension WindowManagerExtensions on WindowManager {
+  Future<void> showAndRestore() async {
+    await show();
+    await restore();
+  }
+}
+
 final trayMenuDataProvider = Provider.autoDispose((ref) {
   return ref.watch(daemonAvailableProvider)
       ? ref.watch(vmStatusesProvider)
@@ -57,7 +64,7 @@ Future<void> setupTrayMenu(ProviderContainer providerContainer) async {
       label: 'Toggle window',
       callback: (_, __) async => await windowManager.isVisible()
           ? windowManager.hide()
-          : windowManager.show(),
+          : windowManager.showAndRestore(),
     );
   }
 
@@ -207,7 +214,7 @@ Future<void> _updateTrayMenu(
           if (providerContainer.exists(provider)) {
             providerContainer.read(provider.notifier).start();
           }
-          windowManager.show();
+          windowManager.showAndRestore();
         },
       );
     } else {


### PR DESCRIPTION
resolve #3667 

`windowManager.restore()` calls gtk_window_deiconify as well as gtk_window_present https://docs.gtk.org/gtk3/method.Window.deiconify.html

In my testing, this has made it so "Open in Multipass" for an instance either
- opens the Multipass window (if keyboard focus is not stolen), or 
- shows the " is ready" dialog if typing focus is on another app 

100% of the time, and fixes the issues seen from #3667 without needing to fork the flutter window_manager plugin