### PR TITLE
Fix Windows GUI crash on close

### DIFF
--- a/src/client/gui/windows/runner/flutter_window.cpp
+++ b/src/client/gui/windows/runner/flutter_window.cpp
@@ -7,7 +7,9 @@
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
 
-FlutterWindow::~FlutterWindow() {}
+FlutterWindow::~FlutterWindow() {
+    this->OnDestroy();
+}
 
 bool FlutterWindow::OnCreate() {
   if (!Win32Window::OnCreate()) {


### PR DESCRIPTION
Previously the GUI would always crash when the GUI is closed. This PR makes it so the GUI does not crash when it is closed. The issue was due to destructor call ordering for the GUI Window. FlutterWindow (subclass of Win32Window) would begin destruction which destructs the FlutterViewController and then the Win32Window base class. The FlutterViewController is registered to a Windows callback that is removed when Win32Window is destructed, but since the FlutterViewController gets destructed before the Win32Window there is some time where the callback is still active but the FlutterViewController is in an invalid state.

MULTI-1711
