### PR TITLE
Remove chmod and duplicated permissions functions

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -73,7 +73,6 @@ public:
     virtual bool exists(const QFile& file) const;
     virtual bool is_open(const QFile& file) const;
     virtual bool open(QFileDevice& file, QIODevice::OpenMode mode) const;
-    virtual QFileDevice::Permissions permissions(const QFile& file) const;
     virtual qint64 read(QFile& file, char* data, qint64 maxSize) const;
     virtual QByteArray read_all(QFile& file) const;
     virtual QString read_line(QTextStream& text_stream) const;
@@ -119,6 +118,8 @@ public:
                                                                          std::error_code& err) const;
     virtual std::unique_ptr<DirIterator> dir_iterator(const fs::path& path, std::error_code& err) const;
     virtual fs::path weakly_canonical(const fs::path& path) const;
+
+    virtual fs::perms get_permissions(const fs::path& file) const;
 
     virtual fs::path remove_extension(const fs::path& path) const;
 };

--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -81,7 +81,6 @@ public:
     virtual bool rename(QFile& file, const QString& newName) const;
     virtual bool resize(QFile& file, qint64 sz) const;
     virtual bool seek(QFile& file, qint64 pos) const;
-    virtual bool setPermissions(QFile& file, QFileDevice::Permissions permissions) const;
     virtual qint64 size(QFile& file) const;
     virtual qint64 write(QFile& file, const char* data, qint64 maxSize) const;
     virtual qint64 write(QFileDevice& file, const QByteArray& data) const;
@@ -114,7 +113,6 @@ public:
     virtual bool remove(const fs::path& path, std::error_code& err) const;
     virtual void create_symlink(const fs::path& to, const fs::path& path, std::error_code& err) const;
     virtual fs::path read_symlink(const fs::path& path, std::error_code& err) const;
