### PR TITLE
Copy paste improvements

### DIFF
--- a/src/client/gui/lib/platform/linux.dart
+++ b/src/client/gui/lib/platform/linux.dart
@@ -31,7 +31,11 @@ class LinuxPlatform extends MpPlatform {
   Map<SingleActivator, Intent> get terminalShortcuts => const {
         SingleActivator(LogicalKeyboardKey.keyC, control: true, shift: true):
             CopySelectionTextIntent.copy,
+        SingleActivator(LogicalKeyboardKey.insert, control: true):
+            CopySelectionTextIntent.copy,
         SingleActivator(LogicalKeyboardKey.keyV, control: true, shift: true):
+            PasteTextIntent(SelectionChangedCause.keyboard),
+        SingleActivator(LogicalKeyboardKey.insert, shift: true):
             PasteTextIntent(SelectionChangedCause.keyboard),
         SingleActivator(LogicalKeyboardKey.equal, control: true):
             IncreaseTerminalFontIntent(),

--- a/src/client/gui/lib/platform/windows.dart
+++ b/src/client/gui/lib/platform/windows.dart
@@ -33,7 +33,11 @@ class WindowsPlatform extends MpPlatform {
   Map<SingleActivator, Intent> get terminalShortcuts => const {
         SingleActivator(LogicalKeyboardKey.keyC, control: true, shift: true):
             CopySelectionTextIntent.copy,
+        SingleActivator(LogicalKeyboardKey.insert, control: true):
+            CopySelectionTextIntent.copy,
         SingleActivator(LogicalKeyboardKey.keyV, control: true, shift: true):
+            PasteTextIntent(SelectionChangedCause.keyboard),
+        SingleActivator(LogicalKeyboardKey.insert, shift: true):
             PasteTextIntent(SelectionChangedCause.keyboard),
         SingleActivator(LogicalKeyboardKey.equal, control: true):
             IncreaseTerminalFontIntent(),


### PR DESCRIPTION
This PR adds Ctrl+Insert and Shift+Insert as copy/paste shortcuts for the terminal on Windows, as well as adding a right-click context menu in the terminal that provides copy/paste functionality.

It also refactors some of the terminal code by extracting some nested widgets into separate variables, since the nesting level was getting too big.

MULTI-1679