### PR TITLE
Update launch.cpp help text

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -219,8 +219,9 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
                   .arg(petenv_name, mp::home_automount_dir, valid_name_desc);
 
     QCommandLineOption nameOption({"n", "name"}, name_option_desc, "name");
-    QCommandLineOption cloudInitOption(
-        "cloud-init", "Path or URL to a user-data cloud-init configuration, or '-' for stdin.", "file> | <url");
+    QCommandLineOption cloudInitOption("cloud-init",
+                                       "Path or URL to a user-data cloud-init configuration, or '-' for stdin.",
+                                       "file> | <url");
     QCommandLineOption networkOption("network",
                                      "Add a network interface to the instance, where <spec> is in the "
                                      "\"key=value,key=value\" format, with the following keys available:\n"

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -235,7 +235,7 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
     QCommandLineOption mountOption("mount",
                                    "Mount a local directory inside the instance. If <target> is omitted, the "
                                    "mount point will be under /home/ubuntu/<source-dir>, where <source-dir> is "
-                                   "the name of the <source> directory",
+                                   "the name of the <source> directory.",
                                    "source>:<target");
 
     parser->addOptions({cpusOption, diskOption, memOption, memOptionDeprecated, nameOption, cloudInitOption,

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -220,7 +220,7 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
 
     QCommandLineOption nameOption({"n", "name"}, name_option_desc, "name");
     QCommandLineOption cloudInitOption(
-        "cloud-init", "Path or URL to a user-data cloud-init configuration, or '-' for stdin", "file> | <url");
+        "cloud-init", "Path or URL to a user-data cloud-init configuration, or '-' for stdin.", "file> | <url");
     QCommandLineOption networkOption("network",
                                      "Add a network interface to the instance, where <spec> is in the "
                                      "\"key=value,key=value\" format, with the following keys available:\n"


### PR DESCRIPTION
Minor update to add a missing "." at the end of the help text for the --mount option.