### PR TITLE
Reduce spurious CI test failures

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2900,10 +2900,23 @@ void mp::Daemon::create_vm(const CreateRequest* request,
             }
             catch (const std::exception& e)
             {
-                preparing_instances.erase(name);
-                release_resources(name);
-                operative_instances.erase(name);
-                persist_instances();
+                try
+                {
+                    preparing_instances.erase(name);
+                    release_resources(name);
+                    operative_instances.erase(name);
+                    persist_instances();
+                }
+                catch (const std::exception& doubleError)
+                {
+                    mpl::log(mpl::Level::error,
+                             category,
+                             fmt::format("Creation of VM \"{}\" failed to revert state while handling error \"{}\": {}",
+                                         name,
+                                         e.what(),
+                                         doubleError.what()));
+                }
+
                 status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
             }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2900,22 +2900,12 @@ void mp::Daemon::create_vm(const CreateRequest* request,
             }
             catch (const std::exception& e)
             {
-                try
-                {
+                mp::top_catch_all(category, [this, &name]() {
                     preparing_instances.erase(name);
                     release_resources(name);
                     operative_instances.erase(name);
                     persist_instances();
-                }
-                catch (const std::exception& doubleError)
-                {
-                    mpl::log(mpl::Level::error,
-                             category,
-                             fmt::format("Creation of VM \"{}\" failed to revert state while handling error \"{}\": {}",
-                                         name,
-                                         e.what(),
-                                         doubleError.what()));
-                }
+                });
 
                 status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
             }

--- a/src/platform/backends/shared/base_snapshot.cpp
+++ b/src/platform/backends/shared/base_snapshot.cpp
@@ -267,7 +267,7 @@ auto mp::BaseSnapshot::erase_helper()
     auto deleting_filepath = tmp_dir->filePath(snapshot_filename);
 
     QFile snapshot_file{snapshot_filepath};
-    if (!MP_FILEOPS.rename(snapshot_file, deleting_filepath) && snapshot_file.exists())
+    if (!MP_FILEOPS.rename(snapshot_file, deleting_filepath) && MP_FILEOPS.exists(snapshot_file))
         throw std::runtime_error{
             fmt::format("Failed to move snapshot file to temporary destination: {}", deleting_filepath)};
 

--- a/tests/json_test_utils.h
+++ b/tests/json_test_utils.h
@@ -27,6 +27,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <QJsonObject>
 #include <QString>
 
 namespace mp = multipass;
@@ -41,6 +42,12 @@ std::unique_ptr<mpt::TempDir> plant_instance_json(const std::string& contents); 
 void check_interfaces_in_json(const QString& file, const std::string& mac,
                               const std::vector<mp::NetworkInterface>& extra_interfaces);
 
-void check_mounts_in_json(const QString& file, std::unordered_map<std::string, mp::VMMount>& mounts);
+void check_interfaces_in_json(const QJsonObject& doc_object,
+                              const std::string& mac,
+                              const std::vector<mp::NetworkInterface>& extra_interfaces);
+
+void check_mounts_in_json(const QString& file, const std::unordered_map<std::string, mp::VMMount>& mounts);
+
+void check_mounts_in_json(const QJsonObject& doc_object, const std::unordered_map<std::string, mp::VMMount>& mounts);
 
 #endif // MULTIPASS_JSON_TEST_UTILS_H

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -19,6 +19,7 @@
 #include "file_operations.h"
 #include "mock_cloud_init_file_ops.h"
 #include "mock_file_ops.h"
+#include "mock_json_utils.h"
 #include "mock_virtual_machine.h"
 #include "path.h"
 
@@ -49,40 +50,7 @@ public:
     MOCK_METHOD(void, capture_impl, (), (override));
     MOCK_METHOD(void, erase_impl, (), (override));
     MOCK_METHOD(void, apply_impl, (), (override));
-
-    friend bool operator==(const MockBaseSnapshot& a, const MockBaseSnapshot& b);
 };
