### PR TITLE
[gui] update tray menu dep so that it has a license

### DIFF
--- a/src/client/gui/pubspec.lock
+++ b/src/client/gui/pubspec.lock
@@ -742,8 +742,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "7c1394c"
-      resolved-ref: "7c1394c46aac4598ebdd3fa6670e4ea2904a4d31"
+      ref: cef5b8f
+      resolved-ref: cef5b8f60d7b2717c6f2eef2163a8e11de3b8d3d
       url: "https://github.com/andrei-toterman/tray_menu.git"
     source: git
     version: "0.0.1"

--- a/src/client/gui/pubspec.yaml
+++ b/src/client/gui/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   tray_menu:
     git:
       url: https://github.com/andrei-toterman/tray_menu.git
-      ref: 7c1394c
+      ref: cef5b8f
   two_dimensional_scrollables: ^0.3.3
   url_launcher: ^6.3.1
   win32: ^5.10.0


### PR DESCRIPTION
Before, this dependency had no license at all. Now it has a LGPL3 license, so we should include that as well.