### PR TITLE
use CopyableText (click-to-copy) in GUI for instance info

### DIFF
--- a/src/client/gui/lib/copyable_text.dart
+++ b/src/client/gui/lib/copyable_text.dart
@@ -14,8 +14,10 @@ class CopyableText extends StatefulWidget {
 
 class _CopyableTextState extends State<CopyableText> {
   bool _copied = false;
+  bool get _isCopyable => widget.text != '-';
 
   void _copyToClipboard() async {
+    if (!_isCopyable) return;
     await Clipboard.setData(ClipboardData(text: widget.text));
     setState(() => _copied = true);
   }
@@ -28,6 +30,15 @@ class _CopyableTextState extends State<CopyableText> {
 
   @override
   Widget build(BuildContext context) {
+    Widget text = Text(
+      widget.text,
+      style: widget.style,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    if (!_isCopyable) return text;
+
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       onExit: (_) => _resetCopied(),
@@ -35,12 +46,7 @@ class _CopyableTextState extends State<CopyableText> {
         onTap: _copyToClipboard,
         child: Tooltip(
           message: _copied ? 'Copied' : 'Click to copy',
-          child: Text(
-            widget.text,
-            style: widget.style,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
+          child: text,
         ),
       ),
     );

--- a/src/client/gui/lib/copyable_text.dart
+++ b/src/client/gui/lib/copyable_text.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart' hide Tooltip;
 import 'package:flutter/services.dart';
+
 import 'tooltip.dart';
 
 class CopyableText extends StatefulWidget {
@@ -13,20 +14,7 @@ class CopyableText extends StatefulWidget {
 }
 
 class _CopyableTextState extends State<CopyableText> {
-  bool _copied = false;
-  bool get _isCopyable => widget.text != '-';
-
-  void _copyToClipboard() async {
-    if (!_isCopyable) return;
-    await Clipboard.setData(ClipboardData(text: widget.text));
-    setState(() => _copied = true);
-  }
-
-  void _resetCopied() {
-    if (_copied) {
-      setState(() => _copied = false);
-    }
-  }
+  var _copied = false;
 
   @override
   Widget build(BuildContext context) {
@@ -37,13 +25,17 @@ class _CopyableTextState extends State<CopyableText> {
       overflow: TextOverflow.ellipsis,
     );
 
-    if (!_isCopyable) return text;
+    // if there is no value, display "-"
+    if (widget.text == '-') return text;
 
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      onExit: (_) => _resetCopied(),
+      onExit: (_) => setState(() => _copied = false),
       child: GestureDetector(
-        onTap: _copyToClipboard,
+        onTap: () async {
+          await Clipboard.setData(ClipboardData(text: widget.text));
+          setState(() => _copied = true);
+        },
         child: Tooltip(
           message: _copied ? 'Copied' : 'Click to copy',
           child: text,

--- a/src/client/gui/lib/copyable_text.dart
+++ b/src/client/gui/lib/copyable_text.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart' hide Tooltip;
+import 'package:flutter/services.dart';
+import 'tooltip.dart';
+
+class CopyableText extends StatefulWidget {
+  final String text;
+  final TextStyle? style;
+
+  const CopyableText(this.text, {super.key, this.style});
+
+  @override
+  State<CopyableText> createState() => _CopyableTextState();
+}
+
+class _CopyableTextState extends State<CopyableText> {
+  bool _copied = false;
+
+  void _copyToClipboard() async {
+    await Clipboard.setData(ClipboardData(text: widget.text));
+    setState(() => _copied = true);
+  }
+
+  void _resetCopied() {
+    if (_copied) {
+      setState(() => _copied = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onExit: (_) => _resetCopied(),
+      child: GestureDetector(
+        onTap: _copyToClipboard,
+        child: Tooltip(
+          message: _copied ? 'Copied' : 'Click to copy',
+          child: Text(
+            widget.text,
+            style: widget.style,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/client/gui/lib/tooltip.dart
+++ b/src/client/gui/lib/tooltip.dart
@@ -37,26 +37,16 @@ class _TooltipState extends fl.State<Tooltip> {
   fl.Widget build(fl.BuildContext context) {
     return fl.TooltipVisibility(
       visible: widget.visible,
-      child: _forceShow
-          ? fl.Tooltip(
-              key: _key,
-              message: widget.message,
-              textAlign: fl.TextAlign.center,
-              decoration: fl.BoxDecoration(
-                color: const fl.Color(0xff111111),
-                borderRadius: fl.BorderRadius.circular(2),
-              ),
-              child: widget.child,
-            )
-          : fl.Tooltip(
-              message: widget.message,
-              textAlign: fl.TextAlign.center,
-              decoration: fl.BoxDecoration(
-                color: const fl.Color(0xff111111),
-                borderRadius: fl.BorderRadius.circular(2),
-              ),
-              child: widget.child,
-            ),
+      child: fl.Tooltip(
+        key: _forceShow ? _key : null,
+        message: widget.message,
+        textAlign: fl.TextAlign.center,
+        decoration: fl.BoxDecoration(
+          color: const fl.Color(0xff111111),
+          borderRadius: fl.BorderRadius.circular(2),
+        ),
+        child: widget.child,
+      ),
     );
   }
 }

--- a/src/client/gui/lib/tooltip.dart
+++ b/src/client/gui/lib/tooltip.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart' as fl;
 
-class Tooltip extends fl.StatelessWidget {
+class Tooltip extends fl.StatefulWidget {
   final fl.Widget child;
   final String message;
   final bool visible;
@@ -13,18 +13,50 @@ class Tooltip extends fl.StatelessWidget {
   });
 
   @override
+  fl.State<Tooltip> createState() => _TooltipState();
+}
+
+class _TooltipState extends fl.State<Tooltip> {
+  final _key = fl.GlobalKey<fl.TooltipState>();
+  bool _forceShow = false;
+
+  @override
+  void didUpdateWidget(Tooltip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.message != widget.message) {
+      setState(() => _forceShow = true);
+      Future.delayed(const Duration(milliseconds: 1), () {
+        if (mounted) {
+          setState(() => _forceShow = false);
+        }
+      });
+    }
+  }
+
+  @override
   fl.Widget build(fl.BuildContext context) {
     return fl.TooltipVisibility(
-      visible: visible,
-      child: fl.Tooltip(
-        message: message,
-        textAlign: fl.TextAlign.center,
-        decoration: fl.BoxDecoration(
-          color: const fl.Color(0xff111111),
-          borderRadius: fl.BorderRadius.circular(2),
-        ),
-        child: child,
-      ),
+      visible: widget.visible,
+      child: _forceShow
+          ? fl.Tooltip(
+              key: _key,
+              message: widget.message,
+              textAlign: fl.TextAlign.center,
+              decoration: fl.BoxDecoration(
+                color: const fl.Color(0xff111111),
+                borderRadius: fl.BorderRadius.circular(2),
+              ),
+              child: widget.child,
+            )
+          : fl.Tooltip(
+              message: widget.message,
+              textAlign: fl.TextAlign.center,
+              decoration: fl.BoxDecoration(
+                color: const fl.Color(0xff111111),
+                borderRadius: fl.BorderRadius.circular(2),
+              ),
+              child: widget.child,
+            ),
     );
   }
 }

--- a/src/client/gui/lib/tooltip.dart
+++ b/src/client/gui/lib/tooltip.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart' as fl;
 
-class Tooltip extends fl.StatefulWidget {
+class Tooltip extends fl.StatelessWidget {
   final fl.Widget child;
   final String message;
   final bool visible;
@@ -13,39 +13,18 @@ class Tooltip extends fl.StatefulWidget {
   });
 
   @override
-  fl.State<Tooltip> createState() => _TooltipState();
-}
-
-class _TooltipState extends fl.State<Tooltip> {
-  final _key = fl.GlobalKey<fl.TooltipState>();
-  bool _forceShow = false;
-
-  @override
-  void didUpdateWidget(Tooltip oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.message != widget.message) {
-      setState(() => _forceShow = true);
-      Future.delayed(const Duration(milliseconds: 1), () {
-        if (mounted) {
-          setState(() => _forceShow = false);
-        }
-      });
-    }
-  }
-
-  @override
   fl.Widget build(fl.BuildContext context) {
     return fl.TooltipVisibility(
-      visible: widget.visible,
+      visible: visible,
       child: fl.Tooltip(
-        key: _forceShow ? _key : null,
-        message: widget.message,
+        key: fl.Key(message),
+        message: message,
         textAlign: fl.TextAlign.center,
         decoration: fl.BoxDecoration(
           color: const fl.Color(0xff111111),
           borderRadius: fl.BorderRadius.circular(2),
         ),
-        child: widget.child,
+        child: child,
       ),
     );
   }

--- a/src/client/gui/lib/vm_details/ip_addresses.dart
+++ b/src/client/gui/lib/vm_details/ip_addresses.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart' hide Tooltip;
+import '../copyable_text.dart';
 
 import '../extensions.dart';
 import '../tooltip.dart';
 
 class IpAddresses extends StatelessWidget {
   final Iterable<String> ips;
+  final bool copyable;
 
-  const IpAddresses(this.ips, {super.key});
+  const IpAddresses(this.ips, {this.copyable = false, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -15,10 +17,12 @@ class IpAddresses extends StatelessWidget {
 
     return Row(children: [
       Expanded(
-        child: Tooltip(
-          message: firstIp,
-          child: Text(firstIp.nonBreaking, overflow: TextOverflow.ellipsis),
-        ),
+        child: copyable
+            ? CopyableText(firstIp)
+            : Tooltip(
+                message: firstIp,
+                child: Text(firstIp.nonBreaking, overflow: TextOverflow.ellipsis),
+              ),
       ),
       if (restIps.isNotEmpty)
         Badge.count(

--- a/src/client/gui/lib/vm_details/ip_addresses.dart
+++ b/src/client/gui/lib/vm_details/ip_addresses.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/material.dart' hide Tooltip;
-import '../copyable_text.dart';
 
+import '../copyable_text.dart';
 import '../extensions.dart';
 import '../tooltip.dart';
 
 class IpAddresses extends StatelessWidget {
   final Iterable<String> ips;
-  final bool copyable;
 
-  const IpAddresses(this.ips, {this.copyable = false, super.key});
+  const IpAddresses(this.ips, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -16,15 +15,7 @@ class IpAddresses extends StatelessWidget {
     final restIps = ips.skip(1).toList();
 
     return Row(children: [
-      Expanded(
-        child: copyable
-            ? CopyableText(firstIp)
-            : Tooltip(
-                message: firstIp,
-                child:
-                    Text(firstIp.nonBreaking, overflow: TextOverflow.ellipsis),
-              ),
-      ),
+      Expanded(child: CopyableText(firstIp)),
       if (restIps.isNotEmpty)
         Badge.count(
           count: restIps.length,

--- a/src/client/gui/lib/vm_details/ip_addresses.dart
+++ b/src/client/gui/lib/vm_details/ip_addresses.dart
@@ -21,7 +21,8 @@ class IpAddresses extends StatelessWidget {
             ? CopyableText(firstIp)
             : Tooltip(
                 message: firstIp,
-                child: Text(firstIp.nonBreaking, overflow: TextOverflow.ellipsis),
+                child:
+                    Text(firstIp.nonBreaking, overflow: TextOverflow.ellipsis),
               ),
       ),
       if (restIps.isNotEmpty)

--- a/src/client/gui/lib/vm_details/vm_details_general.dart
+++ b/src/client/gui/lib/vm_details/vm_details_general.dart
@@ -12,51 +12,7 @@ import 'vm_action_buttons.dart';
 import 'vm_details.dart';
 import 'vm_status_icon.dart';
 import '../tooltip.dart';
-
-class CopyableText extends StatefulWidget {
-  final String text;
-  final TextStyle? style;
-
-  const CopyableText(this.text, {super.key, this.style});
-
-  @override
-  State<CopyableText> createState() => _CopyableTextState();
-}
-
-class _CopyableTextState extends State<CopyableText> {
-  bool _copied = false;
-
-  void _copyToClipboard() async {
-    await Clipboard.setData(ClipboardData(text: widget.text));
-    setState(() => _copied = true);
-  }
-
-  void _resetCopied() {
-    if (_copied) {
-      setState(() => _copied = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onExit: (_) => _resetCopied(),
-      child: GestureDetector(
-        onTap: _copyToClipboard,
-        child: Tooltip(
-          message: _copied ? 'Copied' : 'Click to copy',
-          child: Text(
-            widget.text,
-            style: widget.style,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ),
-      ),
-    );
-  }
-}
+import '../copyable_text.dart';
 
 class VmDetailsHeader extends ConsumerWidget {
   final String name;

--- a/src/client/gui/lib/vm_details/vm_details_general.dart
+++ b/src/client/gui/lib/vm_details/vm_details_general.dart
@@ -1,18 +1,17 @@
 import 'package:basics/basics.dart';
-import 'package:flutter/material.dart' hide Tooltip;
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
-import 'package:flutter/services.dart';
 
+import '../copyable_text.dart';
 import '../extensions.dart';
 import '../providers.dart';
+import '../tooltip.dart';
 import 'cpu_sparkline.dart';
 import 'memory_usage.dart';
 import 'vm_action_buttons.dart';
 import 'vm_details.dart';
 import 'vm_status_icon.dart';
-import '../tooltip.dart';
-import '../copyable_text.dart';
 
 class VmDetailsHeader extends ConsumerWidget {
   final String name;

--- a/src/client/gui/lib/vm_table/vm_table_headers.dart
+++ b/src/client/gui/lib/vm_table/vm_table_headers.dart
@@ -3,6 +3,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart' hide Tooltip;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../copyable_text.dart';
 import '../extensions.dart';
 import '../providers.dart';
 import '../sidebar.dart';
@@ -14,7 +15,6 @@ import '../vm_details/vm_status_icon.dart';
 import 'search_box.dart';
 import 'table.dart';
 import 'vms.dart';
-import '../copyable_text.dart';
 
 final headers = <TableHeader<VmInfo>>[
   TableHeader(
@@ -73,28 +73,20 @@ final headers = <TableHeader<VmInfo>>[
     minWidth: 70,
     cellBuilder: (info) {
       final image = info.instanceInfo.currentRelease;
-      return CopyableText(
-        image.isNotBlank ? image.nonBreaking : '-',
-      );
+      return CopyableText(image.isNotBlank ? image.nonBreaking : '-');
     },
   ),
   TableHeader(
     name: 'PRIVATE IP',
     width: 140,
     minWidth: 100,
-    cellBuilder: (info) => IpAddresses(
-      info.instanceInfo.ipv4.take(1),
-      copyable: true,
-    ),
+    cellBuilder: (info) => IpAddresses(info.instanceInfo.ipv4.take(1)),
   ),
   TableHeader(
     name: 'PUBLIC IP',
     width: 140,
     minWidth: 100,
-    cellBuilder: (info) => IpAddresses(
-      info.instanceInfo.ipv4.skip(1),
-      copyable: true,
-    ),
+    cellBuilder: (info) => IpAddresses(info.instanceInfo.ipv4.skip(1)),
   ),
 ];
 

--- a/src/client/gui/lib/vm_table/vm_table_headers.dart
+++ b/src/client/gui/lib/vm_table/vm_table_headers.dart
@@ -14,6 +14,7 @@ import '../vm_details/vm_status_icon.dart';
 import 'search_box.dart';
 import 'table.dart';
 import 'vms.dart';
+import '../copyable_text.dart';
 
 final headers = <TableHeader<VmInfo>>[
   TableHeader(
@@ -72,9 +73,8 @@ final headers = <TableHeader<VmInfo>>[
     minWidth: 70,
     cellBuilder: (info) {
       final image = info.instanceInfo.currentRelease;
-      return Text(
+      return CopyableText(
         image.isNotBlank ? image.nonBreaking : '-',
-        overflow: TextOverflow.ellipsis,
       );
     },
   ),
@@ -82,13 +82,19 @@ final headers = <TableHeader<VmInfo>>[
     name: 'PRIVATE IP',
     width: 140,
     minWidth: 100,
-    cellBuilder: (info) => IpAddresses(info.instanceInfo.ipv4.take(1)),
+    cellBuilder: (info) => IpAddresses(
+      info.instanceInfo.ipv4.take(1),
+      copyable: true,
+    ),
   ),
   TableHeader(
     name: 'PUBLIC IP',
     width: 140,
     minWidth: 100,
-    cellBuilder: (info) => IpAddresses(info.instanceInfo.ipv4.skip(1)),
+    cellBuilder: (info) => IpAddresses(
+      info.instanceInfo.ipv4.skip(1),
+      copyable: true,
+    ),
   ),
 ];
 


### PR DESCRIPTION
closes https://github.com/canonical/multipass/issues/3821

This pull request introduces a new `CopyableText` widget and updates several components to use this widget for improved text copy functionality. Additionally, it modifies the `Tooltip` widget to be stateful to handle dynamic changes in the tooltip message.

New `CopyableText` widget:

* [`src/client/gui/lib/copyable_text.dart`](diffhunk://#diff-807730c5b270aaec0c016a8cd65a89c673ffaf2001e8925b07d3561e27ea48f0R1-R48): Created a new `CopyableText` widget that allows text to be copied to the clipboard with a click and displays a tooltip indicating the copy status.

Updates to `Tooltip` widget:

* [`src/client/gui/lib/tooltip.dart`](diffhunk://#diff-5665636198f18253cea1d1c8687fe9ee297ee52a18c32c76855bb3bf8c840d96L3-R3): Changed `Tooltip` from a stateless to a stateful widget to handle updates to the tooltip message dynamically.

Integration of `CopyableText` widget:

* [`src/client/gui/lib/vm_details/ip_addresses.dart`](diffhunk://#diff-5ed97cb527799f2cb62f5aa6deda214666421ed100a40e858aae76f6c466ef13R2-R11): Updated the `IpAddresses` widget to optionally use `CopyableText` for IP addresses, enabling copy functionality.
* [`src/client/gui/lib/vm_details/vm_details_general.dart`](diffhunk://#diff-e22cd60e0d02726099977073780841a61c36db96aed48c9626fd4fe056e2b346L2-R5): Replaced several instances of `Text` with `CopyableText` in the `VmDetailsHeader` and `GeneralDetails` widgets to allow copying of VM details such as name, release, and IP addresses.
* [`src/client/gui/lib/vm_table/vm_table_headers.dart`](diffhunk://#diff-16b6bba91b3229e81230af1ca9bfcfd0a5d01630e71ac6037306aa78e945e497R17): Updated the VM table headers to use `CopyableText` for displaying and copying VM image and IP addresses.

[Screencast_20250115_121606.webm](https://github.com/user-attachments/assets/c31d2743-e323-4c27-a4e6-26dff6f00a3d)
