### PR TITLE
[ci] make renovate ask for users instead of team for reviews

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,13 @@
     "config:recommended"
   ],
   "reviewers": [
-    "team:multipass"
+    "andrei-toterman",
+    "georgeliao",
+    "levkropp",
+    "ricab",
+    "sharder996",
+    "Sploder12",
+    "xmkg",
   ],
   "reviewersSampleSize": 1,
   "schedule": "every 2 weeks on Monday",


### PR DESCRIPTION
Apparently, when asking for a team, it asks for the whole team, not just users within that team. The good news is that now we can specify exactly which users from the team qualify for reviews. The bad news is that we must update this list as part of the onboarding/offboarding process :shrug: