### PR TITLE
Replace multipass.run with canonical.com/multipass

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ How, and what happened?
 What did you expect to happen?
 
 **Logs**
-Please provide logs from the daemon, see [accessing logs](https://multipass.run/docs/accessing-logs) on where to find them on your platform.
+Please provide logs from the daemon, see [accessing logs](https://canonical.com/multipass/docs/accessing-logs) on where to find them on your platform.
 
 **Additional info**
  - OS: [e.g. macOS 10.15]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://multipass.run/docs
+    url: https://canonical.com/multipass/docs
     about: See here about potential solutions to some common problems
   - name: Forums
     url: https://discourse.ubuntu.com/c/multipass

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -194,7 +194,7 @@ jobs:
 
         # Wait for LXD container network to be ready like Snapcraft does
         timeout 40 sh -c \
-          'while /snap/bin/lxc --project snapcraft exec '$instance_name' -- getent hosts multipass.run ; \
+          'while /snap/bin/lxc --project snapcraft exec '$instance_name' -- getent hosts canonical.com ; \
              [ $? -ne 0 ] ; do sleep 1; done'
 
         # The following 2 commands workaround the issue in 20.04 where the default parsing of the coverage

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Since it supports metadata for cloud-init, you can simulate a small cloud deploy
 
 * On **Windows**, download the installer [from GitHub](https://github.com/canonical/multipass/releases).
 
-For more information, see [How to install Multipass](https://multipass.run/docs/install-multipass).
+For more information, see [How to install Multipass](https://canonical.com/multipass/docs/install-multipass).
 
 # Usage
 
-Here are some pointers to get started with Multipass. For a more comprehensive learning experience, please check out the Multipass [Tutorial](https://multipass.run/docs/tutorial).
+Here are some pointers to get started with Multipass. For a more comprehensive learning experience, please check out the Multipass [Tutorial](https://canonical.com/multipass/docs/tutorial).
 
 ## Find available images
 
@@ -246,7 +246,7 @@ Changes to this project should be proposed as pull requests. Proposed changes wi
 
 # Additional information
 
-[Multipass documentation](https://multipass.run/docs)
+[Multipass documentation](https://canonical.com/multipass/docs)
 
 [gha-image]: https://github.com/canonical/multipass/workflows/Linux/badge.svg?branch=main
 [gha-url]: https://github.com/canonical/multipass/actions?query=branch%3Amain+workflow%3ALinux

--- a/src/client/gui/lib/help.dart
+++ b/src/client/gui/lib/help.dart
@@ -4,7 +4,7 @@ import 'package:url_launcher/url_launcher.dart';
 class HelpScreen extends StatelessWidget {
   static const sidebarKey = 'help';
 
-  static final docsUrl = Uri.parse('https://multipass.run/docs');
+  static final docsUrl = Uri.parse('https://canonical.com/multipass/docs');
 
   const HelpScreen({super.key});
 

--- a/src/client/gui/lib/update_available.dart
+++ b/src/client/gui/lib/update_available.dart
@@ -61,7 +61,7 @@ final updateProvider = NotifierProvider<UpdateNotifier, UpdateInfo>(
 );
 
 const _color = Color(0xffE95420);
-final installUrl = Uri.parse('https://multipass.run/install');
+final installUrl = Uri.parse('https://canonical.com/multipass/install');
 
 Future<void> launchInstallUrl() => launchUrl(installUrl);
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1908,11 +1908,11 @@ try // clang-format on
                                                        server};
 
     if (!MP_SETTINGS.get_as<bool>(mp::mounts_key))
-        return status_promise->set_value(
-            grpc::Status(grpc::StatusCode::FAILED_PRECONDITION,
-                         "Mounts are disabled on this installation of Multipass.\n\n"
-                         "See https://multipass.run/docs/set-command#local.privileged-mounts for information\n"
-                         "on how to enable them."));
+        return status_promise->set_value(grpc::Status(
+            grpc::StatusCode::FAILED_PRECONDITION,
+            "Mounts are disabled on this installation of Multipass.\n\n"
+            "See https://canonical.com/multipass/docs/set-command#local.privileged-mounts for information\n"
+            "on how to enable them."));
 
     mp::id_mappings uid_mappings, gid_mappings;
     for (const auto& map : request->mount_maps().uid_mappings())

--- a/src/platform/update/new_release_monitor.h
+++ b/src/platform/update/new_release_monitor.h
@@ -45,7 +45,7 @@ class NewReleaseMonitor : public QObject
 {
     Q_OBJECT
 public:
-    static constexpr auto default_update_url = "https://multipass.run/static/latest-release.json";
+    static constexpr auto default_update_url = "https://canonical.com/static/files/latest-multipass-releases.json";
 
     NewReleaseMonitor(const QString& current_version, std::chrono::steady_clock::duration refresh_rate,
                       const QString& update_url = default_update_url);


### PR DESCRIPTION
The multipass.run "microsite" is being replaced canonical.com/multipass. We need to update our URLs accordingly.

Fixes #3839

MULTI-1707