### PR TITLE
[daemon] unified restart, restore and snapshot to grpc::FAILED_PRECON…

### DIFF
--- a/src/client/cli/cmd/clone.h
+++ b/src/client/cli/cmd/clone.h
@@ -37,5 +37,5 @@ private:
 
     CloneRequest rpc_request;
 };
-} // namespace multipass
+} // namespace multipass::cmd
 #endif // MULTIPASS_CLONE_H

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3674,7 +3674,8 @@ std::string mp::Daemon::dest_name_for_clone(const CloneRequest& request)
 {
     return request.has_destination_name()
                ? request.destination_name()
-               : generate_next_clone_name(vm_instance_specs[request.source_name()].clone_count, request.source_name());
+               : generate_next_clone_name(vm_instance_specs.at(request.source_name()).clone_count,
+                                          request.source_name());
 };
 
 grpc::Status mp::Daemon::validate_dest_name(const std::string& name)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2502,6 +2502,10 @@ catch (const mp::InvalidSettingException& e)
 {
     status_promise->set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, e.what(), ""));
 }
+catch (const mp::InstanceStateSettingsException& e)
+{
+    status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
+}
 catch (const std::exception& e)
 {
     status_promise->set_value(grpc::Status(grpc::StatusCode::INTERNAL, e.what(), ""));

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2586,7 +2586,7 @@ try
         using St = VirtualMachine::State;
         if (auto state = vm_ptr->current_state(); state != St::off && state != St::stopped)
             return status_promise->set_value(
-                grpc::Status{grpc::INVALID_ARGUMENT, "Multipass can only take snapshots of stopped instances."});
+                grpc::Status{grpc::FAILED_PRECONDITION, "Multipass can only take snapshots of stopped instances."});
 
         auto snapshot_name = request->snapshot();
         if (!snapshot_name.empty() && !mp::utils::valid_hostname(snapshot_name))
@@ -2641,7 +2641,7 @@ try
         using St = VirtualMachine::State;
         if (auto state = vm_ptr->current_state(); state != St::off && state != St::stopped)
             return status_promise->set_value(
-                grpc::Status{grpc::INVALID_ARGUMENT, "Multipass can only restore snapshots of stopped instances."});
+                grpc::Status{grpc::FAILED_PRECONDITION, "Multipass can only restore snapshots of stopped instances."});
 
         auto spec_it = vm_instance_specs.find(instance_name);
         assert(spec_it != vm_instance_specs.end() && "missing instance specs");
@@ -3246,7 +3246,7 @@ grpc::Status mp::Daemon::reboot_vm(VirtualMachine& vm)
         delayed_shutdown_instances.erase(vm.vm_name);
 
     if (!MP_UTILS.is_running(vm.current_state()))
-        return grpc::Status{grpc::StatusCode::INVALID_ARGUMENT,
+        return grpc::Status{grpc::StatusCode::FAILED_PRECONDITION,
                             fmt::format("Instance '{0}' is already running, but in an unknown state.\n"
                                         "Try to stop and start it instead.",
                                         vm.vm_name),

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2498,13 +2498,13 @@ catch (const mp::UnrecognizedSettingException& e)
 {
     status_promise->set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, e.what(), ""));
 }
