### PR TITLE
use SelectableText in GUI for instance info

### DIFF
--- a/src/client/gui/lib/selectable_text.dart
+++ b/src/client/gui/lib/selectable_text.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart' as fl;
+
+class SelectableText extends fl.StatelessWidget {
+  final String text;
+  final fl.TextStyle? style;
+  final fl.TextAlign? textAlign;
+  final int? maxLines;
+
+  const SelectableText(
+      this.text, {
+        super.key,
+        this.style,
+        this.textAlign,
+        this.maxLines,
+      });
+
+  @override
+  fl.Widget build(fl.BuildContext context) {
+    final textButtonStyle = fl.Theme.of(context).textButtonTheme.style?.copyWith(
+      backgroundColor: const fl.WidgetStatePropertyAll(fl.Colors.transparent),
+    );
+
+    return fl.SelectableText(
+      text,
+      style: style?.copyWith(overflow: fl.TextOverflow.ellipsis) ??
+          const fl.TextStyle(overflow: fl.TextOverflow.ellipsis),
+      textAlign: textAlign,
+      maxLines: maxLines,
+      contextMenuBuilder: (context, editableTextState) {
+        return fl.TapRegion(
+          onTapOutside: (_) => fl.ContextMenuController.removeAny(),
+          child: fl.TextButtonTheme(
+            data: fl.TextButtonThemeData(style: textButtonStyle),
+            child: fl.AdaptiveTextSelectionToolbar.buttonItems(
+              anchors: editableTextState.contextMenuAnchors,
+              buttonItems: editableTextState.contextMenuButtonItems,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/src/client/gui/lib/vm_details/ip_addresses.dart
+++ b/src/client/gui/lib/vm_details/ip_addresses.dart
@@ -1,6 +1,7 @@
-import 'package:flutter/material.dart' hide Tooltip;
+import 'package:flutter/material.dart' hide Tooltip, SelectableText;
 
 import '../extensions.dart';
+import '../selectable_text.dart';
 import '../tooltip.dart';
 
 class IpAddresses extends StatelessWidget {

--- a/src/client/gui/lib/vm_details/ip_addresses.dart
+++ b/src/client/gui/lib/vm_details/ip_addresses.dart
@@ -17,7 +17,7 @@ class IpAddresses extends StatelessWidget {
       Expanded(
         child: Tooltip(
           message: firstIp,
-          child: Text(firstIp.nonBreaking, overflow: TextOverflow.ellipsis),
+          child: SelectableText(firstIp.nonBreaking, maxLines: 1),
         ),
       ),
       if (restIps.isNotEmpty)

--- a/src/client/gui/lib/vm_details/memory_usage.dart
+++ b/src/client/gui/lib/vm_details/memory_usage.dart
@@ -21,7 +21,7 @@ class MemoryUsage extends StatelessWidget {
       color: value < 0.8 ? normalColor : almostFullColor,
     );
 
-    final label = Text(
+    final label = SelectableText(
       value != 0 ? '${_formatMemory(used)} / ${_formatMemory(total)}' : '-',
       style: const TextStyle(fontSize: 11),
     );

--- a/src/client/gui/lib/vm_details/memory_usage.dart
+++ b/src/client/gui/lib/vm_details/memory_usage.dart
@@ -1,4 +1,6 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide SelectableText;
+
+import '../selectable_text.dart';
 
 class MemoryUsage extends StatelessWidget {
   final String used;

--- a/src/client/gui/lib/vm_details/spec_input.dart
+++ b/src/client/gui/lib/vm_details/spec_input.dart
@@ -63,6 +63,21 @@ class SpecInput extends StatelessWidget {
           onSaved: onSaved,
           style: const TextStyle(color: Colors.black),
           validator: validator,
+          contextMenuBuilder: (context, editableTextState) {
+            final textButtonStyle = Theme.of(context).textButtonTheme.style?.copyWith(
+                  backgroundColor: const MaterialStatePropertyAll(Colors.transparent),
+                );
+            return TapRegion(
+              onTapOutside: (_) => ContextMenuController.removeAny(),
+              child: TextButtonTheme(
+                data: TextButtonThemeData(style: textButtonStyle),
+                child: AdaptiveTextSelectionToolbar.buttonItems(
+                  anchors: editableTextState.contextMenuAnchors,
+                  buttonItems: editableTextState.contextMenuButtonItems,
+                ),
+              ),
+            );
+          },
         ),
       ]),
     );

--- a/src/client/gui/lib/vm_details/vm_details_general.dart
+++ b/src/client/gui/lib/vm_details/vm_details_general.dart
@@ -76,11 +76,11 @@ class VmDetailsHeader extends ConsumerWidget {
 
     final list = [
       Expanded(
-        child: Text(
+        child: SelectableText(
           name.nonBreaking,
           style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w300),
           maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.start,
         ),
       ),
       locationButtons,
@@ -150,28 +150,28 @@ class GeneralDetails extends ConsumerWidget {
       width: 150,
       height: baseVmStatHeight,
       label: 'IMAGE',
-      child: Text(info.instanceInfo.currentRelease),
+      child: SelectableText(info.instanceInfo.currentRelease),
     );
 
     final privateIp = VmStat(
       width: 150,
       height: baseVmStatHeight,
       label: 'PRIVATE IP',
-      child: Text(info.instanceInfo.ipv4.firstOrNull ?? '-'),
+      child: SelectableText(info.instanceInfo.ipv4.firstOrNull ?? '-'),
     );
 
     final publicIp = VmStat(
       width: 150,
       height: baseVmStatHeight,
       label: 'PUBLIC IP',
-      child: Text(info.instanceInfo.ipv4.skip(1).firstOrNull ?? '-'),
+      child: SelectableText(info.instanceInfo.ipv4.skip(1).firstOrNull ?? '-'),
     );
 
     final created = VmStat(
       width: 140,
       height: baseVmStatHeight,
       label: 'CREATED',
-      child: Text(
+      child: SelectableText(
         DateFormat('yyyy-MM-dd HH:mm:ss')
             .format(info.instanceInfo.creationTimestamp.toDateTime()),
       ),
@@ -181,7 +181,7 @@ class GeneralDetails extends ConsumerWidget {
       width: 300,
       height: baseVmStatHeight,
       label: 'UPTIME',
-      child: Text(info.instanceInfo.uptime),
+      child: SelectableText(info.instanceInfo.uptime),
     );
 
     return Column(

--- a/src/client/gui/lib/vm_details/vm_details_general.dart
+++ b/src/client/gui/lib/vm_details/vm_details_general.dart
@@ -1,10 +1,11 @@
 import 'package:basics/basics.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide SelectableText;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../extensions.dart';
 import '../providers.dart';
+import '../selectable_text.dart';
 import 'cpu_sparkline.dart';
 import 'memory_usage.dart';
 import 'vm_action_buttons.dart';

--- a/src/client/gui/lib/vm_table/search_box.dart
+++ b/src/client/gui/lib/vm_table/search_box.dart
@@ -8,6 +8,10 @@ class SearchBox extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final textButtonStyle = Theme.of(context).textButtonTheme.style?.copyWith(
+          backgroundColor: const MaterialStatePropertyAll(Colors.transparent),
+        );
+
     return SizedBox(
       width: 220,
       child: TextField(
@@ -16,6 +20,18 @@ class SearchBox extends ConsumerWidget {
           suffixIcon: Icon(Icons.search),
         ),
         onChanged: (name) => ref.read(searchNameProvider.notifier).state = name,
+        contextMenuBuilder: (context, editableTextState) {
+          return TapRegion(
+            onTapOutside: (_) => ContextMenuController.removeAny(),
+            child: TextButtonTheme(
+              data: TextButtonThemeData(style: textButtonStyle),
+              child: AdaptiveTextSelectionToolbar.buttonItems(
+                anchors: editableTextState.contextMenuAnchors,
+                buttonItems: editableTextState.contextMenuButtonItems,
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/src/client/gui/lib/vm_table/vm_table_headers.dart
+++ b/src/client/gui/lib/vm_table/vm_table_headers.dart
@@ -1,10 +1,11 @@
 import 'package:basics/basics.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:flutter/material.dart' hide Tooltip;
+import 'package:flutter/material.dart' hide Tooltip, SelectableText;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../extensions.dart';
 import '../providers.dart';
+import '../selectable_text.dart';
 import '../sidebar.dart';
 import '../tooltip.dart';
 import '../vm_details/cpu_sparkline.dart';

--- a/src/client/gui/lib/vm_table/vm_table_headers.dart
+++ b/src/client/gui/lib/vm_table/vm_table_headers.dart
@@ -72,9 +72,9 @@ final headers = <TableHeader<VmInfo>>[
     minWidth: 70,
     cellBuilder: (info) {
       final image = info.instanceInfo.currentRelease;
-      return Text(
+      return SelectableText(
         image.isNotBlank ? image.nonBreaking : '-',
-        overflow: TextOverflow.ellipsis,
+        maxLines: 1,
       );
     },
   ),


### PR DESCRIPTION
closes #3821 

This PR changes most `Text` widgets in the Instances and VM Details pages to `SelectableText`
`SelectableText` does not support `overflow: ellipsis` so I have set `maxLines: 1` to ensure that table cells are still 1 line max.

I did not make the instance's name selectable in the Instances page because the name column has unique behavior implemented with `VMNameLink` where clicking it links to the instance's shell. Instead, the name of the instance on the Instance details/shell page is now selectable.

[Screencast_20250115_131745.webm](https://github.com/user-attachments/assets/b6780eb4-f88b-43c9-b30e-9da6c20b04c2)