-
-bool operator==(const MockBaseSnapshot& a, const MockBaseSnapshot& b)
-{
-    return std::tuple(a.get_index(),
-                      a.get_name(),
-                      a.get_comment(),
-                      a.get_cloud_init_instance_id(),
-                      a.get_creation_timestamp(),
-                      a.get_num_cores(),
-                      a.get_mem_size(),
-                      a.get_disk_space(),
-                      a.get_extra_interfaces(),
-                      a.get_state(),
-                      a.get_mounts(),
-                      a.get_metadata(),
-                      a.get_parent(),
-                      a.get_id()) == std::tuple(b.get_index(),
-                                                b.get_name(),
-                                                b.get_comment(),
-                                                a.get_cloud_init_instance_id(),
-                                                b.get_creation_timestamp(),
-                                                b.get_num_cores(),
-                                                b.get_mem_size(),
-                                                b.get_disk_space(),
-                                                b.get_extra_interfaces(),
-                                                b.get_state(),
-                                                b.get_mounts(),
-                                                b.get_metadata(),
-                                                b.get_parent(),
-                                                b.get_id());
-}
 
 struct TestBaseSnapshot : public Test
 {
@@ -333,11 +301,15 @@ TEST_F(TestBaseSnapshot, rejectsNullDiskSize)
 
 TEST_F(TestBaseSnapshot, reconstructsFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     MockBaseSnapshot{test_json_file_path, vm, desc};
 }
 
 TEST_F(TestBaseSnapshot, adoptsNameFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto* snapshot_name = "cheeseball";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "name", snapshot_name);
@@ -348,6 +320,8 @@ TEST_F(TestBaseSnapshot, adoptsNameFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsCommentFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto* snapshot_comment = "Look behind you, a three-headed monkey!";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "comment", snapshot_comment);
@@ -358,6 +332,8 @@ TEST_F(TestBaseSnapshot, adoptsCommentFromJson)
 
 TEST_F(TestBaseSnapshot, linksToParentFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto parent_idx = 42;
     constexpr auto parent_name = "s42";
     auto json = test_snapshot_json();
@@ -373,6 +349,8 @@ TEST_F(TestBaseSnapshot, linksToParentFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsInstanceIdFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr std::string_view new_instance_id{"vm2"};
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "cloud_init_instance_id", QJsonValue{new_instance_id.data()});
@@ -383,6 +361,8 @@ TEST_F(TestBaseSnapshot, adoptsInstanceIdFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsIndexFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto index = 31;
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "index", index);
@@ -393,6 +373,8 @@ TEST_F(TestBaseSnapshot, adoptsIndexFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsTimestampFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto timestamp = "1990-10-01T01:02:03.999Z";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "creation_timestamp", timestamp);
@@ -403,6 +385,8 @@ TEST_F(TestBaseSnapshot, adoptsTimestampFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsNumCoresFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto num_cores = 9;
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "num_cores", num_cores);
@@ -413,6 +397,8 @@ TEST_F(TestBaseSnapshot, adoptsNumCoresFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsMemSizeFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto mem = "1073741824";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "mem_size", mem);
@@ -423,6 +409,8 @@ TEST_F(TestBaseSnapshot, adoptsMemSizeFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsDiskSpaceFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto disk = "1073741824";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "disk_space", disk);
@@ -433,6 +421,8 @@ TEST_F(TestBaseSnapshot, adoptsDiskSpaceFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsExtraInterfacesFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     std::vector<mp::NetworkInterface> extra_interfaces{{"eth15", "15:15:15:15:15:15", false}};
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "extra_interfaces", MP_JSONUTILS.extra_interfaces_to_json_array(extra_interfaces));
@@ -443,6 +433,8 @@ TEST_F(TestBaseSnapshot, adoptsExtraInterfacesFromJson)
 
 TEST_F(TestBaseSnapshot, doesNotComplainOnLegacySnapshot)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     auto json = test_legacy_snapshot_json();
 
     auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
@@ -451,6 +443,8 @@ TEST_F(TestBaseSnapshot, doesNotComplainOnLegacySnapshot)
 
 TEST_F(TestBaseSnapshot, adoptsStateFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto state = mp::VirtualMachine::State::stopped;
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "state", static_cast<int>(state));
@@ -461,6 +455,8 @@ TEST_F(TestBaseSnapshot, adoptsStateFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsMetadataFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     auto metadata = QJsonObject{};
     metadata["arguments"] = "Meathook:\n"
                             "You've got a real attitude problem!\n"
@@ -483,6 +479,8 @@ TEST_F(TestBaseSnapshot, adoptsMetadataFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsMountsFromJson)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto src_path = "You fight like a dairy farmer.";
     constexpr auto dst_path = "How appropriate. You fight like a cow.";
     constexpr auto host_uid = 1, instance_uid = 2, host_gid = 3, instance_gid = 4;
@@ -567,6 +565,8 @@ TEST_F(TestBaseSnapshot, refusesIndexAboveMax)
 
 TEST_F(TestBaseSnapshot, setsName)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto new_name = "Murray";
     auto snapshot = MockBaseSnapshot{test_json_file_path, vm, desc};
 
@@ -576,6 +576,8 @@ TEST_F(TestBaseSnapshot, setsName)
 
 TEST_F(TestBaseSnapshot, setsComment)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     constexpr auto new_comment = "I once owned a dog that was smarter than you.\n"
                                  "He must have taught you everything you know.";
     auto snapshot = MockBaseSnapshot{test_json_file_path, vm, desc};
@@ -586,6 +588,8 @@ TEST_F(TestBaseSnapshot, setsComment)
 
 TEST_F(TestBaseSnapshot, setsParent)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     auto child = MockBaseSnapshot{test_json_file_path, vm, desc};
     auto parent = std::make_shared<MockBaseSnapshot>("parent", "", "", nullptr, specs, vm);
 
@@ -600,6 +604,9 @@ class TestSnapshotPersistence : public TestBaseSnapshot,
 
 TEST_P(TestSnapshotPersistence, persistsOnEdition)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
+
     constexpr auto index = 55;
     auto setter = GetParam();
 
@@ -607,11 +614,11 @@ TEST_P(TestSnapshotPersistence, persistsOnEdition)
     mod_snapshot_json(json, "index", index);
 
     MockBaseSnapshot snapshot_orig{plant_snapshot_json(json), vm, desc};
-    setter(snapshot_orig);
-
     const auto file_path = derive_persisted_snapshot_file_path(index);
-    const MockBaseSnapshot snapshot_edited{file_path, vm, desc};
-    EXPECT_EQ(snapshot_edited, snapshot_orig);
+
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(file_path)));
+
+    setter(snapshot_orig);
 }
 
 INSTANTIATE_TEST_SUITE_P(TestBaseSnapshot,
@@ -622,16 +629,21 @@ INSTANTIATE_TEST_SUITE_P(TestBaseSnapshot,
 
 TEST_F(TestBaseSnapshot, capturePersists)
 {
-    NiceMock<MockBaseSnapshot> snapshot{"Big Whoop", "treasure", "", nullptr, specs, vm};
-    snapshot.capture();
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
 
-    const auto expected_file = QFileInfo{derive_persisted_snapshot_file_path(snapshot.get_index())};
-    EXPECT_TRUE(expected_file.exists());
-    EXPECT_TRUE(expected_file.isFile());
+    NiceMock<MockBaseSnapshot> snapshot{"Big Whoop", "treasure", "", nullptr, specs, vm};
+    const auto expected_file = derive_persisted_snapshot_file_path(snapshot.get_index());
+
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(expected_file)));
+
+    snapshot.capture();
 }
 
 TEST_F(TestBaseSnapshot, captureCallsImpl)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     MockBaseSnapshot snapshot{"LeChuck", "'s Revenge", "", nullptr, specs, vm};
     EXPECT_CALL(snapshot, capture_impl).Times(1);
 
