### PR TITLE
Lexically normal mount paths (fix #3733)

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -73,6 +73,7 @@ QString backend_directory_path(const Path& path, const QString& subdirectory);
 std::string filename_for(const std::string& path);
 std::string contents_of(const multipass::Path& file_path);
 bool invalid_target_path(const QString& target_path);
+std::string make_abspath(const QString& input_path);
 QTemporaryFile create_temp_file_with_path(const QString& filename_template);
 void remove_directories(const std::vector<QString>& dirs);
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1928,7 +1928,7 @@ try // clang-format on
         const auto q_target_path = path_entry.target_path().empty()
                                        ? MP_UTILS.default_mount_target(QString::fromStdString(request->source_path()))
                                        : QDir::cleanPath(QString::fromStdString(path_entry.target_path()));
-        const auto target_path = q_target_path.toStdString();
+        const auto target_path = mp::utils::make_abspath(q_target_path);
 
         auto it = operative_instances.find(name);
         if (it == operative_instances.end())
@@ -1938,7 +1938,7 @@ try // clang-format on
         }
         auto& vm = it->second;
 
-        if (mp::utils::invalid_target_path(q_target_path))
+        if (mp::utils::invalid_target_path(QString::fromStdString(target_path)))
         {
             add_fmt_to(errors, "unable to mount to \"{}\"", target_path);
             continue;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -41,6 +41,7 @@
 #include <array>
 #include <cassert>
 #include <cctype>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <random>
@@ -148,6 +149,18 @@ bool mp::utils::valid_hostname(const std::string& name_string)
     QRegularExpression matcher{QRegularExpression::anchoredPattern("^([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])")};
 
     return matcher.match(QString::fromStdString(name_string)).hasMatch();
+}
+
+std::string mp::utils::make_abspath(const QString& input_path)
+{
+    const fs::path base_path("/home/ubuntu");           // Base path for relative paths
+    const fs::path path_obj = input_path.toStdString(); // Convert QString to std::string
+
+    if (path_obj.is_absolute())
+    {
+        return path_obj.lexically_normal().string(); // Return as string if already absolute
+    }
+    return (fs::absolute(base_path / path_obj)).lexically_normal().string(); // Convert to absolute path
 }
 
 bool mp::utils::invalid_target_path(const QString& target_path)


### PR DESCRIPTION
### Fixes for #3733 and Additional Issues Found During Inspection

This PR addresses the problems outlined in #3733, along with some related issues discovered during review. Details below.

### Issues Fixed

#### Relative Paths Incorrectly Resolving to `/home/ubuntu`

The issue occurs when relative paths unintentionally resolve to `/home/ubuntu`, allowing unexpected mounts. Here’s how to reproduce it (same steps as in the issue, repeated for clarity):

```bash
$ mkdir foodir
$ multipass delete -p foo
$ multipass launch --name foo

# Expected to fail, as it does:
$ multipass mount foodir foo:/home/ubuntu  
mount failed: The following errors occurred:
unable to mount to "/home/ubuntu"

# Expected not to work, but it does (matches /home/ubuntu):
$ multipass mount foodir foo:.              
$ multipass mount foodir foo:../ubuntu      
```

#### Relative Paths Allowing Mounts to Restricted Directories

Similar path resolution issues allowed mounting to restricted locations such as `/dev/`, `/`:

```bash
# Expected not to work, but it does (matches /dev):
$ multipass mount foodir foo:../../dev  

# Expected not to work, but it does (matches /):
$ multipass mount foodir foo:../..          
```


#### Issues with Non-Normalized Paths Causing Duplicate Entries

Paths should be normalized before being stored in [vm_mounts](https://github.com/canonical/multipass/blob/724933cbe35e7ec622da63ca4ea19ede668c82c1/src/daemon/daemon.cpp#L1958) to prevent different representations of the same path from being treated as separate entries. Without normalization, paths like `/home/foo` and `../foo` are considered distinct, leading to inconsistencies.

```bash
# Expected to work, and it does:
$ multipass mount foodir foo:/home/foo                     

# Expected NOT to work, and correctly fails (absolute paths are handled properly):
$ multipass mount foodir foo:/home/../home/foo  
mount failed: The following errors occurred:
"/home/foo" is already mounted in 'foo'

# Expected not to work, but it does:
$ multipass mount foodir foo:../foo                                
```

---

#### Fix Implementation

A new function, make_abspath, has been added to src/utils/utils.cpp.

- Converts relative paths to absolute paths, defaulting from /home/ubuntu.
- Guarantees unique, normalized paths for each mount, preventing duplicate entries.

#### Validation & Tests After Fixes

```bash
$ multipass delete -p foo
$ multipass launch --name foo
$ multipass mount foodir foo:/home/ubuntu
mount failed: The following errors occurred:
unable to mount to "/home/ubuntu"
$ multipass mount foodir foo:.
mount failed: The following errors occurred:
unable to mount to "/home/ubuntu"
$ multipass mount foodir foo:../ubuntu
mount failed: The following errors occurred:
unable to mount to "/home/ubuntu"
$ multipass mount foodir foo:../../dev
mount failed: The following errors occurred:
unable to mount to "/dev"
$ multipass mount foodir foo:../..
mount failed: The following errors occurred:
unable to mount to "/"
$ multipass mount foodir foo:/home/foo
$ multipass mount foodir foo:/home/../home/foo
mount failed: The following errors occurred:
"/home/foo" is already mounted in 'foo'
$ multipass mount foodir foo:../foo
mount failed: The following errors occurred:
"/home/foo" is already mounted in 'foo'
```
