### PR TITLE
Update libssh to 0.11.1

### DIFF
--- a/3rd-party/libssh/CMakeLists.txt
+++ b/3rd-party/libssh/CMakeLists.txt
@@ -59,7 +59,7 @@ file(STRINGS libssh/CMakeLists.txt libssh_VERSION REGEX "^project\\(libssh")
 file(STRINGS libssh/CMakeLists.txt LIBRARY_VERSION REGEX "^set\\(LIBRARY_VERSION")
 file(STRINGS libssh/CMakeLists.txt LIBRARY_SOVERSION REGEX "^set\\(LIBRARY_SOVERSION")
 
-string(REGEX MATCH "^project\\(libssh VERSION ([0-9]+)\\.([0-9]+)\\.([0-9]+) LANGUAGES C\\)$"
+string(REGEX MATCH "^project\\(libssh VERSION ([0-9]+)\\.([0-9]+)\\.([0-9]+) LANGUAGES C CXX\\)$"
   libssh_VERSION "${libssh_VERSION}")
 if (NOT libssh_VERSION)
     message(FATAL_ERROR "unable to find libssh project version")

--- a/3rd-party/submodule_info.md
+++ b/3rd-party/submodule_info.md
@@ -12,7 +12,7 @@ Version: 1.52.1 (+[our patches](https://github.com/CanonicalLtd/grpc/compare/v1.
 <https://github.com/grpc/grpc/releases>
 
 ### libssh
-Version: 0.10.6 (+[our patches](https://github.com/canonical/libssh/compare/libssh-0.10.6...multipass)) |
+Version: 0.11.1 (+[our patches](https://github.com/canonical/libssh/compare/libssh-0.11.1...multipass)) |
 <https://github.com/canonical/libssh.git> |
 <https://www.libssh.org/>
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -96,6 +96,7 @@ int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 // Creates a function that will wait for signals or until the passed function returns false.
 // The passed function is checked every `period` milliseconds.
 // If a signal is received the optional contains it, otherwise the optional is empty.
+// `make_quit_watchdog` should only be called once.
 std::function<std::optional<int>(const std::function<bool()>&)> make_quit_watchdog(
     const std::chrono::milliseconds& period); // call while single-threaded; call result later, in dedicated thread
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -93,7 +93,9 @@ std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& conf
 std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spec);
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 
-std::function<int()> make_quit_watchdog(); // call while single-threaded; call result later, in dedicated thread
+std::function<int()> make_quit_watchdog(
+    const std::chrono::milliseconds& timeout,
+    const std::function<bool()>& condition); // call while single-threaded; call result later, in dedicated thread
 
 std::string reinterpret_interface_id(const std::string& ux_id); // give platforms a chance to reinterpret network IDs
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -93,6 +93,9 @@ std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& conf
 std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spec);
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 
+// Creates a function that will wait for signals or until the passed function returns false.
+// The passed function is checked every timeout milliseconds.
+// If a signal is received the optional contains it, otherwise the optional is empty.
 std::function<std::optional<int>(const std::function<bool()>&)> make_quit_watchdog(
     const std::chrono::milliseconds& timeout); // call while single-threaded; call result later, in dedicated thread
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -94,10 +94,10 @@ std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spe
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 
 // Creates a function that will wait for signals or until the passed function returns false.
-// The passed function is checked every timeout milliseconds.
+// The passed function is checked every `period` milliseconds.
 // If a signal is received the optional contains it, otherwise the optional is empty.
 std::function<std::optional<int>(const std::function<bool()>&)> make_quit_watchdog(
-    const std::chrono::milliseconds& timeout); // call while single-threaded; call result later, in dedicated thread
+    const std::chrono::milliseconds& period); // call while single-threaded; call result later, in dedicated thread
 
 std::string reinterpret_interface_id(const std::string& ux_id); // give platforms a chance to reinterpret network IDs
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -93,9 +93,8 @@ std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& conf
 std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spec);
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 
-std::function<int()> make_quit_watchdog(
-    const std::chrono::milliseconds& timeout,
-    const std::function<bool()>& condition); // call while single-threaded; call result later, in dedicated thread
+std::function<int(const std::function<bool()>&)> make_quit_watchdog(
+    const std::chrono::milliseconds& timeout); // call while single-threaded; call result later, in dedicated thread
 
 std::string reinterpret_interface_id(const std::string& ux_id); // give platforms a chance to reinterpret network IDs
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -93,7 +93,7 @@ std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& conf
 std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spec);
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 
-std::function<int(const std::function<bool()>&)> make_quit_watchdog(
+std::function<std::optional<int>(const std::function<bool()>&)> make_quit_watchdog(
     const std::chrono::milliseconds& timeout); // call while single-threaded; call result later, in dedicated thread
 
 std::string reinterpret_interface_id(const std::string& ux_id); // give platforms a chance to reinterpret network IDs

--- a/include/multipass/platform_unix.h
+++ b/include/multipass/platform_unix.h
@@ -32,11 +32,11 @@ namespace multipass::platform
 class SignalWrapper : public Singleton<SignalWrapper>
 {
 public:
-  SignalWrapper(const PrivatePass&) noexcept;
+    SignalWrapper(const PrivatePass&) noexcept;
 
-  virtual int mask_signals(int how, const sigset_t* sigset, sigset_t* old_set = nullptr) const;
-  virtual int send(pthread_t target, int signal) const;
-  virtual int wait(const sigset_t& sigset, int& got) const;
+    virtual int mask_signals(int how, const sigset_t* sigset, sigset_t* old_set = nullptr) const;
+    virtual int send(pthread_t target, int signal) const;
+    virtual int wait(const sigset_t& sigset, int& got) const;
 };
 
 sigset_t make_sigset(const std::vector<int>& sigs);

--- a/include/multipass/platform_unix.h
+++ b/include/multipass/platform_unix.h
@@ -20,23 +20,23 @@
 
 #include <vector>
 
-#include <signal.h>
+#include <csignal>
 
 #include "singleton.h"
 
-#define MP_POSIX_SIGNAL multipass::platform::SignalWrapper::instance()
+#define MP_POSIX_SIGNAL multipass::platform::PosixSignal::instance()
 
 namespace multipass::platform
 {
 
-class SignalWrapper : public Singleton<SignalWrapper>
+class PosixSignal : public Singleton<PosixSignal>
 {
 public:
-    SignalWrapper(const PrivatePass&) noexcept;
+    PosixSignal(const PrivatePass&) noexcept;
 
-    virtual int mask_signals(int how, const sigset_t* sigset, sigset_t* old_set = nullptr) const;
-    virtual int send(pthread_t target, int signal) const;
-    virtual int wait(const sigset_t& sigset, int& got) const;
+    virtual int pthread_sigmask(int how, const sigset_t* sigset, sigset_t* old_set = nullptr) const;
+    virtual int pthread_kill(pthread_t target, int signal) const;
+    virtual int sigwait(const sigset_t& sigset, int& got) const;
 };
 
 sigset_t make_sigset(const std::vector<int>& sigs);

--- a/include/multipass/platform_unix.h
+++ b/include/multipass/platform_unix.h
@@ -22,12 +22,25 @@
 
 #include <signal.h>
 
-namespace multipass
+#include "singleton.h"
+
+#define MP_POSIX_SIGNAL multipass::platform::SignalWrapper::instance()
+
+namespace multipass::platform
 {
-namespace platform
+
+class SignalWrapper : public Singleton<SignalWrapper>
 {
+public:
+  SignalWrapper(const PrivatePass&) noexcept;
+
+  virtual int mask_signals(int how, const sigset_t* sigset, sigset_t* old_set = nullptr) const;
+  virtual int send(pthread_t target, int signal) const;
+  virtual int wait(const sigset_t& sigset, int& got) const;
+};
+
 sigset_t make_sigset(const std::vector<int>& sigs);
 sigset_t make_and_block_signals(const std::vector<int>& sigs);
-} // namespace platform
-}
+
+} // namespace multipass::platform
 #endif // MULTIPASS_PLATFORM_UNIX_H

--- a/include/multipass/ssh/ssh_session.h
+++ b/include/multipass/ssh/ssh_session.h
@@ -33,11 +33,7 @@ class SSHKeyProvider;
 class SSHSession
 {
 public:
-    SSHSession(const std::string& host,
-               int port,
-               const std::string& ssh_username,
-               const SSHKeyProvider& key_provider,
-               const std::chrono::milliseconds timeout = std::chrono::seconds(20));
+    SSHSession(const std::string& host, int port, const std::string& ssh_username, const SSHKeyProvider& key_provider);
 
     // just being explicit (unique_ptr member already caused these to be deleted)
     SSHSession(const SSHSession&) = delete;

--- a/src/platform/console/unix_console.cpp
+++ b/src/platform/console/unix_console.cpp
@@ -71,21 +71,15 @@ mp::UnixConsole::UnixConsole(ssh_channel channel, UnixTerminal* term) : term{ter
 
     if (term->is_live())
     {
-        setup_console();
-
         const char* term_type = std::getenv("TERM");
         term_type = (term_type == nullptr) ? "xterm" : term_type;
 
         update_local_pty_size(term->cout_fd());
 
-        // do not inherit settings from stdin
-        constexpr unsigned char modes[1] = {0};
-        ssh_channel_request_pty_size_modes(channel,
-                                           term_type,
-                                           local_pty_size.columns,
-                                           local_pty_size.rows,
-                                           modes,
-                                           sizeof(modes));
+        ssh_channel_request_pty_size(channel, term_type, local_pty_size.columns, local_pty_size.rows);
+
+        // set stdin to Raw Mode after libssh inherits sane settings from stdin.
+        setup_console();
     }
 }
 

--- a/src/platform/console/unix_console.cpp
+++ b/src/platform/console/unix_console.cpp
@@ -77,7 +77,10 @@ mp::UnixConsole::UnixConsole(ssh_channel channel, UnixTerminal* term) : term{ter
         term_type = (term_type == nullptr) ? "xterm" : term_type;
 
         update_local_pty_size(term->cout_fd());
-        ssh_channel_request_pty_size(channel, term_type, local_pty_size.columns, local_pty_size.rows);
+
+        // do not inherit settings from stdin
+        constexpr unsigned char modes[1] = {0};
+        ssh_channel_request_pty_size_modes(channel, term_type, local_pty_size.columns, local_pty_size.rows, modes, sizeof(modes));
     }
 }
 

--- a/src/platform/console/unix_console.cpp
+++ b/src/platform/console/unix_console.cpp
@@ -80,7 +80,12 @@ mp::UnixConsole::UnixConsole(ssh_channel channel, UnixTerminal* term) : term{ter
 
         // do not inherit settings from stdin
         constexpr unsigned char modes[1] = {0};
-        ssh_channel_request_pty_size_modes(channel, term_type, local_pty_size.columns, local_pty_size.rows, modes, sizeof(modes));
+        ssh_channel_request_pty_size_modes(channel,
+                                           term_type,
+                                           local_pty_size.columns,
+                                           local_pty_size.rows,
+                                           modes,
+                                           sizeof(modes));
     }
 }
 

--- a/src/platform/console/unix_console.cpp
+++ b/src/platform/console/unix_console.cpp
@@ -75,7 +75,6 @@ mp::UnixConsole::UnixConsole(ssh_channel channel, UnixTerminal* term) : term{ter
         term_type = (term_type == nullptr) ? "xterm" : term_type;
 
         update_local_pty_size(term->cout_fd());
-
         ssh_channel_request_pty_size(channel, term_type, local_pty_size.columns, local_pty_size.rows);
 
         // set stdin to Raw Mode after libssh inherits sane settings from stdin.

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -195,13 +195,6 @@ sigset_t mp::platform::make_and_block_signals(const std::vector<int>& sigs)
     return sigset;
 }
 
-template <class Rep, class Period>
-timespec make_timespec(std::chrono::duration<Rep, Period> duration)
-{
-    const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
-    return timespec{seconds.count(), std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds).count()};
-}
-
 std::function<std::optional<int>(const std::function<bool()>&)> mp::platform::make_quit_watchdog(
     const std::chrono::milliseconds& period)
 {

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -186,18 +186,18 @@ timespec make_timespec(std::chrono::duration<Rep, Period> duration)
     return out;
 }
 
