### PR TITLE
add shortcut for + key without shift needed

### DIFF
--- a/src/client/gui/lib/platform/linux.dart
+++ b/src/client/gui/lib/platform/linux.dart
@@ -41,6 +41,8 @@ class LinuxPlatform extends MpPlatform {
             IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):
             IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.add, control: true):
+            IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.add, control: true, shift: true):
             IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.numpadAdd, control: true):

--- a/src/client/gui/lib/platform/windows.dart
+++ b/src/client/gui/lib/platform/windows.dart
@@ -43,6 +43,8 @@ class WindowsPlatform extends MpPlatform {
             IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):
             IncreaseTerminalFontIntent(),
+        SingleActivator(LogicalKeyboardKey.add, control: true):
+            IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.add, control: true, shift: true):
             IncreaseTerminalFontIntent(),
         SingleActivator(LogicalKeyboardKey.numpadAdd, control: true):


### PR DESCRIPTION
fixes #3887 
This pull request resolves an issue on keyboards that have the + key as lowercase, such as German layout keyboards. Previously, we were always checking for shift to be pressed as well as control for <Ctrl><+> since + can only be made by holding shift on US layout keyboards. There is a dedicated LogicalKeyboardKey in Flutter for this lowercase "add" key.

Keyboard shortcut additions:

* [`src/client/gui/lib/platform/linux.dart`](diffhunk://#diff-8d945490628ab65a2dee4475abb3c1a7fe4302438c68de63890dafe66502179cR44-R45): Added a new keyboard shortcut `SingleActivator(LogicalKeyboardKey.add, control: true)` to increase terminal font size.
* [`src/client/gui/lib/platform/windows.dart`](diffhunk://#diff-4ea20cca689dd319ac27577691743b87a135a8c44c07d617d58dc0ec6d33d8c0R46-R47): Added a new keyboard shortcut `SingleActivator(LogicalKeyboardKey.add, control: true)` to increase terminal font size.