### PR TITLE
[ci] make the renovate bot run only every 2 weeks

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,5 @@
   "extends": [
     "config:recommended"
   ],
+  "schedule": "every 2 weeks on Monday",
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,5 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
 }


### PR DESCRIPTION
This PR makes the renovate bot run only every two weeks on Monday, and it also moves the config file to JSON5 so that it can support trailing commas.