### PR TITLE
[ci/BuildAndTest]: upload test coredump to artifacts on crash

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,16 +166,69 @@ jobs:
     - name: Clear CCache stats
       run: ccache --show-stats --zero-stats
 
+    - name: Set /proc/sys/kernel/core_pattern
+      if: ${{ matrix.build-type == 'Debug' }} || ${{ matrix.build-type == 'Coverage' }}
+      run : |
+
+        # The LXC container share the same "/proc/sys/kernel/core_pattern"
+        # with the host and it can't be overridden inside the container. Hence
+        # we need to override it at the runner level.
+        sudo bash -c 'echo "/coredump/%e.%p.%t" > /proc/sys/kernel/core_pattern'
+
+    # - name : Mock failure
+    #   id: mock-fail
+    #   if: ${{ matrix.build-type == 'Debug' }} || ${{ matrix.build-type == 'Coverage' }}
+    #   run: |
+
+    #     # Perform an intentional segfault
+    #     set +e
+    #     set -o xtrace
+    #     # mkdir -p /root/parts/multipass/build/bin/
+    #     instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
+    #     /snap/bin/lxc --project snapcraft start $instance_name
+    #     /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "echo 'int main() { *(int *)0 = 0; }' | gcc -xc -o /root/parts/multipass/build/bin/multipass_tests - && ulimit -c unlimited && /root/parts/multipass/build/bin/multipass_tests"
+    #      # Capture the exit code.
+    #     exit_code="$?"
+    #     # Save the exit code to a action-level variable so we can refer to it in other steps.
+    #     echo "MULTIPASS_TESTS_EXIT_CODE=$exit_code" >> $GITHUB_ENV
+    #     # Re-enable exit on failure
+    #     set -e
+    #     # We're now done with our intermediate "SIGSEGV" special case, finalize the step with
+    #     # the test executable's original exit code.
+    #     set +o xtrace
+    #     exit $exit_code
+
     - name: Test
+      id: test
       if: ${{ matrix.build-type == 'Debug' }}
       timeout-minutes: 2
       run: |
+
         instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
         /snap/bin/lxc --project snapcraft start $instance_name
-        /snap/bin/lxc --project snapcraft exec $instance_name -- \
+        # Let's print the core pattern so we can check if it's successfully propagated to the container.
+        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c 'cat /proc/sys/kernel/core_pattern'
+        # We need to capture the exit code here for the coredump capture steps.
+        # The step `run` sets exit on failure as default, so disable it to allow the code
+        # to capture the exit code. We'll manually do an exit(exit_code) later on.
+        set +e
+        set -o xtrace
+        # Enable coredumps by setting the core dump size to "unlimited", and run the tests.
+        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "\
+           ulimit -c unlimited &&        \
            env CTEST_OUTPUT_ON_FAILURE=1 \
-               LD_LIBRARY_PATH=/root/stage/usr/lib/x86_64-linux-gnu/:/root/stage/lib/:/root/parts/multipass/build/lib/ \
-               /root/parts/multipass/build/bin/multipass_tests
+           LD_LIBRARY_PATH=/root/stage/usr/lib/x86_64-linux-gnu/:/root/stage/lib/:/root/parts/multipass/build/lib/ \
+           /root/parts/multipass/build/bin/multipass_tests"
+        # Capture the exit code.
+        exit_code="$?"
+        # Save the exit code to a action-level variable so we can refer to it in other steps.
+        echo "MULTIPASS_TESTS_EXIT_CODE=$exit_code" >> $GITHUB_ENV
+        # Re-enable exit on failure
+        set -e
+        # We're now done with our intermediate "SIGSEGV" special case, finalize the step with
+        # the test executable's original exit code.
+        set +o xtrace
+        exit $exit_code
 
     - name: Measure coverage
       id: measure-coverage
@@ -184,6 +237,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       timeout-minutes: 5
       run: |
+
         instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
         /snap/bin/lxc --project snapcraft start $instance_name
 
@@ -203,10 +257,68 @@ jobs:
         /snap/bin/lxc --project snapcraft exec $instance_name -- \
            sh -c "sudo sed -i \"s/use JSON::PP/use JSON::XS/\" \`which geninfo\`"
 