-catch (const mp::InvalidSettingException& e)
-{
-    status_promise->set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, e.what(), ""));
-}
 catch (const mp::InstanceStateSettingsException& e)
 {
     status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
+}
+catch (const mp::InvalidSettingException& e)
+{
+    status_promise->set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, e.what(), ""));
 }
 catch (const std::exception& e)
 {

--- a/src/daemon/instance_settings_handler.cpp
+++ b/src/daemon/instance_settings_handler.cpp
@@ -99,8 +99,9 @@ void check_state_for_update(mp::VirtualMachine& instance)
 {
     auto st = instance.current_state();
     if (st != mp::VirtualMachine::State::stopped && st != mp::VirtualMachine::State::off)
-        throw mp::InstanceSettingsException{operation_msg(Operation::Modify), instance.vm_name,
-                                            "Instance must be stopped for modification"};
+        throw mp::InstanceStateSettingsException{operation_msg(Operation::Modify),
+                                                 instance.vm_name,
+                                                 "Instance must be stopped for modification"};
 }
 
 mp::MemorySize get_memory_size(const QString& key, const QString& val)
@@ -176,6 +177,13 @@ void update_bridged(const QString& key,
 
 mp::InstanceSettingsException::InstanceSettingsException(const std::string& reason, const std::string& instance,
                                                          const std::string& detail)
+    : SettingsException{fmt::format("{}; instance: {}; reason: {}", reason, instance, detail)}
+{
+}
+
+mp::InstanceStateSettingsException::InstanceStateSettingsException(const std::string& reason,
+                                                                   const std::string& instance,
+                                                                   const std::string& detail)
     : SettingsException{fmt::format("{}; instance: {}; reason: {}", reason, instance, detail)}
 {
 }

--- a/src/daemon/instance_settings_handler.cpp
+++ b/src/daemon/instance_settings_handler.cpp
@@ -181,13 +181,6 @@ mp::InstanceSettingsException::InstanceSettingsException(const std::string& reas
 {
 }
 
-mp::InstanceStateSettingsException::InstanceStateSettingsException(const std::string& reason,
-                                                                   const std::string& instance,
-                                                                   const std::string& detail)
-    : SettingsException{fmt::format("{}; instance: {}; reason: {}", reason, instance, detail)}
-{
-}
-
 mp::InstanceSettingsHandler::InstanceSettingsHandler(
     std::unordered_map<std::string, VMSpecs>& vm_instance_specs,
     std::unordered_map<std::string, VirtualMachine::ShPtr>& operative_instances,

--- a/src/daemon/instance_settings_handler.h
+++ b/src/daemon/instance_settings_handler.h
@@ -72,10 +72,10 @@ public:
     InstanceSettingsException(const std::string& reason, const std::string& instance, const std::string& detail);
 };
 
-class InstanceStateSettingsException : public SettingsException
+class InstanceStateSettingsException : public InstanceSettingsException
 {
 public:
-    InstanceStateSettingsException(const std::string& reason, const std::string& instance, const std::string& detail);
+    using InstanceSettingsException::InstanceSettingsException;
 };
 
 class NonAuthorizedBridgeSettingsException : public InstanceSettingsException

--- a/src/daemon/instance_settings_handler.h
+++ b/src/daemon/instance_settings_handler.h
@@ -72,6 +72,12 @@ public:
     InstanceSettingsException(const std::string& reason, const std::string& instance, const std::string& detail);
 };
 
+class InstanceStateSettingsException : public SettingsException
+{
+public:
+    InstanceStateSettingsException(const std::string& reason, const std::string& instance, const std::string& detail);
+};
+
 class NonAuthorizedBridgeSettingsException : public InstanceSettingsException
 {
 public:

--- a/tests/test_daemon_snapshot_restore.cpp
+++ b/tests/test_daemon_snapshot_restore.cpp
@@ -131,7 +131,7 @@ TYPED_TEST(TestDaemonSnapshotRestoreCommon, failsOnActiveInstance)
     auto status =
         this->call_daemon_slot(*daemon, TypeParam::daemon_slot_ptr, request, typename TestFixture::MockServer{});
 
-    EXPECT_EQ(status.error_code(), grpc::INVALID_ARGUMENT);
+    EXPECT_EQ(status.error_code(), grpc::FAILED_PRECONDITION);
     EXPECT_THAT(status.error_message(), HasSubstr("stopped"));
 }
 

--- a/tests/test_instance_settings_handler.cpp
+++ b/tests/test_instance_settings_handler.cpp
@@ -572,7 +572,7 @@ TEST_P(TestInstanceModOnNonStoppedInstance, setRefusesToModifyNonStoppedInstance
     EXPECT_CALL(target_instance, current_state).WillOnce(Return(state));
 
     MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, property), "123"),
-                         mp::InstanceSettingsException,
+                         mp::InstanceStateSettingsException,
                          mpt::match_what(AllOf(HasSubstr("Cannot update"), HasSubstr("Instance must be stopped"))));
 
     EXPECT_EQ(original_specs, specs[target_instance_name]);


### PR DESCRIPTION
1.   alias         
2.   aliases       
3.   authenticate: does not check state
4.   clone:              already done
5.   delete:            already done
6.   exec:               does not check state
7.   find:                does not check state
8.   get:                 does not check state
9.   help:               does not check state
10.   info:             does not check state
11.   launch:        not needed
12.   list:               does not check state
13.   mount:        already done
14.   networks:    not needed
15.   prefer:        
16.   purge:         does not check state
17.   recover:       already done
18.   **restart:        done**
19.   **restore:       done**
20.   **set:              done**
21.   shell:           does not check state
22.   **snapshot:   done**
23.   start:           hard to do, due to the coupling with `Daemon::async_wait_for_ready_all->grpc_status_for`
24.   stop:           already done
25.   suspend:    already done
26.   transfer:      
27.   umount:     already done
28.   unalias:      
29.   version:       does not check state

About the client side handler of these changed operations, **snapshot**, **restore** and **restart** all use `standard_failure_handler_for` function, meaning that there is no distinguishment between `INVALID_ARGUMENT` and `FAILED_PRECONDITION`. Likewise, **set** also did not distinguish that via a different way. 

MULTI-1559
Settle the [discussion](https://github.com/canonical/multipass/pull/3264#discussion_r1810731584)