### PR TITLE
add Visual Studio and VSCode project configuration directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
+.vs
+.vscode
 cmake-build-*
 CMakeLists.txt.user
 build


### PR DESCRIPTION
This PR updates the .gitignore file to include the `.vs` and `.vscode` folders. These folders contain IDE-specific configuration files created by Visual Studio and Visual Studio Code, similar to the `.idea` folder for JetBrains IDEs that is already currently in the gitignore.