### PR TITLE
[cli] update messages to clarify default mount target

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -233,9 +233,10 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
                                      "spec");
     QCommandLineOption bridgedOption("bridged", "Adds one `--network bridged` network.");
     QCommandLineOption mountOption("mount",
-                                   "Mount a local directory inside the instance. If <instance-path> is omitted, the "
-                                   "mount point will be the same as the absolute path of <local-path>",
-                                   "local-path>:<instance-path");
+                                   "Mount a local directory inside the instance. If <target> is omitted, the "
+                                   "mount point will be under /home/ubuntu/<source-dir>, where <source-dir> is "
+                                   "the name of the <source> directory",
+                                   "source>:<target");
 
     parser->addOptions({cpusOption, diskOption, memOption, memOptionDeprecated, nameOption, cloudInitOption,
                         networkOption, bridgedOption, mountOption});

--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -113,8 +113,8 @@ mp::ParseCode cmd::Mount::parse_args(mp::ArgParser* parser)
     parser->addPositionalArgument("target",
                                   "Target mount points, in <name>[:<path>] format, where <name> "
                                   "is an instance name, and optional <path> is the mount point. "
-                                  "If omitted, the mount point will be the same as the source's "
-                                  "absolute path",
+                                  "If omitted, the mount point will be under /home/ubuntu/<source-dir>, "
+                                  "where <source-dir> is the name of the <source> directory.",
                                   "<target> [<target> ...]");
 
     QCommandLineOption gid_mappings({"g", "gid-map"},


### PR DESCRIPTION
Now we use a different way of deriving the target path of a mount based on the source path, if the target path is not explicitly specified. We take the directory name of the source and use it under `/home/ubuntu` in the instance.
For example, for a source path `/abc/def/ghi` the corresponding default target is `/home/ubuntu/ghi`