### PR TITLE
Az tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,8 @@ add_executable(multipass_tests
   temp_file.cpp
   test_alias_dict.cpp
   test_argparser.cpp
+  test_base_availability_zone.cpp
+  test_base_availability_zone_manager.cpp
   test_base_snapshot.cpp
   test_base_virtual_machine.cpp
   test_base_virtual_machine_factory.cpp

--- a/tests/test_base_availability_zone.cpp
+++ b/tests/test_base_availability_zone.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common.h"
+#include "mock_file_ops.h"
+#include "mock_json_utils.h"
+#include "mock_logger.h"
+#include "mock_virtual_machine.h"
+
+#include <multipass/base_availability_zone.h>
+#include <multipass/constants.h>
+
+#include <QString>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+namespace mpt = multipass::test;
+using namespace testing;
+
+struct TestBaseAvailabilityZone : public Test
+{
+    TestBaseAvailabilityZone() : mock_logger{mpt::MockLogger::inject()}
+    {
+        mock_logger.mock_logger->screen_logs(mpl::Level::error);
+    }
+
+    const std::string az_name{"zone1"};
+    const mp::fs::path az_dir{"/path/to/zones"};
+    const mp::fs::path az_file = az_dir / (az_name + ".json");
+    const QString az_file_qstr{QString::fromStdString(az_file.u8string())};
+
+    mpt::MockFileOps::GuardedMock mock_file_ops_guard{mpt::MockFileOps::inject()};
+    mpt::MockJsonUtils::GuardedMock mock_json_utils_guard{mpt::MockJsonUtils::inject()};
+    mpt::MockLogger::Scope mock_logger;
+};
+
+TEST_F(TestBaseAvailabilityZone, creates_default_available_zone)
+{
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(az_file)).WillOnce(Return(QJsonObject{}));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::debug), _, _))
+        .Times(2); // Once for subnet missing, once for availability missing
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::trace), _, _))
+        .Times(2); // Once in constructor, once in serialize()
+
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(az_file.u8string())));
+
+    mp::BaseAvailabilityZone zone{az_name, az_dir};
+
+    EXPECT_EQ(zone.get_name(), az_name);
+    EXPECT_TRUE(zone.is_available());
+    EXPECT_TRUE(zone.get_subnet().empty());
+}
+
+TEST_F(TestBaseAvailabilityZone, loads_existing_zone_file)
+{
+    const std::string test_subnet = "10.0.0.0/24";
+    const bool test_available = false;
+
+    QJsonObject json{{"subnet", QString::fromStdString(test_subnet)}, {"available", test_available}};
+
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(az_file)).WillOnce(Return(json));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::trace), _, _))
+        .Times(2); // Once in constructor, once in serialize()
+
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(az_file.u8string())));
+
+    mp::BaseAvailabilityZone zone{az_name, az_dir};
+
+    EXPECT_EQ(zone.get_name(), az_name);
+    EXPECT_EQ(zone.get_subnet(), test_subnet);
+    EXPECT_FALSE(zone.is_available());
+}
+
+TEST_F(TestBaseAvailabilityZone, adds_vm_and_updates_on_availability_change)
+{
+    QJsonObject json{{"available", true}};
+
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(az_file)).WillOnce(Return(json));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::trace), _, _))
+        .Times(3); // Once in constructor, once in serialize(), once in set_available
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::debug), _, _))
+        .Times(3); // Once for subnet missing, once for adding VM, once for availability change
+
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(az_file.u8string())))
+        .Times(2); // Once in constructor, once in set_available
+
+    mp::BaseAvailabilityZone zone{az_name, az_dir};
+
+    const std::string test_vm_name = "test-vm";
+    NiceMock<mpt::MockVirtualMachine> mock_vm{test_vm_name};
+    EXPECT_CALL(mock_vm, make_available(false));
+
+    zone.add_vm(mock_vm);
+    zone.set_available(false);
+}
+
+TEST_F(TestBaseAvailabilityZone, removes_vm_correctly)
+{
+    QJsonObject json{{"available", true}};
+
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(az_file)).WillOnce(Return(json));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::trace), _, _))
+        .Times(2); // Once in constructor, once in serialize()
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::debug), _, _))
+        .Times(3); // Once for subnet missing, once for adding VM, once for removing VM
+
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(az_file.u8string())));
+
+    mp::BaseAvailabilityZone zone{az_name, az_dir};
+
+    const std::string test_vm_name = "test-vm";
+    NiceMock<mpt::MockVirtualMachine> mock_vm{test_vm_name};
+
+    zone.add_vm(mock_vm);
+    zone.remove_vm(mock_vm);
+}
+
+TEST_F(TestBaseAvailabilityZone, availability_state_management)
+{
+    QJsonObject json{{"available", true}};
+
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(az_file)).WillOnce(Return(json));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::trace), _, _))
+        .Times(3); // Once in constructor, once in serialize(), once in set_available(false)
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::debug), _, _))
+        .Times(5); // Once for subnet, once per VM add, once for no-op set_available, once for actual change
+
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(az_file.u8string())))
+        .Times(2); // Once in constructor, once in set_available
+
+    mp::BaseAvailabilityZone zone{az_name, az_dir};
+
+    const std::string vm1_name = "test-vm1";
+    const std::string vm2_name = "test-vm2";
+    NiceMock<mpt::MockVirtualMachine> mock_vm1{vm1_name};
+    NiceMock<mpt::MockVirtualMachine> mock_vm2{vm2_name};
+
+    // Both VMs should be notified when state changes
+    EXPECT_CALL(mock_vm1, make_available(false));
+    EXPECT_CALL(mock_vm2, make_available(false));
+
+    zone.add_vm(mock_vm1);
+    zone.add_vm(mock_vm2);
+
+    // Setting to current state (true) shouldn't trigger VM updates
+    zone.set_available(true);
+
+    // Setting to new state should notify all VMs
+    zone.set_available(false);
+}

