### PR TITLE
Escape mount sources and targets

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -118,7 +118,6 @@ Str&& trim(Str&& s, Filter&& filter);
 template <typename Str>
 Str&& trim(Str&& s);
 std::string& trim_newline(std::string& s);
-std::string escape_char(const std::string& s, char c);
 std::string escape_for_shell(const std::string& s);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
 std::string match_line_for(const std::string& output, const std::string& matcher);

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -307,7 +307,7 @@ void mp::platform::Platform::create_alias_script(const std::string& alias, const
 
     std::string multipass_exec = mpu::in_multipass_snap()
                                      ? "exec /usr/bin/snap run multipass"
-                                     : fmt::format("\"{}\"", QCoreApplication::applicationFilePath());
+                                     : fmt::format("{:?}", QCoreApplication::applicationFilePath());
 
     std::string script = "#!/bin/sh\n\n" + multipass_exec + " " + alias + " -- \"${@}\"\n";
 

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -307,7 +307,7 @@ void mp::platform::Platform::create_alias_script(const std::string& alias, const
 
     std::string multipass_exec = mpu::in_multipass_snap()
                                      ? "exec /usr/bin/snap run multipass"
-                                     : fmt::format("{:?}", QCoreApplication::applicationFilePath());
+                                     : fmt::format("{:?}", QCoreApplication::applicationFilePath().toStdString());
 
     std::string script = "#!/bin/sh\n\n" + multipass_exec + " " + alias + " -- \"${@}\"\n";
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -195,11 +195,6 @@ std::string& mp::utils::trim_newline(std::string& s)
     return s;
 }
 
-std::string mp::utils::escape_char(const std::string& in, char c)
-{
-    return std::regex_replace(in, std::regex({c}), fmt::format("\\{}", c));
-}
-
 // Escape all characters which need to be escaped in the shell.
 std::string mp::utils::escape_for_shell(const std::string& in)
 {
@@ -216,11 +211,11 @@ std::string mp::utils::escape_for_shell(const std::string& in)
 
     for (char c : in)
     {
-        if (0xa == c) // newline
+        if ('\n' == c) // newline
         {
-            *ret_insert++ = 0x22; // double quotes
-            *ret_insert++ = 0xa;  // newline
-            *ret_insert++ = 0x22; // double quotes
+            *ret_insert++ = '"';  // double quotes
+            *ret_insert++ = '\n'; // newline
+            *ret_insert++ = '"';  // double quotes
         }
         else
         {
@@ -228,7 +223,7 @@ std::string mp::utils::escape_for_shell(const std::string& in)
             if (c < 0x25 || c > 0x7a || (c > 0x25 && c < 0x2b) || (c > 0x5a && c < 0x5f) || 0x2c == c || 0x3b == c ||
                 0x3c == c || 0x3e == c || 0x3f == c || 0x60 == c)
             {
-                *ret_insert++ = 0x5c; // backslash
+                *ret_insert++ = '\\'; // backslash
             }
 
             *ret_insert++ = c;
@@ -526,7 +521,7 @@ std::pair<std::string, std::string> mp::utils::get_path_split(mp::SSHSession& se
 
     std::string existing = MP_UTILS.run_in_ssh_session(
         session,
-        fmt::format("sudo /bin/bash -c 'P=\"{}\"; while [ ! -d \"$P/\" ]; do P=\"${{P%/*}}\"; done; echo $P/'",
+        fmt::format("sudo /bin/bash -c 'P={:?}; while [ ! -d \"$P/\" ]; do P=\"${{P%/*}}\"; done; echo $P/'",
                     absolute));
 
     return {existing,
@@ -537,7 +532,7 @@ std::pair<std::string, std::string> mp::utils::get_path_split(mp::SSHSession& se
 void mp::utils::make_target_dir(mp::SSHSession& session, const std::string& root, const std::string& relative_target)
 {
     MP_UTILS.run_in_ssh_session(session,
-                                fmt::format("sudo /bin/bash -c 'cd \"{}\" && mkdir -p \"{}\"'", root, relative_target));
+                                fmt::format("sudo /bin/bash -c 'cd {:?} && mkdir -p {:?}'", root, relative_target));
 }
 
 // Set ownership of all directories on a path starting on a given root.
@@ -546,7 +541,7 @@ void mp::utils::set_owner_for(mp::SSHSession& session, const std::string& root, 
                               int vm_user, int vm_group)
 {
     MP_UTILS.run_in_ssh_session(session,
-                                fmt::format("sudo /bin/bash -c 'cd \"{}\" && chown -R {}:{} \"{}\"'",
+                                fmt::format("sudo /bin/bash -c 'cd {:?} && chown -R {}:{} {:?}'",
                                             root,
                                             vm_user,
                                             vm_group,

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -455,13 +455,6 @@ TEST(Utils, trim_newline_assertion_works)
     ASSERT_DEBUG_DEATH(mp::utils::trim_newline(s), "[Aa]ssert");
 }
 
-TEST(Utils, escape_char_actually_escapes)
-{
-    std::string s{"I've got \"quotes\""};
-    auto res = mp::utils::escape_char(s, '"');
-    EXPECT_THAT(res, ::testing::StrEq("I've got \\\"quotes\\\""));
-}
-
 TEST(Utils, escape_for_shell_actually_escapes)
 {
     std::string s{"I've got \"quotes\""};


### PR DESCRIPTION
Fixes #3759 

Previously, mount targets and sources were not escaped. This caused strange targets and mounts like `" & mkdir hello & "` to be able to execute commands in the instance. Now they are properly escaped so strangely named directories like `" & mkdir hello & "` will work as source or target. 

MULTI-1675