-std::function<int(const std::function<bool()>&)> mp::platform::make_quit_watchdog(
+std::function<std::optional<int>(const std::function<bool()>&)> mp::platform::make_quit_watchdog(
     const std::chrono::milliseconds& timeout)
 {
     return [sigset = make_and_block_signals({SIGQUIT, SIGTERM, SIGHUP}),
-            time = make_timespec(timeout)](const std::function<bool()>& condition) {
+            time = make_timespec(timeout)](const std::function<bool()>& condition) -> std::optional<int> {
         while (condition())
         {
             if (const int sig = sigtimedwait(&sigset, nullptr, &time); sig != -1)
                 return sig;
         }
 
-        return -1;
+        return std::nullopt;
     };
 }
 

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -158,9 +158,9 @@ int mp::platform::symlink_attr_from(const char* path, sftp_attributes_struct* at
     return 0;
 }
 
-mp::platform::SignalWrapper::SignalWrapper(const PrivatePass& pass) noexcept
-: Singleton(pass){}
-
+mp::platform::SignalWrapper::SignalWrapper(const PrivatePass& pass) noexcept : Singleton(pass)
+{
+}
 
 int mp::platform::SignalWrapper::mask_signals(int how, const sigset_t* sigset, sigset_t* old_set) const
 {
@@ -207,11 +207,8 @@ std::function<std::optional<int>(const std::function<bool()>&)> mp::platform::ma
 {
     return [sigset = make_and_block_signals({SIGQUIT, SIGTERM, SIGHUP, SIGUSR2}),
             period](const std::function<bool()>& condition) -> std::optional<int> {
-
         // create a timer to periodically send SIGUSR2
-        utils::Timer signal_generator{period, [signalee = pthread_self()] {
-            MP_POSIX_SIGNAL.send(signalee, SIGUSR2);
-        }};
+        utils::Timer signal_generator{period, [signalee = pthread_self()] { MP_POSIX_SIGNAL.send(signalee, SIGUSR2); }};
 
         // wait on signals and condition
         int latest_signal = SIGUSR2;

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -26,6 +26,7 @@
 #include <unistd.h>
 
 #include <libssh/sftp.h>
+#include <multipass/auto_join_thread.h>
 
 namespace mp = multipass;
 
@@ -183,38 +184,47 @@ timespec make_timespec(std::chrono::duration<Rep, Period> duration)
     return timespec{seconds.count(), std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds).count()};
 }
 
+#include <iostream>
+
 std::function<std::optional<int>(const std::function<bool()>&)> mp::platform::make_quit_watchdog(
     const std::chrono::milliseconds& timeout)
 {
     return [sigset = make_and_block_signals({SIGQUIT, SIGTERM, SIGHUP, SIGUSR2}),
-            time = make_timespec(timeout)](const std::function<bool()>& condition) -> std::optional<int> {
-        // create a timer to send SIGUSR2 which unblocks this thread
-        sigevent sevp{};
-        sevp.sigev_notify = SIGEV_SIGNAL;
-        sevp.sigev_signo = SIGUSR2;
+            timeout](const std::function<bool()>& condition) -> std::optional<int> {
+        std::mutex sig_mtx;
+        std::condition_variable sig_cv;
+        int sig = SIGUSR2;
 
-        timer_t timer{};
-        if (timer_create(CLOCK_MONOTONIC, &sevp, &timer) == -1)
-            throw std::runtime_error(fmt::format("Could not create timer: {}", strerror(errno)));
+        // A signal generator that triggers after `timeout`
+        AutoJoinThread signaler([&sig_mtx, &sig_cv, &sig, &timeout, signalee = pthread_self()] {
+            std::unique_lock lock(sig_mtx);
+            while (sig == SIGUSR2)
+            {
+                auto status = sig_cv.wait_for(lock, timeout);
 
-        // scope guard to make sure the timer is deleted once it's no longer needed
-        const auto timer_guard = sg::make_scope_guard([timer]() noexcept { timer_delete(timer); });
-
-        // set timer interval and initial time to provided timeout
-        const itimerspec timer_interval{time, time};
-        if (timer_settime(timer, 0, &timer_interval, nullptr) == -1)
-            throw std::runtime_error(fmt::format("Could not set timer: {}", strerror(errno)));
+                if (sig == SIGUSR2 && status == std::cv_status::timeout)
+                {
+                    pthread_kill(signalee, SIGUSR2);
+                }
+            }
+        });
 
         // wait on signals and condition
-        int sig = SIGUSR2;
-        while (sig == SIGUSR2 && condition())
+        int ret = SIGUSR2;
+        while (ret == SIGUSR2 && condition())
         {
             // can't use sigtimedwait since macOS doesn't support it
-            sigwait(&sigset, &sig);
+            sigwait(&sigset, &ret);
         }
 
+        {
+            std::unique_lock lock(sig_mtx);
+            sig = ret == SIGUSR2 ? 0 : ret;
+        }
+        sig_cv.notify_all();
+
         // if sig is SIGUSR2 then we know we're exiting because condition() was false
-        return sig == SIGUSR2 ? std::nullopt : std::make_optional(sig);
+        return ret == SIGUSR2 ? std::nullopt : std::make_optional(sig);
     };
 }
 

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -179,11 +179,7 @@ template <class Rep, class Period>
 timespec make_timespec(std::chrono::duration<Rep, Period> duration)
 {
     const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
-
-    timespec out{};
-    out.tv_sec = seconds.count();
-    out.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds).count();
-    return out;
+    return timespec{seconds.count(), std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds).count()};
 }
 
 std::function<std::optional<int>(const std::function<bool()>&)> mp::platform::make_quit_watchdog(

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -17,6 +17,7 @@
 #include <multipass/format.h>
 #include <multipass/platform.h>
 #include <multipass/platform_unix.h>
+#include <multipass/timer.h>
 #include <multipass/utils.h>
 
 #include <grp.h>
@@ -25,7 +26,6 @@
 #include <unistd.h>
 
 #include <libssh/sftp.h>
-#include <multipass/timer.h>
 
 namespace mp = multipass;
 

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -175,12 +175,28 @@ sigset_t mp::platform::make_and_block_signals(const std::vector<int>& sigs)
     return sigset;
 }
 