--- a/tests/test_base_availability_zone_manager.cpp
+++ b/tests/test_base_availability_zone_manager.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common.h"
+#include "mock_file_ops.h"
+#include "mock_json_utils.h"
+#include "mock_logger.h"
+
+#include <multipass/base_availability_zone_manager.h>
+#include <multipass/constants.h>
+#include <multipass/exceptions/availability_zone_exceptions.h>
+
+#include <QString>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+namespace mpt = multipass::test;
+using namespace testing;
+
+struct TestBaseAvailabilityZoneManager : public Test
+{
+    TestBaseAvailabilityZoneManager() : mock_logger{mpt::MockLogger::inject()}
+    {
+        mock_logger.mock_logger->screen_logs(mpl::Level::error);
+    }
+
+    const mp::fs::path data_dir{"/path/to/data"};
+    const mp::fs::path manager_file = data_dir / "az-manager.json";
+    const mp::fs::path zones_dir = data_dir / "zones";
+    const QString manager_file_qstr{QString::fromStdString(manager_file.u8string())};
+
+    mpt::MockFileOps::GuardedMock mock_file_ops_guard{mpt::MockFileOps::inject()};
+    mpt::MockJsonUtils::GuardedMock mock_json_utils_guard{mpt::MockJsonUtils::inject()};
+    mpt::MockLogger::Scope mock_logger;
+};
+
+TEST_F(TestBaseAvailabilityZoneManager, creates_default_zones)
+{
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(manager_file)).WillOnce(Return(QJsonObject{}));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::trace), _, _)).Times(AnyNumber());
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::debug), _, _)).Times(AnyNumber());
+
+    // Default zones will be created
+    const int expected_zone_count = static_cast<int>(mp::default_zone_names.size());
+    for (const auto& zone_name : mp::default_zone_names)
+    {
+        const auto zone_file = zones_dir / (std::string{zone_name} + ".json");
+        EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(zone_file)).WillOnce(Return(QJsonObject{}));
+        EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(zone_file.u8string())));
+    }
+
+    // Manager file gets written with default zone (once in constructor and once in get_automatic_zone_name)
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, manager_file_qstr)).Times(2);
+
+    mp::BaseAvailabilityZoneManager manager{data_dir};
+
+    const auto zones = manager.get_zones();
+    EXPECT_EQ(zones.size(), expected_zone_count);
+
+    // First zone in default_zone_names should be our default
+    EXPECT_EQ(manager.get_default_zone_name(), *mp::default_zone_names.begin());
+    // And also our automatic zone initially
+    EXPECT_EQ(manager.get_automatic_zone_name(), *mp::default_zone_names.begin());
+}
+
+TEST_F(TestBaseAvailabilityZoneManager, automatic_zone_rotation)
+{
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(manager_file)).WillOnce(Return(QJsonObject{}));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::trace), _, _)).Times(AnyNumber());
+    EXPECT_CALL(*mock_logger.mock_logger, log(Eq(mpl::Level::debug), _, _)).Times(AnyNumber());
+
+    // Set up all zones to be created
+    for (const auto& zone_name : mp::default_zone_names)
+    {
+        const auto zone_file = zones_dir / (std::string{zone_name} + ".json");
+        EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(zone_file)).WillOnce(Return(QJsonObject{}));
+        EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(zone_file.u8string())))
+            .Times(AnyNumber());
+    }
+
+    // Manager file will be written multiple times during rotation
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, manager_file_qstr)).Times(AnyNumber());
+
+    mp::BaseAvailabilityZoneManager manager{data_dir};
+
+    // First automatic zone should be the first zone
+    const auto first_zone = manager.get_automatic_zone_name();
+    EXPECT_EQ(first_zone, *mp::default_zone_names.begin());
+
+    // Mark first zone as unavailable
+    manager.get_zone(first_zone).set_available(false);
+
+    // Next automatic zone should be second zone
+    const auto second_zone = manager.get_automatic_zone_name();
+    EXPECT_NE(second_zone, first_zone);
+
+    // Mark all zones unavailable
+    for (const auto& zone : manager.get_zones())
+        const_cast<mp::AvailabilityZone&>(zone.get()).set_available(false);
+
+    // Expect exception when no zones available
+    EXPECT_THROW(manager.get_automatic_zone_name(), mp::NoAvailabilityZoneAvailable);
+}
+
+TEST_F(TestBaseAvailabilityZoneManager, throws_when_zone_not_found)
+{
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(manager_file)).WillOnce(Return(QJsonObject{}));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(_, _, _)).Times(AnyNumber());
+
+    // Set up default zones to be created
+    for (const auto& zone_name : mp::default_zone_names)
+    {
+        const auto zone_file = zones_dir / (std::string{zone_name} + ".json");
+        EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(zone_file)).WillOnce(Return(QJsonObject{}));
+        EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(zone_file.u8string())))
+            .Times(AnyNumber());
+    }
+
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, manager_file_qstr)).Times(AnyNumber());
+
+    mp::BaseAvailabilityZoneManager manager{data_dir};
+
+    EXPECT_THROW(manager.get_zone("nonexistent-zone"), mp::AvailabilityZoneNotFound);
+}
+
+TEST_F(TestBaseAvailabilityZoneManager, cycles_through_available_zones)
+{
+    EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(manager_file)).WillOnce(Return(QJsonObject{}));
+
+    EXPECT_CALL(*mock_logger.mock_logger, log(_, _, _)).Times(AnyNumber());
+
+    // Set up default zones to be created - all initially available
+    for (const auto& zone_name : mp::default_zone_names)
+    {
+        const auto zone_file = zones_dir / (std::string{zone_name} + ".json");
+        EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(zone_file)).WillOnce(Return(QJsonObject{}));
+        EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, QString::fromStdString(zone_file.u8string())))
+            .Times(AnyNumber());
+    }
+
+    EXPECT_CALL(*mock_json_utils_guard.first, write_json(_, manager_file_qstr)).Times(AnyNumber());
+
+    mp::BaseAvailabilityZoneManager manager{data_dir};
+
+    // First call returns initial zone (zone1)
+    auto zone = manager.get_automatic_zone_name();
+    EXPECT_EQ(zone, "zone1");
+
+    // Make zone2 unavailable
+    manager.get_zone("zone2").set_available(false);
+
+    // Second call follows pointer to zone2 (unavailable), so moves to and returns zone3
+    zone = manager.get_automatic_zone_name();
+    EXPECT_EQ(zone, "zone3");
+
+    // Third call follows pointer to zone1 and returns it
+    zone = manager.get_automatic_zone_name();
+    EXPECT_EQ(zone, "zone1");
+
+    // Fourth call follows pointer to zone2 (unavailable), so moves to and returns zone3
+    zone = manager.get_automatic_zone_name();
+    EXPECT_EQ(zone, "zone3");
+}

