### PR TITLE
Ensure terminal doesn't render partial lines & Snap terminal scrolling to line height

### DIFF
--- a/src/client/gui/pubspec.lock
+++ b/src/client/gui/pubspec.lock
@@ -912,10 +912,11 @@ packages:
   xterm:
     dependency: "direct main"
     description:
-      name: xterm
-      sha256: "168dfedca77cba33fdb6f52e2cd001e9fde216e398e89335c19b524bb22da3a2"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "4.0.0+mp"
+      resolved-ref: ff2309c1581c025ba8b9f65e6619fe2fe2252827
+      url: "https://github.com/levkropp/xterm.dart"
+    source: git
     version: "4.0.0"
   zmodem:
     dependency: transitive

--- a/src/client/gui/pubspec.yaml
+++ b/src/client/gui/pubspec.yaml
@@ -52,7 +52,10 @@ dependencies:
       url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
       ref: 6c66ad2
-  xterm: ^4.0.0
+  xterm:
+    git:
+      url: https://github.com/levkropp/xterm.dart
+      ref: 4.0.0+mp
 
 dependency_overrides:
   hotkey_manager_linux:


### PR DESCRIPTION
Via a fork of the flutter xterm.dart plugin, editing ui/render.dart