@@ -648,6 +660,8 @@ TEST_F(TestBaseSnapshot, applyCallsImpl)
 
 TEST_F(TestBaseSnapshot, eraseCallsImpl)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     NiceMock<MockBaseSnapshot> snapshot{"House of Mojo", "voodoo", "", nullptr, specs, vm};
     snapshot.capture();
 
@@ -657,24 +671,33 @@ TEST_F(TestBaseSnapshot, eraseCallsImpl)
 
 TEST_F(TestBaseSnapshot, eraseRemovesFile)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
+
     NiceMock<MockBaseSnapshot> snapshot{"House of Mojo", "voodoo", "", nullptr, specs, vm};
+    const auto expected_file_path = derive_persisted_snapshot_file_path(snapshot.get_index());
+
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(expected_file_path)));
     snapshot.capture();
 
-    const auto expected_file_path = derive_persisted_snapshot_file_path(snapshot.get_index());
-    ASSERT_TRUE(QFileInfo{expected_file_path}.exists());
+    auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
+    EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Eq(expected_file_path)), Ne(expected_file_path))).WillOnce(Return(true));
 
     snapshot.erase();
-    EXPECT_FALSE(QFileInfo{expected_file_path}.exists());
 }
 
 TEST_F(TestBaseSnapshot, eraseThrowsIfUnableToRenameFile)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+
     NiceMock<MockBaseSnapshot> snapshot{"voodoo-sword", "Cursed Cutlass of Kaflu", "", nullptr, specs, vm};
     snapshot.capture();
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
     const auto expected_file_path = derive_persisted_snapshot_file_path(snapshot.get_index());
     EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Eq(expected_file_path)), _)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_file_ops, exists(Matcher<const QFile&>(Property(&QFile::fileName, Eq(expected_file_path)))))