--- a/tests/test_base_availability_zone_manager.cpp
+++ b/tests/test_base_availability_zone_manager.cpp
@@ -31,9 +31,9 @@ namespace mpl = multipass::logging;
 namespace mpt = multipass::test;
 using namespace testing;
 
-struct TestBaseAvailabilityZoneManager : public Test
+struct BaseAvailabilityZoneManagerTest : public Test
 {
-    TestBaseAvailabilityZoneManager() : mock_logger{mpt::MockLogger::inject()}
+    BaseAvailabilityZoneManagerTest()
     {
         mock_logger.mock_logger->screen_logs(mpl::Level::error);
     }
@@ -45,10 +45,10 @@ struct TestBaseAvailabilityZoneManager : public Test
 
     mpt::MockFileOps::GuardedMock mock_file_ops_guard{mpt::MockFileOps::inject()};
     mpt::MockJsonUtils::GuardedMock mock_json_utils_guard{mpt::MockJsonUtils::inject()};
-    mpt::MockLogger::Scope mock_logger;
+    mpt::MockLogger::Scope mock_logger{mpt::MockLogger::inject()};
 };
 
-TEST_F(TestBaseAvailabilityZoneManager, creates_default_zones)
+TEST_F(BaseAvailabilityZoneManagerTest, CreatesDefaultZones)
 {
     EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(manager_file)).WillOnce(Return(QJsonObject{}));
 
