### PR TITLE
Refactor image vault utils

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -87,6 +87,9 @@ public:
     virtual qint64 write(QFileDevice& file, const QByteArray& data) const;
     virtual bool flush(QFile& file) const;
 
+    virtual QString remove_extension(const QString& path) const;
+    virtual bool copy(const QString& from, const QString& to) const;
+
     // QSaveFile operations
     virtual bool commit(QSaveFile& file) const;
 

--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -87,7 +87,6 @@ public:
     virtual qint64 write(QFileDevice& file, const QByteArray& data) const;
     virtual bool flush(QFile& file) const;
 
-    virtual QString remove_extension(const QString& path) const;
     virtual bool copy(const QString& from, const QString& to) const;
 
     // QSaveFile operations
@@ -122,6 +121,8 @@ public:
                                                                          std::error_code& err) const;
     virtual std::unique_ptr<DirIterator> dir_iterator(const fs::path& path, std::error_code& err) const;
     virtual fs::path weakly_canonical(const fs::path& path) const;
+
+    virtual fs::path remove_extension(const fs::path& path) const;
 };
 } // namespace multipass
 

--- a/include/multipass/vm_image_vault.h
+++ b/include/multipass/vm_image_vault.h
@@ -42,14 +42,6 @@ namespace multipass
 class VMImageHost;
 namespace vault
 {
-// Helper functions and classes for all image vault types
-QString filename_for(const Path& path);
-QString copy(const QString& file_name, const QDir& output_dir);
-void delete_file(const Path& path);
-QString compute_image_hash(const Path& image_path);
-void verify_image_download(const Path& image_path, const QString& image_hash);
-QString extract_image(const Path& image_path, const ProgressMonitor& monitor, const bool delete_file = false);
-std::unordered_map<std::string, VMImageHost*> configure_image_host_map(const std::vector<VMImageHost*>& image_hosts);
 
 class DeleteOnException
 {

--- a/include/multipass/vm_image_vault.h
+++ b/include/multipass/vm_image_vault.h
@@ -42,7 +42,6 @@ namespace multipass
 class VMImageHost;
 namespace vault
 {
-
 class DeleteOnException
 {
 public:

--- a/include/multipass/vm_image_vault_utils.h
+++ b/include/multipass/vm_image_vault_utils.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_VM_IMAGE_VAULT_UTILS_H
+#define MULTIPASS_VM_IMAGE_VAULT_UTILS_H
+
+#include "file_ops.h"
+#include "xz_image_decoder.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#define MP_IMAGE_VAULT_UTILS                                                                                           \
+    multipass::ImageVaultUtils                                                                                         \
+    {                                                                                                                  \
+    }
+
+namespace multipass
+{
+class VMImageHost;
+
+class ImageVaultUtils
+{
+public:
+    using DefaultDecoder = XzImageDecoder;
+
+    static QString copy_to_dir(const QString& file, const QDir& output_dir);
+    static QString compute_hash(QIODevice& device);
+    static QString compute_file_hash(const QString& file);
+
+    template <class Hasher = ImageVaultUtils>
+    static void verify_file_hash(const QString& file, const QString& hash, const Hasher& hasher = ImageVaultUtils{});
+
+    template <class Decoder = DefaultDecoder>
+    static QString extract_file(const QString& file,
+                                const ProgressMonitor& monitor,
+                                bool delete_original = false,
+                                const Decoder& decoder = DefaultDecoder{});
+
+    using HostMap = std::unordered_map<std::string, VMImageHost*>;
+    using Hosts = std::vector<VMImageHost*>;
+
+    static HostMap configure_image_host_map(const Hosts& image_hosts);
+};
+
+template <class Hasher>
+void ImageVaultUtils::verify_file_hash(const QString& file, const QString& hash, const Hasher& hasher)
+{
+    auto file_hash = hasher.compute_file_hash(file);
+}
+
+template <class Decoder>
+QString ImageVaultUtils::extract_file(const QString& file,
+                                      const ProgressMonitor& monitor,
+                                      bool delete_original,
+                                      const Decoder& decoder)
+{
+    auto new_path = MP_FILEOPS.remove_extension(file);
+    decoder.decode_to(file, new_path, monitor);
+
+    if (delete_original)
+    {
+        QFile qfile{file};
+        MP_FILEOPS.remove(qfile);
+    }
+
+    return new_path;
+}
+
+} // namespace multipass
+
+#endif // MULTIPASS_VM_IMAGE_VAULT_UTILS_H

--- a/include/multipass/vm_image_vault_utils.h
+++ b/include/multipass/vm_image_vault_utils.h
@@ -25,10 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
-#define MP_IMAGE_VAULT_UTILS                                                                                           \
-    multipass::ImageVaultUtils                                                                                         \
-    {                                                                                                                  \
-    }
+#define MP_IMAGE_VAULT_UTILS multipass::ImageVaultUtils()
 
 namespace multipass
 {
@@ -62,6 +59,9 @@ template <class Hasher>
 void ImageVaultUtils::verify_file_hash(const QString& file, const QString& hash, const Hasher& hasher)
 {
     auto file_hash = hasher.compute_file_hash(file);
+
+    if (file_hash != hash)
+        throw std::runtime_error(fmt::format("Hash of {} does not match {}", file, hash));
 }
 
 template <class Decoder>

--- a/include/multipass/vm_image_vault_utils.h
+++ b/include/multipass/vm_image_vault_utils.h
@@ -52,7 +52,7 @@ public:
     QString extract_file(const QString& file,
                          const ProgressMonitor& monitor,
                          bool delete_original = false,
-                         const DecoderT& = DefaultDecoderT{}) const;
+                         const DecoderT& = DecoderT{}) const;
 
     using HostMap = std::unordered_map<std::string, VMImageHost*>;
     using Hosts = std::vector<VMImageHost*>;

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -655,8 +655,7 @@ mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
 
         if (source_image.image_path.endsWith(".xz"))
         {
-            source_image.image_path =
-                MP_IMAGE_VAULT_UTILS.extract_file(source_image.image_path, monitor, true, XzImageDecoder{});
+            source_image.image_path = MP_IMAGE_VAULT_UTILS.extract_file(source_image.image_path, monitor, true);
         }
 
         auto prepared_image = prepare(source_image);

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -21,6 +21,7 @@
 #include <multipass/exceptions/create_image_exception.h>
 #include <multipass/exceptions/image_vault_exceptions.h>
 #include <multipass/exceptions/unsupported_image_exception.h>
+#include <multipass/file_ops.h>
 #include <multipass/json_utils.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
@@ -30,7 +31,6 @@
 #include <multipass/url_downloader.h>
 #include <multipass/utils.h>
 #include <multipass/vm_image.h>
-#include <multipass/xz_image_decoder.h>
 
 #include <multipass/format.h>
 
@@ -41,7 +41,6 @@
 #include <QtConcurrent/QtConcurrent>
 
 #include <exception>
-#include <multipass/file_ops.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -360,8 +360,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
                                        0,
                                        checksum.has_value()};
 
-                QFileInfo file_info{image_url.path()};
-                const auto image_filename = file_info.fileName();
+                const auto image_filename = QFileInfo{image_url.path()}.fileName();
                 // Attempt to make a sane directory name based on the filename of the image
 
                 const auto image_dir_name =

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -41,6 +41,7 @@
 #include <QtConcurrent/QtConcurrent>
 
 #include <exception>
+#include <multipass/file_ops.h>
 
 namespace mp = multipass;
 namespace mpl = multipass::logging;
@@ -170,7 +171,10 @@ void remove_source_images(const mp::VMImage& source_image, const mp::VMImage& pr
 {
     // The prepare phase may have been a no-op, check and only remove source images
     if (source_image.image_path != prepared_image.image_path)
-        mp::vault::delete_file(source_image.image_path);
+    {
+        QFile source_file{source_image.image_path};
+        MP_FILEOPS.remove(source_file);
+    }
 }
 
 void delete_image_dir(const mp::Path& image_path)

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -83,7 +83,7 @@ QString post_process_downloaded_image(const QString& image_path, const mp::Progr
 
     if (image_path.endsWith(".xz"))
     {
-        new_image_path = MP_IMAGE_VAULT_UTILS.extract_file(image_path, monitor, true, mp::XzImageDecoder{});
+        new_image_path = MP_IMAGE_VAULT_UTILS.extract_file(image_path, monitor, true);
     }
 
     QString original_image_path{new_image_path};

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -307,8 +307,7 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type,
             if (query.query_type != Query::Type::LocalFile)
             {
                 // TODO: Need to make this async like in DefaultVMImageVault
-                QFileInfo file_info{info.image_location};
-                image_path = lxd_import_dir.filePath(file_info.fileName());
+                image_path = lxd_import_dir.filePath(QFileInfo{info.image_location}.fileName());
 
                 url_download_image(info, image_path, monitor);
             }

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -47,6 +47,7 @@
 #include <QTemporaryDir>
 
 #include <chrono>
+#include <multipass/file_ops.h>
 #include <thread>
 
 namespace mp = multipass;
@@ -90,7 +91,8 @@ QString post_process_downloaded_image(const QString& image_path, const mp::Progr
 
     if (original_image_path != new_image_path)
     {
-        mp::vault::delete_file(original_image_path);
+        QFile original_file{original_image_path};
+        MP_FILEOPS.remove(original_file);
     }
 
     return new_image_path;

--- a/src/platform/backends/shared/base_vm_image_vault.h
+++ b/src/platform/backends/shared/base_vm_image_vault.h
@@ -23,6 +23,7 @@
 #include <multipass/vm_image.h>
 #include <multipass/vm_image_host.h>
 #include <multipass/vm_image_vault.h>
+#include <multipass/vm_image_vault_utils.h>
 
 #include <string>
 #include <utility>
@@ -34,7 +35,8 @@ class BaseVMImageVault : public VMImageVault
 {
 public:
     explicit BaseVMImageVault(const std::vector<VMImageHost*>& image_hosts)
-        : image_hosts{image_hosts}, remote_image_host_map{vault::configure_image_host_map(image_hosts)} {};
+        : image_hosts{image_hosts},
+          remote_image_host_map{MP_IMAGE_VAULT_UTILS.configure_image_host_map(image_hosts)} {};
 
     VMImageHost* image_host_for(const std::string& remote_name) const override
     {

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -172,8 +172,9 @@ bool mp::FileOps::flush(QFile& file) const
 
 QString mp::FileOps::remove_extension(const QString& path) const
 {
-    QFileInfo info{path};
-    return info.dir().path() + info.completeBaseName();
+    const QFileInfo info{path};
+    auto extension_len = info.suffix().size();
+    return path.chopped(extension_len != 0 ? extension_len + 1 : 0);
 }
 
 bool mp::FileOps::copy(const QString& from, const QString& to) const

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -170,13 +170,6 @@ bool mp::FileOps::flush(QFile& file) const
     return file.flush();
 }
 
-QString mp::FileOps::remove_extension(const QString& path) const
-{
-    const QFileInfo info{path};
-    auto extension_len = info.suffix().size();
-    return path.chopped(extension_len != 0 ? extension_len + 1 : 0);
-}
-
 bool mp::FileOps::copy(const QString& from, const QString& to) const
 {
     return QFile::copy(from, to);
@@ -303,4 +296,9 @@ std::unique_ptr<mp::DirIterator> mp::FileOps::dir_iterator(const fs::path& path,
 fs::path mp::FileOps::weakly_canonical(const fs::path& path) const
 {
     return fs::weakly_canonical(path);
+}
+
+fs::path mp::FileOps::remove_extension(const fs::path& path) const
+{
+    return path.parent_path() / path.stem();
 }

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -170,6 +170,17 @@ bool mp::FileOps::flush(QFile& file) const
     return file.flush();
 }
 
+QString mp::FileOps::remove_extension(const QString& path) const
+{
+    QFileInfo info{path};
+    return info.dir().path() + info.completeBaseName();
+}
+
+bool mp::FileOps::copy(const QString& from, const QString& to) const
+{
+    return QFile::copy(from, to);
+}
+
 bool mp::FileOps::commit(QSaveFile& file) const
 {
     return file.commit();

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -401,16 +401,6 @@ void mp::utils::validate_server_address(const std::string& address)
         throw std::runtime_error(fmt::format("invalid port number in address '{}'", address));
 }
 
-std::string mp::utils::filename_for(const std::string& path)
-{
-    return QFileInfo(QString::fromStdString(path)).fileName().toStdString();
-}
-
-bool mp::utils::is_dir(const std::string& path)
-{
-    return QFileInfo(QString::fromStdString(path)).isDir();
-}
-
 std::string mp::utils::match_line_for(const std::string& output, const std::string& matcher)
 {
     std::istringstream ss{output};

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -18,6 +18,7 @@
 #include <multipass/format.h>
 #include <multipass/vm_image_host.h>
 #include <multipass/vm_image_vault.h>
+#include <multipass/vm_image_vault_utils.h>
 #include <multipass/xz_image_decoder.h>
 
 #include <QCryptographicHash>
@@ -27,77 +28,25 @@
 
 namespace mp = multipass;
 
-QString mp::vault::filename_for(const mp::Path& path)
+QString mp::ImageVaultUtils::copy_to_dir(const QString& file, const QDir& output_dir)
 {
-    QFileInfo file_info(path);
-    return file_info.fileName();
+    return "";
 }
 
-QString mp::vault::copy(const QString& file_name, const QDir& output_dir)
+QString mp::ImageVaultUtils::compute_hash(QIODevice& device)
 {
-    if (file_name.isEmpty())
-        return {};
-
-    if (!QFileInfo::exists(file_name))
-        throw std::runtime_error(fmt::format("{} missing", file_name));
-
-    QFileInfo info{file_name};
-    const auto source_name = info.fileName();
-    auto new_path = output_dir.filePath(source_name);
-    QFile::copy(file_name, new_path);
-    return new_path;
+    return "";
 }
 
-void mp::vault::delete_file(const mp::Path& path)
+QString mp::ImageVaultUtils::compute_file_hash(const QString& path)
 {
-    QFile file{path};
-    file.remove();
+    return "";
 }
 
-QString mp::vault::compute_image_hash(const mp::Path& image_path)
+mp::ImageVaultUtils::HostMap mp::ImageVaultUtils::configure_image_host_map(const Hosts& image_hosts)
 {
-    QFile image_file(image_path);
-    if (!image_file.open(QFile::ReadOnly))
-    {
-        throw std::runtime_error("Cannot open image file for computing hash");
-    }
-
-    QCryptographicHash hash(QCryptographicHash::Sha256);
-    if (!hash.addData(&image_file))
-    {
-        throw std::runtime_error("Cannot read image file to compute hash");
-    }
-
-    return hash.result().toHex();
-}
-
-void mp::vault::verify_image_download(const mp::Path& image_path, const QString& image_hash)
-{
-    auto computed_hash = compute_image_hash(image_path);
-
-    if (computed_hash != image_hash)
-    {
-        throw std::runtime_error("Downloaded image hash does not match");
-    }
-}
-
-QString mp::vault::extract_image(const mp::Path& image_path, const mp::ProgressMonitor& monitor, const bool delete_file)
-{
-    mp::XzImageDecoder xz_decoder(image_path);
-    QString new_image_path{image_path};
-
-    new_image_path.remove(".xz");
-
-    xz_decoder.decode_to(new_image_path, monitor);
-
-    mp::vault::delete_file(image_path);
-
-    return new_image_path;
-}
-
-std::unordered_map<std::string, mp::VMImageHost*>
-mp::vault::configure_image_host_map(const std::vector<mp::VMImageHost*>& image_hosts)
-{
+    return {};
+    /*
     std::unordered_map<std::string, mp::VMImageHost*> remote_image_host_map;
 
     for (const auto& image_host : image_hosts)
@@ -108,5 +57,5 @@ mp::vault::configure_image_host_map(const std::vector<mp::VMImageHost*>& image_h
         }
     }
 
-    return remote_image_host_map;
+    return remote_image_host_map;*/
 }

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -77,7 +77,8 @@ void mp::ImageVaultUtils::verify_file_hash(const QString& file, const QString& h
 
 QString mp::ImageVaultUtils::extract_file(const QString& file, const Decoder& decoder, bool delete_original) const
 {
-    auto new_path = MP_FILEOPS.remove_extension(file);
+    const auto fs_new_path = MP_FILEOPS.remove_extension(file.toStdU16String());
+    auto new_path = QString::fromStdString(fs_new_path.u8string());
 
     decoder(file, new_path);
 

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -30,25 +30,42 @@ namespace mp = multipass;
 
 QString mp::ImageVaultUtils::copy_to_dir(const QString& file, const QDir& output_dir)
 {
-    return "";
+    if (file.isEmpty())
+        return "";
+
+    const QFileInfo info{file};
+    if (!MP_FILEOPS.exists(info))
+        throw std::runtime_error(fmt::format("File {} not found", file));
+
+    auto new_location = output_dir.filePath(info.fileName());
+
+    if (!MP_FILEOPS.copy(file, new_location))
+        throw std::runtime_error(fmt::format("Failed to copy {} to {}", file, new_location));
+
+    return new_location;
 }
 
 QString mp::ImageVaultUtils::compute_hash(QIODevice& device)
 {
-    return "";
+    QCryptographicHash hash{QCryptographicHash::Sha256};
+    if (!hash.addData(std::addressof(device)))
+        throw std::runtime_error("Failed to read data from device to hash");
+
+    return hash.result().toHex();
 }
 
 QString mp::ImageVaultUtils::compute_file_hash(const QString& path)
 {
-    return "";
+    QFile file{path};
+    if (!MP_FILEOPS.open(file, QFile::ReadOnly))
+        throw std::runtime_error(fmt::format("Failed to open {}", path));
+
+    return compute_hash(file);
 }
 
 mp::ImageVaultUtils::HostMap mp::ImageVaultUtils::configure_image_host_map(const Hosts& image_hosts)
 {
-    return {};
-    /*
-    std::unordered_map<std::string, mp::VMImageHost*> remote_image_host_map;
-
+    HostMap remote_image_host_map{};
     for (const auto& image_host : image_hosts)
     {
         for (const auto& remote : image_host->supported_remotes())
@@ -57,5 +74,5 @@ mp::ImageVaultUtils::HostMap mp::ImageVaultUtils::configure_image_host_map(const
         }
     }
 
-    return remote_image_host_map;*/
+    return remote_image_host_map;
 }

--- a/src/xz_decoder/xz_image_decoder.cpp
+++ b/src/xz_decoder/xz_image_decoder.cpp
@@ -54,15 +54,17 @@ bool verify_decode(const xz_ret& ret)
 }
 } // namespace
 
-mp::XzImageDecoder::XzImageDecoder(const Path& xz_file_path)
-    : xz_file{xz_file_path}, xz_decoder{xz_dec_init(XZ_DYNALLOC, 1u << 26), xz_dec_end}
+mp::XzImageDecoder::XzImageDecoder() : xz_decoder{xz_dec_init(XZ_DYNALLOC, 1u << 26), xz_dec_end}
 {
     xz_crc32_init();
     xz_crc64_init();
 }
 
-void mp::XzImageDecoder::decode_to(const Path& decoded_image_path, const ProgressMonitor& monitor)
+void mp::XzImageDecoder::decode_to(const Path& xz_file_path,
+                                   const Path& decoded_image_path,
+                                   const ProgressMonitor& monitor) const
 {
+    QFile xz_file{xz_file_path};
     if (!xz_file.open(QIODevice::ReadOnly))
         throw std::runtime_error(fmt::format("failed to open {} for reading", xz_file.fileName()));
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(multipass_tests
   test_sftp_utils.cpp
   test_file_ops.cpp
   test_recursive_dir_iter.cpp
+        test_image_vault_utils.cpp
 )
 
 target_include_directories(multipass_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(multipass_tests
   test_global_settings_handlers.cpp
   test_id_mappings.cpp
   test_image_vault.cpp
+  test_image_vault_utils.cpp
   test_instance_settings_handler.cpp
   test_ip_address.cpp
   test_json_utils.cpp
@@ -124,7 +125,6 @@ add_executable(multipass_tests
   test_sftp_utils.cpp
   test_file_ops.cpp
   test_recursive_dir_iter.cpp
-        test_image_vault_utils.cpp
 )
 
 target_include_directories(multipass_tests

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -62,7 +62,6 @@ public:
     MOCK_METHOD(qint64, write, (QFileDevice&, const QByteArray&), (const, override));
     MOCK_METHOD(bool, flush, (QFile & file), (const, override));
 
-    MOCK_METHOD(QString, remove_extension, (const QString& path), (const, override));
     MOCK_METHOD(bool, copy, (const QString&, const QString&), (const, override));
 
     // QSaveFile mock methods
@@ -100,6 +99,8 @@ public:
                 (const fs::path& path, std::error_code& err),
                 (override, const));
     MOCK_METHOD(fs::path, weakly_canonical, (const fs::path& path), (override, const));
+
+    MOCK_METHOD(fs::path, remove_extension, (const fs::path& path), (const, override));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockFileOps, FileOps);
 };

--- a/tests/mock_file_ops.h
+++ b/tests/mock_file_ops.h
@@ -62,6 +62,9 @@ public:
     MOCK_METHOD(qint64, write, (QFileDevice&, const QByteArray&), (const, override));
     MOCK_METHOD(bool, flush, (QFile & file), (const, override));
 
+    MOCK_METHOD(QString, remove_extension, (const QString& path), (const, override));
+    MOCK_METHOD(bool, copy, (const QString&, const QString&), (const, override));
+
     // QSaveFile mock methods
     MOCK_METHOD(bool, commit, (QSaveFile&), (const, override));
 

--- a/tests/mock_image_decoder.h
+++ b/tests/mock_image_decoder.h
@@ -15,31 +15,23 @@
  *
  */
 
-#ifndef MULTIPASS_XZ_IMAGE_DECODER_H
-#define MULTIPASS_XZ_IMAGE_DECODER_H
+#ifndef MULTIPASS_MOCK_IMAGE_DECODER_H
+#define MULTIPASS_MOCK_IMAGE_DECODER_H
+
+#include "common.h"
 
 #include <multipass/path.h>
 #include <multipass/progress_monitor.h>
 
-#include <memory>
-
-#include <QFile>
-
-#include <xz.h>
-
-namespace multipass
+namespace multipass::test
 {
-class XzImageDecoder
+
+class MockImageDecoder
 {
 public:
-    XzImageDecoder();
-
-    void decode_to(const Path& xz_file_path, const Path& decoded_file_path, const ProgressMonitor& monitor) const;
-
-    using XzDecoderUPtr = std::unique_ptr<xz_dec, decltype(xz_dec_end)*>;
-
-private:
-    XzDecoderUPtr xz_decoder;
+    MOCK_METHOD(void, decode_to, (const Path&, const Path&, const ProgressMonitor&), (const));
 };
-} // namespace multipass
-#endif // MULTIPASS_XZ_IMAGE_DECODER_H
+
+} // namespace multipass::test
+
+#endif // MULTIPASS_MOCK_IMAGE_DECODER_H

--- a/tests/mock_image_vault_utils.h
+++ b/tests/mock_image_vault_utils.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_MOCK_IMAGE_VALUE_UTILS_H
+#define MULTIPASS_MOCK_IMAGE_VALUE_UTILS_H
+
+#include "common.h"
+#include "mock_image_decoder.h"
+
+#include <multipass/vm_image_vault_utils.h>
+
+namespace multipass::test
+{
+
+class MockImageVaultUtils
+{
+public:
+    MOCK_METHOD(QString, copy_to_dir, (const QString&, const QDir&), (const));
+    MOCK_METHOD(QString, compute_hash, (QIODevice&), (const));
+    MOCK_METHOD(QString, compute_file_hash, (const QString&), (const));
+    MOCK_METHOD(void, verify_file_hash, (const QString&, const QString&), (const));
+
+    MOCK_METHOD(void, extract_file, (const QString&, const ProgressMonitor&, bool, const MockImageDecoder&), (const));
+};
+
+} // namespace multipass::test
+
+#endif // MULTIPASS_MOCK_IMAGE_VALUE_UTILS_H

--- a/tests/mock_image_vault_utils.h
+++ b/tests/mock_image_vault_utils.h
@@ -19,22 +19,28 @@
 #define MULTIPASS_MOCK_IMAGE_VALUE_UTILS_H
 
 #include "common.h"
-#include "mock_image_decoder.h"
 
 #include <multipass/vm_image_vault_utils.h>
 
 namespace multipass::test
 {
 
-class MockImageVaultUtils
+class MockImageVaultUtils : public ImageVaultUtils
 {
 public:
-    MOCK_METHOD(QString, copy_to_dir, (const QString&, const QDir&), (const));
-    MOCK_METHOD(QString, compute_hash, (QIODevice&), (const));
-    MOCK_METHOD(QString, compute_file_hash, (const QString&), (const));
-    MOCK_METHOD(void, verify_file_hash, (const QString&, const QString&), (const));
+    using ImageVaultUtils::ImageVaultUtils;
 
-    MOCK_METHOD(void, extract_file, (const QString&, const ProgressMonitor&, bool, const MockImageDecoder&), (const));
+    MOCK_METHOD(QString, copy_to_dir, (const QString&, const QDir&), (const, override));
+
+    MOCK_METHOD(QString, compute_hash, (QIODevice&), (const, override));
+    MOCK_METHOD(QString, compute_file_hash, (const QString&), (const, override));
+    MOCK_METHOD(void, verify_file_hash, (const QString&, const QString&), (const, override));
+
+    MOCK_METHOD(QString, extract_file, (const QString&, const Decoder&, bool), (const, override));
+
+    MOCK_METHOD(HostMap, configure_image_host_map, (const Hosts&), (const, override));
+
+    MP_MOCK_SINGLETON_BOILERPLATE(MockImageVaultUtils, ImageVaultUtils);
 };
 
 } // namespace multipass::test

--- a/tests/test_file_ops.cpp
+++ b/tests/test_file_ops.cpp
@@ -198,5 +198,6 @@ TEST_F(FileOps, remove_extension)
     EXPECT_EQ(MP_FILEOPS.remove_extension(""), "");
     EXPECT_EQ(MP_FILEOPS.remove_extension("test.txt"), "test");
     EXPECT_EQ(MP_FILEOPS.remove_extension("tests/test.test.txt"), "tests/test.test");
+    EXPECT_EQ(MP_FILEOPS.remove_extension("tests/bar.foo.tar.gz"), "tests/bar.foo.tar");
     EXPECT_EQ(MP_FILEOPS.remove_extension("/sets/test.png"), "/sets/test");
 }

--- a/tests/test_file_ops.cpp
+++ b/tests/test_file_ops.cpp
@@ -192,3 +192,10 @@ TEST_F(FileOps, posix_lseek)
     EXPECT_EQ(r, file_content.size() - seek);
     EXPECT_STREQ(buffer.data(), file_content.c_str() + seek);
 }
+
+TEST_F(FileOps, remove_extension)
+{
+    EXPECT_EQ(MP_FILEOPS.remove_extension("test.txt"), "test");
+    EXPECT_EQ(MP_FILEOPS.remove_extension("tests/test.test.txt"), "tests/test.test");
+    EXPECT_EQ(MP_FILEOPS.remove_extension("/sets/test.png"), "/sets/test.png");
+}

--- a/tests/test_file_ops.cpp
+++ b/tests/test_file_ops.cpp
@@ -195,7 +195,8 @@ TEST_F(FileOps, posix_lseek)
 
 TEST_F(FileOps, remove_extension)
 {
+    EXPECT_EQ(MP_FILEOPS.remove_extension(""), "");
     EXPECT_EQ(MP_FILEOPS.remove_extension("test.txt"), "test");
     EXPECT_EQ(MP_FILEOPS.remove_extension("tests/test.test.txt"), "tests/test.test");
-    EXPECT_EQ(MP_FILEOPS.remove_extension("/sets/test.png"), "/sets/test.png");
+    EXPECT_EQ(MP_FILEOPS.remove_extension("/sets/test.png"), "/sets/test");
 }

--- a/tests/test_file_ops.cpp
+++ b/tests/test_file_ops.cpp
@@ -196,7 +196,12 @@ TEST_F(FileOps, posix_lseek)
 TEST_F(FileOps, remove_extension)
 {
     EXPECT_EQ(MP_FILEOPS.remove_extension(""), "");
+    EXPECT_EQ(MP_FILEOPS.remove_extension("test"), "test");
+    EXPECT_EQ(MP_FILEOPS.remove_extension(".empty"), ".empty");
+    EXPECT_EQ(MP_FILEOPS.remove_extension("tests/.empty"), "tests/.empty");
+
     EXPECT_EQ(MP_FILEOPS.remove_extension("test.txt"), "test");
+    EXPECT_EQ(MP_FILEOPS.remove_extension("tests/.empty.txt"), "tests/.empty");
     EXPECT_EQ(MP_FILEOPS.remove_extension("tests/test.test.txt"), "tests/test.test");
     EXPECT_EQ(MP_FILEOPS.remove_extension("tests/bar.foo.tar.gz"), "tests/bar.foo.tar");
     EXPECT_EQ(MP_FILEOPS.remove_extension("/sets/test.png"), "/sets/test");

--- a/tests/test_image_vault_utils.cpp
+++ b/tests/test_image_vault_utils.cpp
@@ -83,7 +83,7 @@ TEST_F(TestImageVaultUtils, copy_to_dir_copys_to_dir)
 TEST_F(TestImageVaultUtils, compute_hash_throws_when_cant_read)
 {
     QBuffer buffer{}; // note: buffer is not opened
-    MP_EXPECT_THROW_THAT(auto _ = MP_IMAGE_VAULT_UTILS.compute_hash(buffer),
+    MP_EXPECT_THROW_THAT(std::ignore = MP_IMAGE_VAULT_UTILS.compute_hash(buffer),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Failed to read")));
 }
@@ -106,7 +106,7 @@ TEST_F(TestImageVaultUtils, compute_file_hash_throws_when_cant_open)
                                     })))
         .WillOnce(Return(false));
 
-    MP_EXPECT_THROW_THAT(auto _ = MP_IMAGE_VAULT_UTILS.compute_file_hash(test_path),
+    MP_EXPECT_THROW_THAT(std::ignore = MP_IMAGE_VAULT_UTILS.compute_file_hash(test_path),
                          std::runtime_error,
                          mpt::match_what(AllOf(HasSubstr(test_path.toStdString()), HasSubstr("Failed to open"))));
 }

--- a/tests/test_image_vault_utils.cpp
+++ b/tests/test_image_vault_utils.cpp
@@ -83,7 +83,7 @@ TEST_F(TestImageVaultUtils, copy_to_dir_copys_to_dir)
 TEST_F(TestImageVaultUtils, compute_hash_throws_when_cant_read)
 {
     QBuffer buffer{}; // note: buffer is not opened
-    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.compute_hash(buffer),
+    MP_EXPECT_THROW_THAT(auto _ = MP_IMAGE_VAULT_UTILS.compute_hash(buffer),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Failed to read")));
 }
@@ -106,7 +106,7 @@ TEST_F(TestImageVaultUtils, compute_file_hash_throws_when_cant_open)
                                     })))
         .WillOnce(Return(false));
 
-    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.compute_file_hash(test_path),
+    MP_EXPECT_THROW_THAT(auto _ = MP_IMAGE_VAULT_UTILS.compute_file_hash(test_path),
                          std::runtime_error,
                          mpt::match_what(AllOf(HasSubstr(test_path.toStdString()), HasSubstr("Failed to open"))));
 }

--- a/tests/test_image_vault_utils.cpp
+++ b/tests/test_image_vault_utils.cpp
@@ -40,9 +40,11 @@ struct TestImageVaultUtils : public ::testing::Test
 
     const QDir test_dir{"secrets/secret_filled_folder"};
     const QString test_path{"not_secrets/a_secret.txt"};
+    const mp::fs::path fs_test_path{test_path.toStdU16String()};
     const QFileInfo test_info{test_path};
 
     const QString test_output{"secrets/secret_filled_folder/a_secret.txt"};
+    const mp::fs::path fs_test_output{test_output.toStdU16String()};
 };
 
 TEST_F(TestImageVaultUtils, copy_to_dir_handles_empty_file)
@@ -141,7 +143,7 @@ TEST_F(TestImageVaultUtils, extract_file_will_delete_file)
 
 TEST_F(TestImageVaultUtils, extract_file_wont_delete_file)
 {
-    EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(test_output));
+    EXPECT_CALL(mock_file_ops, remove_extension(fs_test_path)).WillOnce(Return(fs_test_output));
 
     int calls = 0;
     auto decoder = [&](const QString& path, const QString& target) {
@@ -158,7 +160,7 @@ TEST_F(TestImageVaultUtils, extract_file_wont_delete_file)
 
 TEST_F(TestImageVaultUtils, extract_file_extracts_file)
 {
-    EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(test_output));
+    EXPECT_CALL(mock_file_ops, remove_extension(fs_test_path)).WillOnce(Return(fs_test_output));
 
     int calls = 0;
     auto decoder = [&](const QString& path, const QString& target) {
@@ -174,7 +176,7 @@ TEST_F(TestImageVaultUtils, extract_file_extracts_file)
 
 TEST_F(TestImageVaultUtils, extract_file_with_decoder_binds_monitor)
 {
-    EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(test_output));
+    EXPECT_CALL(mock_file_ops, remove_extension(fs_test_path)).WillOnce(Return(fs_test_output));
 
     int type = 1337;
     int progress = 42;

--- a/tests/test_image_vault_utils.cpp
+++ b/tests/test_image_vault_utils.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common.h"
+#include "mock_file_ops.h"
+#include "mock_image_decoder.h"
+#include "mock_image_vault_utils.h"
+
+#include <QBuffer>
+#include <multipass/progress_monitor.h>
+#include <multipass/vm_image_vault_utils.h>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+using namespace testing;
+
+namespace
+{
+
+struct TestImageVaultUtils : public ::testing::Test
+{
+    const mpt::MockFileOps::GuardedMock mock_file_ops_guard{StrictMock<mpt::MockFileOps>::inject()};
+    mpt::MockFileOps& mock_file_ops{*mock_file_ops_guard.first};
+
+    const QDir test_dir{"secrets/secret_filled_folder"};
+    const QString test_path{"not_secrets/a_secret.txt"};
+    QFile test_file{test_path};
+    const QFileInfo test_info{test_path};
+
+    const QString test_output{"secrets/secret_filled_folder/a_secret.txt"};
+};
+
+TEST_F(TestImageVaultUtils, copy_to_dir_handles_empty_file)
+{
+    EXPECT_EQ(MP_IMAGE_VAULT_UTILS.copy_to_dir("", test_dir), "");
+}
+
+TEST_F(TestImageVaultUtils, copy_to_dir_throws_on_nonexistant_file)
+{
+    EXPECT_CALL(mock_file_ops, exists(test_info)).WillOnce(Return(false));
+
+    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir),
+                         std::runtime_error,
+                         mpt::match_what(AllOf(HasSubstr(test_path.toStdString()), HasSubstr("not found"))));
+}
+
+TEST_F(TestImageVaultUtils, copy_to_dir_throws_on_fail_to_copy)
+{
+    EXPECT_CALL(mock_file_ops, exists(test_info)).WillOnce(Return(true));
+    EXPECT_CALL(mock_file_ops, copy(test_path, test_output)).WillOnce(Return(false));
+
+    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir),
+                         std::runtime_error,
+                         mpt::match_what(AllOf(HasSubstr(test_path.toStdString()),
+                                               HasSubstr("Failed to copy"),
+                                               HasSubstr(test_output.toStdString()))));
+}
+
+TEST_F(TestImageVaultUtils, copy_to_dir_copys_to_dir)
+{
+    EXPECT_CALL(mock_file_ops, exists(test_info)).WillOnce(Return(true));
+    EXPECT_CALL(mock_file_ops, copy(test_path, test_output)).WillOnce(Return(true));
+
+    auto result = MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir);
+    EXPECT_EQ(result, test_output);
+}
+
+TEST_F(TestImageVaultUtils, compute_hash_throws_when_cant_read)
+{
+    QBuffer buffer{}; // note: buffer is not opened
+    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.compute_hash(buffer),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr("Failed to read")));
+}
+
+TEST_F(TestImageVaultUtils, compute_hash_computes_sha256)
+{
+    QByteArray data = ":)";
+    QBuffer buffer{&data};
+
+    buffer.open(QIODevice::ReadOnly);
+
+    auto hash = MP_IMAGE_VAULT_UTILS.compute_hash(buffer);
+    EXPECT_EQ(hash, "54d626e08c1c802b305dad30b7e54a82f102390cc92c7d4db112048935236e9c");
+}
+
+TEST_F(TestImageVaultUtils, compute_file_hash_throws_when_cant_open)
+{
+    EXPECT_CALL(mock_file_ops, open(Property(&QFileDevice::fileName, test_path), Truly([](const auto& mode) {
+                                        return (mode & QFile::ReadOnly) > 0;
+                                    })))
+        .WillOnce(Return(false));
+
+    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.compute_file_hash(test_path),
+                         std::runtime_error,
+                         mpt::match_what(AllOf(HasSubstr(test_path.toStdString()), HasSubstr("Failed to open"))));
+}
+
+TEST_F(TestImageVaultUtils, verify_file_hash_throws_on_bad_hash)
+{
+    mpt::MockImageVaultUtils mock_utils;
+    EXPECT_CALL(mock_utils, compute_file_hash(test_path)).WillOnce(Return(":("));
+
+    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.verify_file_hash(test_path, ":)", mock_utils),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr("hash does not match")));
+}
+
+TEST_F(TestImageVaultUtils, verify_file_hash_doesnt_throw_on_good_hash)
+{
+    mpt::MockImageVaultUtils mock_utils;
+    EXPECT_CALL(mock_utils, compute_file_hash(test_path)).WillOnce(Return(":)"));
+
+    EXPECT_NO_THROW(MP_IMAGE_VAULT_UTILS.verify_file_hash(test_path, ":)", mock_utils));
+}
+
+TEST_F(TestImageVaultUtils, extract_image_will_delete_file)
+{
+    mpt::MockImageDecoder decoder{};
+    EXPECT_CALL(decoder, decode_to(_, _, _));
+
+    mp::ProgressMonitor monitor = [](int, int) { return true; };
+
+    EXPECT_CALL(mock_file_ops, remove(Property(&QFile::fileName, test_path)));
+
+    MP_IMAGE_VAULT_UTILS.extract_file(test_path, monitor, true, decoder);
+}
+
+TEST_F(TestImageVaultUtils, extract_image_wont_delete_file)
+{
+    const QString dest{"not_secrets/a_secret"};
+    EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(dest));
+
+    mpt::MockImageDecoder decoder{};
+    EXPECT_CALL(decoder, decode_to(_, _, _));
+
+    mp::ProgressMonitor monitor = [](int, int) { return true; };
+
+    EXPECT_CALL(mock_file_ops, remove(_)).Times(0);
+
+    MP_IMAGE_VAULT_UTILS.extract_file(test_path, monitor, false, decoder);
+}
+
+TEST_F(TestImageVaultUtils, extract_image_extracts_image)
+{
+    const QString dest{"not_secrets/a_secret"};
+    EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(dest));
+
+    mp::ProgressMonitor monitor = [](int, int) { return true; };
+
+    mpt::MockImageDecoder decoder{};
+    EXPECT_CALL(decoder, decode_to(test_path, dest, _));
+
+    auto res = MP_IMAGE_VAULT_UTILS.extract_file(test_path, monitor, false, decoder);
+    EXPECT_EQ(res, dest);
+}
+
+} // namespace

