### PR TITLE
[gui] add ffi for getting mount target from source

### DIFF
--- a/include/multipass/dart_ffi.h
+++ b/include/multipass/dart_ffi.h
@@ -40,6 +40,8 @@ int gid();
 int default_id();
 
 long long memory_in_bytes(char* value);
+
+char* default_mount_target(char* source);
 }
 
 #endif // MULTIPASS_DART_FFI_H

--- a/include/multipass/dart_ffi.h
+++ b/include/multipass/dart_ffi.h
@@ -7,9 +7,9 @@ extern "C"
 // clang-format on
 const char* multipass_version();
 
-const char* generate_petname();
+char* generate_petname();
 
-const char* get_server_address();
+char* get_server_address();
 
 struct KeyCertificatePair
 {
@@ -27,11 +27,11 @@ enum SettingResult
     UnexpectedError,
 };
 
-const char* settings_file();
+char* settings_file();
 
-enum SettingResult get_setting(const char* key, const char** output);
+enum SettingResult get_setting(char* key, char** output);
 
-enum SettingResult set_setting(const char* key, const char* value, const char** output);
+enum SettingResult set_setting(char* key, char* value, char** output);
 
 int uid();
 
@@ -39,7 +39,7 @@ int gid();
 
 int default_id();
 
-long long memory_in_bytes(const char* value);
+long long memory_in_bytes(char* value);
 }
 
 #endif // MULTIPASS_DART_FFI_H

--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -180,15 +180,7 @@ mp::ParseCode cmd::Mount::parse_args(mp::ArgParser* parser)
 
         auto entry = request.add_target_paths();
         entry->set_instance_name(instance_name.toStdString());
-
-        if (target_path.isEmpty())
-        {
-            entry->set_target_path(source_path.toStdString());
-        }
-        else
-        {
-            entry->set_target_path(target_path.toStdString());
-        }
+        entry->set_target_path(target_path.toStdString());
     }
 
     QRegularExpression map_matcher("^([0-9]+[:][0-9]+)$");

--- a/src/client/gui/ffi/dart_ffi.cpp
+++ b/src/client/gui/ffi/dart_ffi.cpp
@@ -4,6 +4,7 @@
 #include "multipass/memory_size.h"
 #include "multipass/name_generator.h"
 #include "multipass/settings/settings.h"
+#include "multipass/utils.h"
 #include "multipass/version.h"
 
 namespace mp = multipass;
@@ -223,6 +224,28 @@ long long memory_in_bytes(char* value)
     {
         mpl::log(mpl::Level::warning, category, error);
         return -1;
+    }
+}
+
+char* default_mount_target(char* source)
+{
+    static constexpr auto error = "failed retrieving default mount target";
+    try
+    {
+        const QString q_source{source};
+        free(source);
+        const auto target = MP_UTILS.default_mount_target(q_source).toStdString();
+        return strdup(target.c_str());
+    }
+    catch (const std::exception& e)
+    {
+        mpl::log(mpl::Level::warning, category, fmt::format("{}: {}", error, e.what()));
+        return nullptr;
+    }
+    catch (...)
+    {
+        mpl::log(mpl::Level::warning, category, error);
+        return nullptr;
     }
 }
 }

--- a/src/client/gui/ffi/dart_ffi.cpp
+++ b/src/client/gui/ffi/dart_ffi.cpp
@@ -22,7 +22,7 @@ const char* multipass_version()
     return mp::version_string;
 }
 
-const char* generate_petname()
+char* generate_petname()
 try
 {
     static mp::NameGenerator::UPtr generator = mp::make_default_name_generator();
@@ -40,7 +40,7 @@ catch (...)
     return nullptr;
 }
 
-const char* get_server_address()
+char* get_server_address()
 try
 {
     const auto address = mpc::get_server_address();
@@ -83,7 +83,7 @@ catch (...)
 
 static std::once_flag initialize_settings_once_flag;
 
-const char* settings_file()
+char* settings_file()
 try
 {
     const auto file_name = mpc::persistent_settings_filename().toStdString();
@@ -100,10 +100,10 @@ catch (...)
     return nullptr;
 }
 
-enum SettingResult get_setting(const char* key, const char** output)
+enum SettingResult get_setting(char* key, char** output)
 {
     const QString key_string{key};
-    free((void*)key);
+    free(key);
     try
     {
         std::call_once(initialize_settings_once_flag, mpc::register_global_settings_handlers);
@@ -135,12 +135,12 @@ enum SettingResult get_setting(const char* key, const char** output)
     }
 }
 
-enum SettingResult set_setting(const char* key, const char* value, const char** output)
+enum SettingResult set_setting(char* key, char* value, char** output)
 {
     const QString key_string{key};
-    free((void*)key);
+    free(key);
     const QString value_string{value};
-    free((void*)value);
+    free(value);
     try
     {
         std::call_once(initialize_settings_once_flag, mpc::register_global_settings_handlers);
@@ -197,11 +197,11 @@ int default_id()
     return mp::default_id;
 }
 
-long long memory_in_bytes(const char* value)
+long long memory_in_bytes(char* value)
 try
 {
     std::string string_value{value};
-    free((void*)value);
+    free(value);
     return mp::in_bytes(string_value);
 }
 catch (const std::exception& e)

--- a/src/client/gui/lib/ffi.dart
+++ b/src/client/gui/lib/ffi.dart
@@ -73,6 +73,10 @@ final _memoryInBytes = _lib.lookupFunction<
     ffi.LongLong Function(ffi.Pointer<Utf8>),
     int Function(ffi.Pointer<Utf8>)>('memory_in_bytes');
 
+final _defaultMountTarget = _lib.lookupFunction<
+    ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>),
+    ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>)>('default_mount_target');
+
 final class _NativeKeyCertificatePair extends ffi.Struct {
   // ignore: non_constant_identifier_names
   external ffi.Pointer<Utf8> pem_cert;
@@ -170,4 +174,8 @@ int memoryInBytes(String value) {
   return result == -1
       ? throw Exception('Could not convert $value to bytes')
       : result;
+}
+
+String defaultMountTarget({required String source}) {
+  return _defaultMountTarget(source.toNativeUtf8()).string;
 }


### PR DESCRIPTION
This PR makes the logic of computing a mount target path from a source path available in the FFI library that we use from Dart. This is so that the GUI can show a preview of what a target path will be before actually sending the request to the daemon.