### PR TITLE
add daemon gRPC boilerplate for AZs

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -579,6 +579,8 @@ auto connect_rpc(mp::DaemonRpc& rpc, mp::Daemon& daemon)
     QObject::connect(&rpc, &mp::DaemonRpc::on_snapshot, &daemon, &mp::Daemon::snapshot);
     QObject::connect(&rpc, &mp::DaemonRpc::on_restore, &daemon, &mp::Daemon::restore);
     QObject::connect(&rpc, &mp::DaemonRpc::on_daemon_info, &daemon, &mp::Daemon::daemon_info);
+    QObject::connect(&rpc, &mp::DaemonRpc::on_zones, &daemon, &mp::Daemon::zones);
+    QObject::connect(&rpc, &mp::DaemonRpc::on_zones_state, &daemon, &mp::Daemon::zones_state);
 }
 
 enum class InstanceGroup
@@ -2793,6 +2795,37 @@ try // clang-format on
     response.set_memory(MP_PLATFORM.get_total_ram());
 
     server->Write(response);
+    status_promise->set_value(grpc::Status{});
+}
+catch (const std::exception& e)
+{
+    status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
+}
+
+void mp::Daemon::zones(const ZonesRequest* request,
+                       grpc::ServerReaderWriterInterface<ZonesReply, ZonesRequest>* server,
+                       std::promise<grpc::Status>* status_promise) // clang-format off
+try // clang-format on
+{
+    mpl::ClientLogger logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
+    ZonesReply response{};
+
+    server->Write(response);
+    status_promise->set_value(grpc::Status{});
+}
+catch (const std::exception& e)
+{
+    status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
+}
+
+void mp::Daemon::zones_state(const ZonesStateRequest* request,
+                             grpc::ServerReaderWriterInterface<ZonesStateReply, ZonesStateRequest>* server,
+                             std::promise<grpc::Status>* status_promise) // clang-format off
+try // clang-format on
+{
+    mpl::ClientLogger logger{mpl::level_from(request->verbosity_level()), *config->logger, server};
+
     status_promise->set_value(grpc::Status{});
 }
 catch (const std::exception& e)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -155,6 +155,12 @@ public slots:
     virtual void daemon_info(const DaemonInfoRequest* request,
                              grpc::ServerReaderWriterInterface<DaemonInfoReply, DaemonInfoRequest>* server,
                              std::promise<grpc::Status>* status_promise);
+    virtual void zones(const ZonesRequest* request,
+                       grpc::ServerReaderWriterInterface<ZonesReply, ZonesRequest>* server,
+                       std::promise<grpc::Status>* status_promise);
+    virtual void zones_state(const ZonesStateRequest* request,
+                             grpc::ServerReaderWriterInterface<ZonesStateReply, ZonesStateRequest>* server,
+                             std::promise<grpc::Status>* status_promise);
 
 private:
     void release_resources(const std::string& instance);

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -418,6 +418,28 @@ grpc::Status mp::DaemonRpc::daemon_info(grpc::ServerContext* context,
         client_cert_from(context));
 }
 
+grpc::Status mp::DaemonRpc::zones(grpc::ServerContext* context,
+                                  grpc::ServerReaderWriter<ZonesReply, ZonesRequest>* server)
+{
+    ZonesRequest request;
+    server->Read(&request);
+
+    return verify_client_and_dispatch_operation(
+        std::bind(&DaemonRpc::on_zones, this, &request, server, std::placeholders::_1),
+        client_cert_from(context));
+}
+
+grpc::Status mp::DaemonRpc::zones_state(grpc::ServerContext* context,
+                                        grpc::ServerReaderWriter<ZonesStateReply, ZonesStateRequest>* server)
+{
+    ZonesStateRequest request;
+    server->Read(&request);
+
+    return verify_client_and_dispatch_operation(
+        std::bind(&DaemonRpc::on_zones_state, this, &request, server, std::placeholders::_1),
+        client_cert_from(context));
+}
+
 template <typename OperationSignal>
 grpc::Status mp::DaemonRpc::verify_client_and_dispatch_operation(OperationSignal signal, const std::string& client_cert)
 {

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -112,6 +112,12 @@ signals:
     void on_daemon_info(const DaemonInfoRequest* request,
                         grpc::ServerReaderWriter<DaemonInfoReply, DaemonInfoRequest>* server,
                         std::promise<grpc::Status>* status_promise);
+    void on_zones(const ZonesRequest* request,
+                  grpc::ServerReaderWriter<ZonesReply, ZonesRequest>* server,
+                  std::promise<grpc::Status>* status_promise);
+    void on_zones_state(const ZonesStateRequest* request,
+                        grpc::ServerReaderWriter<ZonesStateReply, ZonesStateRequest>* server,
+                        std::promise<grpc::Status>* status_promise);
 
 private:
     template <typename OperationSignal>
@@ -167,6 +173,10 @@ protected:
                          grpc::ServerReaderWriter<RestoreReply, RestoreRequest>* server) override;
     grpc::Status daemon_info(grpc::ServerContext* context,
                              grpc::ServerReaderWriter<DaemonInfoReply, DaemonInfoRequest>* server) override;
