### PR TITLE
add 1024x576 as an intermediate GUI resolution for smaller screens

### DIFF
--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -36,11 +36,13 @@ void main() async {
     return screen?.frame.size;
   });
 
-  final windowSize = (screenSize != null &&
-          screenSize.width >= 1600 &&
-          screenSize.height >= 900)
+  final windowSize = (screenSize != null)
+    ? (screenSize.width >= 1600 && screenSize.height >= 900)
       ? const Size(1400, 822) // For screens 1600x900 or larger
-      : const Size(750, 450); // Default window size
+      : (screenSize.width >= 1280 && screenSize.height >= 720)
+        ? const Size(1024, 576) // For screens 1280x720 or larger
+        : const Size(750, 450) // Default window size
+    : const Size(750, 450); // Default window size if screenSize is null
 
   await windowManager.ensureInitialized();
 


### PR DESCRIPTION
Some Macbooks and other small laptops have resolutions such as 1440x900 or 1366x768 that are below the threshold for the "large" GUI resolution of 1400x822's minimum screen size of 1600x900, but the default (minimum) of 750x450 is too small. 

This PR updates the startup application window size logic in main.dart to add an intermediate 1024x576 resolution for smaller screens,

It now sets the window size to 1400x822 for screens 1600x900 or larger, 1024x576 for screens 1280x720 or larger, and defaults to 750x450 otherwise.