### PR TITLE
add `curl` to build dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Please note that these instructions do not support building packages for macOS o
 
 ```
 cd <multipass>
-sudo apt install devscripts equivs
+sudo apt install devscripts equivs curl
 mk-build-deps -s sudo -i
 ```
 


### PR DESCRIPTION
`curl` is required by `vcpkg` to function correctly, and without it installed on the Linux system, vcpkg fails at the `cmake ../` step without telling the user that the problem is a missing dependency for `curl` (the error message has no mention of curl or a missing dependency). curl is not installed by default on e.g. a fresh Ubuntu 22.04 minimal installation. 

I have added it to the "Build Dependencies" step because this is the only time in the build steps where we call `apt install`