@@ -78,7 +78,7 @@ TEST_F(TestBaseAvailabilityZoneManager, creates_default_zones)
     EXPECT_EQ(manager.get_automatic_zone_name(), *mp::default_zone_names.begin());
 }
 
-TEST_F(TestBaseAvailabilityZoneManager, automatic_zone_rotation)
+TEST_F(BaseAvailabilityZoneManagerTest, AutomaticZoneRotation)
 {
     EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(manager_file)).WillOnce(Return(QJsonObject{}));
 
@@ -118,7 +118,7 @@ TEST_F(TestBaseAvailabilityZoneManager, automatic_zone_rotation)
     EXPECT_THROW(manager.get_automatic_zone_name(), mp::NoAvailabilityZoneAvailable);
 }
 
-TEST_F(TestBaseAvailabilityZoneManager, throws_when_zone_not_found)
+TEST_F(BaseAvailabilityZoneManagerTest, ThrowsWhenZoneNotFound)
 {
     EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(manager_file)).WillOnce(Return(QJsonObject{}));
 
@@ -140,7 +140,7 @@ TEST_F(TestBaseAvailabilityZoneManager, throws_when_zone_not_found)
     EXPECT_THROW(manager.get_zone("nonexistent-zone"), mp::AvailabilityZoneNotFound);
 }
 
-TEST_F(TestBaseAvailabilityZoneManager, cycles_through_available_zones)
+TEST_F(BaseAvailabilityZoneManagerTest, CyclesThroughAvailableZones)
 {
     EXPECT_CALL(*mock_json_utils_guard.first, read_object_from_file(manager_file)).WillOnce(Return(QJsonObject{}));
 


### PR DESCRIPTION
MULTI-1714

This pull request introduces new test files for the new AvailabilityZone classes and updates the `CMakeLists.txt` to include these new test files. The new test files include various test cases, providing code coverage and ensuring correct functionality under different scenarios.

Processing file include/multipass/availability_zone_manager.h
  lines=1 hit=1 functions=2 hit=1

Processing file include/multipass/exceptions/availability_zone_exceptions.h
  lines=5 hit=5 functions=2 hit=2
  
Processing file src/platform/backends/shared/base_availability_zone.cpp
  lines=67 hit=63 functions=13 hit=13
  
Processing file src/platform/backends/shared/base_availability_zone_manager.cpp
  lines=78 hit=69 functions=15 hit=15