+        .WillOnce(Return(true));
 
     MP_EXPECT_THROW_THAT(snapshot.erase(),
                          std::runtime_error,
@@ -683,31 +706,29 @@ TEST_F(TestBaseSnapshot, eraseThrowsIfUnableToRenameFile)
 
 TEST_F(TestBaseSnapshot, restoresFileOnFailureToErase)
 {
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
+
     NiceMock<MockBaseSnapshot> snapshot{"ultimate-insult",
                                         "A powerful weapon capable of crippling even the toughest pirate's ego.",
                                         "",
                                         nullptr,
                                         specs,
                                         vm};
+    const auto expected_file_path = derive_persisted_snapshot_file_path(snapshot.get_index());
+
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(expected_file_path)));
     snapshot.capture();
 
-    const auto expected_file_path = derive_persisted_snapshot_file_path(snapshot.get_index());
-    ASSERT_TRUE(QFileInfo{expected_file_path}.exists());
+    auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
+    EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Eq(expected_file_path)), Ne(expected_file_path))).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Ne(expected_file_path)), Eq(expected_file_path)));
 
     EXPECT_CALL(snapshot, erase_impl).WillOnce([&expected_file_path] {
-        ASSERT_FALSE(QFileInfo{expected_file_path}.exists());
         throw std::runtime_error{"test"};
     });
 
-    try
-    {
-        snapshot.erase();
-        FAIL() << "shouldn't be here";
-    }
-    catch (const std::runtime_error&)
-    {
-        EXPECT_TRUE(QFileInfo{expected_file_path}.exists());
-    }
+    MP_EXPECT_THROW_THAT(snapshot.erase(), std::runtime_error, mpt::match_what(StrEq("test")));
 }
 
 TEST_F(TestBaseSnapshot, throwsIfUnableToOpenFile)

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -686,9 +686,7 @@ TEST_F(TestBaseSnapshot, restoresFileOnFailureToErase)
         .WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Ne(expected_file_path)), Eq(expected_file_path)));
 
-    EXPECT_CALL(snapshot, erase_impl).WillOnce([&expected_file_path] {
-        throw std::runtime_error{"test"};
-    });
+    EXPECT_CALL(snapshot, erase_impl).WillOnce([]() { throw std::runtime_error{"test"}; });
 
     MP_EXPECT_THROW_THAT(snapshot.erase(), std::runtime_error, mpt::match_what(StrEq("test")));
 }

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -646,7 +646,8 @@ TEST_F(TestBaseSnapshot, eraseRemovesFile)
     snapshot.capture();
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
-    EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Eq(expected_file_path)), Ne(expected_file_path))).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Eq(expected_file_path)), Ne(expected_file_path)))
+        .WillOnce(Return(true));
 
     snapshot.erase();
 }
@@ -681,7 +682,8 @@ TEST_F(TestBaseSnapshot, restoresFileOnFailureToErase)
     snapshot.capture();
 
     auto [mock_file_ops, guard] = mpt::MockFileOps::inject();