-std::function<int()> mp::platform::make_quit_watchdog()
+template <class Rep, class Period>
+timespec make_timespec(std::chrono::duration<Rep, Period> duration)
 {
-    return [sigset = make_and_block_signals({SIGQUIT, SIGTERM, SIGHUP})]() {
-        int sig = -1;
-        sigwait(&sigset, &sig);
-        return sig;
+    const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
+
+    timespec out{};
+    out.tv_sec = seconds.count();
+    out.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds).count();
+    return out;
+}
+
+std::function<int()> mp::platform::make_quit_watchdog(const std::chrono::milliseconds& timeout,
+                                                      const std::function<bool()>& condition)
+{
+    return [sigset = make_and_block_signals({SIGQUIT, SIGTERM, SIGHUP}), time = make_timespec(timeout), condition]() {
+        while (condition())
+        {
+            if (const int sig = sigtimedwait(&sigset, nullptr, &time); sig != -1)
+                return sig;
+        }
+
+        return SIGCHLD;
     };
 }
 

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -184,8 +184,6 @@ timespec make_timespec(std::chrono::duration<Rep, Period> duration)
     return timespec{seconds.count(), std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds).count()};
 }
 
-#include <iostream>
-
 std::function<std::optional<int>(const std::function<bool()>&)> mp::platform::make_quit_watchdog(
     const std::chrono::milliseconds& timeout)
 {

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -186,17 +186,18 @@ timespec make_timespec(std::chrono::duration<Rep, Period> duration)
     return out;
 }
 
