### PR TITLE
Terminal zoom

### DIFF
--- a/src/client/gui/lib/platform/linux.dart
+++ b/src/client/gui/lib/platform/linux.dart
@@ -35,7 +35,15 @@ class LinuxPlatform extends MpPlatform {
             PasteTextIntent(SelectionChangedCause.keyboard),
         SingleActivator(LogicalKeyboardKey.equal, control: true):
             IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.add, control: true, shift: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.numpadAdd, control: true):
+            IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.minus, control: true):
+            DecreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.numpadSubtract, control: true):
             DecreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.digit0, control: true):
             ResetTerminalFontIntent(),

--- a/src/client/gui/lib/platform/linux.dart
+++ b/src/client/gui/lib/platform/linux.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../settings/autostart_notifiers.dart';
+import '../vm_details/terminal.dart';
 import 'platform.dart';
 
 class LinuxPlatform extends MpPlatform {
@@ -32,6 +33,12 @@ class LinuxPlatform extends MpPlatform {
             CopySelectionTextIntent.copy,
         SingleActivator(LogicalKeyboardKey.keyV, control: true, shift: true):
             PasteTextIntent(SelectionChangedCause.keyboard),
+        SingleActivator(LogicalKeyboardKey.equal, control: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.minus, control: true):
+            DecreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.digit0, control: true):
+            ResetTerminalFontIntent(),
       };
 
   @override

--- a/src/client/gui/lib/platform/macos.dart
+++ b/src/client/gui/lib/platform/macos.dart
@@ -34,7 +34,15 @@ class MacOSPlatform extends MpPlatform {
             PasteTextIntent(SelectionChangedCause.keyboard),
         SingleActivator(LogicalKeyboardKey.equal, meta: true):
             IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.equal, meta: true, shift: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.add, meta: true, shift: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.numpadAdd, meta: true):
+            IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.minus, meta: true):
+            DecreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.numpadSubtract, meta: true):
             DecreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.digit0, meta: true):
             ResetTerminalFontIntent(),

--- a/src/client/gui/lib/platform/macos.dart
+++ b/src/client/gui/lib/platform/macos.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../settings/autostart_notifiers.dart';
+import '../vm_details/terminal.dart';
 import 'platform.dart';
 
 class MacOSPlatform extends MpPlatform {
@@ -31,6 +32,12 @@ class MacOSPlatform extends MpPlatform {
             CopySelectionTextIntent.copy,
         SingleActivator(LogicalKeyboardKey.keyV, meta: true):
             PasteTextIntent(SelectionChangedCause.keyboard),
+        SingleActivator(LogicalKeyboardKey.equal, meta: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.minus, meta: true):
+            DecreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.digit0, meta: true):
+            ResetTerminalFontIntent(),
       };
 
   @override

--- a/src/client/gui/lib/platform/windows.dart
+++ b/src/client/gui/lib/platform/windows.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:win32/win32.dart';
 
 import '../settings/autostart_notifiers.dart';
+import '../vm_details/terminal.dart';
 import 'platform.dart';
 
 class WindowsPlatform extends MpPlatform {
@@ -34,6 +35,12 @@ class WindowsPlatform extends MpPlatform {
             CopySelectionTextIntent.copy,
         SingleActivator(LogicalKeyboardKey.keyV, control: true, shift: true):
             PasteTextIntent(SelectionChangedCause.keyboard),
+        SingleActivator(LogicalKeyboardKey.equal, control: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.minus, control: true):
+            DecreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.digit0, control: true):
+            ResetTerminalFontIntent(),
       };
 
   @override

--- a/src/client/gui/lib/platform/windows.dart
+++ b/src/client/gui/lib/platform/windows.dart
@@ -37,7 +37,15 @@ class WindowsPlatform extends MpPlatform {
             PasteTextIntent(SelectionChangedCause.keyboard),
         SingleActivator(LogicalKeyboardKey.equal, control: true):
             IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.add, control: true, shift: true):
+            IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.numpadAdd, control: true):
+            IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.minus, control: true):
+            DecreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.numpadSubtract, control: true):
             DecreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.digit0, control: true):
             ResetTerminalFontIntent(),

--- a/src/client/gui/lib/vm_details/terminal.dart
+++ b/src/client/gui/lib/vm_details/terminal.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:isolate';
+import 'dart:math';
 
 import 'package:async/async.dart';
 import 'package:dartssh2/dartssh2.dart';
@@ -160,9 +161,27 @@ class VmTerminal extends ConsumerStatefulWidget {
   ConsumerState<VmTerminal> createState() => _VmTerminalState();
 }
 
+class IncreaseTerminalFontIntent extends Intent {
+  const IncreaseTerminalFontIntent();
+}
+
+class DecreaseTerminalFontIntent extends Intent {
+  const DecreaseTerminalFontIntent();
+}
+
+class ResetTerminalFontIntent extends Intent {
+  const ResetTerminalFontIntent();
+}
+
 class _VmTerminalState extends ConsumerState<VmTerminal> {
+  static const defaultFontSize = 13.0;
+  static const minFontSize = 2.5;
+  static const maxFontSize = 36.0;
+  static const fontSizeStep = 0.5;
+
   final scrollController = ScrollController();
   final focusNode = FocusNode();
+  var fontSize = defaultFontSize;
 
   @override
   void initState() {
@@ -228,45 +247,63 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
       );
     }
 