-        /snap/bin/lxc --project snapcraft exec $instance_name -- \
+        # We need to capture the exit code here for the coredump capture steps.
+        # The step `run` sets exit on failure as default, so disable it to allow the code
+        # to capture the exit code. We'll manually do an exit(exit_code) later on.
+        set +e
+        set -o xtrace
+
+        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "\
+          ulimit -c unlimited && \
           env CTEST_OUTPUT_ON_FAILURE=1 \
-            cmake --build /root/parts/multipass/build --target covreport
+            cmake --build /root/parts/multipass/build --target covreport"
+        # Capture the exit code.
+        exit_code="$?"
+        # Save the exit code to a action-level variable so we can refer to it in other steps.
+        echo "MULTIPASS_TESTS_EXIT_CODE=$exit_code" >> $GITHUB_ENV
+        # Re-enable exit on failure
+        set -e
+        # Directly exit without running the codecov if an error occurs
+        if [ $exit_code -ne 0 ] ; then
+          exit $exit_code
+        fi
         bash <(curl -s https://codecov.io/bash) -Z -s ${{ steps.coverage-setup.outputs.build }}
+        exit $exit_code
+
+    - name: Pull coredump and executable from LXC container
+      if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE == '139'}}
+      run: |
+
+        set -o xtrace
+        # Check whether the test executable is crashed or not.
+        # If so, we'll need to pull the core dump and the executable from the container to the
+        # runner, so we can upload them as artifacts later on.
+        if [ $MULTIPASS_TESTS_EXIT_CODE -eq 139 ] ; then
+          echo "Test executable crashed."
+          # Make a directory in tmp to pull the coredump(s) and the test executable.
+          # We'll need both to debug the crash.
+          mkdir -p /tmp/coredump
+          instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
+          # Pull the crashed executable from the container
+          /snap/bin/lxc --project snapcraft file pull "$instance_name/root/parts/multipass/build/bin/multipass_tests" /tmp/multipass_tests
+          echo "Pulled the executable."
+          # List the coredump files into a variable
+          files=`/snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "ls /coredump 2>/dev/null"`
+          echo "$files"
+          # If there's `any`, we need to pull them.
+          if [ ! -z "$files" ]
+          then
+            ARRAY=($files)
+            COREDUMP_FILES=(`printf "$instance_name/coredump/%s " "${ARRAY[@]}"`)
+            /snap/bin/lxc --project snapcraft file pull "${COREDUMP_FILES[@]}" /tmp/coredump
+            echo "Pulled ${#COREDUMP_FILES[@]} coredump(s) from the snap build container"
+          else
+            echo "Executable crashed, but no coredump file found!"
+          fi
+        fi
+        set +o xtrace
+
+    - name: Upload test coredump
+      uses: actions/upload-artifact@v4
+      if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE == '139' }}
+      with:
+        name: buildandtest-test-crash-${{ runner.os }}-${{ matrix.build-type }}
+        path: /tmp/coredump/**
 
     - name: Continue on Error comment
       uses: mainmatter/continue-on-error-comment@v1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -251,28 +251,26 @@ jobs:
         # Check whether the test executable is crashed or not.
         # If so, we'll need to pull the core dump and the executable from the container to the
         # runner, so we can upload them as artifacts later on.
-        if [ $MULTIPASS_TESTS_EXIT_CODE -eq 139 ] ; then
-          echo "Test executable crashed."
-          # Make a directory in tmp to pull the coredump(s) and the test executable.
-          # We'll need both to debug the crash.
-          mkdir -p /tmp/coredump
-          instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
-          # Pull the crashed executable from the container
-          /snap/bin/lxc --project snapcraft file pull "$instance_name/root/parts/multipass/build/bin/multipass_tests" /tmp/multipass_tests
-          echo "Pulled the executable."
-          # List the coredump files into a variable
-          files=`/snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "ls /coredump 2>/dev/null"`
-          echo "$files"
-          # If there's `any`, we need to pull them.
-          if [ ! -z "$files" ]
-          then
-            ARRAY=($files)
-            COREDUMP_FILES=(`printf "$instance_name/coredump/%s " "${ARRAY[@]}"`)
-            /snap/bin/lxc --project snapcraft file pull "${COREDUMP_FILES[@]}" /tmp/coredump
-            echo "Pulled ${#COREDUMP_FILES[@]} coredump(s) from the snap build container"
-          else
-            echo "Executable crashed, but no coredump file found!"
-          fi
+        echo "Test executable crashed."
+        # Make a directory in tmp to pull the coredump(s) and the test executable.
+        # We'll need both to debug the crash.
+        mkdir -p /tmp/coredump
+        instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
+        # Pull the crashed executable from the container
+        /snap/bin/lxc --project snapcraft file pull "$instance_name/root/parts/multipass/build/bin/multipass_tests" /tmp/multipass_tests
+        echo "Pulled the executable."
+        # List the coredump files into a variable
+        files=`/snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "ls /coredump 2>/dev/null"`
+        echo "$files"
+        # If there's `any`, we need to pull them.
+        if [ ! -z "$files" ]
+        then
+          ARRAY=($files)
+          COREDUMP_FILES=(`printf "$instance_name/coredump/%s " "${ARRAY[@]}"`)
+          /snap/bin/lxc --project snapcraft file pull "${COREDUMP_FILES[@]}" /tmp/coredump
+          echo "Pulled ${#COREDUMP_FILES[@]} coredump(s) from the snap build container"
+        else
+          echo "Executable crashed, but no coredump file found!"
         fi
         set +o xtrace
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -175,18 +175,6 @@ jobs:
         # we need to override it at the runner level.
         sudo bash -c 'echo "/coredump/%e.%p.%t" > /proc/sys/kernel/core_pattern'
 
-    - name : Mock failure
-      id: mock-fail
-      if: ${{ matrix.build-type == 'Debug' }} || ${{ matrix.build-type == 'Coverage' }}
-      run: |
-
-        trap 'echo "MULTIPASS_TESTS_EXIT_CODE=$?" >> $GITHUB_ENV' EXIT
-        instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
-        /snap/bin/lxc --project snapcraft start $instance_name
-        # Create the directory for the coredumps
-        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c 'mkdir -p /coredump'
-        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "echo 'int main() { *(int *)0 = 0; }' | gcc -xc -o /root/parts/multipass/build/bin/multipass_tests - && ulimit -c unlimited && /root/parts/multipass/build/bin/multipass_tests"
-
     - name: Test
       id: test
       if: ${{ matrix.build-type == 'Debug' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -167,7 +167,7 @@ jobs:
       run: ccache --show-stats --zero-stats
 
     - name: Set /proc/sys/kernel/core_pattern
-      if: ${{ matrix.build-type == 'Debug' }} || ${{ matrix.build-type == 'Coverage' }}
+      if: ${{ matrix.build-type == 'Debug' || matrix.build-type == 'Coverage' }}
       run : |
 
         # The LXC container share the same "/proc/sys/kernel/core_pattern"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -175,28 +175,17 @@ jobs:
         # we need to override it at the runner level.
         sudo bash -c 'echo "/coredump/%e.%p.%t" > /proc/sys/kernel/core_pattern'
 
-    # - name : Mock failure
-    #   id: mock-fail
-    #   if: ${{ matrix.build-type == 'Debug' }} || ${{ matrix.build-type == 'Coverage' }}
-    #   run: |
+    - name : Mock failure
+      id: mock-fail
+      if: ${{ matrix.build-type == 'Debug' }} || ${{ matrix.build-type == 'Coverage' }}
+      run: |
 
-    #     # Perform an intentional segfault
-    #     set +e
-    #     set -o xtrace
-    #     # mkdir -p /root/parts/multipass/build/bin/
-    #     instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
-    #     /snap/bin/lxc --project snapcraft start $instance_name
-    #     /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "echo 'int main() { *(int *)0 = 0; }' | gcc -xc -o /root/parts/multipass/build/bin/multipass_tests - && ulimit -c unlimited && /root/parts/multipass/build/bin/multipass_tests"
-    #      # Capture the exit code.
-    #     exit_code="$?"
-    #     # Save the exit code to a action-level variable so we can refer to it in other steps.
-    #     echo "MULTIPASS_TESTS_EXIT_CODE=$exit_code" >> $GITHUB_ENV
-    #     # Re-enable exit on failure
-    #     set -e
-    #     # We're now done with our intermediate "SIGSEGV" special case, finalize the step with
-    #     # the test executable's original exit code.
-    #     set +o xtrace
-    #     exit $exit_code
+        trap 'echo "MULTIPASS_TESTS_EXIT_CODE=$?" >> $GITHUB_ENV' EXIT
+        instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
+        /snap/bin/lxc --project snapcraft start $instance_name
+        # Create the directory for the coredumps
+        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c 'mkdir -p /coredump'
+        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "echo 'int main() { *(int *)0 = 0; }' | gcc -xc -o /root/parts/multipass/build/bin/multipass_tests - && ulimit -c unlimited && /root/parts/multipass/build/bin/multipass_tests"
 
     - name: Test
       id: test
@@ -204,31 +193,19 @@ jobs:
       timeout-minutes: 2
       run: |
 
+        trap 'echo "MULTIPASS_TESTS_EXIT_CODE=$?" >> $GITHUB_ENV' EXIT
         instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
         /snap/bin/lxc --project snapcraft start $instance_name
         # Let's print the core pattern so we can check if it's successfully propagated to the container.
         /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c 'cat /proc/sys/kernel/core_pattern'
-        # We need to capture the exit code here for the coredump capture steps.
-        # The step `run` sets exit on failure as default, so disable it to allow the code
-        # to capture the exit code. We'll manually do an exit(exit_code) later on.
-        set +e
-        set -o xtrace
+        # Create the directory for the coredumps
+        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c 'mkdir -p /coredump'
         # Enable coredumps by setting the core dump size to "unlimited", and run the tests.
         /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "\
            ulimit -c unlimited &&        \
            env CTEST_OUTPUT_ON_FAILURE=1 \
            LD_LIBRARY_PATH=/root/stage/usr/lib/x86_64-linux-gnu/:/root/stage/lib/:/root/parts/multipass/build/lib/ \
            /root/parts/multipass/build/bin/multipass_tests"
-        # Capture the exit code.
-        exit_code="$?"
-        # Save the exit code to a action-level variable so we can refer to it in other steps.
-        echo "MULTIPASS_TESTS_EXIT_CODE=$exit_code" >> $GITHUB_ENV
-        # Re-enable exit on failure
-        set -e
-        # We're now done with our intermediate "SIGSEGV" special case, finalize the step with
-        # the test executable's original exit code.
-        set +o xtrace
-        exit $exit_code
 
     - name: Measure coverage
       id: measure-coverage
@@ -238,6 +215,7 @@ jobs:
       timeout-minutes: 5
       run: |
 
+        trap 'echo "MULTIPASS_TESTS_EXIT_CODE=$?" >> $GITHUB_ENV' EXIT
         instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
         /snap/bin/lxc --project snapcraft start $instance_name
 
@@ -257,28 +235,13 @@ jobs:
         /snap/bin/lxc --project snapcraft exec $instance_name -- \
            sh -c "sudo sed -i \"s/use JSON::PP/use JSON::XS/\" \`which geninfo\`"
 
-        # We need to capture the exit code here for the coredump capture steps.
-        # The step `run` sets exit on failure as default, so disable it to allow the code
-        # to capture the exit code. We'll manually do an exit(exit_code) later on.
-        set +e
-        set -o xtrace
-
+        # Create the directory for the coredumps
+        /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c 'mkdir -p /coredump'
         /snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "\
           ulimit -c unlimited && \
           env CTEST_OUTPUT_ON_FAILURE=1 \
             cmake --build /root/parts/multipass/build --target covreport"
-        # Capture the exit code.
-        exit_code="$?"
-        # Save the exit code to a action-level variable so we can refer to it in other steps.
-        echo "MULTIPASS_TESTS_EXIT_CODE=$exit_code" >> $GITHUB_ENV
-        # Re-enable exit on failure
-        set -e
-        # Directly exit without running the codecov if an error occurs
-        if [ $exit_code -ne 0 ] ; then
-          exit $exit_code
-        fi
         bash <(curl -s https://codecov.io/bash) -Z -s ${{ steps.coverage-setup.outputs.build }}
-        exit $exit_code
 
     - name: Pull coredump and executable from LXC container
       if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE == '139'}}


### PR DESCRIPTION
The BuıldAndTest(Debug) step crashes intermittently without any significant clue for us to pursue. The crash does not happen in the local environment so the best next thing is to grab the core dump & crashed executable and upload them to artifacts so we can investigate them.

MULTI-1845