### PR TITLE
Fix typo in launch success notification

### DIFF
--- a/src/client/gui/lib/notifications/notification_entries.dart
+++ b/src/client/gui/lib/notifications/notification_entries.dart
@@ -219,7 +219,7 @@ class LaunchingNotification extends ConsumerWidget {
               children: [
                 Text.rich([
                   '$name is up and running\n'.span.bold,
-                  'You can start using using it now'.span,
+                  'You can start using it now'.span,
                 ].spans),
                 Divider(),
                 Row(children: [


### PR DESCRIPTION
Fixes launch success notification typo. Previously it said `You can start using using it now`. Now it says `You can start using it now`.