### PR TITLE
add `curl` to build dependencies in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,7 @@
 Source: multipass
 Build-Depends: build-essential,
                cmake,
+               curl,
                google-mock,
                libapparmor-dev,
                libvirt-dev,


### PR DESCRIPTION
`curl` is required by `vcpkg` to function correctly, and without it installed on the Linux system, vcpkg fails at the `cmake ../` step. curl is not installed by default on e.g. a fresh Ubuntu 22.04 minimal installation. 