### PR TITLE
Properly exclude QEMU code if QEMU not enabled (#3739)

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -24,7 +24,7 @@ function(add_target TARGET_NAME)
   endif()
 
   foreach(BACKEND IN LISTS MULTIPASS_BACKENDS)
-    string(TOUPPER ${BACKEND}_ENABLED DEF)
+    string(TOUPPER ${BACKEND}_ENABLED=1 DEF)
     target_compile_definitions(${TARGET_NAME} PRIVATE -D${DEF})
 
     target_link_libraries(${TARGET_NAME}

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -272,7 +272,11 @@ bool mp::platform::Platform::is_remote_supported(const std::string& remote) cons
 
 bool mp::platform::Platform::is_backend_supported(const QString& backend) const
 {
-    return (backend == "qemu" && QEMU_ENABLED) || backend == "libvirt" || backend == "lxd";
+    return
+#if QEMU_ENABLED
+        backend == "qemu" ||
+#endif
+        backend == "libvirt" || backend == "lxd";
 }
 
 bool mp::platform::Platform::link(const char* target, const char* link) const
@@ -347,10 +351,13 @@ QString mp::platform::Platform::daemon_config_home() const // temporary
 
 QString mp::platform::Platform::default_driver() const
 {
-    if (QEMU_ENABLED)
-        return QStringLiteral("qemu");
-    else
-        return QStringLiteral("lxd");
+    return QStringLiteral(
+#if QEMU_ENABLED
+        "qemu"
+#else
+        "lxd"
+#endif
+        );
 }
 
 QString mp::platform::Platform::default_privileged_mounts() const

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -33,10 +33,8 @@
 #include "backends/libvirt/libvirt_virtual_machine_factory.h"
 #include "backends/lxd/lxd_virtual_machine_factory.h"
 
-#ifdef QEMU_ENABLED
+#if QEMU_ENABLED
 #include "backends/qemu/qemu_virtual_machine_factory.h"
-#else
-#define QEMU_ENABLED 0
 #endif
 
 #ifdef MULTIPASS_JOURNALD_ENABLED

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -24,7 +24,9 @@
 #include "tests/mock_settings.h"
 #include "tests/mock_standard_paths.h"
 #include "tests/mock_utils.h"
+#if QEMU_ENABLED
 #include "tests/qemu/linux/mock_dnsmasq_server.h"
+#endif
 #include "tests/temp_dir.h"
 #include "tests/test_with_mocked_bin_path.h"
 
@@ -32,7 +34,7 @@
 #include <src/platform/backends/libvirt/libvirt_wrapper.h>
 #include <src/platform/backends/lxd/lxd_virtual_machine_factory.h>
 
-#ifdef QEMU_ENABLED
+#if QEMU_ENABLED
 #include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
 #define DEFAULT_FACTORY mp::QemuVirtualMachineFactory
 #define DEFAULT_DRIVER "qemu"
@@ -71,8 +73,10 @@ struct PlatformLinux : public mpt::TestWithMockedBinPath
     template <typename VMFactoryType>
     void aux_test_driver_factory(const QString& driver)
     {
+#if QEMU_ENABLED
         const mpt::MockDNSMasqServerFactory::GuardedMock dnsmasq_server_factory_attr{
             mpt::MockDNSMasqServerFactory::inject<NiceMock>()};
+#endif
 
         auto factory = mpt::MockProcessFactory::Inject();
         setup_driver_settings(driver);
@@ -142,7 +146,7 @@ TEST_F(PlatformLinux, test_default_driver_produces_correct_factory)
     aux_test_driver_factory<DEFAULT_FACTORY>(DEFAULT_DRIVER);
 }
 
-#ifdef QEMU_ENABLED
+#if QEMU_ENABLED
 TEST_F(PlatformLinux, test_explicit_qemu_driver_produces_correct_factory)
 {
     aux_test_driver_factory<mp::QemuVirtualMachineFactory>("qemu");


### PR DESCRIPTION
This PR:
- Defines `${BACKEND}_ENABLED=1` and ensures that all `<BACKEND>_ENABLED` checks in C++ check the value, not whether it is defined.
- Excludes QEMU code from tests if QEMU is not enabled.
- Changes all `QEMU_ENABLED` checks to happen at compile time, not run time.

Fixes #3739