### PR TITLE
`exec` runs sudo commands with `sudo -E` to preserve environment variables

### DIFF
--- a/src/client/cli/cmd/exec.cpp
+++ b/src/client/cli/cmd/exec.cpp
@@ -171,8 +171,10 @@ mp::ReturnCode cmd::Exec::exec_success(const mp::SSHInfoReply& reply, const std:
                 // If we are running through 'sudo' and need to change directory, it might happen that the default user
                 // does not have access to the folder and thus the cd command will fail. Additionally, `cd` cannot be
                 // ran with sudo, what forces us to run everything through `sh`.
-                auto sh_args = fmt::format("cd {} && {}", *dir, fmt::join(args, " "));
-                all_args = {{"sudo", "sh", "-c", sh_args}};
+                // We need to ensure sudo preserves environment variables with -E flag
+                auto cmd = fmt::format("{}", fmt::join(args.begin() + 1, args.end(), " "));
+                auto sh_args = fmt::format("cd {} && sudo -E {}", *dir, cmd);
+                all_args = {{"sh", "-c", sh_args}};
             }
             else
                 all_args = {{"cd", *dir}, {args}};

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -1671,7 +1671,9 @@ TEST_F(Client, execCmdWithDirAndSudoUsesSh)
         cmds_string += " " + cmds[i];
 
     REPLACE(ssh_channel_request_exec, ([&dir, &cmds_string](ssh_channel, const char* raw_cmd) {
-                EXPECT_EQ(raw_cmd, "sudo sh -c cd\\ " + dir + "\\ \\&\\&\\ " + mpu::escape_for_shell(cmds_string));
+                // We now use sh -c to run the command, with sudo -E to preserve environment variables
+                std::string expected_cmd = "sh -c cd\\ " + dir + "\\ \\&\\&\\ sudo\\ -E\\ pwd";
+                EXPECT_EQ(raw_cmd, expected_cmd);
 
                 return SSH_OK;
             }));


### PR DESCRIPTION
fixes #3933 
This pull request includes changes to the `exec` command functionality in the `src/client/cli/cmd/exec.cpp` and its corresponding test in `tests/test_cli_client.cpp`. The main change ensures that environment variables are preserved when using `sudo` by adding the `-E` flag.

Changes to `exec` command functionality:

* [`src/client/cli/cmd/exec.cpp`](diffhunk://#diff-1be2c16193b468b398ac5e0475efa9944747d6eaa0df53b95d76802aa5ee0e89L174-R177): Modified the command execution to include the `sudo -E` flag in order to preserve environment variables when using `sudo`. This change also updates the way arguments are formatted and passed to the `sh` command.

Updates to tests:

* [`tests/test_cli_client.cpp`](diffhunk://#diff-966c5ac143e04c376d361c1755d1963a29c7b8800d954742b940d1deec14cb07L1674-R1676): Updated the test `TEST_F(Client, execCmdWithDirAndSudoUsesSh)` to reflect the new command format, ensuring that the expected command includes `sudo -E` for preserving environment variables.