### PR TITLE
Fix transfer only partially transferring

### DIFF
--- a/src/ssh/sftp_client.cpp
+++ b/src/ssh/sftp_client.cpp
@@ -330,10 +330,12 @@ void SFTPClient::do_push_file(std::istream& source, const fs::path& target_path)
     if (!remote_file)
         throw SFTPError{"cannot open remote file {}: {}", target_path, ssh_get_error(sftp->session)};
 
+    // create an uninitialized buffer to use.
     const auto max_write = sftp_limits(sftp.get())->max_write_length;
-    std::vector<char> buffer(max_write);
-    while (auto r = source.read(buffer.data(), buffer.size()).gcount())
-        if (sftp_write(remote_file.get(), buffer.data(), r) < 0)
+    const std::unique_ptr<char[]> buffer{new char[max_write]};
+
+    while (auto r = source.read(buffer.get(), max_write).gcount())
+        if (sftp_write(remote_file.get(), buffer.get(), r) < 0)
             throw SFTPError{"cannot write to remote file {}: {}", target_path, ssh_get_error(sftp->session)};
 }
 
@@ -343,14 +345,16 @@ void SFTPClient::do_pull_file(const fs::path& source_path, std::ostream& target)
     if (!remote_file)
         throw SFTPError{"cannot open remote file {}: {}", source_path, ssh_get_error(sftp->session)};
 
+    // create an uninitialized buffer to use.
     const auto max_read = sftp_limits(sftp.get())->max_read_length;
-    std::vector<char> buffer(max_read);
-    while (auto r = sftp_read(remote_file.get(), buffer.data(), buffer.size()))
+    const std::unique_ptr<char[]> buffer{new char[max_read]};
+
+    while (auto r = sftp_read(remote_file.get(), buffer.get(), max_read))
     {
         if (r < 0)
             throw SFTPError{"cannot read from remote file {}: {}", source_path, ssh_get_error(sftp->session)};
 
-        target.write(buffer.data(), r);
+        target.write(buffer.get(), r);
     }
 }
 

--- a/tests/test_sftp_client.cpp
+++ b/tests/test_sftp_client.cpp
@@ -81,6 +81,8 @@ struct SFTPClient : public testing::Test
     MockScope<decltype(mock_sftp_new)> sftp_new;
     MockScope<decltype(mock_sftp_free)> free_sftp;
 
+    sftp_limits_struct limits{32768, 32768, 32768, 0};
+
     const mpt::StubSSHKeyProvider key_provider;
     mpt::MockSSHTestFixture mock_ssh_test_fixture;
 
@@ -115,7 +117,10 @@ TEST_F(SFTPClient, throws_when_failed_to_init)
 
 TEST_F(SFTPClient, is_dir)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
 
     auto mocked_sftp_stat = MOCK(sftp_stat);
     auto sftp_client = make_sftp_client();
@@ -132,7 +137,10 @@ TEST_F(SFTPClient, push_file_success)
 {
     std::string test_data = "test_data";
 
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_read(source_path, _))
@@ -159,7 +167,10 @@ TEST_F(SFTPClient, push_file_success)
 
 TEST_F(SFTPClient, push_file_cannot_open_source)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     auto err = EACCES;
@@ -179,7 +190,10 @@ TEST_F(SFTPClient, push_file_cannot_open_source)
 
 TEST_F(SFTPClient, push_file_cannot_open_target)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_read(source_path, _)).WillOnce(Return(std::make_unique<std::stringstream>()));
@@ -197,7 +211,10 @@ TEST_F(SFTPClient, push_file_cannot_write_target)
 {
     std::string test_data = "test_data";
 
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_read(source_path, _))
@@ -218,7 +235,10 @@ TEST_F(SFTPClient, push_file_cannot_read_source)
 {
     std::string test_data = "test_data";
 
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -248,7 +268,10 @@ TEST_F(SFTPClient, push_file_cannot_set_perms)
 {
     std::string test_data = "test_data";
 
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(false));
     EXPECT_CALL(*mock_sftp_utils, get_remote_file_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_read(source_path, _))
@@ -274,7 +297,10 @@ TEST_F(SFTPClient, pull_file_success)
 {
     std::string test_data = "test_data";
 
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     std::stringstream test_file;
@@ -307,7 +333,10 @@ TEST_F(SFTPClient, pull_file_success)
 
 TEST_F(SFTPClient, pull_file_cannot_open_source)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(); });
     EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_write(target_path, _)).WillOnce(Return(std::make_unique<std::stringstream>()));
@@ -323,7 +352,10 @@ TEST_F(SFTPClient, pull_file_cannot_open_source)
 
 TEST_F(SFTPClient, pull_file_cannot_open_target)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(); });
     EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
     auto err = EACCES;
@@ -343,7 +375,10 @@ TEST_F(SFTPClient, pull_file_cannot_open_target)
 
 TEST_F(SFTPClient, pull_file_cannot_write_target)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto test_file = std::make_unique<std::stringstream>();
@@ -372,7 +407,10 @@ TEST_F(SFTPClient, pull_file_cannot_write_target)
 
 TEST_F(SFTPClient, pull_file_cannot_read_source)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(); });
     EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_write(target_path, _)).WillOnce(Return(std::make_unique<std::stringstream>()));
