### PR TITLE
[gui] make info providers update even if data is equal

### DIFF
--- a/src/client/gui/lib/providers.dart
+++ b/src/client/gui/lib/providers.dart
@@ -85,11 +85,11 @@ final vmInfosProvider = Provider((ref) {
     return !existingVmNames.contains(info.name);
   });
 
-  return existingVms.concat(launchingVms).sortedBy((i) => i.name).toBuiltList();
+  return existingVms.concat(launchingVms).sortedBy((i) => i.name).toList();
 });
 
 final vmInfosMapProvider = Provider((ref) {
-  return {for (final i in ref.watch(vmInfosProvider)) i.name: i}.build();
+  return {for (final i in ref.watch(vmInfosProvider)) i.name: i};
 });
 
 class VmInfoNotifier
@@ -106,7 +106,6 @@ final vmInfoProvider = NotifierProvider.autoDispose
 final vmStatusesProvider = Provider((ref) {
   return ref
       .watch(vmInfosMapProvider)
-      .asMap()
       .mapValue((info) => info.instanceStatus.status)
       .build();
 });


### PR DESCRIPTION
Providers only update on new data. Built collections provide deep equality comparison. But in our case, we want vm info providers to update even if the data is the same. For example, a stopped vm will emit the same info, so CPU sparkline does not update because of that. So this PR makes providers emit regular collections, which do not provide deep equality, so this makes the GUI update even if the data that comes from a vm is the same. This could also be optimized with more granular updates in the needed providers, if we notice the need for more performance.