### PR TITLE
Fix basic process tests on Windows

### DIFF
--- a/tests/mock_process.cpp
+++ b/tests/mock_process.cpp
@@ -2,12 +2,21 @@
 #include <iostream>
 #include <string>
 
+[[noreturn]] void crash()
+{
+#ifdef MULTIPASS_PLATFORM_WINDOWS
+    // Prevent Windows from making a dialogue box or reporting data.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+#endif
+    abort();
+}
+
 int main(int argc, char* argv[])
 {
     if (argc == 1)
     {
         // deliberately will crash if argument 1 missing
-        abort();
+        crash();
     }
     // Exit immediately if only 1 argument
     else if (argc == 2)
@@ -22,7 +31,7 @@ int main(int argc, char* argv[])
     // Crash on demand
     if (s == "crash")
     {
-        abort();
+        crash();
     }
 
     // Print out what was supplied by stdin

--- a/tests/mock_process.cpp
+++ b/tests/mock_process.cpp
@@ -5,8 +5,9 @@
 [[noreturn]] void crash()
 {
 #ifdef MULTIPASS_PLATFORM_WINDOWS
-    // Prevent Windows from making a dialogue box or reporting data.
-    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    // Prevent Windows from making a dialogue box and enable crash data reporting.
+    // If data reporting is not enabled, QProcess will always return NormalExit.
+    _set_abort_behavior(_CALL_REPORTFAULT, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
 #endif
     abort();
 }

--- a/tests/test_basic_process.cpp
+++ b/tests/test_basic_process.cpp
@@ -38,7 +38,7 @@ TEST_F(BasicProcessTest, execute_missing_command)
     EXPECT_FALSE(process_state.completed_successfully());
     EXPECT_FALSE(process_state.exit_code);
 
-    EXPECT_TRUE(process_state.error);
+    ASSERT_TRUE(process_state.error);
     EXPECT_EQ(QProcess::ProcessError::FailedToStart, process_state.error->state);
 }
 
@@ -50,7 +50,7 @@ TEST_F(BasicProcessTest, execute_crashing_command)
     EXPECT_FALSE(process_state.completed_successfully());
     EXPECT_FALSE(process_state.exit_code);
 
-    EXPECT_TRUE(process_state.error);
+    ASSERT_TRUE(process_state.error);
     EXPECT_EQ(QProcess::ProcessError::Crashed, process_state.error->state);
 }
 
@@ -121,7 +121,7 @@ TEST_F(BasicProcessTest, process_state_when_runs_but_fails_to_stop)
     process_state = process.process_state();
     EXPECT_FALSE(process_state.exit_code);
 
-    EXPECT_TRUE(process_state.error);
+    ASSERT_TRUE(process_state.error);
     EXPECT_EQ(QProcess::Timedout, process_state.error->state);
 }
 
@@ -135,7 +135,7 @@ TEST_F(BasicProcessTest, process_state_when_crashes_on_start)
     auto process_state = process.process_state();
 
     EXPECT_FALSE(process_state.exit_code);
-    EXPECT_TRUE(process_state.error);
+    ASSERT_TRUE(process_state.error);
     EXPECT_EQ(QProcess::Crashed, process_state.error->state);
 }
 
@@ -151,7 +151,7 @@ TEST_F(BasicProcessTest, process_state_when_crashes_while_running)
 
     auto process_state = process.process_state();
     EXPECT_FALSE(process_state.exit_code);
-    EXPECT_TRUE(process_state.error);
+    ASSERT_TRUE(process_state.error);
     EXPECT_EQ(QProcess::Crashed, process_state.error->state);
 }
 
@@ -165,7 +165,7 @@ TEST_F(BasicProcessTest, process_state_when_failed_to_start)
     auto process_state = process.process_state();
 
     EXPECT_FALSE(process_state.exit_code);
-    EXPECT_TRUE(process_state.error);
+    ASSERT_TRUE(process_state.error);
     EXPECT_EQ(QProcess::FailedToStart, process_state.error->state);
 }
 


### PR DESCRIPTION
fixes #3787 

Some `EXPECT`s should've been `ASSERT`s because of getting value of `std::nullopt`
Windows compiled with debug has different behavior from release builds, this has been fixed for the tests.

MULTI-1652