### PR TITLE
[compiler] fix the wrongly appended warning flags on gcc compiler.

### DIFF
--- a/src/cert/CMakeLists.txt
+++ b/src/cert/CMakeLists.txt
@@ -22,12 +22,10 @@ add_library(cert STATIC
 target_include_directories(cert PRIVATE
   ${OPENSSL_INCLUDE_DIR})
 
-foreach(flag -Wno-nested-anon-types -Wno-gnu -Wno-pedantic -Wno-ignored-qualifiers)
-  check_cxx_compiler_flag(${flag} SUPPORTED)
-  if(SUPPORTED)
-    target_compile_options(cert PRIVATE ${flag})
-  endif()
-endforeach()
+target_compile_options(cert PRIVATE
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-nested-anon-types -Wno-gnu -Wno-pedantic -Wno-ignored-qualifiers>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-pedantic -Wno-ignored-qualifiers>
+)
 
 target_link_libraries(cert
   fmt


### PR DESCRIPTION
```
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-gnu’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-nested-anon-types’ may have been intended to silence earlier diagnostics
```
The original implementation uses `check_cxx_compiler_flag`, and the cmake function does not seem to return the expected `SUPPORTED` value. As a result, `-Wno-nested-anon-types -Wno-gnu` two warnings flags that are clang-only can pass gcc check and get appended to gcc. To verify this, `make clean && make cert` in the linux + gcc environment will show the message above. The fix is simple as well, append the flags explicitly to respective compilers. 

https://warthogs.atlassian.net/browse/MULTI-1766