### PR TITLE
[cmake] Fix exclusion of build files from coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,7 +295,7 @@ if(cmake_build_type_lower MATCHES "coverage")
         '/usr/*'
         ${CMAKE_SOURCE_DIR}'/3rd-party/*'
         ${CMAKE_SOURCE_DIR}'/tests/*'
-        ${CMAKE_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}'/*'
         --output-file coverage.cleaned
       COMMAND ${CMAKE_COMMAND} -E remove coverage.info
       COMMAND ${GENHTML} -o coverage coverage.cleaned


### PR DESCRIPTION
Fix the pattern for excluding build dir files from the coverage report. Without this, nothing matches the build dir pattern given to `lcov` (at least with my version).

I suppose Codecov knows to exclude anything that is not part of the repo, which would explain why its results are not impacted.

Local test recipe, from build directory:

1. `cmake -DCMAKE_BUILD_TYPE=Coverage ...`
2. `cmake --build . --target covreport`
3. `xdg-open coverage/index.html`