+    grpc::Status zones(grpc::ServerContext* context,
+                       grpc::ServerReaderWriter<ZonesReply, ZonesRequest>* server) override;
+    grpc::Status zones_state(grpc::ServerContext* context,
+                             grpc::ServerReaderWriter<ZonesStateReply, ZonesStateRequest>* server) override;
 };
 } // namespace multipass
 #endif // MULTIPASS_DAEMON_RPC_H

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -45,6 +45,8 @@ service Rpc {
     rpc restore (stream RestoreRequest) returns (stream RestoreReply);
     rpc clone (stream CloneRequest) returns (stream CloneReply);
     rpc daemon_info (stream DaemonInfoRequest) returns (stream DaemonInfoReply);
+    rpc zones (stream ZonesRequest) returns (stream ZonesReply);
+    rpc zones_state (stream ZonesStateRequest) returns (stream ZonesStateReply);
 }
 
 message LaunchRequest {
@@ -73,6 +75,7 @@ message LaunchRequest {
     bool permission_to_bridge = 13;
     int32 timeout = 14;
     string password = 15;
+    string zone = 16;
 }
 
 message LaunchError {
@@ -82,6 +85,8 @@ message LaunchError {
         INVALID_DISK_SIZE = 2;
         INVALID_HOSTNAME = 3;
         INVALID_NETWORK = 4;
+        INVALID_ZONE = 5;
+        ZONE_UNAVAILABLE = 6;
     }
     repeated ErrorCodes error_codes = 1;
 }
@@ -250,6 +255,8 @@ message DetailedInfoItem {
         InstanceDetails instance_info = 7;
         SnapshotDetails snapshot_info = 8;
     }
+
+    Zone zone = 9;
 }
 
 message InfoReply {
@@ -271,6 +278,7 @@ message ListVMInstance {
     repeated string ipv4 = 3;
     repeated string ipv6 = 4;
     string current_release = 5;
+    Zone zone = 6;
 }
 
 message ListVMSnapshot {
@@ -549,4 +557,28 @@ message DaemonInfoReply {
     uint64 available_space = 2;
     uint32 cpus = 3;
     uint64 memory = 4;
+}
+
+message Zone {
+    string name = 1;
+    bool available = 2;
+}
+
+message ZonesRequest {
+    int32 verbosity_level = 1;
+}
+
+message ZonesReply {
+    string log_line = 1;
+    repeated Zone zones = 2;
+}
+
+message ZonesStateRequest {
+    int32 verbosity_level = 1;
+    bool available = 2;
+    repeated string zones = 3;
+}
+
+message ZonesStateReply {
+    string log_line = 1;
 }

--- a/tests/mock_client_rpc.h
+++ b/tests/mock_client_rpc.h
@@ -236,6 +236,30 @@ public:
                 PrepareAsyncdaemon_infoRaw,
                 (grpc::ClientContext * context, grpc::CompletionQueue* cq),
                 (override));
+    MOCK_METHOD((grpc::ClientReaderWriterInterface<multipass::ZonesRequest, multipass::ZonesReply>*),
+                zonesRaw,
+                (grpc::ClientContext * context),
+                (override));
+    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::ZonesRequest, multipass::ZonesReply>*),
+                AsynczonesRaw,
+                (grpc::ClientContext * context, grpc::CompletionQueue* cq, void* tag),
+                (override));
+    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::ZonesRequest, multipass::ZonesReply>*),
+                PrepareAsynczonesRaw,
+                (grpc::ClientContext * context, grpc::CompletionQueue* cq),
+                (override));
+    MOCK_METHOD((grpc::ClientReaderWriterInterface<multipass::ZonesStateRequest, multipass::ZonesStateReply>*),
+                zones_stateRaw,
+                (grpc::ClientContext * context),
+                (override));
+    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::ZonesStateRequest, multipass::ZonesStateReply>*),
+                Asynczones_stateRaw,
+                (grpc::ClientContext * context, grpc::CompletionQueue* cq, void* tag),
+                (override));
+    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::ZonesStateRequest, multipass::ZonesStateReply>*),
+                PrepareAsynczones_stateRaw,
+                (grpc::ClientContext * context, grpc::CompletionQueue* cq),
+                (override));
 };
 } // namespace multipass::test
 

--- a/tests/mock_daemon.h
+++ b/tests/mock_daemon.h
@@ -142,6 +142,18 @@ struct MockDaemon : public Daemon
                  (grpc::ServerReaderWriterInterface<DaemonInfoReply, DaemonInfoRequest>*),
                  std::promise<grpc::Status>*),
                 (override));
+    MOCK_METHOD(void,
+                zones,
+                (const ZonesRequest*,
+                 (grpc::ServerReaderWriterInterface<ZonesReply, ZonesRequest>*),
+                 std::promise<grpc::Status>*),
+                (override));
+    MOCK_METHOD(void,
+                zones_state,
+                (const ZonesStateRequest*,
+                 (grpc::ServerReaderWriterInterface<ZonesStateReply, ZonesStateRequest>*),
+                 std::promise<grpc::Status>*),
+                (override));
 
     template <typename Request, typename Reply>
     void set_promise_value(const Request*, grpc::ServerReaderWriterInterface<Reply, Request>*,


### PR DESCRIPTION
This PR adds AZ information to RPC messages that need it, as well as methods for listing AZs and changing their state.