--- a/tests/test_image_vault_utils.cpp
+++ b/tests/test_image_vault_utils.cpp
@@ -35,7 +35,7 @@ namespace
 
 struct TestImageVaultUtils : public ::testing::Test
 {
-    const mpt::MockFileOps::GuardedMock mock_file_ops_guard{StrictMock<mpt::MockFileOps>::inject()};
+    const mpt::MockFileOps::GuardedMock mock_file_ops_guard{mpt::MockFileOps::inject<NiceMock>()};
     mpt::MockFileOps& mock_file_ops{*mock_file_ops_guard.first};
 
     const QDir test_dir{"secrets/secret_filled_folder"};

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -606,29 +606,6 @@ TEST(Utils, validate_server_address_does_not_throw_on_good_address)
     EXPECT_NO_THROW(mp::utils::validate_server_address("test-server.net:123"));
 }
 
-TEST(Utils, dir_is_a_dir)
-{
-    mpt::TempDir temp_dir;
-    EXPECT_TRUE(mp::utils::is_dir(temp_dir.path().toStdString()));
-}
-
-TEST(Utils, file_is_not_a_dir)
-{
-    mpt::TempDir temp_dir;
-    auto file_name = temp_dir.path() + "/empty_test_file";
-    mpt::make_file_with_content(file_name, "");
-
-    EXPECT_FALSE(mp::utils::is_dir(file_name.toStdString()));
-}
-
-TEST(Utils, filename_only_is_returned)
-{
-    std::string file_name{"my_file"};
-    std::string full_path{"/tmp/foo/" + file_name};
-
-    EXPECT_THAT(mp::utils::filename_for(full_path), Eq(file_name));
-}
-
 TEST(Utils, no_subdirectory_returns_same_path)
 {
     mp::Path original_path{"/tmp/foo"};
@@ -738,35 +715,4 @@ TEST(Utils, check_filesystem_bytes_available_returns_non_negative)
     auto bytes_available = MP_UTILS.filesystem_bytes_available(temp_dir.path());
 
     EXPECT_GE(bytes_available, 0);
-}
-
-TEST(VaultUtils, copy_creates_new_file_and_returned_path_exists)
-{
-    mpt::TempDir temp_dir1, temp_dir2;
-    auto orig_file_path = QDir(temp_dir1.path()).filePath("test_file");
-
-    mpt::make_file_with_content(orig_file_path);
-
-    auto new_file_path = mp::vault::copy(orig_file_path, temp_dir2.path());
-
-    EXPECT_TRUE(QFile::exists(new_file_path));
-}
-
-TEST(VaultUtils, copy_returns_empty_path_when_file_name_is_empty)
-{
-    mpt::TempDir temp_dir;
-
-    auto path = mp::vault::copy("", temp_dir.path());
-
-    EXPECT_TRUE(path.isEmpty());
-}
-
-TEST(VaultUtils, copy_throws_when_file_does_not_exist)
-{
-    mpt::TempDir temp_dir;
-
-    const QString file_name{"/foo/bar"};
-
-    MP_EXPECT_THROW_THAT(mp::vault::copy(file_name, temp_dir.path()), std::runtime_error,
-                         mpt::match_what(StrEq(fmt::format("{} missing", file_name))));
 }


### PR DESCRIPTION
This PR refactors several functions related to image vault utilities. All util functions now have unit test coverage and can be mocked to ease testing for components that use the utilities. Some functions have been removed or moved to file_ops since they already exist or fit better there.

MULTI-1653