-    return RawScrollbar(
-      controller: scrollController,
-      thickness: 9,
-      child: ClipRect(
-        child: TerminalView(
-          terminal,
-          scrollController: scrollController,
-          focusNode: focusNode,
-          shortcuts: mpPlatform.terminalShortcuts,
-          hardwareKeyboardOnly: true,
-          padding: const EdgeInsets.all(4),
-          textStyle: TerminalStyle(
-            fontFamily: 'UbuntuMono',
-            fontFamilyFallback: ['NotoColorEmoji', 'FreeSans'],
-          ),
-          theme: const TerminalTheme(
-            cursor: Color(0xFFE5E5E5),
-            selection: Color(0x80E5E5E5),
-            foreground: Color(0xffffffff),
-            background: Color(0xff380c2a),
-            black: Color(0xFF000000),
-            white: Color(0xFFE5E5E5),
-            red: Color(0xFFCD3131),
-            green: Color(0xFF0DBC79),
-            yellow: Color(0xFFE5E510),
-            blue: Color(0xFF2472C8),
-            magenta: Color(0xFFBC3FBC),
-            cyan: Color(0xFF11A8CD),
-            brightBlack: Color(0xFF666666),
-            brightRed: Color(0xFFF14C4C),
-            brightGreen: Color(0xFF23D18B),
-            brightYellow: Color(0xFFF5F543),
-            brightBlue: Color(0xFF3B8EEA),
-            brightMagenta: Color(0xFFD670D6),
-            brightCyan: Color(0xFF29B8DB),
-            brightWhite: Color(0xFFFFFFFF),
-            searchHitBackground: Color(0XFFFFFF2B),
-            searchHitBackgroundCurrent: Color(0XFF31FF26),
-            searchHitForeground: Color(0XFF000000),
+    return Actions(
+      actions: {
+        IncreaseTerminalFontIntent: CallbackAction<IncreaseTerminalFontIntent>(
+          onInvoke: (_) => setState(() {
+            fontSize = min(fontSize + fontSizeStep, maxFontSize);
+          }),
+        ),
+        DecreaseTerminalFontIntent: CallbackAction<DecreaseTerminalFontIntent>(
+          onInvoke: (_) => setState(() {
+            fontSize = max(fontSize - fontSizeStep, minFontSize);
+          }),
+        ),
+        ResetTerminalFontIntent: CallbackAction<ResetTerminalFontIntent>(
+          onInvoke: (_) => setState(() => fontSize = defaultFontSize),
+        ),
+      },
+      child: RawScrollbar(
+        controller: scrollController,
+        thickness: 9,
+        child: ClipRect(
+          child: TerminalView(
+            terminal,
+            scrollController: scrollController,
+            focusNode: focusNode,
+            shortcuts: mpPlatform.terminalShortcuts,
+            hardwareKeyboardOnly: true,
+            padding: const EdgeInsets.all(4),
+            textStyle: TerminalStyle(
+              fontFamily: 'UbuntuMono',
+              fontFamilyFallback: ['NotoColorEmoji', 'FreeSans'],
+              fontSize: fontSize,
+            ),
+            theme: const TerminalTheme(
+              cursor: Color(0xFFE5E5E5),
+              selection: Color(0x80E5E5E5),
+              foreground: Color(0xffffffff),
+              background: Color(0xff380c2a),
+              black: Color(0xFF000000),
+              white: Color(0xFFE5E5E5),
+              red: Color(0xFFCD3131),
+              green: Color(0xFF0DBC79),
+              yellow: Color(0xFFE5E510),
+              blue: Color(0xFF2472C8),
+              magenta: Color(0xFFBC3FBC),
+              cyan: Color(0xFF11A8CD),
+              brightBlack: Color(0xFF666666),
+              brightRed: Color(0xFFF14C4C),
+              brightGreen: Color(0xFF23D18B),
+              brightYellow: Color(0xFFF5F543),
+              brightBlue: Color(0xFF3B8EEA),
+              brightMagenta: Color(0xFFD670D6),
+              brightCyan: Color(0xFF29B8DB),
+              brightWhite: Color(0xFFFFFFFF),
+              searchHitBackground: Color(0XFFFFFF2B),
+              searchHitBackgroundCurrent: Color(0XFF31FF26),
+              searchHitForeground: Color(0XFF000000),
+            ),
           ),
         ),
       ),

--- a/src/client/gui/lib/vm_details/terminal.dart
+++ b/src/client/gui/lib/vm_details/terminal.dart
@@ -192,12 +192,12 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
     }));
 
     final buttonStyle = ButtonStyle(
-      foregroundColor: MaterialStateColor.resolveWith((states) {
-        final disabled = states.contains(MaterialState.disabled);
+      foregroundColor: WidgetStateColor.resolveWith((states) {
+        final disabled = states.contains(WidgetState.disabled);
         return Colors.white.withOpacity(disabled ? 0.5 : 1.0);
       }),
-      side: MaterialStateBorderSide.resolveWith((states) {
-        final disabled = states.contains(MaterialState.disabled);
+      side: WidgetStateBorderSide.resolveWith((states) {
+        final disabled = states.contains(WidgetState.disabled);
         var color = Colors.white.withOpacity(disabled ? 0.5 : 1.0);
         return BorderSide(color: color);
       }),

--- a/src/client/gui/lib/vm_details/terminal_tabs.dart
+++ b/src/client/gui/lib/vm_details/terminal_tabs.dart
@@ -149,6 +149,7 @@ class TerminalTabs extends ConsumerWidget {
       );
 
       final shell = VmTerminal(
+        key: GlobalObjectKey(shellId),
         name,
         shellId,
         isCurrent: index == currentIndex,


### PR DESCRIPTION
This PR adds the ability to change the font size in the GUI terminals, using common shortcuts like `Ctrl`+`+` to increase, `Ctrl`+`-` to decrease and `Ctrl`+`0` to reset. `Command` is used instead of `Ctrl` on macOS.

It also include two small, drive-by fixes, which change the deprecated `MaterialStateColor` with the newer `WidgetStateColor`. Those were done because they were in the same files as the other, relevant changes.

MULTI-1678