### PR TITLE
[tests] add log level to string unit tests

### DIFF
--- a/docs/how-to-guides/customise-multipass/build-multipass-images-with-packer.md
+++ b/docs/how-to-guides/customise-multipass/build-multipass-images-with-packer.md
@@ -58,7 +58,7 @@ Anything you do here will be reflected in the resulting image. You can install p
 
 Go to [Packer's documentation](https://developer.hashicorp.com/packer/docs) to learn about the QEMU builder, other provisioners and their configurations as well as everything else that might come in handy. Alternatively, you could extend `user-data` with other `cloud-init` [modules](https://cloudinit.readthedocs.io/en/latest/reference/modules.html) to provision your image.
 
-Join the discussion on the [Multipass forum](https://discourse.ubuntu.com/c/multipass/) and let us know about your images!
+Join the discussion on the [Multipass forum](https://discourse.ubuntu.com/c/project/multipass/21/) and let us know about your images!
 
 ---
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -683,7 +683,7 @@ Congratulations! You can now use Multipass proficiently.
 
 There's more to learn about Multipass and its capabilities. Check out our [How-to guides](/how-to-guides/index) for ideas and help with your project. In our [Explanation](/explanation/index) and [Reference](/reference/index) pages you can find definitions of key concepts, a complete CLI command reference, settings options and more.
 
-Join the discussion on the [Multipass forum](https://discourse.ubuntu.com/c/multipass/) and let us know what you are doing with your instances!
+Join the discussion on the [Multipass forum](https://discourse.ubuntu.com/c/project/multipass/21/) and let us know what you are doing with your instances!
 
 ---
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(multipass_tests
   test_sftp_utils.cpp
   test_file_ops.cpp
   test_recursive_dir_iter.cpp
+  test_log.cpp
 )
 
 target_include_directories(multipass_tests

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <multipass/logging/level.h>
+
+namespace mpl = multipass::logging;
+
+struct log_tests : ::testing::Test
+{
+};
+
+TEST_F(log_tests, test_levels_as_string)
+{
+    ASSERT_STREQ(mpl::as_string(mpl::Level::debug).c_str(), "debug");
+    ASSERT_STREQ(mpl::as_string(mpl::Level::error).c_str(), "error");
+    ASSERT_STREQ(mpl::as_string(mpl::Level::info).c_str(), "info");
+    ASSERT_STREQ(mpl::as_string(mpl::Level::warning).c_str(), "warning");
+    ASSERT_STREQ(mpl::as_string(mpl::Level::trace).c_str(), "trace");
+    ASSERT_STREQ(mpl::as_string(static_cast<mpl::Level>(-1)).c_str(), "unknown");
+    ASSERT_STREQ(mpl::as_string(static_cast<mpl::Level>(5)).c_str(), "unknown");
+}


### PR DESCRIPTION
This MP adds log level to string unit test case to ensure all cases are covered.

The MP also includes the commits from https://github.com/canonical/multipass/pull/3944 to resolve cyclic dependency between the two branches causing a CI failure

[giuliazanchi] Fixed link to Multipass Discourse landing page

MULTI-1831