-    EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Eq(expected_file_path)), Ne(expected_file_path))).WillOnce(Return(true));
+    EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Eq(expected_file_path)), Ne(expected_file_path)))
+        .WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, rename(Property(&QFile::fileName, Ne(expected_file_path)), Eq(expected_file_path)));
 
     EXPECT_CALL(snapshot, erase_impl).WillOnce([&expected_file_path] {

--- a/tests/test_base_snapshot.cpp
+++ b/tests/test_base_snapshot.cpp
@@ -133,6 +133,8 @@ struct TestBaseSnapshot : public Test
     NiceMock<mpt::MockVirtualMachine> vm{"a-vm"};
     const mpt::MockCloudInitFileOps::GuardedMock mock_cloud_init_file_ops_injection =
         mpt::MockCloudInitFileOps::inject<NiceMock>();
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
     QString test_json_file_path = mpt::test_data_path_for(test_json_filename);
 };
 
@@ -301,15 +303,11 @@ TEST_F(TestBaseSnapshot, rejectsNullDiskSize)
 
 TEST_F(TestBaseSnapshot, reconstructsFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     MockBaseSnapshot{test_json_file_path, vm, desc};
 }
 
 TEST_F(TestBaseSnapshot, adoptsNameFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto* snapshot_name = "cheeseball";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "name", snapshot_name);
@@ -320,8 +318,6 @@ TEST_F(TestBaseSnapshot, adoptsNameFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsCommentFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto* snapshot_comment = "Look behind you, a three-headed monkey!";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "comment", snapshot_comment);
@@ -332,8 +328,6 @@ TEST_F(TestBaseSnapshot, adoptsCommentFromJson)
 
 TEST_F(TestBaseSnapshot, linksToParentFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto parent_idx = 42;
     constexpr auto parent_name = "s42";
     auto json = test_snapshot_json();
@@ -349,8 +343,6 @@ TEST_F(TestBaseSnapshot, linksToParentFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsInstanceIdFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr std::string_view new_instance_id{"vm2"};
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "cloud_init_instance_id", QJsonValue{new_instance_id.data()});
@@ -361,8 +353,6 @@ TEST_F(TestBaseSnapshot, adoptsInstanceIdFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsIndexFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto index = 31;
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "index", index);
@@ -373,8 +363,6 @@ TEST_F(TestBaseSnapshot, adoptsIndexFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsTimestampFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto timestamp = "1990-10-01T01:02:03.999Z";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "creation_timestamp", timestamp);
@@ -385,8 +373,6 @@ TEST_F(TestBaseSnapshot, adoptsTimestampFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsNumCoresFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto num_cores = 9;
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "num_cores", num_cores);
@@ -397,8 +383,6 @@ TEST_F(TestBaseSnapshot, adoptsNumCoresFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsMemSizeFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto mem = "1073741824";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "mem_size", mem);
@@ -409,8 +393,6 @@ TEST_F(TestBaseSnapshot, adoptsMemSizeFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsDiskSpaceFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto disk = "1073741824";
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "disk_space", disk);
@@ -421,11 +403,11 @@ TEST_F(TestBaseSnapshot, adoptsDiskSpaceFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsExtraInterfacesFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     std::vector<mp::NetworkInterface> extra_interfaces{{"eth15", "15:15:15:15:15:15", false}};
     auto json = test_snapshot_json();
-    mod_snapshot_json(json, "extra_interfaces", MP_JSONUTILS.extra_interfaces_to_json_array(extra_interfaces));
+    mod_snapshot_json(json,
+                      "extra_interfaces",
+                      MP_JSONUTILS.JsonUtils::extra_interfaces_to_json_array(extra_interfaces));
 
     auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
     EXPECT_EQ(snapshot.get_extra_interfaces(), extra_interfaces);
@@ -433,8 +415,6 @@ TEST_F(TestBaseSnapshot, adoptsExtraInterfacesFromJson)
 
 TEST_F(TestBaseSnapshot, doesNotComplainOnLegacySnapshot)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     auto json = test_legacy_snapshot_json();
 
     auto snapshot = MockBaseSnapshot{plant_snapshot_json(json), vm, desc};
@@ -443,8 +423,6 @@ TEST_F(TestBaseSnapshot, doesNotComplainOnLegacySnapshot)
 
 TEST_F(TestBaseSnapshot, adoptsStateFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto state = mp::VirtualMachine::State::stopped;
     auto json = test_snapshot_json();
     mod_snapshot_json(json, "state", static_cast<int>(state));
@@ -455,8 +433,6 @@ TEST_F(TestBaseSnapshot, adoptsStateFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsMetadataFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     auto metadata = QJsonObject{};
     metadata["arguments"] = "Meathook:\n"
                             "You've got a real attitude problem!\n"
@@ -479,8 +455,6 @@ TEST_F(TestBaseSnapshot, adoptsMetadataFromJson)
 
 TEST_F(TestBaseSnapshot, adoptsMountsFromJson)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto src_path = "You fight like a dairy farmer.";
     constexpr auto dst_path = "How appropriate. You fight like a cow.";
     constexpr auto host_uid = 1, instance_uid = 2, host_gid = 3, instance_gid = 4;
@@ -565,8 +539,6 @@ TEST_F(TestBaseSnapshot, refusesIndexAboveMax)
 
 TEST_F(TestBaseSnapshot, setsName)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto new_name = "Murray";
     auto snapshot = MockBaseSnapshot{test_json_file_path, vm, desc};
 
@@ -576,8 +548,6 @@ TEST_F(TestBaseSnapshot, setsName)
 
 TEST_F(TestBaseSnapshot, setsComment)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     constexpr auto new_comment = "I once owned a dog that was smarter than you.\n"
                                  "He must have taught you everything you know.";
     auto snapshot = MockBaseSnapshot{test_json_file_path, vm, desc};
@@ -588,8 +558,6 @@ TEST_F(TestBaseSnapshot, setsComment)
 
 TEST_F(TestBaseSnapshot, setsParent)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     auto child = MockBaseSnapshot{test_json_file_path, vm, desc};
     auto parent = std::make_shared<MockBaseSnapshot>("parent", "", "", nullptr, specs, vm);
 
@@ -604,9 +572,6 @@ class TestSnapshotPersistence : public TestBaseSnapshot,
 
 TEST_P(TestSnapshotPersistence, persistsOnEdition)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
-
     constexpr auto index = 55;
     auto setter = GetParam();
 
@@ -616,7 +581,17 @@ TEST_P(TestSnapshotPersistence, persistsOnEdition)
     MockBaseSnapshot snapshot_orig{plant_snapshot_json(json), vm, desc};
     const auto file_path = derive_persisted_snapshot_file_path(index);
 
-    EXPECT_CALL(mock_json_utils, write_json(_, Eq(file_path)));
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(file_path)))
+        .WillOnce(WithArg<0>([&snapshot_orig](const QJsonObject& obj) {
+            const auto& new_snapshot = obj["snapshot"];
+
+            ASSERT_TRUE(new_snapshot.isObject());
+            const auto& new_obj = new_snapshot.toObject();
+
+            EXPECT_EQ(snapshot_orig.get_name(), new_obj["name"].toString().toStdString());
+            EXPECT_EQ(snapshot_orig.get_comment(), new_obj["comment"].toString().toStdString());
+            EXPECT_EQ(snapshot_orig.get_parents_index(), new_obj["parent"].toInt());
+        }));
 
     setter(snapshot_orig);
 }
@@ -629,9 +604,6 @@ INSTANTIATE_TEST_SUITE_P(TestBaseSnapshot,
 
 TEST_F(TestBaseSnapshot, capturePersists)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
-
     NiceMock<MockBaseSnapshot> snapshot{"Big Whoop", "treasure", "", nullptr, specs, vm};
     const auto expected_file = derive_persisted_snapshot_file_path(snapshot.get_index());
 
@@ -642,8 +614,6 @@ TEST_F(TestBaseSnapshot, capturePersists)
 
 TEST_F(TestBaseSnapshot, captureCallsImpl)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     MockBaseSnapshot snapshot{"LeChuck", "'s Revenge", "", nullptr, specs, vm};
     EXPECT_CALL(snapshot, capture_impl).Times(1);
 
@@ -660,8 +630,6 @@ TEST_F(TestBaseSnapshot, applyCallsImpl)
 
 TEST_F(TestBaseSnapshot, eraseCallsImpl)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     NiceMock<MockBaseSnapshot> snapshot{"House of Mojo", "voodoo", "", nullptr, specs, vm};
     snapshot.capture();
 
@@ -671,9 +639,6 @@ TEST_F(TestBaseSnapshot, eraseCallsImpl)
 
 TEST_F(TestBaseSnapshot, eraseRemovesFile)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
-
     NiceMock<MockBaseSnapshot> snapshot{"House of Mojo", "voodoo", "", nullptr, specs, vm};
     const auto expected_file_path = derive_persisted_snapshot_file_path(snapshot.get_index());
 
@@ -688,8 +653,6 @@ TEST_F(TestBaseSnapshot, eraseRemovesFile)
 
 TEST_F(TestBaseSnapshot, eraseThrowsIfUnableToRenameFile)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-
     NiceMock<MockBaseSnapshot> snapshot{"voodoo-sword", "Cursed Cutlass of Kaflu", "", nullptr, specs, vm};
     snapshot.capture();
 
@@ -706,9 +669,6 @@ TEST_F(TestBaseSnapshot, eraseThrowsIfUnableToRenameFile)
 
 TEST_F(TestBaseSnapshot, restoresFileOnFailureToErase)
 {
-    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
-    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
-
     NiceMock<MockBaseSnapshot> snapshot{"ultimate-insult",
                                         "A powerful weapon capable of crippling even the toughest pirate's ego.",
                                         "",

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -138,6 +138,9 @@ struct Daemon : public mpt::DaemonTestFixture
 
     mpt::MockSettings::GuardedMock mock_settings_injection = mpt::MockSettings::inject<StrictMock>();
     mpt::MockSettings& mock_settings = *mock_settings_injection.first;
+
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
+    mpt::MockJsonUtils& mock_json_utils = *mock_json_utils_injection.first;
 };
 
 TEST_F(Daemon, receives_commands_and_calls_corresponding_slot)
@@ -375,6 +378,18 @@ struct DaemonCreateLaunchAliasTestSuite : public Daemon, public FakeAliasConfig,
     {
         EXPECT_CALL(mpt::MockStandardPaths::mock_instance(), writableLocation(_))
             .WillRepeatedly(Return(fake_alias_dir.path()));
+
+        EXPECT_CALL(mock_json_utils, write_json(_, _)).WillRepeatedly([](auto&& a, auto&& b) {
+            // this try catch is necessary since propagating the error hangs the test.
+            try
+            {
+                MP_JSONUTILS.JsonUtils::write_json(a, b);
+            }
+            catch (...)
+            {
+                FAIL() << "write_json threw an unexpected error.";
+            }
+        });
     }
 };
 
@@ -1374,17 +1389,10 @@ TEST_F(DaemonCreateLaunchTestSuite, blueprintFromFileCallsCorrectFunction)
     send_command({"launch", "file://blah.yaml"});
 }
 
-void check_maps_in_json(const QString& file, const mp::id_mappings& expected_gid_mappings,
+void check_maps_in_json(const QJsonObject& doc_object,
+                        const mp::id_mappings& expected_gid_mappings,
                         const mp::id_mappings& expected_uid_mappings)
 {
-    QByteArray json = mpt::load(file);
-
-    QJsonParseError parse_error;
-    const auto doc = QJsonDocument::fromJson(json, &parse_error);
-    EXPECT_FALSE(doc.isNull());
-    EXPECT_TRUE(doc.isObject());
-
-    const auto doc_object = doc.object();
     const auto instance_object = doc_object["real-zebraphant"].toObject();
 
     const auto mounts = instance_object["mounts"].toArray();
@@ -1444,13 +1452,12 @@ TEST_F(Daemon, reads_mac_addresses_from_json)
         EXPECT_THAT(list_reply.instance_list().instances(), instance_matcher);
     }
 
-    // Removing the JSON is possible now because data was already read. This step is not necessary, but doing it we
-    // make sure that the file was indeed rewritten after the next step.
-    QFile::remove(filename);
-    daemon.persist_instances();
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(filename)))
+        .WillOnce(WithArg<0>([&mac_addr, &extra_interfaces](const QJsonObject& obj) {
+            check_interfaces_in_json(obj, mac_addr, extra_interfaces);
+        }));
 
-    // Finally, check the contents of the file. If they match with what we read, we are done.
-    check_interfaces_in_json(filename, mac_addr, extra_interfaces);
+    daemon.persist_instances();
 }
 
 TEST_F(Daemon, writesAndReadsMountsInJson)
