### PR TITLE
log all QNetworkReply error messages at debug level

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -27,5 +27,6 @@ add_library(ip_address STATIC
 target_link_libraries(network
   fmt
   logger
+  utils
   Qt6::Core
   Qt6::Network)

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -114,7 +114,24 @@ download(QNetworkAccessManager* manager, const Time& timeout, QUrl const& url, P
 
     if (reply->error() != QNetworkReply::NoError)
     {
-        const auto msg = download_timeout.isActive() ? reply->errorString().toStdString() : "Network timeout";
+        const auto error_code = reply->error();
+        const auto error_string = reply->errorString().toStdString();
+
+        // Log the original error message at debug level
+        mpl::log(mpl::Level::debug,
+                 category,
+                 fmt::format("Qt error {}: {}", static_cast<int>(error_code), error_string));
+
+        const auto msg = (error_code == QNetworkReply::TimeoutError) ? "Network timeout" : error_string;
+
+        if (error_code == QNetworkReply::TimeoutError)
+        {
+            // Log a debug message to verify our assumption about download_timeout
+            if (download_timeout.isActive())
+            {
+                mpl::log(mpl::Level::debug, category, "Timeout error detected but download_timeout is still active");
+            }
+        }
 
         if (reply->error() == QNetworkReply::ProxyAuthenticationRequiredError || abort_download)
         {
@@ -124,10 +141,14 @@ download(QNetworkAccessManager* manager, const Time& timeout, QUrl const& url, P
         if (cache_load_control == QNetworkRequest::CacheLoadControl::AlwaysCache)
         {
             on_error();
+            // Log at error level since we are giving up
+            mpl::log(mpl::Level::error, category, fmt::format("Failed to get {}: {}", adjusted_url.toString(), msg));
             throw mp::DownloadException{adjusted_url.toString().toStdString(), msg};
         }
-        mpl::log(mpl::Level::warning, category,
-                 fmt::format("Error getting {}: {} - trying cache.", url.toString(), msg));
+        // Log at warning level when we are going to retry
+        mpl::log(mpl::Level::warning,
+                 category,
+                 fmt::format("Failed to get {}: {} - trying cache.", adjusted_url.toString(), msg));
         return ::download(manager,
                           timeout,
                           adjusted_url,


### PR DESCRIPTION
The enum for timeouts in Qt's networking library is `QNetworkReply::TimeoutError`. Different logs are printed at debug, warning, and error levels.

MULTI-1529