### PR TITLE
[log] introduce log function w/ formatting

### DIFF
--- a/include/multipass/logging/log.h
+++ b/include/multipass/logging/log.h
@@ -22,10 +22,43 @@
 #include <multipass/logging/level.h>
 #include <multipass/logging/logger.h>
 
+#include <fmt/std.h>   // standard library formatters
+#include <fmt/xchar.h> // char-type agnostic formatting
+
 namespace multipass
 {
 namespace logging
 {
+
+/**
+ * Log with formatting support
+ *
+ * The old (legacy) log function and this overload are distinguished
+ * via presence of a format argument. When a format argument is absent
+ * both the old function and the new one are valid candidates for a
+ * `log(Level::debug, "test", "test")` call. The ambiguity is resolved
+ * by the fact that a non-templated overload is a better fit.
+ *
+ * @ref https://en.cppreference.com/w/cpp/language/overload_resolution#Best_viable_function
+ *
+ * @tparam Args Type of the format arguments
+ * @param level Log level
+ * @param category Log category
+ * @param fmt Format string
+ * @param args Format arguments
+ */
+template <typename... Args>
+constexpr void log(Level level, const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
+{
+    const auto formatted_log_msg = fmt::format(fmt, std::forward<Args>(args)...);
+    // CString{} is necessary here. Without it, this function would infinitely recurse.
+    // The reason "why" is: the non-templated log() overload requires an implicit
+    // const std::string& -> CString conversion for the category argument, which
+    // makes it a "worse" overload than this templated function. We do the conversion
+    // here in order to prevent that.
+    log(level, CString{category}, formatted_log_msg);
+}
+
 void log(Level level, CString category, CString message);
 void set_logger(std::shared_ptr<Logger> logger);
 Level get_logging_level();

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -15,13 +15,17 @@
  *
  */
 
+#include "mock_logger.h"
+
 #include <gtest/gtest.h>
 #include <multipass/logging/level.h>
 
 namespace mpl = multipass::logging;
+namespace mpt = multipass::test;
 
 struct log_tests : ::testing::Test
 {
+    mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject();
 };
 
 TEST_F(log_tests, test_levels_as_string)
@@ -33,4 +37,36 @@ TEST_F(log_tests, test_levels_as_string)
     ASSERT_STREQ(mpl::as_string(mpl::Level::trace).c_str(), "trace");
     ASSERT_STREQ(mpl::as_string(static_cast<mpl::Level>(-1)).c_str(), "unknown");
     ASSERT_STREQ(mpl::as_string(static_cast<mpl::Level>(5)).c_str(), "unknown");
+}
+
+TEST_F(log_tests, test_non_format_overload)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::error, "no format whatsoever {}");
+    mpl::log(mpl::Level::error, "test_category", "no format whatsoever {}");
+}
+
+TEST_F(log_tests, test_format_overload_single_arg)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::error, "with formatting 1");
+    mpl::log(mpl::Level::error, "test_category", "with formatting {}", 1);
+}
+
+TEST_F(log_tests, test_format_overload_multiple_args)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::error, "with formatting 1 test");
+    mpl::log(mpl::Level::error, "test_category", "with formatting {} {}", 1, "test");
+}
+
+TEST_F(log_tests, test_format_overload_multiple_args_superfluous)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::error, "with formatting 1 test");
+    // Superfluous arguments are ignored. This should be an error with C++20
+    mpl::log(mpl::Level::error, "test_category", "with formatting {} {}", 1, "test", "superfluous");
+}
+
+TEST_F(log_tests, test_format_overload_multiple_args_missing)
+{
+    // Missing arguments are runtime error in C++17. This should be a compile
+    // time error with the C++20
+    EXPECT_THROW({ mpl::log(mpl::Level::error, "test_category", "with formatting {} {}", 1); }, fmt::format_error);
 }


### PR DESCRIPTION
the most usual case for a log() call is to produce a log message using `fmt::format()`. the new log() variadic template function streamlines that by providing the formatting by default with minimal intrusion. The old log() API is preserved as-is -- the new code can opt in using the new log() API by passing a format string and format arguments directly:

before
```c++
mpl::log(lvl::debug, "cat", fmt::format("{} {}", 1, 2)); // uses the existing log() overload
```

after

```c++
mpl::log(lvl::debug, "cat", "{} {}", 1 ,2); // uses the new variadic overload
```

The new log() function also uses fmt::format_string<...> to capture the format string argument which means the code will get compile time format string checks for free when the codebase switches to C++20.

MULTI-1844