### PR TITLE
Fix crash when purge deleting while starting

### DIFF
--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -98,7 +98,8 @@ private:
     void on_restart();
     void initialize_vm_process();
 
-    void connect_signals();
+    void connect_vm_signals();
+    void disconnect_vm_signals();
 
     VirtualMachineDescription desc;
     std::unique_ptr<Process> vm_process{nullptr};
@@ -111,6 +112,8 @@ private:
     bool update_shutdown_status{true};
     bool is_starting_from_suspend{false};
     bool force_shutdown{false};
+    std::mutex vm_signal_mutex;
+    bool vm_signals_connected{false};
     std::chrono::steady_clock::time_point network_deadline;
 };
 } // namespace multipass

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -98,6 +98,8 @@ private:
     void on_restart();
     void initialize_vm_process();
 
+    void connect_signals();
+
     VirtualMachineDescription desc;
     std::unique_ptr<Process> vm_process{nullptr};
     const std::string mac_addr;


### PR DESCRIPTION
resolves #3279 

There are several sources of crashes when running `delete -p` and `start` at the same time.
One source stems from a race condition in the daemon involving multiple reads and writes to `operative_instances` concurrently. The crash source is from a callback created in `on_restart` which can unsafely write into `operative_instances` if the instance has been deleted. A workaround is to ensure this is always a read operation and catching the resulting error, but this still causes UB and puts the thread in a corrupt state. Preventing the callback or having safe access into the `operative_instances` map would be better.
  
Another is from callbacks in the `QemuVirtualMachine` which are called during or after the destruction of the VM instance. This is addressed by disconnecting the callbacks so they are not called when they shouldn't be and reconnecting them when appropriate.