### PR TITLE
updated vcpkg to 2024.02.14

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "ca7b1b15f548c25c766360593a2c732d56ed0133",
+  "builtin-baseline": "fba75d09065fcc76a25dcf386b1d00d33f5175af",
   "dependencies": [
     "poco",
     "grpc"


### PR DESCRIPTION
Updated the vcpkg from 2023.10.19~628 to 2024.02.14. This small update does not leap vcpkg to the latest version which is 2024.12.16, but it can fix the windows build without breaking the old grpc build. 