### PR TITLE
[ci] update clang-format to 16

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -29,7 +29,7 @@ runs:
 
   - name: Install clang-format
     shell: bash
-    run: sudo apt-get install --no-install-recommends --yes clang-format-12
+    run: sudo apt-get install --no-install-recommends --yes clang-format-16
 
   - name: Run clang-format through the diff
     shell: bash
@@ -37,7 +37,7 @@ runs:
       set -e -o pipefail
 
       # On pull requests, HEAD^1 will always be the merge base, so consider that diff for formatting.
-      git diff -U0 --no-color HEAD^1 | clang-format-diff-12 -p1 | tee ${HOME}/clang-diff
+      git diff -U0 --no-color HEAD^1 | clang-format-diff-16 -p1 | tee ${HOME}/clang-diff
       if [ "$( stat --printf='%s' ${HOME}/clang-diff )" -ne 0 ]; then
         echo "##[error] Please apply the above diff to correct formatting"
         exit 1


### PR DESCRIPTION
Lint action is broken because it can't find clang-format-12.
Fix stolen from [here](https://github.com/canonical/multipass/pull/3845/files#diff-b75b025d551d3387aae641b07b3d675985802e588607716e79373d0c3adceae8). Thanks, @georgeliao!