### PR TITLE
[ci/clang-format] fix the language standard string

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@
 BasedOnStyle: LLVM
 ---
 Language: Cpp
-Standard: Cpp17
+Standard: c++17
 
 AccessModifierOffset: -4
 AllowAllArgumentsOnNextLine: false

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -36,6 +36,9 @@ runs:
     run: |
       set -e -o pipefail
 
+      # Ensure that the .clang-format configuration is valid
+      clang-format-16  --dump-config > /dev/null
+
       # On pull requests, HEAD^1 will always be the merge base, so consider that diff for formatting.
       git diff -U0 --no-color HEAD^1 | clang-format-diff-16 -p1 | tee ${HOME}/clang-diff
       if [ "$( stat --printf='%s' ${HOME}/clang-diff )" -ne 0 ]; then


### PR DESCRIPTION
The CI lint action does not detect invalid syntax in the .clang-format file if the pull request does not contain any code changes.

This patch corrects the `Standard` value and adds a `clang-format --dump-config` run to ensure that the .clang-format is syntatically valid.