### PR TITLE
[cli/mount] remove default target if not specified

### DIFF
--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -180,15 +180,7 @@ mp::ParseCode cmd::Mount::parse_args(mp::ArgParser* parser)
 
         auto entry = request.add_target_paths();
         entry->set_instance_name(instance_name.toStdString());
-
-        if (target_path.isEmpty())
-        {
-            entry->set_target_path(source_path.toStdString());
-        }
-        else
-        {
-            entry->set_target_path(target_path.toStdString());
-        }
+        entry->set_target_path(target_path.toStdString());
     }
 
     QRegularExpression map_matcher("^([0-9]+[:][0-9]+)$");


### PR DESCRIPTION
This PR simply removes the responsibility of the CLI to choose a mount target path if it is not given, since that will now be the responsibility of the daemon. Thus, the CLI can now pass an empty target path to the daemon.