@@ -1511,9 +1518,11 @@ TEST_F(Daemon, writesAndReadsMountsInJson)
         EXPECT_THAT(list_reply.instance_list().instances(), instance_matcher);
     }
 
-    QFile::remove(filename);    // Remove the JSON.
-    daemon.persist_instances(); // Write it again to disk.
-    check_mounts_in_json(filename, mounts);
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(filename))).WillOnce(WithArg<0>([&mounts](const QJsonObject& obj) {
+        check_mounts_in_json(obj, mounts);
+    }));
+
+    daemon.persist_instances();
 }
 
 TEST_F(Daemon, writes_and_reads_ordered_maps_in_json)
@@ -1541,11 +1550,12 @@ TEST_F(Daemon, writes_and_reads_ordered_maps_in_json)
     send_command({"list"}, stream);
     EXPECT_THAT(stream.str(), HasSubstr("real-zebraphant"));
 
-    QFile::remove(filename);
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(filename)))
+        .WillOnce(WithArg<0>([&uid_mappings, &gid_mappings](const QJsonObject& obj) {
+            check_maps_in_json(obj, uid_mappings, gid_mappings);
+        }));
 
     send_command({"purge"});
-
-    check_maps_in_json(filename, uid_mappings, gid_mappings);
 }
 
 TEST_F(Daemon, launches_with_valid_network_interface)
