### PR TITLE
Fix `stop` succeeding when instance isn't stopped

### DIFF
--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -29,6 +29,7 @@
 #include <multipass/logging/log.h>
 #include <multipass/memory_size.h>
 #include <multipass/platform.h>
+#include <multipass/top_catch_all.h>
 #include <multipass/utils.h>
 #include <multipass/vm_mount.h>
 #include <multipass/vm_status_monitor.h>
@@ -286,14 +287,16 @@ mp::QemuVirtualMachine::~QemuVirtualMachine()
     {
         update_shutdown_status = false;
 
-        if (state == State::running)
-        {
-            suspend();
-        }
-        else
-        {
-            shutdown();
-        }
+        mp::top_catch_all(vm_name, [this]() {
+            if (state == State::running)
+            {
+                suspend();
+            }
+            else
+            {
+                shutdown();
+            }
+        });
     }
 }
 

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -372,7 +372,7 @@ void mp::QemuVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
             if (vm_process != nullptr && !vm_process->wait_for_finished(kill_process_timeout))
             {
                 throw std::runtime_error{
-                    fmt::format("The QEMU process did not finish within {} miliseconds after being killed",
+                    fmt::format("The QEMU process did not finish within {} milliseconds after being killed",
                                 kill_process_timeout)};
             }
         }
@@ -412,7 +412,7 @@ void mp::QemuVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
             else
             {
                 throw std::runtime_error{
-                    fmt::format("The QEMU process did not finish within {} miliseconds after being shutdown",
+                    fmt::format("The QEMU process did not finish within {} milliseconds after being shutdown",
                                 shutdown_timeout)};
             }
         }

--- a/tests/qemu/test_qemu_backend.cpp
+++ b/tests/qemu/test_qemu_backend.cpp
@@ -302,6 +302,9 @@ TEST_F(QemuBackend, throws_when_shutdown_while_starting)
 
 TEST_F(QemuBackend, throws_on_shutdown_timeout)
 {
+    static const std::string sub_error_msg1{"The QEMU process did not finish within "};
+    static const std::string sub_error_msg2{"seconds after being shutdown"};
+
     mpt::MockProcess* vmproc = nullptr;
     process_factory->register_callback([&vmproc](mpt::MockProcess* process) {
         if (process->program().startsWith("qemu-system-") &&
@@ -328,7 +331,10 @@ TEST_F(QemuBackend, throws_on_shutdown_timeout)
 
     machine->state = mp::VirtualMachine::State::running;
 
-    EXPECT_THROW(machine->shutdown(), std::runtime_error);
+    MP_EXPECT_THROW_THAT(machine->shutdown(),
+                         std::runtime_error,
+                         mpt::match_what(AllOf(HasSubstr(sub_error_msg1), HasSubstr(sub_error_msg2))));
+
     EXPECT_NE(machine->current_state(), mp::VirtualMachine::State::off);
 }
 


### PR DESCRIPTION
resolves #2907 

When running `stop` on an instance that could not be stopped no error would be reported. This was because `QemuVirtualMachine::shutdown(force=false)` ignored the result of `vm_process->wait_for_finished(shutdown_timeout)` which indicates if a timeout occurred or not. This issue does not seem to be present in other VM backends.

This PR makes it so the timeout is not ignored and the timeout is properly reported.