### PR TITLE
Increase robustness of driver factory tests

### DIFF
--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -71,13 +71,8 @@ struct PlatformLinux : public mpt::TestWithMockedBinPath
     template <typename VMFactoryType>
     void aux_test_driver_factory(const QString& driver)
     {
-        mpt::MockDNSMasqServerFactory::GuardedMock dnsmasq_server_factory_attr{
+        const mpt::MockDNSMasqServerFactory::GuardedMock dnsmasq_server_factory_attr{
             mpt::MockDNSMasqServerFactory::inject<NiceMock>()};
-        mpt::MockDNSMasqServerFactory* mock_dnsmasq_server_factory = dnsmasq_server_factory_attr.first;
-
-        ON_CALL(*mock_dnsmasq_server_factory, make_dnsmasq_server).WillByDefault([this](auto...) {
-            return std::make_unique<mpt::MockDNSMasqServer>();
-        });
 
         auto factory = mpt::MockProcessFactory::Inject();
         setup_driver_settings(driver);

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -24,6 +24,7 @@
 #include "tests/mock_settings.h"
 #include "tests/mock_standard_paths.h"
 #include "tests/mock_utils.h"
+#include "tests/qemu/linux/mock_dnsmasq_server.h"
 #include "tests/temp_dir.h"
 #include "tests/test_with_mocked_bin_path.h"
 
@@ -70,6 +71,14 @@ struct PlatformLinux : public mpt::TestWithMockedBinPath
     template <typename VMFactoryType>
     void aux_test_driver_factory(const QString& driver)
     {
+        mpt::MockDNSMasqServerFactory::GuardedMock dnsmasq_server_factory_attr{
+            mpt::MockDNSMasqServerFactory::inject<NiceMock>()};
+        mpt::MockDNSMasqServerFactory* mock_dnsmasq_server_factory = dnsmasq_server_factory_attr.first;
+
+        ON_CALL(*mock_dnsmasq_server_factory, make_dnsmasq_server).WillByDefault([this](auto...) {
+            return std::make_unique<mpt::MockDNSMasqServer>();
+        });
+
         auto factory = mpt::MockProcessFactory::Inject();
         setup_driver_settings(driver);
 


### PR DESCRIPTION
Previously the following tests could fail when a user did not have permissions for ip related processes
- `PlatformLinux.test_default_driver_produces_correct_factory`
- `PlatformLinux.test_explicit_qemu_driver_produces_correct_factory`
- `PlatformLinux.test_libvirt_in_env_var_is_ignored`

Since these tests are not meant to fail for this case, these failures are unwanted. To resolve the issue, mocking the DNSMasqServerFactory allows the tests to focus more on testing the driver factories.