@@ -1740,6 +1750,13 @@ TEST_F(Daemon, ctor_drops_removed_instances)
     EXPECT_CALL(*mock_factory, create_virtual_machine(Field(&mp::VirtualMachineDescription::vm_name, gone), _, _))
         .Times(0);
 
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(filename)))
+        .WillOnce(Return())
+        .WillOnce(WithArg<0>([&stayed, &gone](const QJsonObject& obj) {
+            QJsonDocument doc{obj};
+            EXPECT_THAT(doc.toJson().toStdString(), AllOf(HasSubstr(stayed), Not(HasSubstr(gone))));
+        }));
+
     mp::Daemon daemon{config_builder.build()};
 
     StrictMock<mpt::MockServerReaderWriter<mp::ListReply, mp::ListRequest>> mock_server;
@@ -1750,9 +1767,6 @@ TEST_F(Daemon, ctor_drops_removed_instances)
 
     EXPECT_TRUE(call_daemon_slot(daemon, &mp::Daemon::list, mp::ListRequest{}, mock_server).ok());
     EXPECT_THAT(list_reply.instance_list().instances(), stayed_matcher);
-
-    auto updated_json = mpt::load(filename);
-    EXPECT_THAT(updated_json.toStdString(), AllOf(HasSubstr(stayed), Not(HasSubstr(gone))));
 }
 
 TEST_P(ListIP, lists_with_ip)
