### PR TITLE
Fix console creation

### DIFF
--- a/include/multipass/console.h
+++ b/include/multipass/console.h
@@ -28,8 +28,6 @@
 
 namespace multipass
 {
-class Terminal;
-
 class Console : private DisabledCopyMove
 {
 public:
@@ -47,7 +45,6 @@ public:
     virtual void write_console() = 0;
     virtual void exit_console() = 0;
 
-    static UPtr make_console(ssh_channel channel, Terminal* term);
     static void setup_environment();
 
 protected:

--- a/include/multipass/terminal.h
+++ b/include/multipass/terminal.h
@@ -19,12 +19,15 @@
 #define MULTIPASS_TERMINAL_H
 
 #include <istream>
+#include <libssh/libssh.h>
 #include <memory>
 #include <ostream>
 #include <string>
 
 namespace multipass
 {
+class Console;
+
 class Terminal
 {
 public:
@@ -44,6 +47,9 @@ public:
 
     using UPtr = std::unique_ptr<Terminal>;
     static UPtr make_terminal();
+
+    using ConsolePtr = std::unique_ptr<Console>;
+    virtual ConsolePtr make_console(ssh_channel channel) = 0;
 };
 } // namespace multipass
 

--- a/src/client/cli/cmd/exec.cpp
+++ b/src/client/cli/cmd/exec.cpp
@@ -160,7 +160,7 @@ mp::ReturnCode cmd::Exec::exec_success(const mp::SSHInfoReply& reply, const std:
 
     try
     {
-        auto console_creator = [&term](auto channel) { return Console::make_console(channel, term); };
+        auto console_creator = [&term](auto channel) { return term->make_console(channel); };
         mp::SSHClient ssh_client{host, port, username, priv_key_blob, console_creator};
 
         std::vector<std::vector<std::string>> all_args;

--- a/src/client/cli/cmd/shell.cpp
+++ b/src/client/cli/cmd/shell.cpp
@@ -74,7 +74,7 @@ mp::ReturnCode cmd::Shell::run(mp::ArgParser* parser)
 
         try
         {
-            auto console_creator = [this](auto channel) { return Console::make_console(channel, term); };
+            auto console_creator = [this](auto channel) { return term->make_console(channel); };
             mp::SSHClient ssh_client{host, port, username, priv_key_blob, console_creator};
             ssh_client.connect();
         }

--- a/src/platform/console/console.cpp
+++ b/src/platform/console/console.cpp
@@ -23,11 +23,6 @@
 
 namespace mp = multipass;
 
-mp::Console::UPtr mp::Console::make_console(ssh_channel channel, Terminal* term)
-{
-    return std::make_unique<UnixConsole>(channel, static_cast<UnixTerminal*>(term));
-}
-
 void mp::Console::setup_environment()
 {
     UnixConsole::setup_environment();

--- a/src/platform/console/unix_terminal.cpp
+++ b/src/platform/console/unix_terminal.cpp
@@ -22,6 +22,8 @@
 #include <termios.h>
 #include <unistd.h>
 
+#include "unix_console.h"
+
 namespace mp = multipass;
 
 int mp::UnixTerminal::cin_fd() const
@@ -55,4 +57,9 @@ void mp::UnixTerminal::set_cin_echo(const bool enable)
         tty.c_lflag |= ECHO;
 
     tcsetattr(cin_fd(), TCSANOW, &tty);
+}
+
+mp::UnixTerminal::ConsolePtr mp::UnixTerminal::make_console(ssh_channel channel)
+{
+    return std::make_unique<UnixConsole>(channel, this);
 }

--- a/src/platform/console/unix_terminal.h
+++ b/src/platform/console/unix_terminal.h
@@ -32,6 +32,8 @@ public:
     bool cout_is_live() const override;
 
     void set_cin_echo(const bool enable) override;
+
+    ConsolePtr make_console(ssh_channel channel) override;
 };
 } // namespace multipass
 

--- a/tests/mock_terminal.h
+++ b/tests/mock_terminal.h
@@ -34,6 +34,7 @@ struct MockTerminal : public Terminal
     MOCK_METHOD(bool, cin_is_live, (), (const, override));
     MOCK_METHOD(bool, cout_is_live, (), (const, override));
     MOCK_METHOD(void, set_cin_echo, (const bool), (override));
+    MOCK_METHOD(ConsolePtr, make_console, (ssh_channel), (override));
 };
 } // namespace test
 } // namespace multipass

--- a/tests/stub_terminal.h
+++ b/tests/stub_terminal.h
@@ -20,6 +20,8 @@
 
 #include <multipass/terminal.h>
 
+#include "stub_console.h"
+
 namespace multipass
 {
 namespace test
@@ -61,10 +63,26 @@ public:
     {
     }
 
+    ConsolePtr set_console(ConsolePtr new_console)
+    {
+        return std::exchange(console, std::move(new_console));
+    }
+
+    ConsolePtr make_console(ssh_channel channel) override
+    {
+        if (!console)
+        {
+            return std::make_unique<StubConsole>();
+        }
+
+        return std::exchange(console, nullptr);
+    }
+
 private:
     std::ostream &cout_stream;
     std::ostream& cerr_stream;
     std::istream& cin_stream;
+    ConsolePtr console{nullptr};
 };
 
 } // namespace test

--- a/tests/stub_terminal.h
+++ b/tests/stub_terminal.h
@@ -63,26 +63,15 @@ public:
     {
     }
 
-    ConsolePtr set_console(ConsolePtr new_console)
-    {
-        return std::exchange(console, std::move(new_console));
-    }
-
     ConsolePtr make_console(ssh_channel channel) override
     {
-        if (!console)
-        {
-            return std::make_unique<StubConsole>();
-        }
-
-        return std::exchange(console, nullptr);
+        return std::make_unique<StubConsole>();
     }
 
 private:
     std::ostream &cout_stream;
     std::ostream& cerr_stream;
     std::istream& cin_stream;
-    ConsolePtr console{nullptr};
 };
 
 } // namespace test

--- a/tests/unix/test_unix_terminal.cpp
+++ b/tests/unix/test_unix_terminal.cpp
@@ -19,6 +19,7 @@
 
 #include "mock_libc_functions.h"
 
+#include <src/platform/console/unix_console.h>
 #include <src/platform/console/unix_terminal.h>
 
 #include <tuple>
@@ -109,4 +110,17 @@ TEST_F(TestUnixTerminal, unsetsEchoOnTerminal)
     });
 
     unix_terminal.set_cin_echo(false);
+}
+
+TEST_F(TestUnixTerminal, make_console_makes_unix_console)
+{
+    // force is_live() to return false so UnixConsole ctor doesn't break
+    REPLACE(fileno, [this](auto) { return fake_fd; });
+    REPLACE(isatty, [this](auto fd) {
+        EXPECT_EQ(fd, fake_fd);
+        return 0;
+    });
+
+    auto console = unix_terminal.make_console(nullptr);
+    EXPECT_NE(dynamic_cast<multipass::UnixConsole*>(console.get()), nullptr);
 }


### PR DESCRIPTION
Fixes #3788 

Previously the test output would disappear since `StubTerminal*` was being cast to `WindowsTerminal*` and then `cin`/`cout`/`cerr` would get deleted. Now `StubTerminal*` is not cast at all and `Console` creation is handled by their respective Terminals.

MULTI-1676 