-    virtual void permissions(const fs::path& path, fs::perms perms, std::error_code& err) const;
     virtual fs::file_status status(const fs::path& path, std::error_code& err) const;
     virtual fs::file_status symlink_status(const fs::path& path, std::error_code& err) const;
     virtual std::unique_ptr<RecursiveDirIterator> recursive_dir_iterator(const fs::path& path,

--- a/include/multipass/path.h
+++ b/include/multipass/path.h
@@ -20,12 +20,10 @@
 #ifndef MULTIPASS_PATH_H
 #define MULTIPASS_PATH_H
 
-#include <QFileDevice>
 #include <QString>
 
 namespace multipass
 {
 using Path = QString;
-using Perms = QFileDevice::Permissions;
 }
 #endif // MULTIPASS_PATH_H

--- a/include/multipass/path.h
+++ b/include/multipass/path.h
@@ -20,10 +20,12 @@
 #ifndef MULTIPASS_PATH_H
 #define MULTIPASS_PATH_H
 
+#include <QFileDevice>
 #include <QString>
 
 namespace multipass
 {
 using Path = QString;
+using Perms = QFileDevice::Permissions;
 }
 #endif // MULTIPASS_PATH_H

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -58,7 +58,7 @@ public:
     virtual bool is_remote_supported(const std::string& remote) const;
     virtual bool is_backend_supported(const QString& backend) const; // temporary (?)
     virtual int chown(const char* path, unsigned int uid, unsigned int gid) const;
-    virtual bool set_permissions(const Path& path, const Perms permissions) const;
+    virtual bool set_permissions(const std::filesystem::path& path, std::filesystem::perms permissions) const;
     virtual bool link(const char* target, const char* link) const;
     virtual bool symlink(const char* target, const char* link, bool is_dir) const;
     virtual int utime(const char* path, int atime, int mtime) const;

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -58,7 +58,7 @@ public:
     virtual bool is_remote_supported(const std::string& remote) const;
     virtual bool is_backend_supported(const QString& backend) const; // temporary (?)
     virtual int chown(const char* path, unsigned int uid, unsigned int gid) const;
-    virtual bool set_permissions(const multipass::Path& path, const QFileDevice::Permissions permissions) const;
+    virtual bool set_permissions(const Path& path, const Perms permissions) const;
     virtual bool link(const char* target, const char* link) const;
     virtual bool symlink(const char* target, const char* link, bool is_dir) const;
     virtual int utime(const char* path, int atime, int mtime) const;

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -58,8 +58,7 @@ public:
     virtual bool is_remote_supported(const std::string& remote) const;
     virtual bool is_backend_supported(const QString& backend) const; // temporary (?)
     virtual int chown(const char* path, unsigned int uid, unsigned int gid) const;
-    virtual int chmod(const char* path, unsigned int mode) const;
-    virtual bool set_permissions(const multipass::Path path, const QFileDevice::Permissions permissions) const;
+    virtual bool set_permissions(const multipass::Path& path, const QFileDevice::Permissions permissions) const;
     virtual bool link(const char* target, const char* link) const;
     virtual bool symlink(const char* target, const char* link, bool is_dir) const;
     virtual int utime(const char* path, int atime, int mtime) const;

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -206,9 +206,10 @@ public:
     virtual std::string contents_of(const multipass::Path& file_path) const;
     virtual void make_file_with_content(const std::string& file_name, const std::string& content,
                                         const bool& overwrite = false);
-    virtual Path make_dir(const QDir& a_dir, const QString& name,
-                          QFileDevice::Permissions permissions = QFileDevice::Permissions(0));
-    virtual Path make_dir(const QDir& dir, QFileDevice::Permissions permissions = QFileDevice::Permissions(0));
+    virtual Path make_dir(const QDir& a_dir,
+                          const QString& name,
+                          std::filesystem::perms permissions = std::filesystem::perms::none);
+    virtual Path make_dir(const QDir& dir, std::filesystem::perms permissions = std::filesystem::perms::none);
 
     // command and process helpers
     virtual std::string run_cmd_for_output(const QString& cmd, const QStringList& args,

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -28,6 +28,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <chrono>
+#include <filesystem>
 #include <functional>
 #include <future>
 #include <sstream>

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
 
     auto storage_path = MP_PLATFORM.multipass_storage_location();
     if (!storage_path.isEmpty())
-        MP_UTILS.make_dir(storage_path, QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
+        MP_UTILS.make_dir(storage_path, std::filesystem::perms::owner_all);
 
     if (cache_directory.isEmpty())
     {

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -313,11 +313,10 @@ void mp::platform::Platform::create_alias_script(const std::string& alias, const
 
     MP_UTILS.make_file_with_content(file_path, script, true);
 
-    QFile file(QString::fromStdString(file_path));
     auto permissions =
-        MP_FILEOPS.permissions(file) | QFileDevice::ExeOwner | QFileDevice::ExeGroup | QFileDevice::ExeOther;
+        MP_FILEOPS.get_permissions(file_path) | fs::perms::owner_exec | fs::perms::group_exec | fs::perms::others_exec;
 
-    if (!MP_PLATFORM.set_permissions(file.fileName(), permissions))
+    if (!MP_PLATFORM.set_permissions(file_path, permissions))
         throw std::runtime_error(fmt::format("cannot set permissions to alias script '{}'", file_path));
 }
 

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -317,7 +317,7 @@ void mp::platform::Platform::create_alias_script(const std::string& alias, const
     auto permissions =
         MP_FILEOPS.permissions(file) | QFileDevice::ExeOwner | QFileDevice::ExeGroup | QFileDevice::ExeOther;
 
-    if (!MP_FILEOPS.setPermissions(file, permissions))
+    if (!MP_PLATFORM.set_permissions(file.fileName(), permissions))
         throw std::runtime_error(fmt::format("cannot set permissions to alias script '{}'", file_path));
 }
 

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -59,7 +59,7 @@ int mp::platform::Platform::chown(const char* path, unsigned int uid, unsigned i
     return ::lchown(path, uid, gid);
 }
 
-bool mp::platform::Platform::set_permissions(const mp::Path& path, const QFileDevice::Permissions permissions) const
+bool mp::platform::Platform::set_permissions(const Path& path, const Perms permissions) const
 {
     return QFile::setPermissions(path, permissions);
 }
@@ -127,9 +127,8 @@ void mp::platform::Platform::set_server_socket_restrictions(const std::string& s
     if (chown(socket_path.c_str(), 0, gid) == -1)
         throw std::runtime_error(fmt::format("Could not set ownership of the multipass socket: {}", strerror(errno)));
 
-    if (!set_permissions(socket_path.c_str(), mode))
-        throw std::runtime_error(
-            fmt::format("Could not set permissions for the multipass socket: {}", strerror(errno)));
+    if (!set_permissions(QString::fromStdString(socket_path), mode))
+        throw std::runtime_error(fmt::format("Could not set permissions for the multipass socket"));
 }
 
 QString mp::platform::Platform::multipass_storage_location() const

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -65,7 +65,14 @@ bool mp::platform::Platform::set_permissions(const std::filesystem::path& path,
     std::error_code ec{};
     std::filesystem::permissions(path, permissions, ec);
 
-    return !static_cast<bool>(ec);
+    if (ec)
+    {
+        mpl::log(mpl::Level::warning,
+                 "permissions",
+                 fmt::format("failed to set permissions for {}: {}", path.u8string(), ec.message()));
+    }
+
+    return !ec;
 }
 
 bool mp::platform::Platform::symlink(const char* target, const char* link, bool is_dir) const

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -59,9 +59,13 @@ int mp::platform::Platform::chown(const char* path, unsigned int uid, unsigned i
     return ::lchown(path, uid, gid);
 }
 
-bool mp::platform::Platform::set_permissions(const Path& path, const Perms permissions) const
+bool mp::platform::Platform::set_permissions(const std::filesystem::path& path,
+                                             std::filesystem::perms permissions) const
 {
-    return QFile::setPermissions(path, permissions);
+    std::error_code ec{};
+    std::filesystem::permissions(path, permissions, ec);
+
+    return !static_cast<bool>(ec);
 }
 
 bool mp::platform::Platform::symlink(const char* target, const char* link, bool is_dir) const
@@ -95,6 +99,9 @@ std::string mp::platform::Platform::alias_path_message() const
 void mp::platform::Platform::set_server_socket_restrictions(const std::string& server_address,
                                                             const bool restricted) const
 {
+    // With C++20 change to using enum
+    using namespace std::filesystem;
+
     auto tokens = mp::utils::split(server_address, ":");
     if (tokens.size() != 2u)
         throw std::runtime_error(fmt::format("invalid server address specified: {}", server_address));
@@ -104,7 +111,7 @@ void mp::platform::Platform::set_server_socket_restrictions(const std::string& s
         return;
 
     int gid{0};
-    auto mode{QFileDevice::ReadUser | QFileDevice::WriteUser | QFileDevice::ReadGroup | QFileDevice::WriteGroup};
+    auto mode{perms::owner_read | perms::owner_write | perms::group_read | perms::group_write};
 
     if (restricted)
     {
@@ -120,14 +127,14 @@ void mp::platform::Platform::set_server_socket_restrictions(const std::string& s
     }
     else
     {
-        mode |= QFileDevice::ReadOther | QFileDevice::WriteOther;
+        mode |= perms::others_read | perms::others_write;
     }
 
     const auto socket_path = tokens[1];
     if (chown(socket_path.c_str(), 0, gid) == -1)
         throw std::runtime_error(fmt::format("Could not set ownership of the multipass socket: {}", strerror(errno)));
 
-    if (!set_permissions(QString::fromStdString(socket_path), mode))
+    if (!set_permissions(socket_path, mode))
         throw std::runtime_error(fmt::format("Could not set permissions for the multipass socket"));
 }
 

--- a/src/ssh/sftp_client.cpp
+++ b/src/ssh/sftp_client.cpp
@@ -20,6 +20,7 @@
 #include "ssh_client_key_provider.h"
 #include <multipass/file_ops.h>
 #include <multipass/logging/log.h>
+#include <multipass/platform.h>
 #include <multipass/ssh/sftp_utils.h>
 #include <multipass/ssh/throw_on_error.h>
 #include <multipass/utils.h>
@@ -146,9 +147,8 @@ void SFTPClient::pull_file(const fs::path& source_path, const fs::path& target_p
     do_pull_file(source_path, *local_file);
 
     auto source_perms = mp_sftp_stat(sftp.get(), source_path.u8string().c_str())->permissions;
-    std::error_code err;
-    if (MP_FILEOPS.permissions(target_path, static_cast<fs::perms>(source_perms), err); err)
-        throw SFTPError{"cannot set permissions for local file {}: {}", target_path, err.message()};
+    if (!MP_PLATFORM.set_permissions(QString::fromStdWString(target_path.wstring()), static_cast<Perms>(source_perms)))
+        throw SFTPError{"cannot set permissions for local file {}", target_path};
 
     if (local_file->fail())
         throw SFTPError{"cannot write to local file {}: {}", target_path, strerror(errno)};
@@ -301,11 +301,11 @@ bool SFTPClient::pull_dir(const fs::path& source_path, const fs::path& target_pa
     for (auto it = subdirectory_perms.crbegin(); it != subdirectory_perms.crend(); ++it)
     {
         const auto& [path, perms] = *it;
-        MP_FILEOPS.permissions(path, static_cast<fs::perms>(perms), err);
-        if (err)
+        if (!MP_PLATFORM.set_permissions(QString::fromStdWString(path.wstring()), static_cast<Perms>(perms)))
         {
-            mpl::log(mpl::Level::error, log_category,
-                     fmt::format("cannot set permissions for local directory {}: {}", path, err.message()));
+            mpl::log(mpl::Level::error,
+                     log_category,
+                     fmt::format("cannot set permissions for local directory {}", path));
             success = false;
         }
     }

--- a/src/ssh/sftp_client.cpp
+++ b/src/ssh/sftp_client.cpp
@@ -147,7 +147,7 @@ void SFTPClient::pull_file(const fs::path& source_path, const fs::path& target_p
     do_pull_file(source_path, *local_file);
 
     auto source_perms = mp_sftp_stat(sftp.get(), source_path.u8string().c_str())->permissions;
-    if (!MP_PLATFORM.set_permissions(QString::fromStdString(target_path.u8string()), static_cast<Perms>(source_perms)))
+    if (!MP_PLATFORM.set_permissions(target_path, static_cast<fs::perms>(source_perms)))
         throw SFTPError{"cannot set permissions for local file {}", target_path};
 
     if (local_file->fail())
@@ -301,7 +301,7 @@ bool SFTPClient::pull_dir(const fs::path& source_path, const fs::path& target_pa
     for (auto it = subdirectory_perms.crbegin(); it != subdirectory_perms.crend(); ++it)
     {
         const auto& [path, perms] = *it;
-        if (!MP_PLATFORM.set_permissions(QString::fromStdString(path.u8string()), static_cast<Perms>(perms)))
+        if (!MP_PLATFORM.set_permissions(path, static_cast<fs::perms>(perms)))
         {
             mpl::log(mpl::Level::error,
                      log_category,

--- a/src/ssh/sftp_client.cpp
+++ b/src/ssh/sftp_client.cpp
@@ -147,7 +147,7 @@ void SFTPClient::pull_file(const fs::path& source_path, const fs::path& target_p
     do_pull_file(source_path, *local_file);
 
     auto source_perms = mp_sftp_stat(sftp.get(), source_path.u8string().c_str())->permissions;
-    if (!MP_PLATFORM.set_permissions(QString::fromStdWString(target_path.wstring()), static_cast<Perms>(source_perms)))
+    if (!MP_PLATFORM.set_permissions(QString::fromStdString(target_path.u8string()), static_cast<Perms>(source_perms)))
         throw SFTPError{"cannot set permissions for local file {}", target_path};
 
     if (local_file->fail())
@@ -301,7 +301,7 @@ bool SFTPClient::pull_dir(const fs::path& source_path, const fs::path& target_pa
     for (auto it = subdirectory_perms.crbegin(); it != subdirectory_perms.crend(); ++it)
     {
         const auto& [path, perms] = *it;
-        if (!MP_PLATFORM.set_permissions(QString::fromStdWString(path.wstring()), static_cast<Perms>(perms)))
+        if (!MP_PLATFORM.set_permissions(QString::fromStdString(path.u8string()), static_cast<Perms>(perms)))
         {
             mpl::log(mpl::Level::error,
                      log_category,

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -990,7 +990,7 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
             return reply_perm_denied(msg);
         }
 
-        QFileInfo file_info{filename};
+        QFileInfo file_info{QString::fromStdString(filename.u8string())};
         if (!file_info.isSymLink() && !MP_FILEOPS.exists(file_info))
         {
             mpl::log(mpl::Level::trace,
@@ -1013,7 +1013,7 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
 
     if (msg->attr->flags & SSH_FILEXFER_ATTR_SIZE)
     {
-        QFile file{filename};
+        QFile file{QString::fromStdString(filename.u8string())};
         if (!MP_FILEOPS.resize(file, msg->attr->size))
         {
             mpl::log(mpl::Level::trace,

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -531,13 +531,11 @@ int mp::SftpServer::handle_mkdir(sftp_client_message msg)
         return reply_failure(msg);
     }
 
-    std::error_code err;
-    MP_FILEOPS.permissions(filename, static_cast<fs::perms>(msg->attr->permissions), err);
-    if (err)
+    if (!MP_PLATFORM.set_permissions(filename, static_cast<Perms>(msg->attr->permissions)))
     {
         mpl::log(mpl::Level::trace,
                  category,
-                 fmt::format("{}: set permissions failed for '{}': {}", __FUNCTION__, filename, err.message()));
+                 fmt::format("{}: set permissions failed for '{}'", __FUNCTION__, filename));
         return reply_failure(msg);
     }
 
@@ -1022,13 +1020,11 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
 
     if (msg->attr->flags & SSH_FILEXFER_ATTR_PERMISSIONS)
     {
-        std::error_code err;
-        MP_FILEOPS.permissions(file.fileName().toStdString(), static_cast<fs::perms>(msg->attr->permissions), err);
-        if (err)
+        if (!MP_PLATFORM.set_permissions(file.fileName(), static_cast<Perms>(msg->attr->permissions)))
         {
             mpl::log(mpl::Level::trace,
                      category,
-                     fmt::format("{}: set permissions failed for '{}': {}", __FUNCTION__, filename, err.message()));
+                     fmt::format("{}: set permissions failed for '{}'", __FUNCTION__, filename));
             return reply_failure(msg);
         }
     }

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -1000,7 +1000,7 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
         }
     }
 
-    QFileInfo file_info{filename};
+    QFileInfo file_info{QString::fromStdString(filename.u8string())};
     if (!has_id_mappings_for(file_info))
     {
         mpl::log(mpl::Level::trace,

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -105,11 +105,6 @@ bool mp::FileOps::open(QFileDevice& file, QIODevice::OpenMode mode) const
     return file.open(mode);
 }
 
-QFileDevice::Permissions mp::FileOps::permissions(const QFile& file) const
-{
-    return file.permissions();
-}
-
 qint64 mp::FileOps::read(QFile& file, char* data, qint64 maxSize) const
 {
     return file.read(data, maxSize);
@@ -291,4 +286,9 @@ fs::path mp::FileOps::weakly_canonical(const fs::path& path) const
 fs::path mp::FileOps::remove_extension(const fs::path& path) const
 {
     return path.parent_path() / path.stem();
+}
+
+fs::perms mp::FileOps::get_permissions(const fs::path& file) const
+{
+    return fs::status(file).permissions();
 }

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -145,11 +145,6 @@ bool mp::FileOps::seek(QFile& file, qint64 pos) const
     return file.seek(pos);
 }
 
-bool mp::FileOps::setPermissions(QFile& file, QFileDevice::Permissions permissions) const
-{
-    return file.setPermissions(permissions);
-}
-
 qint64 mp::FileOps::size(QFile& file) const
 {
     return file.size();
@@ -265,11 +260,6 @@ void mp::FileOps::create_symlink(const fs::path& to, const fs::path& path, std::
 fs::path mp::FileOps::read_symlink(const fs::path& path, std::error_code& err) const
 {
     return fs::read_symlink(path, err);
-}
-
-void mp::FileOps::permissions(const fs::path& path, fs::perms perms, std::error_code& err) const
-{
-    fs::permissions(path, perms, err);
 }
 
 fs::file_status mp::FileOps::status(const fs::path& path, std::error_code& err) const

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -275,7 +275,7 @@ std::string mp::Utils::run_in_ssh_session(mp::SSHSession& session, const std::st
     return mp::utils::trim_end(output);
 }
 
-mp::Path mp::Utils::make_dir(const QDir& a_dir, const QString& name, QFileDevice::Permissions permissions)
+mp::Path mp::Utils::make_dir(const QDir& a_dir, const QString& name, std::filesystem::perms permissions)
 {
     mp::Path dir_path;
     bool success{false};
@@ -296,15 +296,15 @@ mp::Path mp::Utils::make_dir(const QDir& a_dir, const QString& name, QFileDevice
         throw std::runtime_error(fmt::format("unable to create directory '{}'", dir_path));
     }
 
-    if (permissions)
+    if (permissions != std::filesystem::perms::none)
     {
-        MP_PLATFORM.set_permissions(dir_path, permissions);
+        MP_PLATFORM.set_permissions(dir_path.toStdU16String(), permissions);
     }
 
     return dir_path;
 }
 
-mp::Path mp::Utils::make_dir(const QDir& dir, QFileDevice::Permissions permissions)
+mp::Path mp::Utils::make_dir(const QDir& dir, std::filesystem::perms permissions)
 {
     return make_dir(dir, QString(), permissions);
 }

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -636,9 +636,8 @@ TEST_F(PlatformLinux, create_alias_script_overwrites)
     EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillOnce(Return(true));
 
     // Calls the platform function directly since MP_PLATFORM is mocked.
-    EXPECT_NO_THROW(
-        mock_platform->Platform::create_alias_script("alias_name",
-                                                     mp::AliasDefinition{"instance", "other_command", "map"}));
+    EXPECT_NO_THROW(MP_PLATFORM.Platform::create_alias_script("alias_name",
+                                                              mp::AliasDefinition{"instance", "other_command", "map"}));
 }
 
 TEST_F(PlatformLinux, create_alias_script_throws_if_cannot_create_path)
@@ -677,7 +676,7 @@ TEST_F(PlatformLinux, create_alias_script_throws_if_cannot_set_permissions)
     EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(
-        mock_platform->Platform::create_alias_script("alias_name", mp::AliasDefinition{"instance", "command", "map"}),
+        MP_PLATFORM.Platform::create_alias_script("alias_name", mp::AliasDefinition{"instance", "command", "map"}),
         std::runtime_error,
         mpt::match_what(HasSubstr("cannot set permissions to alias script '")));
 }

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -56,6 +56,7 @@
 #include <QString>
 
 #include <stdexcept>
+#include <tests/mock_platform.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;
@@ -627,13 +628,16 @@ TEST_F(PlatformLinux, create_alias_script_overwrites)
 {
     auto [mock_utils, guard1] = mpt::MockUtils::inject();
     auto [mock_file_ops, guard2] = mpt::MockFileOps::inject();
+    auto [mock_platform, guard3] = mpt::MockPlatform::inject();
 
     EXPECT_CALL(*mock_utils, make_file_with_content(_, _, true)).Times(1);
     EXPECT_CALL(*mock_file_ops, permissions(_)).WillOnce(Return(QFileDevice::ReadOwner | QFileDevice::WriteOwner));
-    EXPECT_CALL(*mock_file_ops, setPermissions(_, _)).WillOnce(Return(true));
+    EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillOnce(Return(true));
 
+    // Calls the platform function directly since MP_PLATFORM is mocked.
     EXPECT_NO_THROW(
-        MP_PLATFORM.create_alias_script("alias_name", mp::AliasDefinition{"instance", "other_command", "map"}));
+        mock_platform->Platform::create_alias_script("alias_name",
+                                                     mp::AliasDefinition{"instance", "other_command", "map"}));
 }
 
 TEST_F(PlatformLinux, create_alias_script_throws_if_cannot_create_path)
@@ -664,14 +668,16 @@ TEST_F(PlatformLinux, create_alias_script_throws_if_cannot_set_permissions)
 {
     auto [mock_utils, guard1] = mpt::MockUtils::inject();
     auto [mock_file_ops, guard2] = mpt::MockFileOps::inject();
+    auto [mock_platform, guard3] = mpt::MockPlatform::inject();
 
     EXPECT_CALL(*mock_utils, make_file_with_content(_, _, true)).Times(1);
     EXPECT_CALL(*mock_file_ops, permissions(_)).WillOnce(Return(QFileDevice::ReadOwner | QFileDevice::WriteOwner));
-    EXPECT_CALL(*mock_file_ops, setPermissions(_, _)).WillOnce(Return(false));
+    EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(
-        MP_PLATFORM.create_alias_script("alias_name", mp::AliasDefinition{"instance", "command", "map"}),
-        std::runtime_error, mpt::match_what(HasSubstr("cannot set permissions to alias script '")));
+        mock_platform->Platform::create_alias_script("alias_name", mp::AliasDefinition{"instance", "command", "map"}),
+        std::runtime_error,
+        mpt::match_what(HasSubstr("cannot set permissions to alias script '")));
 }
 
 TEST_F(PlatformLinux, remove_alias_script_works)

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -632,7 +632,7 @@ TEST_F(PlatformLinux, create_alias_script_overwrites)
 
     EXPECT_CALL(*mock_utils, make_file_with_content(_, _, true)).Times(1);
     EXPECT_CALL(*mock_file_ops, get_permissions(_))
-        .WillOnce(Return(std::filesystem::perms::owner_read | std::filesystem::perms::owner_write));
+        .WillOnce(Return(mp::fs::perms::owner_read | mp::fs::perms::owner_write));
     EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillOnce(Return(true));
 
     // Calls the platform function directly since MP_PLATFORM is mocked.
@@ -673,7 +673,7 @@ TEST_F(PlatformLinux, create_alias_script_throws_if_cannot_set_permissions)
 
     EXPECT_CALL(*mock_utils, make_file_with_content(_, _, true)).Times(1);
     EXPECT_CALL(*mock_file_ops, get_permissions(_))
-        .WillOnce(Return(std::filesystem::perms::owner_read | std::filesystem::perms::owner_write));
+        .WillOnce(Return(mp::fs::perms::owner_read | mp::fs::perms::owner_write));
     EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -631,7 +631,8 @@ TEST_F(PlatformLinux, create_alias_script_overwrites)
     auto [mock_platform, guard3] = mpt::MockPlatform::inject();
 
     EXPECT_CALL(*mock_utils, make_file_with_content(_, _, true)).Times(1);
-    EXPECT_CALL(*mock_file_ops, permissions(_)).WillOnce(Return(QFileDevice::ReadOwner | QFileDevice::WriteOwner));
+    EXPECT_CALL(*mock_file_ops, get_permissions(_))
+        .WillOnce(Return(std::filesystem::perms::owner_read | std::filesystem::perms::owner_write));
     EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillOnce(Return(true));
 
     // Calls the platform function directly since MP_PLATFORM is mocked.
@@ -671,7 +672,8 @@ TEST_F(PlatformLinux, create_alias_script_throws_if_cannot_set_permissions)
     auto [mock_platform, guard3] = mpt::MockPlatform::inject();
 
     EXPECT_CALL(*mock_utils, make_file_with_content(_, _, true)).Times(1);
-    EXPECT_CALL(*mock_file_ops, permissions(_)).WillOnce(Return(QFileDevice::ReadOwner | QFileDevice::WriteOwner));
+    EXPECT_CALL(*mock_file_ops, get_permissions(_))
+        .WillOnce(Return(std::filesystem::perms::owner_read | std::filesystem::perms::owner_write));
     EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillOnce(Return(false));
 
     MP_EXPECT_THROW_THAT(

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -56,7 +56,6 @@ public:
     MOCK_METHOD(bool, rename, (QFile&, const QString& newName), (const, override));
     MOCK_METHOD(bool, resize, (QFile&, qint64 sz), (const, override));
     MOCK_METHOD(bool, seek, (QFile&, qint64 pos), (const, override));
-    MOCK_METHOD(bool, setPermissions, (QFile&, QFileDevice::Permissions), (const, override));
     MOCK_METHOD(qint64, size, (QFile&), (const, override));
     MOCK_METHOD(qint64, write, (QFile&, const char*, qint64), (const, override));
     MOCK_METHOD(qint64, write, (QFileDevice&, const QByteArray&), (const, override));
@@ -89,7 +88,6 @@ public:
     MOCK_METHOD(void, create_symlink, (const fs::path& to, const fs::path& path, std::error_code& err),
                 (override, const));
     MOCK_METHOD(fs::path, read_symlink, (const fs::path& path, std::error_code& err), (override, const));
-    MOCK_METHOD(void, permissions, (const fs::path& path, fs::perms perms, std::error_code& err), (override, const));
     MOCK_METHOD(fs::file_status, status, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(fs::file_status, symlink_status, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(std::unique_ptr<multipass::RecursiveDirIterator>, recursive_dir_iterator,

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -48,7 +48,6 @@ public:
     MOCK_METHOD(bool, exists, (const QFile&), (const, override));
     MOCK_METHOD(bool, is_open, (const QFile&), (const, override));
     MOCK_METHOD(bool, open, (QFileDevice&, QIODevice::OpenMode), (const, override));
-    MOCK_METHOD(QFileDevice::Permissions, permissions, (const QFile&), (const, override));
     MOCK_METHOD(qint64, read, (QFile&, char*, qint64), (const, override));
     MOCK_METHOD(QByteArray, read_all, (QFile&), (const, override));
     MOCK_METHOD(QString, read_line, (QTextStream&), (const, override));
@@ -97,6 +96,7 @@ public:
                 (const fs::path& path, std::error_code& err),
                 (override, const));
     MOCK_METHOD(fs::path, weakly_canonical, (const fs::path& path), (override, const));
+    MOCK_METHOD(fs::perms, get_permissions, (const fs::path&), (const, override));
 
     MOCK_METHOD(fs::path, remove_extension, (const fs::path& path), (const, override));
 

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -40,7 +40,7 @@ public:
     MOCK_METHOD(bool, is_remote_supported, (const std::string&), (const, override));
     MOCK_METHOD(bool, is_backend_supported, (const QString&), (const, override));
     MOCK_METHOD(bool, is_alias_supported, (const std::string&, const std::string&), (const, override));
-    MOCK_METHOD(bool, set_permissions, (const multipass::Path&, const QFileDevice::Permissions), (const, override));
+    MOCK_METHOD(bool, set_permissions, (const std::filesystem::path&, std::filesystem::perms), (const, override));
     MOCK_METHOD(int, chown, (const char*, unsigned int, unsigned int), (const, override));
     MOCK_METHOD(bool, link, (const char*, const char*), (const, override));
     MOCK_METHOD(bool, symlink, (const char*, const char*, bool), (const, override));

--- a/tests/mock_platform.h
+++ b/tests/mock_platform.h
@@ -40,7 +40,7 @@ public:
     MOCK_METHOD(bool, is_remote_supported, (const std::string&), (const, override));
     MOCK_METHOD(bool, is_backend_supported, (const QString&), (const, override));
     MOCK_METHOD(bool, is_alias_supported, (const std::string&, const std::string&), (const, override));
-    MOCK_METHOD(int, chmod, (const char*, unsigned int), (const, override));
+    MOCK_METHOD(bool, set_permissions, (const multipass::Path&, const QFileDevice::Permissions), (const, override));
     MOCK_METHOD(int, chown, (const char*, unsigned int, unsigned int), (const, override));
     MOCK_METHOD(bool, link, (const char*, const char*), (const, override));
     MOCK_METHOD(bool, symlink, (const char*, const char*, bool), (const, override));

--- a/tests/mock_utils.h
+++ b/tests/mock_utils.h
@@ -38,8 +38,8 @@ public:
     MOCK_METHOD(std::string, contents_of, (const multipass::Path&), (const, override));
     MOCK_METHOD(void, make_file_with_content, (const std::string&, const std::string&), ());
     MOCK_METHOD(void, make_file_with_content, (const std::string&, const std::string&, const bool&), (override));
-    MOCK_METHOD(Path, make_dir, (const QDir&, const QString&, QFileDevice::Permissions), (override));
-    MOCK_METHOD(Path, make_dir, (const QDir&, QFileDevice::Permissions), (override));
+    MOCK_METHOD(Path, make_dir, (const QDir&, const QString&, std::filesystem::perms), (override));
+    MOCK_METHOD(Path, make_dir, (const QDir&, std::filesystem::perms), (override));
     MOCK_METHOD(std::string, get_kernel_version, (), (const, override));
     MOCK_METHOD(QString, generate_scrypt_hash_for, (const QString&), (const, override));
     MOCK_METHOD(bool, client_certs_exist, (const QString&), (const));

--- a/tests/test_client_cert_store.cpp
+++ b/tests/test_client_cert_store.cpp
@@ -61,8 +61,7 @@ struct ClientCertStore : public testing::Test
 {
     ClientCertStore()
     {
-        cert_dir = MP_UTILS.make_dir(temp_dir.path(), mp::authenticated_certs_dir,
-                                     QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
+        cert_dir = MP_UTILS.make_dir(temp_dir.path(), mp::authenticated_certs_dir, std::filesystem::perms::owner_all);
     }
     mpt::TempDir temp_dir;
     mp::Path cert_dir;

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -280,7 +280,7 @@ TEST_F(Daemon, daemonAppliesPermissionsToStorageDirectory)
     mpt::SetEnvScope storage(mp::multipass_storage_env_var, storage_dir.path().toUtf8());
 
     EXPECT_CALL(mock_platform, multipass_storage_location()).WillOnce(Return(mp::utils::get_multipass_storage()));
-    EXPECT_CALL(mock_utils, make_dir(_, QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner));
+    EXPECT_CALL(mock_utils, make_dir(_, std::filesystem::perms::owner_all));
 
     auto config = config_builder.build();
 }
@@ -314,7 +314,7 @@ TEST_F(Daemon, data_path_with_storage_valid)
     EXPECT_CALL(mock_platform, multipass_storage_location()).WillOnce(Return(mp::utils::get_multipass_storage()));
 
     ON_CALL(mock_utils, make_dir(_, _, _))
-        .WillByDefault([this](const QDir& a_dir, const QString& name, QFileDevice::Permissions permissions) {
+        .WillByDefault([this](const QDir& a_dir, const QString& name, std::filesystem::perms permissions) {
             return mock_utils.Utils::make_dir(a_dir, name, permissions);
         });
 
@@ -1463,7 +1463,7 @@ TEST_F(Daemon, reads_mac_addresses_from_json)
 TEST_F(Daemon, writesAndReadsMountsInJson)
 {
     ON_CALL(mock_utils, make_dir(_, _, _))
-        .WillByDefault([this](const QDir& a_dir, const QString& name, QFileDevice::Permissions permissions) {
+        .WillByDefault([this](const QDir& a_dir, const QString& name, std::filesystem::perms permissions) {
             return mock_utils.Utils::make_dir(a_dir, name, permissions);
         });
 
@@ -1474,9 +1474,9 @@ TEST_F(Daemon, writesAndReadsMountsInJson)
 
     // Create a temp folder containing three subfolders, and create mount points for all of them.
     auto temp_mount_dir = QDir(mpt::TempDir().path());
-    auto temp_mount_1 = MP_UTILS.make_dir(temp_mount_dir, QString("a"), QFileDevice::Permissions{}).toStdString();
-    auto temp_mount_2 = MP_UTILS.make_dir(temp_mount_dir, QString("b"), QFileDevice::Permissions{}).toStdString();
-    auto temp_mount_3 = MP_UTILS.make_dir(temp_mount_dir, QString("c"), QFileDevice::Permissions{}).toStdString();
+    auto temp_mount_1 = MP_UTILS.make_dir(temp_mount_dir, QString("a"), std::filesystem::perms::none).toStdString();
+    auto temp_mount_2 = MP_UTILS.make_dir(temp_mount_dir, QString("b"), std::filesystem::perms::none).toStdString();
+    auto temp_mount_3 = MP_UTILS.make_dir(temp_mount_dir, QString("c"), std::filesystem::perms::none).toStdString();
 
     mp::id_mappings uid_mappings_1{{123, 321}};
     mp::id_mappings gid_mappings_1{{456, 654}};

--- a/tests/test_file_ops.cpp
+++ b/tests/test_file_ops.cpp
@@ -108,14 +108,6 @@ TEST_F(FileOps, symlink)
     EXPECT_FALSE(err);
 }
 
-TEST_F(FileOps, permissions)
-{
-    MP_FILEOPS.permissions(temp_file, fs::perms::all, err);
-    EXPECT_FALSE(err);
-    MP_FILEOPS.permissions(temp_dir / "nonexistent", fs::perms::all, err);
-    EXPECT_TRUE(err);
-}
-
 TEST_F(FileOps, status)
 {
     auto dir_status = MP_FILEOPS.status(temp_dir, err);

--- a/tests/test_sftp_client.cpp
+++ b/tests/test_sftp_client.cpp
@@ -293,7 +293,7 @@ TEST_F(SFTPClient, pull_file_success)
     REPLACE(sftp_stat, [&](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_REGULAR, "", perms); });
     mp::Perms written_perms;
     EXPECT_CALL(mock_platform,
-                set_permissions(QString::fromStdWString(target_path.wstring()), static_cast<mp::Perms>(perms)))
+                set_permissions(QString::fromStdString(target_path.u8string()), static_cast<mp::Perms>(perms)))
         .WillOnce([&](auto, auto perms) {
             written_perms = perms;
             return true;
@@ -361,7 +361,7 @@ TEST_F(SFTPClient, pull_file_cannot_write_target)
     };
     REPLACE(sftp_read, mocked_sftp_read);
     REPLACE(sftp_stat, [&](auto...) { return get_dummy_sftp_attr(); });
-    EXPECT_CALL(mock_platform, set_permissions(QString::fromStdWString(target_path.wstring()), _))
+    EXPECT_CALL(mock_platform, set_permissions(QString::fromStdString(target_path.u8string()), _))
         .WillOnce(Return(true));
     REPLACE(sftp_setstat, [](auto...) { return SSH_FX_OK; });
 
@@ -402,7 +402,7 @@ TEST_F(SFTPClient, pull_file_cannot_set_perms)
     REPLACE(sftp_stat, [&](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_REGULAR, "", perms); });
 
     EXPECT_CALL(mock_platform,
-                set_permissions(QString::fromStdWString(target_path.wstring()), static_cast<mp::Perms>(perms)))
+                set_permissions(QString::fromStdString(target_path.u8string()), static_cast<mp::Perms>(perms)))
         .WillOnce(Return(false));
 
     auto sftp_client = make_sftp_client();
@@ -751,13 +751,13 @@ TEST_F(SFTPClient, pull_dir_success_regular)
     mp::Perms dir_written_perms;
     EXPECT_CALL(
         mock_platform,
-        set_permissions(QString::fromStdWString((target_path / "file").wstring()), static_cast<mp::Perms>(perms)))
+        set_permissions(QString::fromStdString((target_path / "file").u8string()), static_cast<mp::Perms>(perms)))
         .WillOnce([&](auto, auto perms) {
             file_written_perms = perms;
             return true;
         });
     EXPECT_CALL(mock_platform,
-                set_permissions(QString::fromStdWString(target_path.wstring()), static_cast<mp::Perms>(perms)))
+                set_permissions(QString::fromStdString(target_path.u8string()), static_cast<mp::Perms>(perms)))
         .WillOnce([&](auto, auto perms) {
             dir_written_perms = perms;
             return true;

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -1490,6 +1490,9 @@ TEST_F(SftpServer, open_chown_failure_fails)
 
 TEST_F(SftpServer, open_no_handle_allocated_fails)
 {
+    const auto [platform, mock_platform_guard] = mpt::MockPlatform::inject<NiceMock>();
+    EXPECT_CALL(*platform, set_permissions(_, _)).WillRepeatedly(Return(true));
+
     mpt::TempDir temp_dir;
     auto file_name = temp_dir.path() + "/test-file";
 
@@ -1760,6 +1763,9 @@ TEST_F(SftpServer, handles_fstat)
 
 TEST_F(SftpServer, handles_fsetstat)
 {
+    const auto [platform, mock_platform_guard] = mpt::MockPlatform::inject<NiceMock>();
+    EXPECT_CALL(*platform, set_permissions(_, _)).WillRepeatedly(Return(true));
+
     mpt::TempDir temp_dir;
     auto file_name = temp_dir.path() + "/test-file";
 
@@ -1804,6 +1810,9 @@ TEST_F(SftpServer, handles_fsetstat)
 
 TEST_F(SftpServer, handles_setstat)
 {
+    const auto [platform, mock_platform_guard] = mpt::MockPlatform::inject<NiceMock>();
+    EXPECT_CALL(*platform, set_permissions(_, _)).WillRepeatedly(Return(true));
+
     mpt::TempDir temp_dir;
     auto file_name = temp_dir.path() + "/test-file";
     mpt::make_file_with_content(file_name);

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -544,9 +544,9 @@ TEST_F(SftpServer, handles_mkdir)
     msg->attr = &attr;
 
     const auto [file_ops, mock_file_ops_guard] = mpt::MockFileOps::inject();
-    EXPECT_CALL(*file_ops, permissions(A<const mp::fs::path&>(), _, _)).WillOnce([](auto, auto, std::error_code& err) {
-        err.clear();
-    });
+    const auto [platform, mock_platform_guard] = mpt::MockPlatform::inject();
+
+    EXPECT_CALL(*platform, set_permissions(A<const mp::Path&>(), _)).WillOnce(Return(true));
     EXPECT_CALL(*file_ops, ownerId(_)).WillRepeatedly([](const QFileInfo& file) { return file.ownerId(); });
     EXPECT_CALL(*file_ops, groupId(_)).WillRepeatedly([](const QFileInfo& file) { return file.groupId(); });
 
@@ -600,8 +600,8 @@ TEST_F(SftpServer, mkdir_set_permissions_fails)
     auto new_dir_name = name_as_char_array(new_dir);
 
     const auto [file_ops, mock_file_ops_guard] = mpt::MockFileOps::inject();
-    EXPECT_CALL(*file_ops, permissions(_, _, _))
-        .WillOnce(SetArgReferee<2>(std::make_error_code(std::errc::operation_not_permitted)));
+    const auto [platform, mock_platform_guard] = mpt::MockPlatform::inject();
+    EXPECT_CALL(*platform, set_permissions(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*file_ops, ownerId(_)).WillRepeatedly([](const QFileInfo& file) { return file.ownerId(); });
     EXPECT_CALL(*file_ops, groupId(_)).WillRepeatedly([](const QFileInfo& file) { return file.groupId(); });
 
@@ -636,6 +636,7 @@ TEST_F(SftpServer, mkdir_chown_failure_fails)
     const auto [mock_platform, guard] = mpt::MockPlatform::inject();
 
     EXPECT_CALL(*mock_platform, chown(_, _, _)).WillOnce(Return(-1));
+    EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillRepeatedly(Return(true));
 
     auto sftp = make_sftpserver(temp_dir.path().toStdString());
     auto msg = make_msg(SFTP_MKDIR);
@@ -1930,9 +1931,9 @@ TEST_F(SftpServer, setstat_set_permissions_failure_fails)
     msg->flags = SSH_FXF_WRITE;
 
     const auto [file_ops, mock_file_ops_guard] = mpt::MockFileOps::inject();
+    const auto [platform, mock_platform_guard] = mpt::MockPlatform::inject();
     EXPECT_CALL(*file_ops, resize).WillOnce(Return(true));
-    EXPECT_CALL(*file_ops, permissions(_, _, _))
-        .WillOnce(SetArgReferee<2>(std::make_error_code(std::errc::permission_denied)));
+    EXPECT_CALL(*platform, set_permissions(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*file_ops, ownerId(_)).WillRepeatedly([](const QFileInfo& file) { return file.ownerId(); });
     EXPECT_CALL(*file_ops, groupId(_)).WillRepeatedly([](const QFileInfo& file) { return file.groupId(); });
     EXPECT_CALL(*file_ops, exists(A<const QFileInfo&>())).WillRepeatedly([](const QFileInfo& file) {
@@ -2704,6 +2705,7 @@ TEST_F(SftpServer, DISABLE_ON_WINDOWS(mkdir_chown_honors_maps_in_the_host))
 
     EXPECT_CALL(*mock_platform, chown(_, host_uid, host_gid)).Times(1);
     EXPECT_CALL(*mock_platform, chown(_, sftp_uid, sftp_gid)).Times(0);
+    EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillRepeatedly(Return(true));
 
     sftp.run();
 }
@@ -2730,6 +2732,7 @@ TEST_F(SftpServer, DISABLE_ON_WINDOWS(mkdir_chown_works_when_ids_are_not_mapped)
     QFileInfo parent_dir(temp_dir.path());
 
     EXPECT_CALL(*mock_platform, chown(_, parent_dir.ownerId(), parent_dir.groupId())).Times(1);
+    EXPECT_CALL(*mock_platform, set_permissions(_, _)).WillRepeatedly(Return(true));
 
     sftp.run();
 }

--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -546,7 +546,7 @@ TEST_F(SftpServer, handles_mkdir)
     const auto [file_ops, mock_file_ops_guard] = mpt::MockFileOps::inject();
     const auto [platform, mock_platform_guard] = mpt::MockPlatform::inject();
 
-    EXPECT_CALL(*platform, set_permissions(A<const mp::Path&>(), _)).WillOnce(Return(true));
+    EXPECT_CALL(*platform, set_permissions(A<const std::filesystem::path&>(), _)).WillOnce(Return(true));
     EXPECT_CALL(*file_ops, ownerId(_)).WillRepeatedly([](const QFileInfo& file) { return file.ownerId(); });
     EXPECT_CALL(*file_ops, groupId(_)).WillRepeatedly([](const QFileInfo& file) { return file.groupId(); });
 

--- a/tests/unix/test_platform_unix.cpp
+++ b/tests/unix/test_platform_unix.cpp
@@ -117,7 +117,7 @@ TEST_F(TestPlatformUnix, setServerSocketRestrictionsChmodFailsThrows)
     MP_EXPECT_THROW_THAT(
         MP_PLATFORM.Platform::set_server_socket_restrictions(fmt::format("unix:{}", file.name()), false),
         std::runtime_error,
-        mpt::match_what(StrEq("Could not set permissions for the multipass socket: Operation not permitted")));
+        mpt::match_what(StrEq("Could not set permissions for the multipass socket")));
 }
 
 TEST_F(TestPlatformUnix, chmodSetsFileModsAndReturns)

--- a/tests/unix/test_platform_unix.cpp
+++ b/tests/unix/test_platform_unix.cpp
@@ -40,10 +40,11 @@ struct TestPlatformUnix : public Test
 {
     mpt::TempFile file;
 
-    static constexpr auto restricted_permissions{QFileDevice::ReadUser | QFileDevice::WriteUser |
-                                                 QFileDevice::ReadGroup | QFileDevice::WriteGroup};
-    static constexpr auto relaxed_permissions{restricted_permissions | QFileDevice::ReadOther |
-                                              QFileDevice::WriteOther};
+    static constexpr auto restricted_permissions{
+        std::filesystem::perms::owner_read | std::filesystem::perms::owner_write | std::filesystem::perms::group_read |
+        std::filesystem::perms::group_write};
+    static constexpr auto relaxed_permissions{restricted_permissions | std::filesystem::perms::others_read |
+                                              std::filesystem::perms::others_write};
 };
 } // namespace
 
@@ -120,12 +121,12 @@ TEST_F(TestPlatformUnix, setServerSocketRestrictionsChmodFailsThrows)
         mpt::match_what(StrEq("Could not set permissions for the multipass socket")));
 }
 
-TEST_F(TestPlatformUnix, chmodSetsFileModsAndReturns)
+TEST_F(TestPlatformUnix, setPermissionsSetsFileModsAndReturns)
 {
     auto perms = QFileInfo(file.name()).permissions();
     ASSERT_EQ(perms, QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ReadUser | QFileDevice::WriteUser);
 
-    EXPECT_EQ(MP_PLATFORM.set_permissions(file.name(), restricted_permissions), true);
+    EXPECT_EQ(MP_PLATFORM.set_permissions(file.name().toStdU16String(), restricted_permissions), true);
 
     perms = QFileInfo(file.name()).permissions();
 


### PR DESCRIPTION
This PR removes `chmod` from `Platform.h` as well as functions that are similar in `file_ops.h`. They have all been changed to use `MP_PLATFORM.set_permissions`. This should not change behavior on Unix systems. On Windows this changes the behavior to modify ACLs as well as DOS permissions instead of just DOS permissions.

MULTI-1420