### PR TITLE
[cmake] bump macos project version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_policy(SET CMP0079 NEW) # Allow target_link_libraries() in subdirs
 cmake_host_system_information(RESULT HOST_OS_NAME QUERY OS_NAME)
 
 if("${HOST_OS_NAME}" STREQUAL "macOS")
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0") # needs to be set before "project"
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0") # needs to be set before "project"
   set(VCPKG_HOST_OS "osx")
 elseif("${HOST_OS_NAME}" STREQUAL "Windows")
   set(VCPKG_HOST_OS "windows-static-md")


### PR DESCRIPTION
Now that CI runners are on MacOS 12, bump the CMake project minimum MacOS version up to 12.