### PR TITLE
Tweak Jira bot

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -6,3 +6,4 @@ settings:
   status_mapping:
     opened: Untriaged
     closed: Done
+    not_planned: rejected

--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -3,6 +3,8 @@ settings:
   jira_project_key: MULTI
   labels:
     - jira
+  label_mapping:
+    enhancement: Story
   status_mapping:
     opened: Untriaged
     closed: Done


### PR DESCRIPTION
Tweak mappings in the Jira bot config to:
  - closed as not planned on GH ➡ rejected in Jira
  - enhancements on GH ➡ stories in Jira