@@ -2453,15 +2467,19 @@ TEST_F(Daemon, purgePersistsInstances)
     const auto [temp_dir, filename] = plant_instance_json(json_contents);
     config_builder.data_directory = temp_dir->path();
 
+    EXPECT_CALL(mock_json_utils, write_json(_, Eq(filename)))
+        .WillOnce(Return())
+        .WillOnce(Return())
+        .WillOnce(WithArg<0>([&name1, &name2](const QJsonObject& obj) {
+            QJsonDocument doc{obj};
+            EXPECT_THAT(doc.toJson().toStdString(), AllOf(HasSubstr(name1), HasSubstr(name2)));
+        }));
+
     config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
     mp::Daemon daemon{config_builder.build()};
 
-    QFile::remove(filename);
     call_daemon_slot(daemon, &mp::Daemon::purge, mp::PurgeRequest{},
                      NiceMock<mpt::MockServerReaderWriter<mp::PurgeReply, mp::PurgeRequest>>{});
-
-    auto updated_json = mpt::load(filename);
-    EXPECT_THAT(updated_json.toStdString(), AllOf(HasSubstr(name1), HasSubstr(name2)));
 }
 
 TEST_F(Daemon, launch_fails_with_incompatible_blueprint)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -380,15 +380,7 @@ struct DaemonCreateLaunchAliasTestSuite : public Daemon, public FakeAliasConfig,
             .WillRepeatedly(Return(fake_alias_dir.path()));
 
         EXPECT_CALL(mock_json_utils, write_json(_, _)).WillRepeatedly([](auto&& a, auto&& b) {
-            // this try catch is necessary since propagating the error hangs the test.
-            try
-            {
-                MP_JSONUTILS.JsonUtils::write_json(a, b);
-            }
-            catch (...)
-            {
-                FAIL() << "write_json threw an unexpected error.";
-            }
+            MP_JSONUTILS.JsonUtils::write_json(std::forward<decltype(a)>(a), std::forward<decltype(b)>(b));
         });
     }
 };

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -379,9 +379,7 @@ struct DaemonCreateLaunchAliasTestSuite : public Daemon, public FakeAliasConfig,
         EXPECT_CALL(mpt::MockStandardPaths::mock_instance(), writableLocation(_))
             .WillRepeatedly(Return(fake_alias_dir.path()));
 
-        EXPECT_CALL(mock_json_utils, write_json(_, _)).WillRepeatedly([](auto&& a, auto&& b) {
-            MP_JSONUTILS.JsonUtils::write_json(std::forward<decltype(a)>(a), std::forward<decltype(b)>(b));
-        });
+        MP_DELEGATE_MOCK_CALLS_ON_BASE(mock_json_utils, write_json, JsonUtils);
     }
 };
 

--- a/tests/test_daemon_launch.cpp
+++ b/tests/test_daemon_launch.cpp
@@ -19,6 +19,7 @@
 #include "common.h"
 #include "daemon_test_fixture.h"
 #include "mock_image_host.h"
+#include "mock_json_utils.h"
 #include "mock_platform.h"
 #include "mock_server_reader_writer.h"
 #include "mock_settings.h"
@@ -51,6 +52,8 @@ struct TestDaemonLaunch : public mpt::DaemonTestFixture
 
     mpt::MockSettings::GuardedMock mock_settings_injection = mpt::MockSettings::inject<StrictMock>();
     mpt::MockSettings& mock_settings = *mock_settings_injection.first;
+
+    const mpt::MockJsonUtils::GuardedMock mock_json_utils_injection = mpt::MockJsonUtils::inject<NiceMock>();
 };
 
 TEST_F(TestDaemonLaunch, blueprintFoundMountsWorkspaceWithNameOverride)


### PR DESCRIPTION
Previously CI could fail while writing to JSON files, especially in snapshot tests. Now, snapshot tests and many daemon tests minimally rely on the filesystem so the chance of spurious filesystem failures should be reduced.

MULTI-1230