### PR TITLE
[snapcraft] Scrape files with LICENSE or full path contains LICENSE

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -232,7 +232,7 @@ parts:
       sed -i -e 's@^Icon=\(.\+\)$@Icon=/usr/share/icons/hicolor/scalable/apps/\1.svg@' ${CRAFT_PART_INSTALL}/usr/share/applications/multipass.gui.desktop
 
       cd ${CRAFT_PART_SRC}/3rd-party
-      find . -name 'LICENSE*' -print0 | xargs -0 -I FILE install --mode=644 -D --no-target-directory FILE ${CRAFT_PART_INSTALL}/licenses/FILE
+      find . -type f \( -name 'LICENSE*' -o -path '*/LICENSE*/*' \) -print0 | xargs -0 -I FILE install --mode=644 -D --no-target-directory FILE ${CRAFT_PART_INSTALL}/licenses/FILE
 
   qemu:
     build-environment:


### PR DESCRIPTION
Scrape license files that either:
- Have a name starting with LICENSE, or
- Have a full path that contains /LICENSE/

MULTI-1763