### PR TITLE
[renovatebot] Auto assign random reviewer from Multipass GitHub team

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,5 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "reviewers": [
+    "team:multipass"
+  ],
+  "reviewersSampleSize": 1,
   "schedule": "every 2 weeks on Monday",
 }


### PR DESCRIPTION
Unfortunately, this means that @jibel will get the occasional review request. 

But, I think this is a better approach than manually listing all Multipass developers and having to maintain it when developers join/leave.

P.S. and @giuliazanchi!