### PR TITLE
Modified the 3rd party compilation order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,11 +122,18 @@ if(cmake_build_type_lower MATCHES "coverage")
   endif()
 endif()
 
-# OpenSSL config
+# OpenSSL config; Debug messages confirms which OpenSSL installation is being used
 find_package(OpenSSL REQUIRED)
+message(STATUS "OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
+message(STATUS "OpenSSL libraries ${OPENSSL_LIBRARIES}")
 
 # gRPC config
 find_package(gRPC CONFIG REQUIRED)
+
+# Ensure custom libraries are built first
+add_subdirectory(3rd-party/libssh)
+add_subdirectory(3rd-party/grpc)
+add_subdirectory(3rd-party/poco)
 
 # Needs to be here before we set further compilation options
 add_subdirectory(3rd-party)


### PR DESCRIPTION
This pull request addresses Issue #3802 where manually building Multipass fails due to OpenSSL header detection errors in libssh. The issue was caused due to an incorrect dependency order in the CMakeLists.txt file. This resulted in the system's OpenSSL installation verison being used instead of the custom built 3rd party libraries.