### PR TITLE
[daemon] let daemon choose mount target if not specified

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -235,6 +235,8 @@ public:
     virtual QString make_uuid(const std::optional<std::string>& seed = std::nullopt) const;
     virtual void sleep_for(const std::chrono::milliseconds& ms) const;
     virtual bool is_ipv4_valid(const std::string& ipv4) const;
+
+    virtual Path default_mount_target(const Path& source) const;
 };
 } // namespace multipass
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1912,7 +1912,10 @@ try // clang-format on
     for (const auto& path_entry : request->target_paths())
     {
         const auto& name = path_entry.instance_name();
-        const auto target_path = QDir::cleanPath(QString::fromStdString(path_entry.target_path())).toStdString();
+        const auto q_target_path = path_entry.target_path().empty()
+                                       ? MP_UTILS.default_mount_target(QString::fromStdString(request->source_path()))
+                                       : QDir::cleanPath(QString::fromStdString(path_entry.target_path()));
+        const auto target_path = q_target_path.toStdString();
 
         auto it = operative_instances.find(name);
         if (it == operative_instances.end())
@@ -1922,7 +1925,7 @@ try // clang-format on
         }
         auto& vm = it->second;
 
-        if (mp::utils::invalid_target_path(QString::fromStdString(target_path)))
+        if (mp::utils::invalid_target_path(q_target_path))
         {
             add_fmt_to(errors, "unable to mount to \"{}\"", target_path);
             continue;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -582,6 +582,11 @@ bool mp::Utils::is_ipv4_valid(const std::string& ipv4) const
     return true;
 }
 
+mp::Path mp::Utils::default_mount_target(const Path& source) const
+{
+    return source.isEmpty() ? "" : QDir{QDir::cleanPath(source)}.dirName().prepend("/home/ubuntu/");
+}
+
 auto mp::utils::find_bridge_with(const std::vector<mp::NetworkInterfaceInfo>& networks,
                                  const std::string& target_network,
                                  const std::string& bridge_type) -> std::optional<mp::NetworkInterfaceInfo>

--- a/tests/mock_utils.h
+++ b/tests/mock_utils.h
@@ -52,6 +52,7 @@ public:
     MOCK_METHOD(QString, make_uuid, (const std::optional<std::string>&), (const, override));
     MOCK_METHOD(void, sleep_for, (const std::chrono::milliseconds&), (const, override));
     MOCK_METHOD(bool, is_ipv4_valid, (const std::string& ipv4), (const, override));
+    MOCK_METHOD(Path, default_mount_target, (const Path& source), (const, override));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockUtils, Utils);
 };


### PR DESCRIPTION
This PR adds the functionality for the daemon to choose a mount target path if it is not given. Right now the logic is to take the last directory name in the source path and append it to `/home/ubuntu` e.g. given the source path `/home/andrei/projects/multipass`, the default target path would be `/home/ubuntu/multipass`