### PR TITLE
[CI] run tics on weekly schedule

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -17,6 +17,8 @@ jobs:
       VCPKG_FORCE_SYSTEM_BINARIES: 1
       BUILD_DIR: ${{ github.workspace }}/build
       COVERAGE_DIR: ${{ github.workspace }}/coverage
+      NEEDRESTART_SUSPEND: yes
+      DEBIAN_FRONTEND: noninteractive
 
     steps:
     - name: Checkout code
@@ -32,7 +34,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install --yes devscripts equivs lcov ninja-build python3-venv python3-pip
+        sudo apt-get --preserve-env install --yes devscripts equivs lcov ninja-build python3-venv python3-pip
         mk-build-deps -s sudo -i
 
     - name: Configure

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -3,7 +3,7 @@ name: Linux
 on:
     schedule:
     # 0:00 UTC every Sunday
-    - cron: 0 0 * * 0
+    - cron: 11 4 * * 0
 
 jobs:
   build:

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install --yes devscripts equivs lcov ninja-build
+        sudo apt-get install --yes devscripts equivs lcov ninja-build python3-venv python3-pip
         mk-build-deps -s sudo -i
 
     - name: Configure
@@ -46,8 +46,18 @@ jobs:
         cmake --build ${{ env.BUILD_DIR }} \
               --target covreport \
               -j$(nproc)
+
+    - name: Convert lcov to Cobertura XML
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install gcovr
+
         mkdir -p ${{ env.COVERAGE_DIR }}
-        mv ${{ env.BUILD_DIR }}/coverage/index.html ${{ env.COVERAGE_DIR }}/coverage.html
+        gcovr -r ${{ github.workspace }} \
+              --object-directory ${{ env.BUILD_DIR }} \
+              --cobertura ${{ env.COVERAGE_DIR }}/coverage.xml \
+              --gcov-ignore-parse-errors
 
     - name: Run TICS Analysis
       uses: tiobe/tics-github-action@v3

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, reactive, amd64, large-tiobe, noble]
+    runs-on: [self-hosted, reactive, amd64, 2xlarge, noble]
 
     outputs:
       label: ${{ steps.build-params.outputs.label }}
@@ -31,9 +31,8 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y devscripts equivs lcov
-        mk-build-deps -s sudo -i
+        sudo --preserve-env apt-get install --yes devscripts equivs lcov ninja-build
+        sudo --preserve-env apt-get build-dep --yes ./
 
     - name: Configure
       run: |

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -31,8 +31,9 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        sudo --preserve-env apt-get install --yes devscripts equivs lcov ninja-build
-        sudo --preserve-env apt-get build-dep --yes ./
+        sudo apt-get update
+        sudo apt-get install --yes devscripts equivs lcov ninja-build
+        mk-build-deps -s sudo -i
 
     - name: Configure
       run: |

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, reactive, amd64, large-tiobe, noble]
 
     outputs:
       label: ${{ steps.build-params.outputs.label }}

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -61,6 +61,13 @@ jobs:
               --cobertura ${{ env.COVERAGE_DIR }}/coverage.xml \
               --gcov-ignore-parse-errors
 
+    - name: Install Dart
+      uses: dart-lang/setup-dart@v1
+
+    - name: Install Dart analysis tools
+      run: |
+        dart pub global activate cobertura
+
     - name: Run TICS Analysis
       uses: tiobe/tics-github-action@v3
       with:

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -1,0 +1,72 @@
+name: Linux
+
+on:
+    schedule:
+    # 0:00 UTC every Sunday
+    - cron: 0 0 * * 0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    outputs:
+      label: ${{ steps.build-params.outputs.label }}
+      channel: ${{ steps.build-params.outputs.channel }}
+
+    env:
+      VCPKG_FORCE_SYSTEM_BINARIES: 1
+      BUILD_DIR: ${{ github.workspace }}/build
+      COVERAGE_DIR: ${{ github.workspace }}/coverage
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Determine build parameters
+      id: build-params
+      uses: ./.github/actions/build-params
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y devscripts equivs lcov python3-pip
+        sudo pip3 install gcovr
+        mk-build-deps -s sudo -i
+
+    - name: Configure
+      run: |
+        cmake -B${{ env.BUILD_DIR }} \
+              -DCMAKE_BUILD_TYPE=Coverage \
+              -DMULTIPASS_BUILD_LABEL=${{ steps.build-params.outputs.label }}
+
+    - name: BuildAndTest
+      run: |
+        cmake --build ${{ env.BUILD_DIR }} \
+              --target covreport \
+              -j$(nproc)
+
+    - name: Convert lcov to Cobertura
+      run: |
+        mkdir -p ${{ env.COVERAGE_DIR }}
+        gcovr -r ${{ github.workspace }} \
+              --object-directory ${{ env.BUILD_DIR }} \
+              --cobertura ${{ env.COVERAGE_DIR }}/coverage.xml \
+              --gcov-ignore-parse-errors
+
+    - name: Run TICS Analysis
+      uses: tiobe/tics-github-action@v3
+      with:
+        mode: qserver
+        project: multipass
+        viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+        ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+        installTics: true
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: cobertura.xml
+        path: ${{ env.COVERAGE_DIR }}/coverage.xml

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -32,8 +32,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y devscripts equivs lcov python3-pip
-        sudo pip3 install gcovr
+        sudo apt-get install -y devscripts equivs lcov
         mk-build-deps -s sudo -i
 
     - name: Configure
