### PR TITLE
 Fix the snap qemu native mount regression

### DIFF
--- a/src/platform/backends/qemu/qemu_vm_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vm_process_spec.cpp
@@ -123,6 +123,10 @@ profile %1 flags=(attach_disconnected) {
   capability setgid,
   capability setuid,
 
+  # for bridge helper
+  capability net_admin,
+  capability net_raw,
+
   network inet stream,
   network inet6 stream,
 
@@ -154,7 +158,7 @@ profile %1 flags=(attach_disconnected) {
   /{usr/,}bin/cat rmix,
 
   # to execute bridge helper
-  %4/bin/bridge_helper,
+  %4/bin/bridge_helper ix,
 
   # for restore
   /{usr/,}bin/bash rmix,


### PR DESCRIPTION
Fix #3834
Possible explanation on the behavior we saw. 
1. The original code just added  `%4/bin/bridge_helper` without any permissions. The behavior for this case is the bridging feature can run with the permissions it needs and the mount folder lost its write permission somehow. The reason behind this is that `bridge_helper` operates in the unrestricted mode when no permissions are specified, meaning that it inherits all permissions and capabilities from the parent process. That is why the bridging feature is able to run. When AppArmor is in unrestricted mode (`%4/bin/bridge_helper` without explicit permissions), the mode may interfere with the rule order in the profile. More specifically, it can result in mounted folder permissions which is defined later in this profile being overridden or deprioritized. That is why the write permission issue occurs. 
2. If `%4/bin/bridge_helper ix` is used, AppArmor applies strict enforcement on the executable. In this case, it does not seem to disrupt the mount folder permissions setting, so the mount folder feature works properly. On the other side, since it is strict mode, we need to specify everything it requires to make the bridging works. That includes 
```
capability net_admin,
capability net_raw,
```

The key take away from this is always use explicit permissions (strict mode) on newly added binaries and find the minimal setup (permissions and capabilities) to make it work. 

The functional testing should cover the bridging feature (`multipass launch -n vm2 --network=mpqemubr0`) and the linux qemu native mount. 