@@ -390,7 +428,10 @@ TEST_F(SFTPClient, pull_file_cannot_read_source)
 
 TEST_F(SFTPClient, pull_file_cannot_set_perms)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_sftp_utils, get_local_file_target(source_path, target_path, _)).WillOnce(Return(target_path));
     EXPECT_CALL(*mock_file_ops, open_write(target_path, _)).WillOnce(Return(std::make_unique<std::stringstream>()));
     REPLACE(sftp_open, [](auto sftp, auto...) { return get_dummy_sftp_file(sftp); });
@@ -410,7 +451,10 @@ TEST_F(SFTPClient, pull_file_cannot_set_perms)
 
 TEST_F(SFTPClient, push_dir_success_regular)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -449,7 +493,10 @@ TEST_F(SFTPClient, push_dir_success_regular)
 
 TEST_F(SFTPClient, push_dir_success_dir)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -480,7 +527,10 @@ TEST_F(SFTPClient, push_dir_success_dir)
 
 TEST_F(SFTPClient, push_dir_fail_dir)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -513,7 +563,10 @@ TEST_F(SFTPClient, push_dir_fail_dir)
 
 TEST_F(SFTPClient, push_dir_success_symlink)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -543,7 +596,10 @@ TEST_F(SFTPClient, push_dir_success_symlink)
 
 TEST_F(SFTPClient, push_dir_cannot_read_symlink)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -576,7 +632,10 @@ TEST_F(SFTPClient, push_dir_cannot_read_symlink)
 
 TEST_F(SFTPClient, push_dir_cannot_create_symlink)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -610,7 +669,10 @@ TEST_F(SFTPClient, push_dir_cannot_create_symlink)
 
 TEST_F(SFTPClient, push_dir_symlink_over_dir)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -641,7 +703,10 @@ TEST_F(SFTPClient, push_dir_symlink_over_dir)
 
 TEST_F(SFTPClient, push_dir_unknown_file_type)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -668,7 +733,10 @@ TEST_F(SFTPClient, push_dir_unknown_file_type)
 
 TEST_F(SFTPClient, push_dir_open_iter_fail)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_sftp_utils, get_remote_dir_target(_, source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -687,7 +755,10 @@ TEST_F(SFTPClient, push_dir_open_iter_fail)
 
 TEST_F(SFTPClient, push_dir_cannot_access_target)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
 
     auto err = std::make_error_code(std::errc::permission_denied);
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce([&](auto, std::error_code& e) {
@@ -703,7 +774,10 @@ TEST_F(SFTPClient, push_dir_cannot_access_target)
 
 TEST_F(SFTPClient, push_dir_r_not_specified)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_file_ops, is_directory(source_path, _)).WillOnce(Return(true));
 
     auto sftp_client = make_sftp_client();
@@ -715,7 +789,10 @@ TEST_F(SFTPClient, push_dir_r_not_specified)
 
 TEST_F(SFTPClient, pull_dir_success_regular)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
     auto iter = std::make_unique<mpt::MockSFTPDirIterator>();
@@ -767,7 +844,10 @@ TEST_F(SFTPClient, pull_dir_success_regular)
 
 TEST_F(SFTPClient, pull_dir_success_dir)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
     EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -788,7 +868,10 @@ TEST_F(SFTPClient, pull_dir_success_dir)
 
 TEST_F(SFTPClient, pull_dir_fail_dir)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
     EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -818,7 +901,10 @@ TEST_F(SFTPClient, pull_dir_fail_dir)
 
 TEST_F(SFTPClient, pull_dir_success_symlink)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
     EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -843,7 +929,10 @@ TEST_F(SFTPClient, pull_dir_success_symlink)
 
 TEST_F(SFTPClient, pull_dir_cannot_read_symlink)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
     EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -869,7 +958,10 @@ TEST_F(SFTPClient, pull_dir_cannot_read_symlink)
 
 TEST_F(SFTPClient, pull_dir_cannot_create_symlink)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
     EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -898,7 +990,10 @@ TEST_F(SFTPClient, pull_dir_cannot_create_symlink)
 
 TEST_F(SFTPClient, pull_dir_symlink_over_dir)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
     EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -923,7 +1018,10 @@ TEST_F(SFTPClient, pull_dir_symlink_over_dir)
 
 TEST_F(SFTPClient, pull_dir_unknown_file_type)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
     EXPECT_CALL(*mock_sftp_utils, get_local_dir_target(source_path, target_path, _)).WillOnce(Return(target_path));
 
@@ -945,7 +1043,10 @@ TEST_F(SFTPClient, pull_dir_unknown_file_type)
 
 TEST_F(SFTPClient, pull_dir_r_not_specified)
 {
-    REPLACE(sftp_init, [](auto...) { return SSH_OK; });
+    REPLACE(sftp_init, [this](sftp_session sftp) {
+        sftp->limits = &limits;
+        return SSH_OK;
+    });
     REPLACE(sftp_stat, [](auto...) { return get_dummy_sftp_attr(SSH_FILEXFER_TYPE_DIRECTORY); });
 
     auto sftp_client = make_sftp_client();


### PR DESCRIPTION
Fixes the issue of `multipass transfer` only transferring some chunks of the file. This uses `sftp_limits` instead of the constant `65536u` to determine the correct buffer size for SFTP reads and writes.

Fixes #3892 
MULTI-1768