@@ -47,14 +46,8 @@ jobs:
         cmake --build ${{ env.BUILD_DIR }} \
               --target covreport \
               -j$(nproc)
-
-    - name: Convert lcov to Cobertura
-      run: |
         mkdir -p ${{ env.COVERAGE_DIR }}
-        gcovr -r ${{ github.workspace }} \
-              --object-directory ${{ env.BUILD_DIR }} \
-              --cobertura ${{ env.COVERAGE_DIR }}/coverage.xml \
-              --gcov-ignore-parse-errors
+        mv ${{ env.BUILD_DIR }}/coverage/index.html ${{ env.COVERAGE_DIR }}/coverage.html
 
     - name: Run TICS Analysis
       uses: tiobe/tics-github-action@v3
@@ -64,9 +57,3 @@ jobs:
         viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
         ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
         installTics: true
-
-    - name: Upload coverage report
-      uses: actions/upload-artifact@v4
-      with:
-        name: cobertura.xml
-        path: ${{ env.COVERAGE_DIR }}/coverage.xml

--- a/tests/lxd/test_lxd_backend.cpp
+++ b/tests/lxd/test_lxd_backend.cpp
@@ -2078,29 +2078,6 @@ TEST_P(LXDNetworksBadJson, handles_gibberish_networks_reply)
 INSTANTIATE_TEST_SUITE_P(LXDBackend, LXDNetworksBadJson,
                          Values("gibberish", "unstarted}", "{unfinished", "strange\"", "{noval}", "]["));
 
-struct LXDNetworksBadFields : LXDBackend, WithParamInterface<QByteArray>
-{
-};
-
-TEST_P(LXDNetworksBadFields, ignores_network_without_expected_fields)
-{
-    EXPECT_CALL(*mock_network_access_manager,
-                createRequest(QNetworkAccessManager::CustomOperation, network_request_matcher, _))
-        .WillOnce(Return(new mpt::MockLocalSocketReply{GetParam()}));
-
-    mp::LXDVirtualMachineFactory backend{std::move(mock_network_access_manager), data_dir.path(), base_url};
-    EXPECT_THAT(backend.networks(), IsEmpty());
-}
-
-INSTANTIATE_TEST_SUITE_P(LXDBackend, LXDNetworksBadFields,
-                         Values("{}", "{\"other\": \"stuff\"}", "{\"metadata\": \"notarray\"}",
-                                "{\"metadata\": [\"notdict\"]}",
-                                "{\"metadata\": [{\"type\": \"bridge\", \"but\": \"noname\"}]}",
-                                "{\"metadata\": [{\"name\": \"\", \"type\": \"bridge\", \"but\": \"empty name\"}]}",
-                                "{\"metadata\": [{\"name\": \"bla\", \"but\": \"notype\"}]}",
-                                "{\"metadata\": [{\"name\": 123, \"type\": \"bridge\"}]}",
-                                "{\"metadata\": [{\"name\": \"eth0\", \"type\": 123}]}"));
-
 struct LXDNetworksOnlySupportedTypes : LXDBackend, WithParamInterface<QByteArray>
 {
 };


### PR DESCRIPTION
Adds Tiobe's TICS github action to the Multipass project
- Runs on a weekly basis (the Desktop team [SSDLC guide](https://docs.google.com/document/d/11BLKA6XC_HmrHVJO5qDhurnkq3xYTQBODTL5oEVmoVE/edit?tab=t.gewyardc36dz) suggests nightly)
- Each analysis takes about 4+hrs to run (may vary depending on the number of changed files between runs)
- The TICS custom action has some specific requirements which are not always clear
  - The coverage report must be at `${{ github.workspace }}/coverage/coverage.xml`
  - The project must be built beforehand with standard build tools and build directories
    - Build files should be in `${{ github.workspace }}/build`
    - `make` must be used for compilation (using `ninja` generator will fail the action)
- TICS analysis now includes and analyzes the `tests/` subdirectory (this is inline with similar projects such as Mir)
- Current metrics from test runs can be found [here](https://canonical.tiobe.com/tiobeweb/TICS/TqiDashboard.html#axes=Project(multipass),Sub()&metric=tqi)

---

MULTI-1759

---

Closes #3962 