### PR TITLE
fix #3898 by adding -fPIC to xz-embedded

### DIFF
--- a/3rd-party/xz-decoder/CMakeLists.txt
+++ b/3rd-party/xz-decoder/CMakeLists.txt
@@ -26,5 +26,7 @@ add_library(xz-embedded STATIC
   xz-embedded/linux/lib/xz/xz_dec_stream.c
 )
 
+set_property(TARGET xz-embedded PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(xz-embedded INTERFACE
   xz-embedded/linux/include/linux)


### PR DESCRIPTION
Fix #3898 by enabling `-fPIC` for the 3rd-party dep  `xz-embedded`. @ricab 