### PR TITLE
[gui] Open and close terminal tabs keyboard shortcuts

### DIFF
--- a/src/client/gui/lib/platform/linux.dart
+++ b/src/client/gui/lib/platform/linux.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 
 import '../settings/autostart_notifiers.dart';
 import '../vm_details/terminal.dart';
+import '../vm_details/terminal_tabs.dart';
 import 'platform.dart';
 
 class LinuxPlatform extends MpPlatform {
@@ -37,6 +38,10 @@ class LinuxPlatform extends MpPlatform {
             PasteTextIntent(SelectionChangedCause.keyboard),
         SingleActivator(LogicalKeyboardKey.insert, shift: true):
             PasteTextIntent(SelectionChangedCause.keyboard),
+        SingleActivator(LogicalKeyboardKey.keyW, control: true):
+            CloseTerminalIntent(),
+        SingleActivator(LogicalKeyboardKey.keyT, control: true):
+            AddTerminalIntent(),
         SingleActivator(LogicalKeyboardKey.equal, control: true):
             IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):

--- a/src/client/gui/lib/platform/macos.dart
+++ b/src/client/gui/lib/platform/macos.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 
 import '../settings/autostart_notifiers.dart';
 import '../vm_details/terminal.dart';
+import '../vm_details/terminal_tabs.dart';
 import 'platform.dart';
 
 class MacOSPlatform extends MpPlatform {
@@ -32,6 +33,10 @@ class MacOSPlatform extends MpPlatform {
             CopySelectionTextIntent.copy,
         SingleActivator(LogicalKeyboardKey.keyV, meta: true):
             PasteTextIntent(SelectionChangedCause.keyboard),
+        SingleActivator(LogicalKeyboardKey.keyW, meta: true):
+            CloseTerminalIntent(),
+        SingleActivator(LogicalKeyboardKey.keyT, meta: true):
+            AddTerminalIntent(),
         SingleActivator(LogicalKeyboardKey.equal, meta: true):
             IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.equal, meta: true, shift: true):

--- a/src/client/gui/lib/platform/windows.dart
+++ b/src/client/gui/lib/platform/windows.dart
@@ -8,6 +8,7 @@ import 'package:win32/win32.dart';
 
 import '../settings/autostart_notifiers.dart';
 import '../vm_details/terminal.dart';
+import '../vm_details/terminal_tabs.dart';
 import 'platform.dart';
 
 class WindowsPlatform extends MpPlatform {
@@ -39,6 +40,10 @@ class WindowsPlatform extends MpPlatform {
             PasteTextIntent(SelectionChangedCause.keyboard),
         SingleActivator(LogicalKeyboardKey.insert, shift: true):
             PasteTextIntent(SelectionChangedCause.keyboard),
+        SingleActivator(LogicalKeyboardKey.keyW, control: true):
+            CloseTerminalIntent(),
+        SingleActivator(LogicalKeyboardKey.keyT, control: true):
+            AddTerminalIntent(),
         SingleActivator(LogicalKeyboardKey.equal, control: true):
             IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):

--- a/src/client/gui/lib/vm_details/terminal_tabs.dart
+++ b/src/client/gui/lib/vm_details/terminal_tabs.dart
@@ -125,6 +125,14 @@ class Tab extends StatelessWidget {
   }
 }
 
+class CloseTerminalIntent extends Intent {
+  const CloseTerminalIntent();
+}
+
+class AddTerminalIntent extends Intent {
+  const AddTerminalIntent();
+}
+
 class TerminalTabs extends ConsumerWidget {
   final String name;
 
@@ -136,6 +144,14 @@ class TerminalTabs extends ConsumerWidget {
     final notifier = provider.notifier;
     final (:ids, :currentIndex) = ref.watch(provider);
 
+    void closeTab(int index) {
+      ref.read(notifier).remove(index);
+    }
+
+    void addTab() {
+      ref.read(notifier).add();
+    }
+
     final tabsAndShells = ids.mapIndexed((index, shellId) {
       final tab = ReorderableDragStartListener(
         key: ValueKey(shellId.id),
@@ -144,7 +160,7 @@ class TerminalTabs extends ConsumerWidget {
           title: 'Shell ${shellId.id}',
           selected: index == currentIndex,
           onTap: () => ref.read(notifier).setCurrent(index),
-          onClose: () => ref.read(notifier).remove(index),
+          onClose: () => closeTab(index),
         ),
       );
 
@@ -164,7 +180,7 @@ class TerminalTabs extends ConsumerWidget {
         hoverColor: Colors.white24,
         splashRadius: 10,
         icon: const Icon(Icons.add, color: Colors.white, size: 20),
-        onPressed: () => ref.read(notifier).add(),
+        onPressed: () => addTab(),
       ),
     );
 
@@ -187,13 +203,23 @@ class TerminalTabs extends ConsumerWidget {
       ),
     );
 
-    return Column(children: [
-      Container(
-        color: const Color(0xff222222),
-        height: 35,
-        child: tabList,
-      ),
-      Expanded(child: shellStack),
-    ]);
+    return Actions(
+      actions: {
+        CloseTerminalIntent: CallbackAction<CloseTerminalIntent>(
+          onInvoke: (_) => closeTab(currentIndex),
+        ),
+        AddTerminalIntent: CallbackAction<AddTerminalIntent>(
+          onInvoke: (_) => addTab(),
+        ),
+      },
+      child: Column(children: [
+        Container(
+          color: const Color(0xff222222),
+          height: 35,
+          child: tabList,
+        ),
+        Expanded(child: shellStack),
+      ]),
+    );
   }
 }


### PR DESCRIPTION
Tried playing around with the GUI and adding a change I'd personally like to see. Behaviour still isn't exactly how I'd like it. @andrei-toterman, a little help if you have time :)

Tabs open and close as expected with Ctrl+t/Ctrl+w or Cmd+t/Cmd+w when the vm is running and ssh connections can be made. However, if the vm is stopped (Terminal tabs are blank with the "Open shell" button), my keyboard shortcuts don't work. Maybe the intents/callback actions need to be in `terminal.dart` instead of `terminal_tabs.dart`, I'm not sure.