### PR TITLE
Improve docs landing pages, improve syntax and links, add "Edit" button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical.com/multipass/docs"
+ogp_site_url = "https://documentation.ubuntu.com/multipass"
 
 
 # Preview name of the documentation website
@@ -106,7 +106,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "documentation.ubuntu.com",
+    "product_page": "canonical.com/multipass",
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # TODO: To add a tag image, uncomment and update as needed.
@@ -117,15 +117,15 @@ html_context = {
     #
     # NOTE: If set, adding ':discourse: 123' to an .rst file
     #       will add a link to Discourse topic 123 at the bottom of the page.
-    "discourse": "https://discourse.ubuntu.com",
+    "discourse": "https://discourse.ubuntu.com/c/project/multipass/21",
     # Your Mattermost channel URL
     #
     # TODO: Change to your Mattermost channel URL or leave empty.
-    "mattermost": "https://chat.canonical.com/canonical/channels/documentation",
+    "mattermost": "https://chat.canonical.com/canonical/channels/multipass",
     # Your Matrix channel URL
     #
     # TODO: Change to your Matrix channel URL or leave empty.
-    "matrix": "https://matrix.to/#/#documentation:ubuntu.com",
+    "matrix": "https://app.element.io/#/room/#Multipass:matrix.org",
     # Your documentation GitHub repository URL
     #
     # TODO: Change to your documentation GitHub repository URL or leave empty.
@@ -145,9 +145,15 @@ html_context = {
     # Valid options: none, prev, next, both
     # "sequential_nav": "both",
     # TODO: To enable listing contributors on individual pages, set to True
-    "display_contributors": False,
+    "display_contributors": True,
     # The following line enables the "Give feedback" button.
     "github_issues": "enabled",
+}
+
+html_theme_options = {
+    "source_repository": "https://github.com/canonical/multipass",
+    "source_branch": "main",
+    "source_directory": "docs/", 
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
@@ -155,7 +161,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'multipass'
 
 
 # Template and asset locations
@@ -273,10 +279,6 @@ rst_epilog = """
 # TODO: To disable the button, uncomment this.
 
 # disable_feedback_button = True
-
-# NOTE TO GIULIA: This line was suggested by Shane to enable the feedback button,
-# but it doesn't work at the moment.
-# 'github_issues': 'enabled',
 
 # Your manpage URL
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ html_context = {
     # Your Mattermost channel URL
     #
     # TODO: Change to your Mattermost channel URL or leave empty.
-    "mattermost": "https://chat.canonical.com/canonical/channels/multipass",
+    # "mattermost": "https://chat.canonical.com/canonical/channels/multipass",
     # Your Matrix channel URL
     #
     # TODO: Change to your Matrix channel URL or leave empty.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,7 +154,7 @@ html_context = {
 html_theme_options = {
     "source_repository": "https://github.com/canonical/multipass",
     "source_branch": "main",
-    "source_directory": "docs/", 
+    "source_directory": "docs/",
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,6 +150,7 @@ html_context = {
     "github_issues": "enabled",
 }
 
+# The following instructions are to display a clickable pencil "Edit" button on every page, in the top-right.
 html_theme_options = {
     "source_repository": "https://github.com/canonical/multipass",
     "source_branch": "main",

--- a/docs/explanation/blueprint.md
+++ b/docs/explanation/blueprint.md
@@ -9,7 +9,7 @@ Blueprints consist of a base image, cloud-init initialisation, and a set of para
 
 Blueprints are defined from a YAML file with the following schema:
 
-```
+```{code-block} text
 # v1/<name>.yaml
 
 description: <string>      # * a short description of the blueprint ("tagline")
@@ -36,6 +36,6 @@ health-check: |            # a health-check shell script ran by integration test
 
 ```
 
-Blueprints currently integrated into Multipass can be found with the [`multipass find`](/reference/command-line-interface/find) command.
+Blueprints currently integrated into Multipass can be found with the [`find`](/reference/command-line-interface/find) command.
 
 For more information on creating a blueprint for inclusion into Multipass, please refer to the [GitHub project](https://github.com/canonical/multipass-blueprints).

--- a/docs/explanation/driver.md
+++ b/docs/explanation/driver.md
@@ -43,7 +43,7 @@ Nonetheless, instances are preserved across drivers. After switching back to a p
 There are two exceptions to the above:
 
   - On Linux, QEMU and libvirt share the same driver scope.
-  - On macOS, stopped Hyperkit instances are automatically migrated to QEMU by Multipass's version 1.12 or later (see: [How to migrate from Hyperkit to QEMU on macOS](/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos)).
+  - On macOS, stopped Hyperkit instances are automatically migrated to QEMU by Multipass's version 1.12 or later (see [How to migrate from Hyperkit to QEMU on macOS](/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos)).
 
 (driver-feature-disparities)=
 ## Feature disparities

--- a/docs/explanation/id-mapping.md
+++ b/docs/explanation/id-mapping.md
@@ -9,7 +9,7 @@ Since ID mappings take effect from host to instance, as well as in the opposite 
 
 For example, the user ID `501` can be mapped to the user ID `1000` in the "foo" instance:
 
-```
+```{code-block} text
 multipass mount ~/Documents foo:Documents -u 501:1000
 ```
 
@@ -19,7 +19,7 @@ On the other hand, it is not possible to map this same user to a second user ID 
 
 Instead, a valid mount that maps two different user IDs could be defined as follows:
 
-```
+```{code-block} text
 multipass mount ~/Documents foo:Documents -u 501:1000 -u 502:1001
 ```
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -3,26 +3,10 @@
 
 The following explanations provide context and clarification on key-topics related to the use and configuration of Multipass. <!--- The following  was provided by @nielsenjared-->
 
-- [About security](about-security)
-- [About performance](about-performance)
-- [Alias](alias)
-- [Authentication](authentication)
-- [Blueprint](blueprint)
-- [Driver](driver)
-- [Host](host)
-- [ID mapping](id-mapping)
-- [Image](image)
-- [Instance](instance)
-- [Mount](mount)
-- [Multipass `exec` and shells](multipass-exec-and-shells)
-- [Platform](platform)
-- [Service](service)
-- [Snapshot](snapshot)
-
 ```{toctree}
-:hidden:
 :titlesonly:
 :maxdepth: 2
 :glob:
 
 *
+```

--- a/docs/explanation/instance.md
+++ b/docs/explanation/instance.md
@@ -10,7 +10,7 @@ An **instance** is a virtual machine created and managed by Multipass.
 (primary-instance)=
 ## Primary instance
 
-The Multipass [Command-Line Interface](/reference/command-line-interface/index) (CLI) provides a few shortcuts using a special instance, called *primary* instance. By default, this is the instance named `primary`.
+The Multipass [Command-line interface](/reference/command-line-interface/index) (CLI) provides a few shortcuts using a special instance, called *primary* instance. By default, this is the instance named `primary`.
 
 When invoked without positional arguments, state transition commands — [`start`](/reference/command-line-interface/start), [`restart`](/reference/command-line-interface/restart), [`stop`](/reference/command-line-interface/stop), and [`suspend`](/reference/command-line-interface/suspend) — operate on this special instance. So does the [`shell`](/reference/command-line-interface/shell) command. Furthermore, `start` and `shell` create the primary instance if it does not yet exist.
 

--- a/docs/explanation/multipass-exec-and-shells.md
+++ b/docs/explanation/multipass-exec-and-shells.md
@@ -1,7 +1,7 @@
 (explanation-multipass-exec-and-shells)=
 # Multipass `exec` and shells
 
-> See also: [`exec` command](/reference/command-line-interface/exec)
+> See also: [`exec`](/reference/command-line-interface/exec)
 
 ## How `exec` parses commands
 

--- a/docs/explanation/service.md
+++ b/docs/explanation/service.md
@@ -5,7 +5,7 @@
 
 In Multipass, **service** refers to the Multipass server that clients connect to and that controls and manages Multipass instances. This can also be referred to as the **daemon**.
 
-The Multipass daemon (`multipassd`) runs in the background and processes the requests from the Multipass [command-line interface](/reference/command-line-interface/index) and [GUI client](/reference/gui-client). The daemon is also in charge of the lifecycle of Multipass [instances](/explanation/instance). 
+The Multipass daemon (`multipassd`) runs in the background and processes the requests from the Multipass [command-line interface](/reference/command-line-interface/index) and [GUI client](/reference/gui-client). The daemon is also in charge of the lifecycle of Multipass [instances](/explanation/instance).
 
 The separation between client (CLI or GUI) and daemon is a popular architecture because of its main advantage, that is, flexibility. For instance, the daemon process can be on a different machine from the client; see [Use Multipass remotely](https://discourse.ubuntu.com/t/how-to-use-multipass-remotely/26360) for more details.
 

--- a/docs/explanation/service.md
+++ b/docs/explanation/service.md
@@ -3,6 +3,10 @@
 
 > See also: [Command-line interface](/reference/command-line-interface/index), [GUI client](/reference/gui-client), [Instance](/explanation/instance)
 
-In Multipass, the **service** refers to the Multipass server that clients connect to and controls and manages Multipass instances. This can also be referred to as the 'daemon'. Multipass daemon (`multipassd)` runs in the background and it processes the requests from the Multipass [command-line interface](/reference/command-line-interface/index), [GUI client](/reference/gui-client), daemon is also in charge of the lifecycle of the [Instances](/explanation/instance). The separation between the client (CLI or GUI) and daemon is a popular architecture because of his advantage, flexibility. For instance, the daemon process can be on a different machine from the client, see [Use Multipass remotely](https://discourse.ubuntu.com/t/how-to-use-multipass-remotely/26360) for more details.
+In Multipass, **service** refers to the Multipass server that clients connect to and that controls and manages Multipass instances. This can also be referred to as the **daemon**.
+
+The Multipass daemon (`multipassd`) runs in the background and processes the requests from the Multipass [command-line interface](/reference/command-line-interface/index) and [GUI client](/reference/gui-client). The daemon is also in charge of the lifecycle of Multipass [instances](/explanation/instance). 
+
+The separation between client (CLI or GUI) and daemon is a popular architecture because of its main advantage, that is, flexibility. For instance, the daemon process can be on a different machine from the client; see [Use Multipass remotely](https://discourse.ubuntu.com/t/how-to-use-multipass-remotely/26360) for more details.
 
 The automatic start of the daemon process is triggered right after the Multipass installation. After that, it is also set up to start automatically at system boot. This setup ensures that the Multipass client can immediately interact with the instances without the need to launch the daemon manually, and restores any persistent instances of Multipass after a system restart.

--- a/docs/explanation/settings-keys-values.md
+++ b/docs/explanation/settings-keys-values.md
@@ -1,0 +1,18 @@
+(explanation-settings-keys-values)=
+# Settings keys and values
+
+> See also: [Settings](/reference/settings/index)
+
+Multipass settings are organised in a tree structure, where each individual setting is identified by a unique **key** and takes on a single **value** at any given time.
+
+## Settings keys
+
+A **settings key** is a string in the form of a dot-separated path through the settings tree (such as `client.primary-name`). It specifies a path along the settings tree, from the root to a leaf. Thus, individual settings correspond to the leaves of the settings tree.
+
+Conceptually, branches of the tree can be singled out with wildcards, to refer to multiple settings at once. For instance, `local.<instance-name>.*` designates the settings that affect a specific instance. Wildcards can also be used to select separate branches. For example `local.*.cpus` refers to the number of CPUs of Multipass instances.
+
+## Settings values
+
+A **settings value** is a string whose syntax (possible values/representations) and semantics (their interpretation) is determined by the setting in question.
+
+Values often express common concepts (such as `true`, `false`, `42`, etc.) and are interpreted internally using the corresponding data types (such as boolean, integer, etc.). They can also be more complex (such as a key combination), but they are always specified and displayed through a string representation (for example: `Ctrl+Alt+U`).

--- a/docs/explanation/settings-keys-values.md
+++ b/docs/explanation/settings-keys-values.md
@@ -13,6 +13,6 @@ Conceptually, branches of the tree can be singled out with wildcards, to refer t
 
 ## Settings values
 
-A **settings value** is a string whose syntax (possible values/representations) and semantics (their interpretation) is determined by the setting in question.
+A **settings value** is a string whose syntax (possible values or their representations) and semantics (their interpretation) is determined by the setting in question.
 
 Values often express common concepts (such as `true`, `false`, `42`, etc.) and are interpreted internally using the corresponding data types (such as boolean, integer, etc.). They can also be more complex (such as a key combination), but they are always specified and displayed through a string representation (for example: `Ctrl+Alt+U`).

--- a/docs/explanation/snapshot.md
+++ b/docs/explanation/snapshot.md
@@ -9,7 +9,7 @@ To achieve this, a snapshot records all mutable properties of an instance, that 
 
 You can take a snapshot of an instance with the [`snapshot`](/reference/command-line-interface/snapshot) command, and restore it with the [`restore`](/reference/command-line-interface/restore) command. Taking and restoring a snapshot requires the instance to be stopped.
 
-You can view a list of the available snapshots with `multipass list --snapshots` and the details of a particular snapshot with `multipass info <instance>.<snapshot>`. To delete a snapshot, use the [`multipass delete`](/reference/command-line-interface/delete) command.
+You can view a list of the available snapshots with `multipass list --snapshots` and the details of a particular snapshot with `multipass info <instance>.<snapshot>`. To delete a snapshot, use the [`delete`](/reference/command-line-interface/delete) command.
 
 > See also: [`list`](/reference/command-line-interface/list), [`info`](/reference/command-line-interface/info)
 

--- a/docs/how-to-guides/customise-multipass/build-multipass-images-with-packer.md
+++ b/docs/how-to-guides/customise-multipass/build-multipass-images-with-packer.md
@@ -11,7 +11,7 @@ Custom images are only supported on Linux.
 
 The easiest way is to start from an existing [Ubuntu Cloud Image](https://cloud-images.ubuntu.com/), and the base project setup follows (you can click on the filenames to see their contents, `meta-data` is empty on purpose):
 
-```
+```{code-block} text
 ├── cloud-data
 │   ├── meta-data
 │   └── <a href="https://paste.ubuntu.com/p/6vbtNXttqZ/">user-data</a>

--- a/docs/how-to-guides/customise-multipass/index.md
+++ b/docs/how-to-guides/customise-multipass/index.md
@@ -32,3 +32,4 @@ use-a-different-terminal-from-the-system-icon
 integrate-with-windows-terminal
 configure-where-multipass-stores-external-data
 configure-multipass-default-logging-level
+```

--- a/docs/how-to-guides/customise-multipass/integrate-with-windows-terminal.md
+++ b/docs/how-to-guides/customise-multipass/integrate-with-windows-terminal.md
@@ -28,7 +28,7 @@ Open a terminal (Windows Terminal or any other) and enable the integration with 
 multipass set client.apps.windows-terminal.profiles=primary
 ```
 
-For more information on this setting, see: [`client.apps.windows-terminal.profiles`](/reference/settings/client-apps-windows-terminal-profiles). Until you modify it, Multipass will try to add the profile if it finds it missing. To remove the profile see {ref}`integrate-with-windows-terminal-revert` below.
+For more information on this setting, see [`client.apps.windows-terminal.profiles`](/reference/settings/client-apps-windows-terminal-profiles). Until you modify it, Multipass will try to add the profile if it finds it missing. To remove the profile see {ref}`integrate-with-windows-terminal-revert` below.
 
 ## Open a Multipass tab
 

--- a/docs/how-to-guides/customise-multipass/integrate-with-windows-terminal.md
+++ b/docs/how-to-guides/customise-multipass/integrate-with-windows-terminal.md
@@ -24,7 +24,7 @@ The first step is to [install Windows Terminal](https://github.com/microsoft/ter
 
 Open a terminal (Windows Terminal or any other) and enable the integration with the following command:
 
-```
+```{code-block} text
 multipass set client.apps.windows-terminal.profiles=primary
 ```
 
@@ -50,7 +50,7 @@ That's it!
 
 If you want to disable the profile again, you can do so with:
 
-```
+```{code-block} text
 multipass set client.apps.windows-terminal.profiles=none
 ```
 

--- a/docs/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos.md
+++ b/docs/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos.md
@@ -5,9 +5,9 @@
 
 As of Multipass 1.12, the Hyperkit driver is being deprecated. New installs will start with the QEMU driver set by default, but existing installs will retain the previous driver setting. Multipass will warn Hyperkit users of the deprecation and ask them to move to QEMU. To facilitate that, Multipass 1.12 will migrate Hyperkit instances to QEMU.
 
-To migrate from Hyperkit to QEMU and bring your instances along, simply stop them and set the driver to QEMU:
+To migrate from Hyperkit to QEMU and bring your instances along, simply stop them and set the driver to QEMU: 
 
-```
+```{code-block} text
 multipass stop --all
 multipass set local.driver=qemu
 ```
@@ -18,7 +18,7 @@ If you already had QEMU instances, they are not affected by the migration. Insta
 
 The original Hyperkit instances are retained until explicitly deleted. You can achieve that by temporarily moving back to Hyperkit and using the delete command:
 
-```
+```{code-block} text
 multipass set local.driver=hyperkit
 multipass delete [-p] <instance> [...]
 multipass set local.driver=qemu

--- a/docs/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos.md
+++ b/docs/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos.md
@@ -5,7 +5,7 @@
 
 As of Multipass 1.12, the Hyperkit driver is being deprecated. New installs will start with the QEMU driver set by default, but existing installs will retain the previous driver setting. Multipass will warn Hyperkit users of the deprecation and ask them to move to QEMU. To facilitate that, Multipass 1.12 will migrate Hyperkit instances to QEMU.
 
-To migrate from Hyperkit to QEMU and bring your instances along, simply stop them and set the driver to QEMU: 
+To migrate from Hyperkit to QEMU and bring your instances along, simply stop them and set the driver to QEMU:
 
 ```{code-block} text
 multipass stop --all

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -278,7 +278,7 @@ Name:            en3: Thunderbolt 2
 ...
 ```
 
-Finally, tell VirtualBox to use it as the "parent" for the second interface (see more info on bridging in [VirtualBox documentation](https://www.virtualbox.org/manual/ch06.html#network_bridged) on this topic):
+Finally, tell VirtualBox to use it as the "parent" for the second interface (for more information on this topic, see [VirtualBox documentation](https://www.virtualbox.org/manual/ch06.html#network_bridged)):
 
 ```{code-block} text
 sudo VBoxManage modifyvm primary --nic2 bridged --bridgeadapter2 en0

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -62,3 +62,4 @@ install-multipass
 manage-instances/index
 customise-multipass/index
 troubleshoot/index
+```

--- a/docs/how-to-guides/manage-instances/add-a-network-to-an-existing-instance.md
+++ b/docs/how-to-guides/manage-instances/add-a-network-to-an-existing-instance.md
@@ -22,13 +22,13 @@ mpbr0     bridge     Network bridge for Multipass
 virbr0    bridge     Network bridge
 ```
 
-Set the preferred network (for example, `eth0`) using the [`multipass set`](/reference/command-line-interface/set) command:
+Set the preferred network (for example, `eth0`) using the [`set`](/reference/command-line-interface/set) command:
 
 ```{code-block} text
 multipass set local.bridged-network=eth0
 ```
 
-Before bridging the network, you need to stop the instance (called `ultimate-grosbeak` in our example) using the [`multipass stop`](/reference/command-line-interface/stop) command:
+Before bridging the network, you need to stop the instance (called `ultimate-grosbeak` in our example) using the [`stop`](/reference/command-line-interface/stop) command:
 
 ```{code-block} text
 multipass stop ultimate-grosbeak
@@ -47,7 +47,7 @@ multipass set local.bridged-network=eth1
 multipass set local.ultimate-grosbeak.bridged=true
 ```
 
-Use the [`multipass get`](/reference/command-line-interface/get) command to check whether an instance is bridged with the currently configured preferred network:
+Use the [`get`](/reference/command-line-interface/get) command to check whether an instance is bridged with the currently configured preferred network:
 
 ```{code-block} text
 multipass get local.ultimate-grosbeak.bridged

--- a/docs/how-to-guides/manage-instances/configure-static-ips.md
+++ b/docs/how-to-guides/manage-instances/configure-static-ips.md
@@ -11,14 +11,14 @@ The first step is to create a new bridge/switch with a static IP on your host.
 
 This is beyond the scope of Multipass but, as an example, here is how this can be achieved with NetworkManager on Linux (e.g. on Ubuntu Desktop):
 
-```
+```{code-block} text
 nmcli connection add type bridge con-name localbr ifname localbr \
     ipv4.method manual ipv4.addresses 10.13.31.1/24
 ```
 
 This will create a bridge named `localbr` with IP `10.13.31.1/24`. You can see the new device and address with `ip -c -br addr show dev localbr`. This should show:
 
-```
+```{code-block} text
 localbr           DOWN           10.13.31.1/24
 ```
 
@@ -28,7 +28,7 @@ You can also run `multipass networks` to confirm the bridge is available for Mul
 
 Next we launch an instance with an extra network in manual mode, connecting it to this bridge:
 
-```
+```{code-block} text
 multipass launch --name test1 --network name=localbr,mode=manual,mac="52:54:00:4b:ab:cd"
 ```
 
@@ -38,7 +38,7 @@ You can also leave the MAC address unspecified (just `--network name=localbr,mod
 
 We now need to configure the manual network interface inside the instance. We can achieve that using Netplan. The following command plants the required Netplan configuration file in the instance:
 
-```
+```{code-block} text
 multipass exec -n test1 -- sudo bash -c 'cat << EOF > /etc/netplan/10-custom.yaml
 network:
     version: 2
@@ -59,7 +59,7 @@ If you want to set a different name for the interface, you can add a [`set-name`
 
 We now tell Netplan to apply the new configuration inside the instance:
 
-```
+```{code-block} text
 multipass exec -n test1 -- sudo netplan apply
 ```
 
@@ -69,19 +69,19 @@ You may also use `netplan try`, to have the outcome reverted if something goes w
 
 You can confirm that the new IP is present in the instance with Multipass:
 
-```
+```{code-block} text
 multipass info test1
 ```
 
 The command above should show two IPs, the second of which is the one we just configured (`10.13.31.13`). You can use `ping` to confirm that it can be reached from the host:
 
-```
+```{code-block} text
 ping 10.13.31.13
 ```
 
 Conversely, you can also ping from the instance to the host:
 
-```
+```{code-block} text
 multipass exec -n test1 -- ping 10.13.31.1
 ```
 
@@ -89,7 +89,7 @@ multipass exec -n test1 -- ping 10.13.31.1
 
 If desired, repeat steps 2-5 with different names/MACs/IP terminations (e.g. `10.13.31.14`) to launch other instances with static IPs in the same network. You can ping from one instance to another to confirm that they are connected. For example:
 
-```
+```{code-block} text
 multipass exec -n test1 -- ping 10.13.31.14
 ```
 

--- a/docs/how-to-guides/manage-instances/create-an-instance.md
+++ b/docs/how-to-guides/manage-instances/create-an-instance.md
@@ -106,7 +106,7 @@ An instance can obtain the primary status at creation time if its name is `prima
 multipass launch kinetic --name primary
 ```
 
-For more information, see: [How to use the primary instance](/how-to-guides/manage-instances/use-the-primary-instance).
+For more information, see [How to use the primary instance](/how-to-guides/manage-instances/use-the-primary-instance).
 
 (create-an-instance-with-multiple-network-interfaces)=
 ## Create an instance with multiple network interfaces

--- a/docs/how-to-guides/manage-instances/index.md
+++ b/docs/how-to-guides/manage-instances/index.md
@@ -36,3 +36,4 @@ configure-static-ips
 use-a-blueprint
 use-the-docker-blueprint
 run-a-docker-container-in-multipass
+```

--- a/docs/how-to-guides/manage-instances/share-data-with-an-instance.md
+++ b/docs/how-to-guides/manage-instances/share-data-with-an-instance.md
@@ -9,7 +9,7 @@ This guide explains how to share data between your host and an instance. There a
 
 ## Using `mount`
 
-You can use the [`multipass mount`](/reference/command-line-interface/mount) command to share data between your host and an instance, by making specific folders in your host's filesystem available in your instance's filesystem, with read and write permissions. Mounted paths are persistent, meaning that they will remain available until they are explicitly unmounted.
+You can use the [`mount`](/reference/command-line-interface/mount) command to share data between your host and an instance, by making specific folders in your host's filesystem available in your instance's filesystem, with read and write permissions. Mounted paths are persistent, meaning that they will remain available until they are explicitly unmounted.
 
 The basic syntax of the `mount` command is:
 
@@ -44,7 +44,7 @@ If the `/some/path` directory already exists in the instance's filesystem, its c
 For this reason, it is not possible to mount an external folder path over the instance's $HOME directory, because it also contains the SSH keys required to access the instance: by hiding them, you would no longer be able to shell into the instance.
 ```
 
-You can also define mounts when you create an instance, using the [`multipass launch`](/reference/command-line-interface/launch) command with the `--mount` option:
+You can also define mounts when you create an instance, using the [`launch`](/reference/command-line-interface/launch) command with the `--mount` option:
 
 ```{code-block} text
 multipass launch --mount /local/path:/instance/path
@@ -52,7 +52,7 @@ multipass launch --mount /local/path:/instance/path
 
 ### Unmounting shared directories
 
-To unmount previously mounted paths, use the [`multipass umount`](/reference/command-line-interface/umount) command.
+To unmount previously mounted paths, use the [`umount`](/reference/command-line-interface/umount) command.
 
 You can specify the folder path to unmount:
 
@@ -68,7 +68,7 @@ multipass umount keen-yak
 
 ## Using `transfer`
 
-You can also use the [`multipass transfer`](/reference/command-line-interface/transfer) command to copy files from your local filesystem to the instance's filesystem, and vice versa.
+You can also use the [`transfer`](/reference/command-line-interface/transfer) command to copy files from your local filesystem to the instance's filesystem, and vice versa.
 
 To indicate that a file is inside an instance, prefix its path with `<instance name>:`.
 

--- a/docs/how-to-guides/manage-instances/use-a-blueprint.md
+++ b/docs/how-to-guides/manage-instances/use-a-blueprint.md
@@ -11,7 +11,7 @@ To see what blueprints are available, run
 multipass find --only-blueprints
 ```
 
-> See more: [`multipass find`](/reference/command-line-interface/find)
+> See also: [`find`](/reference/command-line-interface/find)
 
 To use a blueprint run:
 

--- a/docs/how-to-guides/manage-instances/use-instance-command-aliases.md
+++ b/docs/how-to-guides/manage-instances/use-instance-command-aliases.md
@@ -9,7 +9,7 @@ This guide demonstrates how to create, list, run and remove aliases for commands
 
 > See also: [`alias`](/reference/command-line-interface/alias)
 
-To create an alias that runs a command on a given instance, use the command [`multipass alias`](/reference/command-line-interface/alias). The code below uses this command to create an alias `lscc` that will run the command `ls` inside an instance `crazy-cat`:
+To create an alias that runs a command on a given instance, use the [`alias`](/reference/command-line-interface/alias) command. The code below uses this command to create an alias `lscc` that will run the command `ls` inside an instance `crazy-cat`:
 
 ```{code-block} text
 multipass alias crazy-cat:ls lscc

--- a/docs/how-to-guides/manage-instances/use-the-primary-instance.md
+++ b/docs/how-to-guides/manage-instances/use-the-primary-instance.md
@@ -22,7 +22,7 @@ In the command line, it is used as the default when no instance name is specifie
 When launching the primary instance, whether implicitly or explicitly, Multipass automatically mounts the user's home inside it, in the folder `Home`. As with any other mount, you can unmount it with `multipass umount`. For instance, `multipass umount primary` will unmount all mounts made by Multipass inside `primary`, including the auto-mounted `Home`.
 
 ```{note}
-On Windows mounts are disabled by default for security reasons. See [`multipass set`](/reference/command-line-interface/set) and [local.privileged-mounts](/reference/settings/local-privileged-mounts) for information on how to enable them if needed.
+On Windows mounts are disabled by default for security reasons. See [`set`](/reference/command-line-interface/set) and [local.privileged-mounts](/reference/settings/local-privileged-mounts) for information on how to enable them if needed.
 ```
 (changing-the-primary-instance)=
 ## Changing the primary instance

--- a/docs/how-to-guides/troubleshoot/access-logs.md
+++ b/docs/how-to-guides/troubleshoot/access-logs.md
@@ -5,6 +5,8 @@ Logs are our first go-to when something goes wrong. Multipass is comprised of a 
 
 The `multipass` command accepts the `--verbose` option (`-v` for short), which can be repeated to go from the default (*error*) level through *warning*, *info*, *debug* up to *trace*.
 
+> See also: [Logging levels](/reference/logging-levels), [Configure Multipass’s default logging level](/how-to-guides/customise-multipass/configure-multipass-default-logging-level), 
+
 We use the underlying platform's logging facilities to ensure you get the familiar behaviour wherever you are.
 
 `````{tabs}

--- a/docs/how-to-guides/troubleshoot/access-logs.md
+++ b/docs/how-to-guides/troubleshoot/access-logs.md
@@ -5,7 +5,7 @@ Logs are our first go-to when something goes wrong. Multipass is comprised of a 
 
 The `multipass` command accepts the `--verbose` option (`-v` for short), which can be repeated to go from the default (*error*) level through *warning*, *info*, *debug* up to *trace*.
 
-> See also: [Logging levels](/reference/logging-levels), [Configure Multipass’s default logging level](/how-to-guides/customise-multipass/configure-multipass-default-logging-level), 
+> See also: [Logging levels](/reference/logging-levels), [Configure Multipass’s default logging level](/how-to-guides/customise-multipass/configure-multipass-default-logging-level)
 
 We use the underlying platform's logging facilities to ensure you get the familiar behaviour wherever you are.
 

--- a/docs/how-to-guides/troubleshoot/index.md
+++ b/docs/how-to-guides/troubleshoot/index.md
@@ -18,3 +18,4 @@ access-logs
 mount-an-encrypted-home-folder
 troubleshoot-launch-start-issues
 troubleshoot-networking
+```

--- a/docs/how-to-guides/troubleshoot/troubleshoot-launch-start-issues.md
+++ b/docs/how-to-guides/troubleshoot/troubleshoot-launch-start-issues.md
@@ -163,7 +163,7 @@ The macOS firewall is known to cause `vmnet` to malfunction, because it blocks A
 
 You may be able to work around it by disabling the firewall entirely, or executing
 
-{code-block} text
+```{code-block} text
 /usr/libexec/ApplicationFirewall/socketfilterfw --add /usr/libexec/bootpd
 /usr/libexec/ApplicationFirewall/socketfilterfw --unblock /usr/libexec/bootpd
 ```

--- a/docs/how-to-guides/troubleshoot/troubleshoot-launch-start-issues.md
+++ b/docs/how-to-guides/troubleshoot/troubleshoot-launch-start-issues.md
@@ -22,12 +22,12 @@ The possible reasons that can lead the `launch` or `start` commands to fail are:
 
 Follow these steps to diagnose your issue and identify the most likely scenario:
 
-1. If the `multipass launch` command fails with the message "Downloaded image hash does not match", see: {ref}`launch-start-issues-stale-network-cache`.
+1. If the `multipass launch` command fails with the message "Downloaded image hash does not match", see {ref}`launch-start-issues-stale-network-cache`.
 
-2. *(Windows, Hyper-V driver)* Inspect the file `C:\WINDOWS\System32\drivers\etc\hosts.ics` and see if there is more than one entry with your instance name in it. If that's the case, see: {ref}`launch-start-issues-stale-sharing-lease`.
+2. *(Windows, Hyper-V driver)* Inspect the file `C:\WINDOWS\System32\drivers\etc\hosts.ics` and see if there is more than one entry with your instance name in it. If that's the case, see {ref}`launch-start-issues-stale-sharing-lease`.
 
 3. *(Linux/macOS, QEMU driver)* Inspect the Multipass logs and look for a message mentioning `NIC_RX_FILTER_CHANGED`. This message indicates that the network interface has been initialised.
-    * If you don't find it, it means that the VM didn't manage to bring up the interface; see: {ref}`launch-start-issues-vm-boot-failure`.
+    * If you don't find it, it means that the VM didn't manage to bring up the interface; see {ref}`launch-start-issues-vm-boot-failure`.
     * If the message is present, proceed to check DHCP traffic in the next step.
 
 4. *(Linux/macOS, QEMU driver)* Check DHCP traffic from your host to the instance, to find out if there are requests and replies. Adapt and run the following command *right after starting/launching* the instance:
@@ -43,7 +43,7 @@ Follow these steps to diagnose your issue and identify the most likely scenario:
     ```
 
     * If you see `NIC_RX_FILTER_CHANGED`, you should also see DHCP requests. If you don't, see {ref}`launch-start-issues-vm-boot-failure` and please [let us know](https://github.com/canonical/multipass/issues/new/choose).
-    * If you see a DHCP request, but no reply, it means that the VM is still waiting for an IP address to be assigned; see: {ref}`launch-start-issues-no-ip-assigned`.
+    * If you see a DHCP request, but no reply, it means that the VM is still waiting for an IP address to be assigned; see {ref}`launch-start-issues-no-ip-assigned`.
     * If you see DHCP requests and replies, continue to the next step.
 
 5. Look for messages regarding SSH in Multipass's logs. The instance may have obtained an IP and/or be properly connected, but still refuse Multipass when it tries to SSH into it.
@@ -141,7 +141,7 @@ Here are some options to attempt recovery:
      - In the recovery menu, select **`resume`** to continue with the normal boot process.
      - The system should now boot normally if `fsck` was able to repair the filesystem.
 
-- *(Linux/macOS)* Alternatively, run `fsck` over a mounted image on the host (see: {ref}`launch-start-issues-reading-data-from-an-image`).
+- *(Linux/macOS)* Alternatively, run `fsck` over a mounted image on the host (see {ref}`launch-start-issues-reading-data-from-an-image`).
 - Run `qemu-img check -r` on the image.
     * `qemu-img`, shipped with Multipass, can also be used to check and repair disk images.
     * See {ref}`launch-start-issues-locate-multipass-binaries` below.
@@ -202,7 +202,7 @@ If SSH doesn't function properly in the VM, or Multipass is blocked from accessi
 
 To gain access to an instance without SSH you can try the following methods.
 
-* Mount the instance's image file on your host (see: {ref}`launch-start-issues-reading-data-from-an-image`) and make necessary changes through the filesystem.
+* Mount the instance's image file on your host (see {ref}`launch-start-issues-reading-data-from-an-image`) and make necessary changes through the filesystem.
 
 * Run the instance VM directly. This will require a username and password to log in. The username is the default user, `ubuntu`, and the password is what was set in cloud-init if you used a custom cloud-init config. If you do not have a password you can modify the instance's `cloud-init-config.iso` file to change it. One way to do so is as follows.
   1. Back up your existing `cloud-init-config.iso`.

--- a/docs/how-to-guides/troubleshoot/troubleshoot-networking.md
+++ b/docs/how-to-guides/troubleshoot/troubleshoot-networking.md
@@ -28,7 +28,7 @@ Note that, according to **System Preferences > Sharing**, the **Internet Sharing
     * Tunnelblick doesn’t cause problems.
 * Cisco Umbrella Roaming Client it binds to localhost:53 which clashes with Internet Sharing, breaking the instance’s DNS.
 <!-- THIS LINK IS BROKEN
-(see: [Umbrella Roaming Client OS X and Internet Sharing](https://support.umbrella.com/hc/en-us/articles/230561007-Umbrella-Roaming-Client-OS-X-and-Internet-Sharing)) -->
+(see [Umbrella Roaming Client OS X and Internet Sharing](https://support.umbrella.com/hc/en-us/articles/230561007-Umbrella-Roaming-Client-OS-X-and-Internet-Sharing)) -->
 * dnscrypt-proxy/dnscrypt-wrapper/cloudflared-proxy \
 The default configuration binds to localhost port 53, clashing with Internet Sharing.
 * Another `dnsmasq` process bound to localhost port 53

--- a/docs/how-to-guides/troubleshoot/troubleshoot-networking.md
+++ b/docs/how-to-guides/troubleshoot/troubleshoot-networking.md
@@ -265,7 +265,7 @@ Any other command appearing in that output means a process is conflicting with *
 
 1. Configure DNS inside the instance to use an external working DNS server. Can do so by appending this line to /etc/resolv.conf manually:
 
-    ```
+    ```{code-block} text
     nameserver 1.1.1.1
     ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,3 +50,4 @@ how-to-guides/index
 reference/index
 explanation/index
 contribute-to-multipass-docs
+```

--- a/docs/reference/command-line-interface/clone.md
+++ b/docs/reference/command-line-interface/clone.md
@@ -20,7 +20,7 @@ By default, the `multipass clone` command automatically generates a name for the
 
 Alternatively, you can specify a custom name for the cloned instance using `--name` option, following the [standard instance name format](/reference/instance-name-format). For example:
 
-```
+```{code-block} text
 multipass clone natty-nilgai --name custom-clone
 ```
 

--- a/docs/reference/command-line-interface/delete.md
+++ b/docs/reference/command-line-interface/delete.md
@@ -13,7 +13,7 @@ multipass delete --purge legal-takin calm-squirrel.snapshot2
 
 Deleted instances are marked as such and removed from use, but you can still recover them using the `multipass recover` command, unless you used the `-p`/`--purge` option to delete them permanently.
 
-To completely destroy instances and release the disk space they take up, use the `--purge` option or the [`multipass purge`](/reference/command-line-interface/purge) command.
+To completely destroy instances and release the disk space they take up, use the `--purge` option or the [`purge`](/reference/command-line-interface/purge) command.
 
 ```{caution}
 When you delete a [snapshot](/explanation/snapshot), or when you delete an instance using the [GUI client](/reference/gui-client), Multipass removes them permanently (even if you didn't use the `--purge` option) and they cannot be recovered.

--- a/docs/reference/command-line-interface/get.md
+++ b/docs/reference/command-line-interface/get.md
@@ -26,7 +26,7 @@ local.passphrase
 local.privileged-mounts
 ```
 
-To set the value of a particular setting, see [`set` command](/reference/command-line-interface/set).
+To set the value of a particular setting, see [`set`](/reference/command-line-interface/set).
 
 You can read more about the available settings in the [Settings](/reference/settings/index) reference page.
 

--- a/docs/reference/command-line-interface/index.md
+++ b/docs/reference/command-line-interface/index.md
@@ -7,40 +7,10 @@ The **`multipass`** CLI (command line interface) client is used to communicate w
 
 You can use `multipass help <command>` to display more information on the purpose and available options of each command.
 
-- [`alias`](alias)
-- [`aliases`](aliases)
-- [`authenticate`](authenticate)
-- [`clone`](clone)
-- [`delete`](delete)
-- [`exec`](exec)
-- [`find`](find)
-- [`get`](get)
-- [`help`](help)
-- [`info`](info)
-- [`launch`](launch)
-- [`list`](list)
-- [`mount`](mount)
-- [`networks`](networks)
-- [`prefer`](prefer)
-- [`purge`](purge)
-- [`recover`](recover)
-- [`restart`](restart)
-- [`restore`](restore)
-- [`set`](set)
-- [`shell`](shell)
-- [`snapshot`](snapshot)
-- [`start`](start)
-- [`stop`](stop)
-- [`suspend`](suspend)
-- [`transfer`](transfer)
-- [`umount`](umount)
-- [`unalias`](unalias)
-- [`version`](version)
-
 ```{toctree}
-:hidden:
 :titlesonly:
 :maxdepth: 2
 :glob:
 
 *
+```

--- a/docs/reference/command-line-interface/launch.md
+++ b/docs/reference/command-line-interface/launch.md
@@ -3,7 +3,7 @@
 
 The `multipass launch` command without any argument will create and start a new instance based on the default image, using a random generated name; for example:
 
-```
+```{code-block} text
 ...
 Launched: relishing-lionfish
 ```

--- a/docs/reference/command-line-interface/purge.md
+++ b/docs/reference/command-line-interface/purge.md
@@ -1,7 +1,7 @@
 (reference-command-line-interface-purge)=
 # purge
 
-> See also: [`multipass delete`](/reference/command-line-interface/delete), [`multipass recover`](/reference/command-line-interface/recover)
+> See also: [`delete`](/reference/command-line-interface/delete), [`recover`](/reference/command-line-interface/recover)
 
 The `multipass purge` command will permanently remove all instances deleted with the `multipass delete` command. This will destroy all the traces of the instance, and cannot be undone.
 

--- a/docs/reference/command-line-interface/recover.md
+++ b/docs/reference/command-line-interface/recover.md
@@ -1,7 +1,7 @@
 (reference-command-line-interface-recover)=
 # recover
 
-> See also: [`multipass delete`](/reference/command-line-interface/delete), [`multipass purge`](/reference/command-line-interface/purge)
+> See also: [`delete`](/reference/command-line-interface/delete), [`purge`](/reference/command-line-interface/purge)
 
 The `multipass recover` command will revive an instance that was previously removed with `multipass delete`. For this to be possible, the instance cannot have been purged with `multipass purge` nor with `multipass delete --purge`.
 

--- a/docs/reference/command-line-interface/restore.md
+++ b/docs/reference/command-line-interface/restore.md
@@ -24,7 +24,7 @@ Snapshot taken: relative-lion.snapshot3
 Snapshot restored: relative-lion.snapshot2
 ```
 
-As shown in the example, with no further options, the command will offer to take another snapshot. This automatic snapshot saves the instance's current state before it is thrown away. It will be named following the [`multipass snapshot`](/reference/command-line-interface/snapshot) default naming convention, and it will have an automatic comment to indicate its purpose.
+As shown in the example, with no further options, the command will offer to take another snapshot. This automatic snapshot saves the instance's current state before it is thrown away. It will be named following the [`snapshot`](/reference/command-line-interface/snapshot) command's default naming convention, and it will have an automatic comment to indicate its purpose.
 
 In our example, if you run:
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,56 +1,34 @@
 (reference-index)=
 # Reference
 
-This section provides detailed reference material for Multipass, from CLI commands to settings keys.
+This section provides detailed reference material for Multipass, such as all available commands, configuration settings keys, and more. 
 
-- [Command-Line Interface](command-line-interface/index)
-    - [alias](command-line-interface/alias)
-    - [aliases](command-line-interface/aliases)
-    - [authenticate](command-line-interface/authenticate)
-    - [clone](command-line-interface/clone)
-    - [delete](command-line-interface/delete)
-    - [exec](command-line-interface/exec)
-    - [find](command-line-interface/find)
-    - [get](command-line-interface/get)
-    - [help](command-line-interface/help)
-    - [info](command-line-interface/info)
-    - [launch](command-line-interface/launch)
-    - [list](command-line-interface/list)
-    - [mount](command-line-interface/mount)
-    - [networks](command-line-interface/networks)
-    - [prefer](command-line-interface/prefer)
-    - [purge](command-line-interface/purge)
-    - [recover](command-line-interface/recover)
-    - [restart](command-line-interface/restart)
-    - [restore](command-line-interface/restore)
-    - [set](command-line-interface/set)
-    - [shell](command-line-interface/shell)
-    - [snapshot](command-line-interface/snapshot)
-    - [start](command-line-interface/start)
-    - [stop](command-line-interface/stop)
-    - [suspend](command-line-interface/suspend)
-    - [transfer](command-line-interface/transfer)
-    - [umount](command-line-interface/umount)
-    - [unalias](command-line-interface/unalias)
-    - [version](command-line-interface/version)
-- [GUI client](gui-client)
+## Command line reference
+
+Multipass offers a powerful command-line interface for creating and managing virtual machines effortlessly.
+
+For a complete list of Multipass CLI commands and their usage is available, see: [Command-Line Interface](command-line-interface/index).
+
+## GUI client
+
+Multipass also comes with a user-friendly desktop application to create and manage your VMs, that also includes a virtual shell interface. For more details, see: [GUI client](gui-client).
+
+## Instances
+
+To find out more about the naming convention for Multipass VMs (also called instances) and the possible states they can assume, see: 
+
 - [Instance name format](instance-name-format)
 - [Instance states](instance-states)
-- [Settings](settings/index)
-    - [client.apps.windows-terminal.profiles](settings/client-apps-windows-terminal-profiles)
-    - [client.gui.autostart](settings/client-gui-autostart)
-    - [client.gui.hotkey](settings/client-gui-hotkey)
-    - [client.primary-name](settings/client-primary-name)
-    - [local.bridged-network](settings/local-bridged-network)
-    - [local.driver](settings/local-driver)
-    - [local.passphrase](settings/local-passphrase)
-    - [local.privileged-mounts](settings/local-privileged-mounts)
-    - [local.\<instance-name>.bridged](settings/local-instance-name-bridged)
-    - [local.\<instance-name>.cpus](settings/local-instance-name-cpus)
-    - [local.\<instance-name>.disk](settings/local-instance-name-disk)
-    - [local.\<instance-name>.memory](settings/local-instance-name-memory)
-    - [local.\<instance-name>.\<snapshot-name>.name](settings/local-instance-name-snapshot-name-name)
-    - [local.\<instance-name>.\<snapshot-name>.comment](settings/local-instance-name-snapshot-name-comment)
+
+## Logs
+
+For more information on the different logging levels that can be configured in Multipass, see: [Logging levels](logging-levels).
+
+## Settings
+
+Multipass can be fine-tuned to suit your needs with various configuration settings that can be read and written via CLI commands. Some settings can also be configured using the GUI client. 
+
+For a comprehensive list of all available settings, see: [Settings](settings/index).
 
 ```{toctree}
 :hidden:
@@ -64,3 +42,4 @@ instance-name-format
 instance-states
 logging-levels
 settings/index
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,9 +1,9 @@
 (reference-index)=
 # Reference
 
-This section provides detailed reference material for Multipass, such as all available commands, configuration settings keys, and more. 
+This section provides detailed reference material for Multipass, such as all available commands, configuration settings keys, and more.
 
-## Command line reference
+## Command-line reference
 
 Multipass offers a powerful command-line interface for creating and managing virtual machines effortlessly.
 
@@ -15,7 +15,7 @@ Multipass also comes with a user-friendly desktop application to create and mana
 
 ## Instances
 
-To find out more about the naming convention for Multipass VMs (also called instances) and the possible states they can assume, see: 
+To find out more about the naming convention for Multipass VMs (also called instances) and the possible states they can assume, see:
 
 - [Instance name format](instance-name-format)
 - [Instance states](instance-states)
@@ -26,7 +26,7 @@ For more information on the different logging levels that can be configured in M
 
 ## Settings
 
-Multipass can be fine-tuned to suit your needs with various configuration settings that can be read and written via CLI commands. Some settings can also be configured using the GUI client. 
+Multipass can be fine-tuned to suit your needs with various configuration settings that can be read and written via CLI commands. Some settings can also be configured using the GUI client.
 
 For a comprehensive list of all available settings, see: [Settings](settings/index).
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,11 +7,11 @@ This section provides detailed reference material for Multipass, such as all ava
 
 Multipass offers a powerful command-line interface for creating and managing virtual machines effortlessly.
 
-For a complete list of Multipass CLI commands and their usage is available, see: [Command-line interface](command-line-interface/index).
+For a complete list of Multipass CLI commands and their usage, see [Command-line interface].(command-line-interface/index).
 
 ## GUI client
 
-Multipass also comes with a user-friendly desktop application to create and manage your VMs, that also includes a virtual shell interface. For more details, see: [GUI client](gui-client).
+Multipass also comes with a user-friendly desktop application to create and manage your VMs, which also includes a virtual shell interface. For more details, see [GUI client](gui-client).
 
 ## Instances
 
@@ -22,13 +22,13 @@ To find out more about the naming convention for Multipass VMs (also called inst
 
 ## Logs
 
-For more information on the different logging levels that can be configured in Multipass, see: [Logging levels](logging-levels).
+For more information on the different logging levels that can be configured in Multipass, see [Logging levels](logging-levels).
 
 ## Settings
 
 Multipass can be fine-tuned to suit your needs with various configuration settings that can be read and written via CLI commands. Some settings can also be configured using the GUI client.
 
-For a comprehensive list of all available settings, see: [Settings](settings/index).
+For a comprehensive list of all available settings, see [Settings](settings/index).
 
 ```{toctree}
 :hidden:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,7 +7,7 @@ This section provides detailed reference material for Multipass, such as all ava
 
 Multipass offers a powerful command-line interface for creating and managing virtual machines effortlessly.
 
-For a complete list of Multipass CLI commands and their usage is available, see: [Command-Line Interface](command-line-interface/index).
+For a complete list of Multipass CLI commands and their usage is available, see: [Command-line interface](command-line-interface/index).
 
 ## GUI client
 

--- a/docs/reference/instance-states.md
+++ b/docs/reference/instance-states.md
@@ -1,7 +1,7 @@
 (reference-instance-states)=
 # Instance states
 
-> See also: [Command-Line-Interface](/reference/command-line-interface/index)
+> See also: [Command-line interface](/reference/command-line-interface/index)
 
 Instances in Multipass can be in a number of different states:
 

--- a/docs/reference/instance-states.md
+++ b/docs/reference/instance-states.md
@@ -29,4 +29,4 @@ Instances in Multipass can be in a number of different states:
 - `Unknown`: The state of the instance cannot be determined or retrieved. This might occur due to unexpected errors or issues with Multipass.
 -->
 
-These instance states reflect the various stages an instance can be in while using Multipass. Instances in different states can accept different commands. See [Command-Line-Interface](/reference/command-line-interface/index) for more information on which commands can be used and when.
+These instance states reflect the various stages an instance can be in while using Multipass. Instances in different states can accept different commands. See [Command-line interface](/reference/command-line-interface/index) for more information on which commands can be used and when.

--- a/docs/reference/logging-levels.md
+++ b/docs/reference/logging-levels.md
@@ -1,9 +1,9 @@
 (reference-logging-levels)=
 # Logging levels
 
-> See also: [Configure Multipass’s default logging level](/how-to-guides/customise-multipass/configure-multipass-default-logging-level)
+> See also: [Configure Multipass’s default logging level](/how-to-guides/customise-multipass/configure-multipass-default-logging-level), [How to access logs](/how-to-guides/troubleshoot/access-logs)
 
-In Multipass, a hierarchy of logging levels is used is used to convey severity and improve visibility of important events. Multipass uses the following levels ranked from most severe to least severe for its background daemon and child processes.
+In Multipass, a hierarchy of logging levels is used to convey severity and improve visibility of important events. Multipass uses the following levels ranked from most severe to least severe for its background daemon and child processes.
 
 ## Error
 

--- a/docs/reference/logging-levels.md
+++ b/docs/reference/logging-levels.md
@@ -3,7 +3,7 @@
 
 > See also: [Configure Multipass’s default logging level](/how-to-guides/customise-multipass/configure-multipass-default-logging-level), [How to access logs](/how-to-guides/troubleshoot/access-logs)
 
-In Multipass, a hierarchy of logging levels is used to convey severity and improve visibility of important events. Multipass uses the following levels ranked from most severe to least severe for its background daemon and child processes.
+In Multipass, a hierarchy of logging levels is used to convey severity and improve visibility of important events. Multipass uses the following levels, ranked from most severe to least severe, for its background daemon and child processes.
 
 ## Error
 

--- a/docs/reference/settings/index.md
+++ b/docs/reference/settings/index.md
@@ -5,6 +5,8 @@
 
 Multipass can be configured with a number of **settings** that are read and written by the [`get`](/reference/command-line-interface/get) and [`set`](/reference/command-line-interface/set) CLI commands, respectively. Some settings are also available in the [GUI client](/reference/gui-client).
 
+<!-- Moved explanation of settings keys and values to a separate page, and added link to "See also" above -->
+
 ## Available settings
 
 At any given time, the available settings depend on the state of the system. Some settings are only available on some platforms, while daemon settings can only be accessed when the Multipass daemon itself can be reached.

--- a/docs/reference/settings/index.md
+++ b/docs/reference/settings/index.md
@@ -1,23 +1,9 @@
 (reference-settings-index)=
 # Settings
 
-> See also: [`get`](/reference/command-line-interface/get), [`set`](/reference/command-line-interface/set), [GUI client](/reference/gui-client)
+> See also: [Settings keys and values](/explanation/settings-keys-values), [`get`](/reference/command-line-interface/get), [`set`](/reference/command-line-interface/set), [GUI client](/reference/gui-client)
 
 Multipass can be configured with a number of **settings** that are read and written by the [`get`](/reference/command-line-interface/get) and [`set`](/reference/command-line-interface/set) CLI commands, respectively. Some settings are also available in the [GUI client](/reference/gui-client).
-
-Settings are organised in a tree structure, where each individual setting is identified by a unique **key** and takes on a single **value** at any given time.
-
-## Settings keys
-
-A **settings key** is a string in the form of a dot-separated path through the settings tree (such as `client.primary-name`). It specifies a path along the settings tree, from the root to a leaf. Thus, individual settings correspond to the leaves of the settings tree.
-
-Conceptually, branches of the tree can be singled out with wildcards, to refer to multiple settings at once. For instance, `local.<instance-name>.*` designates the settings that affect a specific instance. Wildcards can also be used to select separate branches. For example `local.*.cpus` refers to the number of CPUs of Multipass instances.
-
-## Settings values
-
-A **settings value** is a string whose syntax (possible values/representations) and semantics (their interpretation) is determined by the setting in question.
-
-Values often express common concepts (such as `true`, `false`, `42`, etc.) and are interpreted internally using the corresponding data types (such as boolean, integer, etc.). They can also be more complex (such as a key combination), but they are always specified and displayed through a string representation (for example: `Ctrl+Alt+U`).
 
 ## Available settings
 
@@ -30,18 +16,18 @@ The command `multipass get --keys` shows what settings are available at any give
 
 As of now, this is the total set of settings available:
 
-- [`client.apps.windows-terminal.profiles`](client-apps-windows-terminal-profiles)
-- [`client.primary-name`](client-primary-name)
-- [`local.<instance-name>.bridged`](local-instance-name-bridged)
-- [`local.<instance-name>.cpus`](local-instance-name-cpus)
-- [`local.<instance-name>.disk`](local-instance-name-disk)
-- [`local.<instance-name>.memory`](local-instance-name-memory)
-- [`local.<instance-name>.<snapshot-name>.name`](local-instance-name-snapshot-name-name)
-- [`local.<instance-name>.<snapshot-name>.comment`](local-instance-name-snapshot-name-comment)
-- [`local.bridged-network`](local-bridged-network)
-- [`local.driver`](local-driver)
-- [`local.passphrase`](local-passphrase)
-- [`local.privileged-mounts`](local-privileged-mounts)
+- [client.apps.windows-terminal.profiles](client-apps-windows-terminal-profiles)
+- [client.primary-name](client-primary-name)
+- [local.bridged-network](local-bridged-network)
+- [local.driver](local-driver)
+- [local.\<instance-name>.bridged](local-instance-name-bridged)
+- [local.\<instance-name>.cpus](local-instance-name-cpus)
+- [local.\<instance-name>.disk](local-instance-name-disk)
+- [local.\<instance-name>.memory](local-instance-name-memory)
+- [local.\<instance-name>.\<snapshot-name>.comment](local-instance-name-snapshot-name-comment)
+- [local.\<instance-name>.\<snapshot-name>.name](local-instance-name-snapshot-name-name)
+- [local.passphrase](local-passphrase)
+- [local.privileged-mounts](local-privileged-mounts)
 
 ```{caution}
 Starting from Multipass version 1.14, the following settings have been removed from the CLI and are only available in the [GUI client](/reference/gui-client):
@@ -58,3 +44,4 @@ Starting from Multipass version 1.14, the following settings have been removed f
 :glob:
 
 *
+```

--- a/docs/reference/settings/local-bridged-network.md
+++ b/docs/reference/settings/local-bridged-network.md
@@ -13,9 +13,9 @@ The name of the interface to connect the instance to when the shortcut `launch -
 
 ## Possible values
 
-Any name from [`multipass networks`](/reference/command-line-interface/networks).
+Any name from the output of [`multipass networks`](/reference/command-line-interface/networks).
 
-Validation is deferred to [`multipass launch`](/reference/command-line-interface/launch).
+Validation is deferred to the [`launch`](/reference/command-line-interface/launch) command.
 
 ## Examples
 

--- a/docs/reference/settings/local-passphrase.md
+++ b/docs/reference/settings/local-passphrase.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-Passphrase used by clients requesting access to the Multipass service via the [`multipass authenticate`](/reference/command-line-interface/authenticate) command.
+Passphrase used by clients requesting access to the Multipass service via the [`authenticate`](/reference/command-line-interface/authenticate) command.
 
 The passphrase can be given directly in the command line; if omitted, the user will be prompted to enter it.
 

--- a/docs/reference/settings/local-privileged-mounts.md
+++ b/docs/reference/settings/local-privileged-mounts.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-Controls whether [`multipass mount`](/reference/command-line-interface/mount) is allowed.
+Controls whether the [`mount`](/reference/command-line-interface/mount) command is allowed.
 
 ## Possible values
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -64,7 +64,7 @@ Clicking this button does many things in the background:
 <!-- note added for https://github.com/canonical/multipass/issues/3537 -->
 
 ```{caution}
-If your local home folder is encrypted using `fscrypt` and you are having trouble accessing its contents when it is automatically mounted inside your primary instance, see: [Mount an encrypted home folder](/how-to-guides/troubleshoot/mount-an-encrypted-home-folder).
+If your local home folder is encrypted using `fscrypt` and you are having trouble accessing its contents when it is automatically mounted inside your primary instance, see [Mount an encrypted home folder](/how-to-guides/troubleshoot/mount-an-encrypted-home-folder).
 ```
 
 You can see elements of this in the printout below:

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -885,4 +885,5 @@ When that's the case, the title of the page also needs to change to "Tutorials".
 :titlesonly:
 :maxdepth: 2
 :glob:
+```
 -->


### PR DESCRIPTION
This PR applies a series of fixes to Multipass documentation, in particular: 
- Updated project-specific details in `conf.py` + added instructions to display a clickable pencil icon ("Edit") on every page
- Improved landing pages, most notably the `/reference/index.md` page
- New explanation page `/explanation/settings-keys-values.md` separated from `/reference/settings/index.md`
- Even application of code block syntax and uniformity in link text when referencing commands
- Some other minor fixes 

NOTE: To build the docs locally, go in the `docs` folder and run the command `make run`. 