-std::function<int()> mp::platform::make_quit_watchdog(const std::chrono::milliseconds& timeout,
-                                                      const std::function<bool()>& condition)
+std::function<int(const std::function<bool()>&)> mp::platform::make_quit_watchdog(
+    const std::chrono::milliseconds& timeout)
 {
-    return [sigset = make_and_block_signals({SIGQUIT, SIGTERM, SIGHUP}), time = make_timespec(timeout), condition]() {
+    return [sigset = make_and_block_signals({SIGQUIT, SIGTERM, SIGHUP}),
+            time = make_timespec(timeout)](const std::function<bool()>& condition) {
         while (condition())
         {
             if (const int sig = sigtimedwait(&sigset, nullptr, &time); sig != -1)
                 return sig;
         }
 
-        return SIGCHLD;
+        return -1;
     };
 }
 

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -33,14 +33,13 @@ namespace mpl = multipass::logging;
 mp::SSHSession::SSHSession(const std::string& host,
                            int port,
                            const std::string& username,
-                           const SSHKeyProvider& key_provider,
-                           const std::chrono::milliseconds timeout)
+                           const SSHKeyProvider& key_provider)
     : session{ssh_new(), ssh_free}, mut{}
 {
     if (session == nullptr)
         throw mp::SSHException("could not allocate ssh session");
 
-    const long timeout_secs = std::chrono::duration_cast<std::chrono::seconds>(timeout).count();
+    const long timeout_secs = LONG_MAX;
     const int nodelay{1};
     auto ssh_dir = QDir(MP_STDPATHS.writableLocation(StandardPaths::AppConfigLocation)).filePath("ssh").toStdString();
 

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -39,7 +39,7 @@ mp::SSHSession::SSHSession(const std::string& host,
     if (session == nullptr)
         throw mp::SSHException("could not allocate ssh session");
 
-    const long timeout_secs = LONG_MAX;
+    const long timeout_secs = std::numeric_limits<long>::max();
     const int nodelay{1};
     auto ssh_dir = QDir(MP_STDPATHS.writableLocation(StandardPaths::AppConfigLocation)).filePath("ssh").toStdString();
 

--- a/src/sshfs_mount/sshfs_mount.cpp
+++ b/src/sshfs_mount/sshfs_mount.cpp
@@ -151,21 +151,28 @@ auto make_sftp_server(mp::SSHSession&& session, const std::string& source, const
 
 } // namespace
 
-mp::SshfsMount::SshfsMount(SSHSession&& session, const std::string& source, const std::string& target,
-                           const mp::id_mappings& gid_mappings, const mp::id_mappings& uid_mappings)
-    : sftp_server{make_sftp_server(std::move(session), source, target, gid_mappings, uid_mappings)},
+mp::SshfsMount::SshfsMount(SSHSession&& session,
+                           const std::string& source,
+                           const std::string& target,
+                           const mp::id_mappings& gid_mappings,
+                           const mp::id_mappings& uid_mappings)
+    : running{true},
+      sftp_server{make_sftp_server(std::move(session), source, target, gid_mappings, uid_mappings)},
       sftp_thread{[this]() {
           mp::top_catch_all(category, [this] {
               std::cout << "Connected" << std::endl;
               sftp_server->run();
               std::cout << "Stopped" << std::endl;
           });
+
+          running.store(false, std::memory_order_release);
       }}
 {
 }
 
 mp::SshfsMount::~SshfsMount()
 {
+    running.store(false, std::memory_order_release);
     stop();
 }
 
@@ -174,4 +181,9 @@ void mp::SshfsMount::stop()
     sftp_server->stop();
     if (sftp_thread.joinable())
         sftp_thread.join();
+}
+
+bool mp::SshfsMount::alive() const
+{
+    return running.load(std::memory_order_acquire);
 }

--- a/src/sshfs_mount/sshfs_mount.h
+++ b/src/sshfs_mount/sshfs_mount.h
@@ -38,7 +38,11 @@ public:
 
     void stop();
 
+    [[nodiscard]]
+    bool alive() const;
+
 private:
+    std::atomic<bool> running;
     // sftp_server Doesn't need to be a pointer, but done for now to avoid bringing sftp.h
     // which has an error with -pedantic.
     std::unique_ptr<SftpServer> sftp_server;

--- a/src/sshfs_mount/sshfs_mount.h
+++ b/src/sshfs_mount/sshfs_mount.h
@@ -38,8 +38,7 @@ public:
 
     void stop();
 
-    [[nodiscard]]
-    bool alive() const;
+    [[nodiscard]] bool alive() const;
 
 private:
     std::atomic<bool> running;

--- a/src/sshfs_mount/sshfs_mount.h
+++ b/src/sshfs_mount/sshfs_mount.h
@@ -41,7 +41,14 @@ public:
     [[nodiscard]] bool alive() const;
 
 private:
-    std::atomic<bool> running;
+    enum class State
+    {
+        Unstarted,
+        Running,
+        Stopped
+    };
+
+    std::atomic<State> state{State::Unstarted};
     // sftp_server Doesn't need to be a pointer, but done for now to avoid bringing sftp.h
     // which has an error with -pedantic.
     std::unique_ptr<SftpServer> sftp_server;

--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -105,10 +105,12 @@ int main(int argc, char* argv[])
 
     try
     {
-        auto watchdog = mpp::make_quit_watchdog(); // called while there is only one thread
-
         mp::SSHSession session{host, port, username, mp::SSHClientKeyProvider{priv_key_blob}};
         mp::SshfsMount sshfs_mount(std::move(session), source_path, target_path, gid_mappings, uid_mappings);
+
+        auto watchdog = mpp::make_quit_watchdog(std::chrono::milliseconds{2500}, [&sshfs_mount] {
+            return sshfs_mount.alive();
+        }); // called while there is only one thread
 
         // ssh lives on its own thread, use this thread to listen for quit signal
         if (int sig = watchdog())

--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
         if (sig.has_value())
             cout << "Received signal " << *sig << ". Stopping" << endl;
         else
-            cout << "SFTP server thread stopped unexpectedly." << endl;
+            cerr << "SFTP server thread stopped unexpectedly." << endl;
 
         sshfs_mount.stop();
         exit(sig.has_value() ? EXIT_SUCCESS : EXIT_FAILURE);

--- a/src/sshfs_mount/sshfs_server.cpp
+++ b/src/sshfs_mount/sshfs_server.cpp
@@ -112,15 +112,15 @@ int main(int argc, char* argv[])
         mp::SshfsMount sshfs_mount(std::move(session), source_path, target_path, gid_mappings, uid_mappings);
 
         // ssh lives on its own thread, use this thread to listen for quit signal
-        int sig = watchdog([&sshfs_mount] { return sshfs_mount.alive(); });
+        auto sig = watchdog([&sshfs_mount] { return sshfs_mount.alive(); });
 
-        if (sig != -1)
-            cout << "Received signal " << sig << ". Stopping" << endl;
+        if (sig.has_value())
+            cout << "Received signal " << *sig << ". Stopping" << endl;
         else
             cout << "SFTP server thread stopped unexpectedly." << endl;
 
         sshfs_mount.stop();
-        exit(sig == -1 ? EXIT_FAILURE : EXIT_SUCCESS);
+        exit(sig.has_value() ? EXIT_SUCCESS : EXIT_FAILURE);
     }
     catch (const mp::SSHFSMissingError&)
     {

--- a/tests/unix/mock_signal_wrapper.h
+++ b/tests/unix/mock_signal_wrapper.h
@@ -25,16 +25,16 @@
 namespace multipass::test
 {
 
-class MockSignalWrapper : public platform::SignalWrapper
+class MockPosixSignal : public platform::PosixSignal
 {
 public:
-    using SignalWrapper::SignalWrapper;
+    using PosixSignal::PosixSignal;
 
-    MOCK_METHOD(int, mask_signals, (int, const sigset_t*, sigset_t*), (const, override));
-    MOCK_METHOD(int, send, (pthread_t, int), (const, override));
-    MOCK_METHOD(int, wait, (const sigset_t&, int&), (const, override));
+    MOCK_METHOD(int, pthread_sigmask, (int, const sigset_t*, sigset_t*), (const, override));
+    MOCK_METHOD(int, pthread_kill, (pthread_t, int), (const, override));
+    MOCK_METHOD(int, sigwait, (const sigset_t&, int&), (const, override));
 
-    MP_MOCK_SINGLETON_BOILERPLATE(MockSignalWrapper, platform::SignalWrapper);
+    MP_MOCK_SINGLETON_BOILERPLATE(MockPosixSignal, platform::PosixSignal);
 };
 
 } // namespace multipass::test

--- a/tests/unix/mock_signal_wrapper.h
+++ b/tests/unix/mock_signal_wrapper.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MULTIPASS_MOCK_SIGNAL_WRAPPER_H
+#define MULTIPASS_MOCK_SIGNAL_WRAPPER_H
+
+#include "../common.h"
+#include "../mock_singleton_helpers.h"
+
+#include <multipass/platform_unix.h>
+
+namespace multipass::test
+{
+
+class MockSignalWrapper : public platform::SignalWrapper
+{
+public:
+    using SignalWrapper::SignalWrapper;
+
+    MOCK_METHOD(int, mask_signals, (int, const sigset_t*, sigset_t*), (const, override));
+    MOCK_METHOD(int, send, (pthread_t, int), (const, override));
+    MOCK_METHOD(int, wait, (const sigset_t&, int&), (const, override));
+
+    MP_MOCK_SINGLETON_BOILERPLATE(MockSignalWrapper, platform::SignalWrapper);
+};
+
+} // namespace multipass::test
+
+#endif // MULTIPASS_MOCK_SIGNAL_WRAPPER_H

--- a/tests/unix/test_platform_unix.cpp
+++ b/tests/unix/test_platform_unix.cpp
@@ -27,6 +27,8 @@
 #include <multipass/format.h>
 #include <multipass/platform.h>
 
+#include <thread>
+
 namespace mp = multipass;
 namespace mpt = multipass::test;
 
@@ -274,8 +276,10 @@ TEST_F(TestPlatformUnix, quit_watchdog_signals_itself_asynchronously)
     EXPECT_CALL(*mock_signals, wait(_, _))
         .WillRepeatedly(DoAll(
             [&signaled, &times] {
+                // busy wait until signaled
                 while (!signaled.load(std::memory_order_acquire))
                 {
+                    std::this_thread::yield();
                 }
                 times.fetch_add(1, std::memory_order_release);
                 signaled.store(false, std::memory_order_release);

--- a/tests/unix/test_platform_unix.cpp
+++ b/tests/unix/test_platform_unix.cpp
@@ -21,6 +21,7 @@
 #include <tests/temp_file.h>
 
 #include "mock_libc_functions.h"
+#include "mock_signal_wrapper.h"
 
 #include <multipass/constants.h>
 #include <multipass/format.h>
@@ -153,4 +154,139 @@ TEST_F(TestPlatformUnix, get_total_ram_returns_greater_than_zero)
 {
     // On any real system, there should be some RAM
     EXPECT_GT(MP_PLATFORM.get_total_ram(), 0LL);
+}
+
+void test_sigset_empty(const sigset_t& set)
+{
+    // there is no standard empty check to try a few different signals
+    EXPECT_EQ(sigismember(&set, SIGABRT), 0);
+    EXPECT_EQ(sigismember(&set, SIGALRM), 0);
+    EXPECT_EQ(sigismember(&set, SIGCHLD), 0);
+    EXPECT_EQ(sigismember(&set, SIGINT), 0);
+    EXPECT_EQ(sigismember(&set, SIGSEGV), 0);
+    EXPECT_EQ(sigismember(&set, SIGKILL), 0);
+    EXPECT_EQ(sigismember(&set, SIGQUIT), 0);
+    EXPECT_EQ(sigismember(&set, SIGTERM), 0);
+    EXPECT_EQ(sigismember(&set, SIGUSR1), 0);
+    EXPECT_EQ(sigismember(&set, SIGUSR2), 0);
+}
+
+bool test_sigset_has(const sigset_t& set, const std::vector<int>& sigs)
+{
+    bool good = true;
+    for (auto sig : sigs)
+    {
+        auto has_sig = sigismember(&set, sig) == 1;
+        if (!has_sig)
+            good = false;
+
+        EXPECT_TRUE(has_sig);
+    }
+
+    return good;
+}
+
+TEST_F(TestPlatformUnix, make_sigset_returns_emptyset)
+{
+    auto set = mp::platform::make_sigset({});
+    test_sigset_empty(set);
+}
+
+TEST_F(TestPlatformUnix, make_sigset_makes_sigset)
+{
+    auto set = mp::platform::make_sigset({SIGINT, SIGUSR2});
+
+    // check signals are set
+    test_sigset_has(set, {SIGINT, SIGUSR2});
+
+    // unset set signals
+    sigdelset(&set, SIGUSR2);
+    sigdelset(&set, SIGINT);
+
+    // check other signals aren't set
+    test_sigset_empty(set);
+}
+
+TEST_F(TestPlatformUnix, make_and_block_signals_works)
+{
+    auto [mock_signals, guard] = mpt::MockSignalWrapper::inject<StrictMock>();
+
+    EXPECT_CALL(
+        *mock_signals,
+        mask_signals(SIG_BLOCK, Pointee(Truly([](const auto& set) { return test_sigset_has(set, {SIGINT}); })), _));
+
+    auto set = mp::platform::make_and_block_signals({SIGINT});
+
+    test_sigset_has(set, {SIGINT});
+
+    sigdelset(&set, SIGINT);
+    test_sigset_empty(set);
+}
+
+TEST_F(TestPlatformUnix, make_quit_watchdog_blocks_signals)
+{
+    auto [mock_signals, guard] = mpt::MockSignalWrapper::inject<StrictMock>();
+
+    EXPECT_CALL(*mock_signals,
+                mask_signals(SIG_BLOCK,
+                             Pointee(Truly([](const auto& set) {
+                                 return test_sigset_has(set, {SIGQUIT, SIGTERM, SIGHUP, SIGUSR2});
+                             })),
+                             _));
+
+    mp::platform::make_quit_watchdog(std::chrono::milliseconds{1});
+}
+
+TEST_F(TestPlatformUnix, quit_watchdog_quits_on_condition)
+{
+    auto [mock_signals, guard] = mpt::MockSignalWrapper::inject<StrictMock>();
+
+    EXPECT_CALL(*mock_signals, mask_signals(SIG_BLOCK, _, _));
+    EXPECT_CALL(*mock_signals, wait(_, _)).WillRepeatedly(DoAll(SetArgReferee<1>(SIGUSR2), Return(0)));
+    ON_CALL(*mock_signals, send(pthread_self(), SIGUSR2)).WillByDefault(Return(0));
+
+    auto watchdog = mp::platform::make_quit_watchdog(std::chrono::milliseconds{1});
+    EXPECT_EQ(watchdog([] { return false; }), std::nullopt);
+}
+
+TEST_F(TestPlatformUnix, quit_watchdog_quits_on_signal)
+{
+    auto [mock_signals, guard] = mpt::MockSignalWrapper::inject<StrictMock>();
+
+    EXPECT_CALL(*mock_signals, mask_signals(SIG_BLOCK, _, _));
+    EXPECT_CALL(*mock_signals, wait(_, _))
+        .WillOnce(DoAll(SetArgReferee<1>(SIGUSR2), Return(0)))
+        .WillOnce(DoAll(SetArgReferee<1>(SIGTERM), Return(0)));
+    ON_CALL(*mock_signals, send(pthread_self(), SIGUSR2)).WillByDefault(Return(0));
+
+    auto watchdog = mp::platform::make_quit_watchdog(std::chrono::milliseconds{1});
+    EXPECT_EQ(watchdog([] { return true; }), SIGTERM);
+}
+
+TEST_F(TestPlatformUnix, quit_watchdog_signals_itself_asynchronously)
+{
+    auto [mock_signals, guard] = mpt::MockSignalWrapper::inject<StrictMock>();
+
+    std::atomic<bool> signaled = false;
+    std::atomic<int> times = 0;
+
+    EXPECT_CALL(*mock_signals, mask_signals(SIG_BLOCK, _, _));
+    EXPECT_CALL(*mock_signals, wait(_, _))
+        .WillRepeatedly(DoAll(
+            [&signaled, &times] {
+                while (!signaled.load(std::memory_order_acquire))
+                {
+                }
+                times.fetch_add(1, std::memory_order_release);
+                signaled.store(false, std::memory_order_release);
+            },
+            SetArgReferee<1>(SIGUSR2),
+            Return(0)));
+
+    EXPECT_CALL(*mock_signals, send(pthread_self(), SIGUSR2))
+        .WillRepeatedly(DoAll([&signaled] { signaled.store(true, std::memory_order_release); }, Return(0)));
+
+    auto watchdog = mp::platform::make_quit_watchdog(std::chrono::milliseconds{1});
+    EXPECT_EQ(watchdog([&times] { return times.load(std::memory_order_acquire) < 10; }), std::nullopt);
+    EXPECT_GE(times.load(std::memory_order_acquire), 10);
 }


### PR DESCRIPTION
Sets the timeout to infinite since no messages for extended periods of time is expected behavior. Libssh updated to fix timeout being ignored.
Sets the pty mode explicitly to default since Libssh updated to inherit settings from `stdin`.

Fixes #3745

MULTI-1528