### PR TITLE
Fix gui launch bridged error

### DIFF
--- a/src/client/gui/lib/catalogue/launch_form.dart
+++ b/src/client/gui/lib/catalogue/launch_form.dart
@@ -117,7 +117,7 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
         final message = networks.isEmpty
             ? 'No networks found.'
             : validBridgedNetwork
-                ? "Connect to the bridged network.\nOnce connection is established, you won't be able to unset it."
+                ? "Connect to the bridged network.\nOnce established, you won't be able to unset the connection."
                 : 'No valid bridged network is set.\nYou can set one in the Settings page.';
 
         return Switch(

--- a/src/client/gui/lib/settings/virtualization_settings.dart
+++ b/src/client/gui/lib/settings/virtualization_settings.dart
@@ -42,8 +42,8 @@ class VirtualizationSettings extends ConsumerWidget {
         Dropdown<String>(
           label: 'Bridged network',
           width: 260,
-          value: networks.contains(bridgedNetwork) ? bridgedNetwork : null,
-          items: Map.fromIterable(networks),
+          value: networks.contains(bridgedNetwork) ? bridgedNetwork : '',
+          items: {'': 'None', ...Map.fromIterable(networks)},
           onChanged: (value) {
             ref.read(bridgedNetworkProvider.notifier).set(value!).onError(
                 ref.notifyError((e) => 'Failed to set bridged network: $e'));

--- a/src/client/gui/lib/switch.dart
+++ b/src/client/gui/lib/switch.dart
@@ -6,6 +6,7 @@ class Switch extends StatelessWidget {
   final String label;
   final bool trailingSwitch;
   final double size;
+  final bool enabled;
 
   const Switch({
     super.key,
@@ -14,6 +15,7 @@ class Switch extends StatelessWidget {
     this.label = '',
     this.trailingSwitch = false,
     this.size = 25,
+    this.enabled = true,
   });
 
   @override
@@ -22,10 +24,10 @@ class Switch extends StatelessWidget {
       height: size,
       child: FittedBox(
         child: CupertinoSwitch(
-          activeColor: CupertinoColors.activeBlue,
-          trackColor: const Color(0xffd9d9d9),
+          activeTrackColor: CupertinoColors.activeBlue,
+          inactiveTrackColor: const Color(0xffd9d9d9),
           value: value,
-          onChanged: onChanged,
+          onChanged: enabled ? onChanged : null,
         ),
       ),
     );

--- a/src/client/gui/lib/vm_details/vm_details_bridge.dart
+++ b/src/client/gui/lib/vm_details/vm_details_bridge.dart
@@ -54,7 +54,7 @@ class _BridgedDetailsState extends ConsumerState<BridgedDetails> {
         final message = networks.isEmpty
             ? 'No networks found.'
             : validBridgedNetwork
-                ? "Once connection is established, you won't be able to unset it."
+                ? "Once established, you won't be able to unset the connection."
                 : 'No valid bridged network is set.';
 
         return CheckboxListTile(


### PR DESCRIPTION
This PR introduces the following changes:
- when launching an instance with some mounts specified, if the reply stream of the launch RPC yielded an error, the launch operation would not end early, and it would proceed to attempt the mounts. now, instead of yielding directly from the launch reply stream, we use `await for` to iterate over the stream and manually yield the replies. this turns errors from the stream into exceptions that are thrown, interrupting the launch process early, so mounts are no longer attempted
- we now allow our custom `Switch` to be conditionally disabled. there were also some minor changes to it, related to using newer styling properties in place of deprecated ones, with no effect to visuals
- in the launch form, we check if a bridged network was set correctly, and if not, we disable the switch for connecting to the bridged network, with an appropriate message
- we now allow un-setting the bridged network from the Settings page, by introducing a 'None' option, equivalent to `multipass set local.bridged-network=''`

fix #3881
MULTI-1764