### PR TITLE
Small fixes to docs structure

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,8 @@ html_context = {
     # "sequential_nav": "both",
     # TODO: To enable listing contributors on individual pages, set to True
     "display_contributors": False,
+    # The following line enables the "Give feedback" button.
+    "github_issues": "enabled",
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
@@ -264,8 +266,7 @@ html_css_files = [
 rst_epilog = """
 .. include:: /reuse/links.txt
 """
-# The following line enables the "Give feedback" button.
-"github_issues": "enabled",
+
 
 # Feedback button at the top; enabled by default
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,10 +133,6 @@ html_context = {
     # NOTE: If set, links for viewing the documentation source files
     #       and creating GitHub issues are added at the bottom of each page.
     "github_url": "https://github.com/canonical/multipass",
-    # NOTE TO GIULIA: This line was suggested by Shane to enable the feedback button,
-    # but it doesn't work at the moment.
-    # 'github_issues': 'enabled',
-
     # Docs branch in the repo; used in links for viewing the source files
     #
     # TODO: To customise the branch, uncomment and update as needed.
@@ -268,6 +264,8 @@ html_css_files = [
 rst_epilog = """
 .. include:: /reuse/links.txt
 """
+# The following line enables the "Give feedback" button.
+"github_issues": "enabled",
 
 # Feedback button at the top; enabled by default
 #

--- a/docs/explanation/authentication.md
+++ b/docs/explanation/authentication.md
@@ -5,21 +5,21 @@
 
 Before executing any commands, Multipass requires clients to authenticate with the service. Multipass employs an authentication process based on x509 certificates signed by elliptic curve (EC) keys, powered by OpenSSL, to authenticate clients. When a client connects, Multipass verifies the client's certificate, ensuring only authenticated clients can communicate with the service.
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 Linux and macOS hosts currently use a Unix domain socket for client and daemon communication. Upon first use, this socket only allows a client to connect via a user belonging to the group that owns the socket. For example, this group could be `sudo`, `admin`, or `wheel` and the user needs to belong to this group or else permission will be denied when connecting.
 
 After the first client connects with a user belonging to the socket's admin group, the client's OpenSSL certificate will be accepted by the daemon and the socket will be then be open for all users to connect. Any other user trying to connect to the Multipass service will need to authenticate with the service using the previously set [`local.passphrase`](/reference/settings/local-passphrase).
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 Linux and macOS hosts currently use a Unix domain socket for client and daemon communication. Upon first use, this socket only allows a client to connect via a user belonging to the group that owns the socket. For example, this group could be `sudo`, `admin`, or `wheel` and the user needs to belong to this group or else permission will be denied when connecting.
 
 After the first client connects with a user belonging to the socket's admin group, the client's OpenSSL certificate will be accepted by the daemon and the socket will be then be open for all users to connect. Any other user trying to connect to the Multipass service will need to authenticate with the service using the previously set [`local.passphrase`](/reference/settings/local-passphrase).
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 The Windows host uses a TCP socket listening on port 50051 for client connections. This socket is open for all to use since there is no concept of file ownership for TCP sockets. This is not very secure in that any Multipass client can connect to the service and issue any commands.
 
 To close this gap, the client will now need to be authenticated with the Multipass service. To ease the burden of having to authenticate the client, the user who installs the updated version of Multipass will automatically have their clients authenticated with the service. Any other users connecting to the service will have to use authenticate using the previously set [`local.passphrase`](/reference/settings/local-passphrase).

--- a/docs/explanation/mount.md
+++ b/docs/explanation/mount.md
@@ -30,19 +30,19 @@ Native mounts use driver-dependent technologies to achieve the high performance.
 (security-considerations-mount)=
 ## Security considerations
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 Because mounts are performed as `root` -- unless installed via snap, see below -- they allow write access to the whole host operating system. But since only privileged users (members of `sudo`, `wheel`, `admin` groups) can use Multipass, this isn't a concern on Linux.
 
 If Multipass is installed via snap package, [snap confinement](https://snapcraft.io/docs/snap-confinement) prevents mounts outside of the `/home` directory (and to hidden files/folders in the `/home` directory) and possibly, removable media (depending on the connected interfaces). Still, a user (A) with access to Multipass could access mounts that a different user (B) established to B's home directory (that is, outside of A's home).
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 Because mounts are performed as `root`, they allow write access to the whole host operating system. But since only privileged users (members of `sudo`, `wheel`, `admin` groups) can use Multipass, this isn't a concern on macOS.
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 Because mounts are performed as privileged users (`SYSTEM` on Windows), they allow write access to the whole host operating system.
 
 For historical reasons, mounts are disabled by default on Windows, even though in the current version of Multipass users need to authenticate with the daemon before it will service their requests. See [`local.privileged-mounts`](/reference/settings/local-privileged-mounts) for information on how to enable them if needed.

--- a/docs/how-to-guides/customise-multipass/configure-multipass-default-logging-level.md
+++ b/docs/how-to-guides/customise-multipass/configure-multipass-default-logging-level.md
@@ -1,4 +1,4 @@
-(how-to-guides-customise-multipass-configure-multipasss-default-logging-level)=
+(how-to-guides-customise-multipass-configure-multipass-default-logging-level)=
 # Configure Multipass’s default logging level
 
 > See also: [Logging levels](/reference/logging-levels)

--- a/docs/how-to-guides/customise-multipass/configure-multipasss-default-logging-level.md
+++ b/docs/how-to-guides/customise-multipass/configure-multipasss-default-logging-level.md
@@ -7,9 +7,9 @@ This document demonstrates how to configure the default logging level of the Mul
 
 ## Changing the default logging level
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 First, stop the Multipass daemon:
 
@@ -37,7 +37,7 @@ sudo snap start multipass
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 First, become `root`:
 
@@ -61,7 +61,7 @@ launchctl load /Library/LaunchDaemons/com.canonical.multipassd.plist
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 First, open an administrator privileged PowerShell prompt.
 

--- a/docs/how-to-guides/customise-multipass/configure-where-multipass-stores-external-data.md
+++ b/docs/how-to-guides/customise-multipass/configure-where-multipass-stores-external-data.md
@@ -12,9 +12,9 @@ This document demonstrates how to configure the location where Multipass stores 
 - When uninstalling Multipass, the uninstaller will not remove data stored in custom locations, so you'll have to deleted it manually.
 ```
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 First, stop the Multipass daemon:
 
@@ -86,7 +86,7 @@ sudo rm -rf /var/snap/multipass/common/cache/multipassd
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 First, become `root`:
 
@@ -124,7 +124,7 @@ launchctl load /Library/LaunchDaemons/com.canonical.multipassd.plist
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 First, open a PowerShell prompt with administration privileges.
 
@@ -169,9 +169,9 @@ Remove-Item -Path "C:\ProgramData\Multipass\*" -Recurse
 
 ## Reverting back to the default location
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 Stop the Multipass daemon:
 
@@ -214,7 +214,7 @@ sudo rm -rf <path>
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 First, become `root`:
 
@@ -248,7 +248,7 @@ launchctl load /Library/LaunchDaemons/com.canonical.multipassd.plist
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 First, open a PowerShell prompt with administrator privileges.
 

--- a/docs/how-to-guides/customise-multipass/index.md
+++ b/docs/how-to-guides/customise-multipass/index.md
@@ -1,5 +1,5 @@
 (how-to-guides-customise-multipass-index)=
-# Customise-Multipass
+# Customise Multipass
 
 The following guides provide step-by-step instructions on how to customise Multipass to address specific needs, from managing Multipass drivers to configuring a graphical user interface.
 

--- a/docs/how-to-guides/customise-multipass/index.md
+++ b/docs/how-to-guides/customise-multipass/index.md
@@ -11,7 +11,7 @@ The following guides provide step-by-step instructions on how to customise Multi
 - [Use a different terminal from the system icon](use-a-different-terminal-from-the-system-icon)
 - [Integrate with Windows Terminal](integrate-with-windows-terminal)
 - [Configure where Multipass stores external data](configure-where-multipass-stores-external-data)
-- [Configure Multipass’s default logging level](configure-multipasss-default-logging-level)
+- [Configure Multipass’s default logging level](configure-multipass-default-logging-level)
 
 <!-- REMOVED FROM DOCS AND MOVED TO COMMUNITY KNOWLEDGE
 - [Use Multipass remotely](/)
@@ -28,4 +28,12 @@ The following guides provide step-by-step instructions on how to customise Multi
 :maxdepth: 2
 :glob:
 
-*
+set-up-the-driver
+migrate-from-hyperkit-to-qemu-on-macos
+authenticate-clients-with-the-multipass-service
+build-multipass-images-with-packer
+set-up-a-graphical-interface
+use-a-different-terminal-from-the-system-icon
+integrate-with-windows-terminal
+configure-where-multipass-stores-external-data
+configure-multipass-default-logging-level

--- a/docs/how-to-guides/customise-multipass/set-up-a-graphical-interface.md
+++ b/docs/how-to-guides/customise-multipass/set-up-a-graphical-interface.md
@@ -80,9 +80,9 @@ In this example, we will use the IP address `10.49.93.209` to connect to the RDP
 If the IP address of the instance is not displayed in the output of `multipass list`, you can obtain it directly from the instance, with the command `ip addr`.
 ```
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 On Linux, there are applications such as Remmina to visualise the desktop (make sure the package `remmina-plugin-rdp` is installed in your host along with `remmina`).
 
@@ -98,13 +98,13 @@ The system will ask for a username (`ubuntu`) and the password set above, and th
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 To connect on macOS, we can use the “Microsoft Remote Desktop” application, from the Mac App Store.
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 On Windows, we can connect to the RDP server with the “Remote Desktop Connection” application. There, we enter the virtual machine’s IP address, set the session to XOrg and enter the username and password we created on the previous step.
 
@@ -118,9 +118,9 @@ And we are done... a graphical desktop!
 
 It might be the case that we only want Multipass to launch one application and to see only that window, without having the need for a complete desktop. It turns out that this setup is simpler than the RDP approach, because we do not need the Multipass instance to deploy a full desktop. Instead, we can use X11 to connect the applications in the instance with the graphical capabilities of the host.
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 Linux runs X by default, so no extra software in the host is needed.
 
@@ -155,7 +155,7 @@ A small window containing the X logo will show up. Done!
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 The first step in Mac is to make sure a X server is running. The easiest way is to install [XQuartz](https://www.xquartz.org).
 
@@ -167,7 +167,7 @@ Note to Apple Silicon users: some applications requiring OpenGL will not work th
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 Windows knows nothing about X, therefore we need to install an X server. Here we will use [VcXsrv](https://sourceforge.net/projects/vcxsrv/). Other options would be [Xming](http://www.straightrunning.com/XmingNotes/) (the newest versions are paid, but older versions can still be downloaded for free from their [SourceForge site](https://sourceforge.net/projects/xming/)) or installing an X server in [Cygwin](https://cygwin.com/).
 

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -162,7 +162,7 @@ Multipass runs as the _System_ account, so to see the instances in VirtualBox, o
 & $env:USERPROFILE\Downloads\PSTools\PsExec.exe -s -i $env:VBOX_MSI_INSTALL_PATH\VirtualBox.exe
 ```
 
-![Multipass instances in VirtualBox](https://assets.ubuntu.com/v1/edce2443-multipass-windows-virtualbox-manager)
+![Multipass instances in VirtualBox](https://assets.ubuntu.com/v1/edce2443-multipass-windows-virtualbox-manager.png)
 
 To list the instances on the command line:
 

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -7,21 +7,21 @@ This document demonstrates how to choose, set up, and manage the drivers behind 
 
 ## Default driver
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 By default, Multipass on Linux uses the `qemu` or `lxd` driver (depending on the architecture).
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 By default, Multipass on macOS uses the `qemu` driver.
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 By default, Multipass on Windows uses the `hyperv` driver.
 
@@ -31,9 +31,9 @@ By default, Multipass on Windows uses the `hyperv` driver.
 
 ## Install an alternative driver
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 If you want more control over your VMs after they are launched, you can also use the experimental [libvirt](https://libvirt.org/) driver.
 
@@ -64,7 +64,7 @@ You can still use the `multipass` client and the tray icon, and any changes you 
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 An alternative option is to use VirtualBox.
 
@@ -78,7 +78,7 @@ From now on, all instances started with `multipass launch` will use VirtualBox b
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 If you want to (or have to), you can change the hypervisor that Multipass uses to VirtualBox.
 
@@ -102,9 +102,9 @@ From then on, all instances started with `multipass launch` will use VirtualBox 
 
 ## Use the driver to view Multipass instances
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 You can view instances with libvirt in two ways, using the `virsh` CLI or the [`virt-manager` GUI](https://virt-manager.org/).
 
@@ -127,7 +127,7 @@ Alternatively, to use the `virt-manager` GUI, ...
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 Multipass runs as the `root` user, so to see the instances in  VirtualBox, or through the `VBoxManage` command, you have to run those as `root`, too. To see the instances in VirtualBox, use the command:
 
@@ -154,7 +154,7 @@ You can still use the `multipass` client and the system menu icon, and any chang
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 Multipass runs as the _System_ account, so to see the instances in VirtualBox, or through the `VBoxManage` command, you have to run those as that user via [`PsExec -s`](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec). Download and unpack [PSTools.zip](https://download.sysinternals.com/files/PSTools.zip) in your *Downloads* folder, and in an administrative PowerShell, run:
 
@@ -187,15 +187,15 @@ You can still use the `multipass` client and the system menu icon, and any chang
 
 ## Use VirtualBox to set up port forwarding for a Multipass instance
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 This option only applies to macOS and Windows systems.
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 To expose a service running inside the instance on your host, you can use [VirtualBox's port forwarding feature](https://www.virtualbox.org/manual/ch06.html#natforward), for example:
 
@@ -207,7 +207,7 @@ You can then open, say, https://localhost:8081/, and the service running inside 
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 To expose a service running inside the instance on your host, you can use [VirtualBox's port forwarding feature](https://www.virtualbox.org/manual/ch06.html#natforward), for example:
 
@@ -223,15 +223,15 @@ You can then open, say, https://localhost:8081/, and the service running inside 
 
 ## Use VirtualBox to set up network bridging for a Multipass instance
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 This option only applies to macOS systems.
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 An often requested Multipass feature is network bridging. You can add a second network interface to the instance and expose it on your physical network.
 
@@ -322,7 +322,7 @@ All the services running inside the instance should now be available on your phy
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 This option only applies to macOS systems.
 
@@ -334,9 +334,9 @@ This option only applies to macOS systems.
 
 > See also: {ref}`reference-command-line-interface-stop`, {ref}`reference-settings-local-driver`
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 To switch back to the default `qemu` driver, first you need to stop all instances again:
 
@@ -353,7 +353,7 @@ This will make you lose any customisations you made to the instance in `libvirt`
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 If you want to switch back to the default driver, run:
 
@@ -365,7 +365,7 @@ Instances created with VirtualBox don't get transferred, but you can always come
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 If you want to switch back to the default driver:
 

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -37,7 +37,7 @@ You may also want to customise Multipass to address specific needs, from managin
 - [Use a different terminal from the system icon](customise-multipass/use-a-different-terminal-from-the-system-icon)
 - [Integrate with Windows Terminal](customise-multipass/integrate-with-windows-terminal)
 - [Configure where Multipass stores external data](customise-multipass/configure-where-multipass-stores-external-data)
-- [Configure Multipass’s default logging level](customise-multipass/configure-multipasss-default-logging-level)
+- [Configure Multipass’s default logging level](customise-multipass/configure-multipass-default-logging-level)
 
 <!-- REMOVED FROM DOCS AND MOVED TO COMMUNITY KNOWLEDGE
 - [Use Multipass remotely](/)
@@ -63,7 +63,7 @@ Use the following how-to guides to troubleshoot issues with your Multipass insta
 :maxdepth: 2
 :glob:
 
-customise-multipass/index
+install-multipass
 manage-instances/index
+customise-multipass/index
 troubleshoot/index
-*

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -1,5 +1,5 @@
 (how-to-guides-index)=
-# How-To-Guides
+# How-to guides
 
 The following how-to guides provide step-by-step instructions on the installation, use, management and troubleshooting of Multipass.
 

--- a/docs/how-to-guides/install-multipass.md
+++ b/docs/how-to-guides/install-multipass.md
@@ -13,15 +13,15 @@ Select the tab corresponding to your operating system (e.g. Linux) to display th
 (install-multipass-prerequisites)=
 ## Check prerequisites
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 Multipass for Linux is published as a [snap package](https://snapcraft.io/docs/), available on the [Snap Store](https://snapcraft.io/multipass). Before you can use it, you need to [install `snapd`](https://docs.snapcraft.io/core/install). `snapd` is included in Ubuntu by default.
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 <!--### Hypervisor.framework / hyperkit-->
 
@@ -29,7 +29,7 @@ The default backend on macOS is `qemu`, wrapping Apple's Hypervisor framework. Y
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 ### Hyper-V
 
@@ -45,9 +45,9 @@ Multipass also supports using VirtualBox as a virtualisation provider. You can d
 
 ## Install
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 To install Multipass, run the following command:
 
@@ -122,7 +122,7 @@ installed:          1.3.0                            (2205) 228MB -
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 ```{note}
 You will need an account with administrator privileges to complete the installation.
@@ -136,7 +136,7 @@ Run the downloaded installer and follow the guided procedure.
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 ```{note}
 You will need either Hyper-V enabled (only Windows 10 Professional or Enterprise), or VirtualBox installed. See {ref}`install-multipass-prerequisites`.
@@ -154,15 +154,15 @@ Alternatively, you can also check your preferred package manager to see if it pr
 
 ## Run
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 You've installed Multipass. Time to run your first commands! Use `multipass version` to check your version or `multipass launch` to create your first instance.
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 You've installed Multipass. Time to run your first commands! Use `multipass version` to check your version or `multipass launch` to create your first instance.
 
@@ -170,7 +170,7 @@ You've installed Multipass. Time to run your first commands! Use `multipass vers
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 You've installed Multipass. Time to run your first commands! Launch a **Command Prompt** (`cmd.exe`) or **PowerShell** as a regular user. Use `multipass version` to check your version or `multipass launch` to create your first instance.
 
@@ -188,15 +188,15 @@ multipass set local.driver=virtualbox
 
 ## Upgrade
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 As the installation happened via snap, you don't need to worry about upgrading---it will be done automatically.
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 ```{note}
 You will need an account with administrator privileges to complete the upgrade.
@@ -210,7 +210,7 @@ Any existing instances will be preserved.
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 To upgrade, [download the latest installer](https://canonical.com/multipass/download/windows) and run it. You can also get pre-release versions from the [GitHub releases](https://github.com/canonical/multipass/releases/) page, look for the `.msi` package.
 
@@ -222,9 +222,9 @@ You will be asked to uninstall the old version, and then whether to remove all d
 
 ## Uninstall
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 To uninstall Multipass, run the following command:
 
@@ -234,7 +234,7 @@ snap remove multipass
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 To uninstall Multipass, run the script:
 ```{code-block} text
@@ -243,7 +243,7 @@ sudo sh "/Library/Application Support/com.canonical.multipass/uninstall.sh"
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 Uninstall Multipass as you would any other program, following the usual procedure.
 

--- a/docs/how-to-guides/manage-instances/index.md
+++ b/docs/how-to-guides/manage-instances/index.md
@@ -29,4 +29,15 @@ Multipass allows you to create Ubuntu instances with a single command. As your n
 :maxdepth: 2
 :glob:
 
-*
+create-an-instance
+modify-an-instance
+use-an-instance
+use-the-primary-instance
+use-instance-command-aliases
+share-data-with-an-instance
+remove-an-instance
+add-a-network-to-an-existing-instance
+configure-static-ips
+use-a-blueprint
+use-the-docker-blueprint
+run-a-docker-container-in-multipass

--- a/docs/how-to-guides/manage-instances/index.md
+++ b/docs/how-to-guides/manage-instances/index.md
@@ -1,5 +1,5 @@
 (how-to-guides-manage-instances-index)=
-# Manage-Instances
+# Manage instances
 
 The following guides provide step-by-step instructions on how to manage Multipass instances.
 

--- a/docs/how-to-guides/manage-instances/use-instance-command-aliases.md
+++ b/docs/how-to-guides/manage-instances/use-instance-command-aliases.md
@@ -110,9 +110,9 @@ aliases to work without prefixing with `multipass`:
 PATH="$PATH:/home/user/snap/multipass/common/bin"
 ```
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 On Linux, you'll have to edit the shell configuration file. In most Linux distributions, the shell used by default is `bash`. You can configure this option by editing the file `.bashrc` in the user's home directory using a text editor; for example:
 
@@ -134,7 +134,7 @@ If your shell is `zsh` and not `bash`, the file to modify is `.zshrc` instead of
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 On macOS, you'll have to edit the shell configuration file. The shell used by default is `zsh`. You can configure this option by editing the file `.zshrc` in the user's home directory using a text editor.
 
@@ -151,7 +151,7 @@ Remember to replace the correct folder, as indicated in the output of the Multip
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 On Windows, to make the change permanent, use PowerShell to store the old system path, add the alias folder to it, and store the new path:
 

--- a/docs/how-to-guides/troubleshoot/access-logs.md
+++ b/docs/how-to-guides/troubleshoot/access-logs.md
@@ -7,9 +7,9 @@ The `multipass` command accepts the `--verbose` option (`-v` for short), which c
 
 We use the underlying platform's logging facilities to ensure you get the familiar behaviour wherever you are.
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 On Linux, [`systemd-journald`](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) is used, integrating with the de-facto standard for this on modern Linux systems.
 
@@ -23,7 +23,7 @@ The Multipass GUI produces its own logs, that can be found under `~/snap/multipa
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 On macOS, log files are stored in `/Library/Logs/Multipass`, where `multipassd.log` has the daemon messages. You will need `sudo` to access it.
 
@@ -31,7 +31,7 @@ The Multipass GUI produces its own logs, that can be found under `~/Library/Appl
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 On Windows, the Event system is used and Event Viewer lets you access them. Our logs are currently under "Windows Logs/Application", where you can filter by "Multipass" Event source. You can then export the selected events to a file.
 

--- a/docs/how-to-guides/troubleshoot/index.md
+++ b/docs/how-to-guides/troubleshoot/index.md
@@ -19,4 +19,7 @@ The following guides provide step-by-step instructions on how to troubleshoot is
 :maxdepth: 2
 :glob:
 
-*
+access-logs
+mount-an-encrypted-home-folder
+troubleshoot-launch-start-issues
+troubleshoot-networking

--- a/docs/reference/command-line-interface/index.md
+++ b/docs/reference/command-line-interface/index.md
@@ -1,5 +1,5 @@
 (reference-command-line-interface-index)=
-# Command-Line-Interface
+# Command-line interface
 
 > See also: [Instance](/explanation/instance), [Service](/explanation/service)
 

--- a/docs/reference/gui-client.md
+++ b/docs/reference/gui-client.md
@@ -44,7 +44,7 @@ Here you can see an overview of all your instances and perform bulk actions such
 
 You can perform actions on an individual instance, such as starting, stopping, suspending or deleting it. You can also open shells within a running instance, where you can do all of your work that is specific to that instance.
 
-![Instance shell page](https://assets.ubuntu.com/v1/740d7ab4-multipass-gui-instance)
+![Instance shell page](https://assets.ubuntu.com/v1/740d7ab4-multipass-gui-instance.png)
 
 ```{caution}
 Please note that when you delete an instance using the GUI client, Multipass removes it permanently and they cannot be recovered. This behaviour is equivalent to running the [`multipass delete --purge`](/reference/command-line-interface/delete) command.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -64,5 +64,8 @@ This section provides detailed reference material for Multipass, from CLI comman
 :glob:
 
 command-line-interface/index
+gui-client
+instance-name-format
+instance-states
+logging-levels
 settings/index
-*

--- a/docs/reference/logging-levels.md
+++ b/docs/reference/logging-levels.md
@@ -1,7 +1,7 @@
 (reference-logging-levels)=
 # Logging levels
 
-> See also: [Configure Multipass’s default logging level](/how-to-guides/customise-multipass/configure-multipasss-default-logging-level)
+> See also: [Configure Multipass’s default logging level](/how-to-guides/customise-multipass/configure-multipass-default-logging-level)
 
 In Multipass, a hierarchy of logging levels is used is used to convey severity and improve visibility of important events. Multipass uses the following levels ranked from most severe to least severe for its background daemon and child processes.
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -17,9 +17,9 @@ Select the tab corresponding to your operating system (e.g. Linux) to display th
 
 ## Create and use a basic instance
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 Start Multipass from the application launcher. In Ubuntu, press the super key and type "Multipass", or find Multipass in the Applications panel on the lower left of the desktop.
 
@@ -99,7 +99,7 @@ This folder could be a great place to keep files that need to be accessed by bot
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 Start Multipass from the application launcher. In macOS, open the application launcher, type "Multipass", and launch the application.
 
@@ -165,7 +165,7 @@ ubuntu@primary:~/Home/Multipass_Files$
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 Start Multipass from the application launcher. Press the Windows key and type "Multipass", then launch the application.
 
@@ -282,9 +282,9 @@ minikube                                      latest           minikube is local
 
 Launch an instance running Ubuntu 22.10 ("Kinetic Kudu") by typing the `multipass launch kinetic` command.
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 Now, you have an instance running and it has been named randomly by Multipass. In this case, it has been named "coherent-trumpetfish".
 
@@ -318,7 +318,7 @@ You can now launch the type of instance you need by running this command:
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 Now, you have an instance running and it has been named randomly by Multipass. In this case, it has been named "breezy-liger".
 
@@ -352,7 +352,7 @@ You can now launch the type of instance you need by running this command:
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 Now, you have an instance running and it has been named randomly by Multipass. In this case, it has been named "decorous-skate".
 
@@ -392,9 +392,9 @@ You can now launch the type of instance you need by running this command:
 
 You can confirm that the new instance has the specs you need by running `multipass info ltsInstance`.
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 ```{code-block} text
 $ multipass info ltsInstance
@@ -431,7 +431,7 @@ ltsInstance             Running           10.110.66.139    Ubuntu 22.04 LTS
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 ```{code-block} text
 $ multipass info ltsInstance
@@ -468,7 +468,7 @@ ltsInstance             Running           192.168.64.3     Ubuntu 22.04 LTS
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 ```{code-block} text
 C:\WINDOWS\system32> multipass info ltsInstance
@@ -533,17 +533,17 @@ sudo apt install apache2
 
 Open a browser and type in the IP address of your instance into the address bar. You should now see the default Apache homepage.
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 ![|720x545](https://assets.ubuntu.com/v1/e106f7f9-mp-linux-4.png)
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 ![|720x545](https://assets.ubuntu.com/v1/e106f7f9-mp-macos-5.png)
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 ![|720x545](https://assets.ubuntu.com/v1/e106f7f9-mp-windows-12.png)
 ````
 
@@ -562,9 +562,9 @@ You can launch an instance using the Docker Blueprint by running `multipass laun
 
 Once that's done, run `multipass info docker-dev` to note down the IP of the new instance.
 
-`````{tab-set}
+`````{tabs}
 
-````{tab-item} Linux
+````{group-tab} Linux
 
 ```{code-block} text
 $ multipass launch docker --name docker-dev
@@ -601,7 +601,7 @@ From the Portainer dashboard, you can see the ports available on nginx. To verif
 
 ````
 
-````{tab-item} macOS
+````{group-tab} macOS
 
 ```{code-block} text
 $ multipass launch docker --name docker-dev
@@ -638,7 +638,7 @@ From the Portainer dashboard, you can see the ports available on nginx. To verif
 
 ````
 
-````{tab-item} Windows
+````{group-tab} Windows
 
 ```{code-block} text
 C:\WINDOWS\system32> multipass launch docker --name docker-dev
@@ -693,9 +693,12 @@ Join the discussion on the [Multipass forum](https://discourse.ubuntu.com/c/mult
 
 <small>**Contributors:** @nhart, @saviq, @townsend, @andreitoterman, @tmihoc, @luisp, @ricab, @sharder996, @georgeliaojia, @mscho7969, @itecompro, @mr-cal, @sally-makin, @gzanchi, @bagustris , @pitifulpete </small>
 
+<!-- Hiding for now, this will be useful to have when we have more than one tutorial. 
+When that's the case, the title of the page also needs to change to "Tutorials".
 
 ```{toctree}
 :hidden:
 :titlesonly:
 :maxdepth: 2
 :glob:
+-->

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -693,7 +693,7 @@ Join the discussion on the [Multipass forum](https://discourse.ubuntu.com/c/mult
 
 <small>**Contributors:** @nhart, @saviq, @townsend, @andreitoterman, @tmihoc, @luisp, @ricab, @sharder996, @georgeliaojia, @mscho7969, @itecompro, @mr-cal, @sally-makin, @gzanchi, @bagustris , @pitifulpete </small>
 
-<!-- Hiding for now, this will be useful to have when we have more than one tutorial. 
+<!-- Hiding for now, this will be useful to have when we have more than one tutorial.
 When that's the case, the title of the page also needs to change to "Tutorials".
 
 ```{toctree}


### PR DESCRIPTION
- Changed MyST syntax to render tabs
- Improved labels in the navigation tree
- Fixed two broken image links (asset manager)
- Fixed order of pages in the navigation tree (now it's the same as in https://canonical.com/multipass/docs)
- Updated `conf.py` to display the "Give feedback" button on all pages

NOTE: To build the docs locally, go in the `/docs/` folder and run the command `make run`.