### PR TITLE
`exec` runs sudo commands with `-u` to preserve user

### DIFF
--- a/src/client/cli/cmd/exec.cpp
+++ b/src/client/cli/cmd/exec.cpp
@@ -168,13 +168,10 @@ mp::ReturnCode cmd::Exec::exec_success(const mp::SSHInfoReply& reply, const std:
         {
             if (args[0] == "sudo")
             {
-                // Extract the command without the sudo prefix
-                std::vector<std::string> cmd_args(args.begin() + 1, args.end());
-
                 // Use sudo to access the directory, but run the command as the ubuntu user,
-                // then use sudo again to execute the original command
                 // This preserves the correct SUDO_ environment variables
-                auto sh_args = fmt::format("cd {} && sudo -u {} sudo {}", *dir, username, fmt::join(cmd_args, " "));
+                const auto sh_args = fmt::format("cd {} && sudo -u {} {}", *dir, username, fmt::join(args, " "));
+
                 all_args = {{"sudo", "sh", "-c", sh_args}};
             }
             else

--- a/src/client/cli/cmd/exec.cpp
+++ b/src/client/cli/cmd/exec.cpp
@@ -168,10 +168,13 @@ mp::ReturnCode cmd::Exec::exec_success(const mp::SSHInfoReply& reply, const std:
         {
             if (args[0] == "sudo")
             {
-                // If we are running through 'sudo' and need to change directory, it might happen that the default user
-                // does not have access to the folder and thus the cd command will fail. Additionally, `cd` cannot be
-                // ran with sudo, what forces us to run everything through `sh`.
-                auto sh_args = fmt::format("cd {} && {}", *dir, fmt::join(args, " "));
+                // Extract the command without the sudo prefix
+                std::vector<std::string> cmd_args(args.begin() + 1, args.end());
+
+                // Use sudo to access the directory, but run the command as the ubuntu user,
+                // then use sudo again to execute the original command
+                // This preserves the correct SUDO_ environment variables
+                auto sh_args = fmt::format("cd {} && sudo -u {} sudo {}", *dir, username, fmt::join(cmd_args, " "));
                 all_args = {{"sudo", "sh", "-c", sh_args}};
             }
             else


### PR DESCRIPTION
<details>
<summary>fixes #3933 </summary>

I had to run the `sudo concierge prepare -p dev --extra-snaps terraform` command twice whether I was shelled in with `multipass shell` or using `multipass exec`. Running `multipass exec juju-dev -- sudo env | grep SUDO_` gives the correct SUDO environment variables

```text
~/CLionProjects/multipass/build$ ./bin/multipass launch noble --disk 50G --memory 4G --cpus 2 --mount .  --name juju-dev
Launched: juju-dev
Mounted '.' into 'juju-dev:'
~/CLionProjects/multipass/build$ ./bin/multipass exec juju-dev -- sudo snap install concierge --classic
concierge 0.11.1 from Jon Seager (jnsgruk✪) installed
frame@frame-laptop:~/CLionProjects/multipass/build$ ./bin/multipass exec juju-dev -- sudo concierge prepare -p dev --extra-snaps terraform
time=2025-02-26T09:49:17.825-05:00 level=INFO msg="Preset selected" preset=dev
time=2025-02-26T09:49:37.624-05:00 level=INFO msg="Installed snap" snap=charmcraft
time=2025-02-26T09:49:47.641-05:00 level=INFO msg="Installed apt package" package=python3-pip
time=2025-02-26T09:49:50.327-05:00 level=INFO msg="Installed snap" snap=jq
time=2025-02-26T09:49:51.198-05:00 level=INFO msg="Installed apt package" package=python3-venv
time=2025-02-26T09:49:54.497-05:00 level=INFO msg="Installed snap" snap=yq
time=2025-02-26T09:50:29.489-05:00 level=INFO msg="Installed snap" snap=rockcraft
time=2025-02-26T09:50:42.662-05:00 level=INFO msg="Installed snap" snap=snapcraft
time=2025-02-26T09:51:02.735-05:00 level=INFO msg="Installed snap" snap=jhack
time=2025-02-26T09:51:08.384-05:00 level=INFO msg="Installed snap" snap=terraform
time=2025-02-26T09:51:22.508-05:00 level=INFO msg="Installed snap" snap=k8s
time=2025-02-26T09:51:28.145-05:00 level=INFO msg="Installed snap" snap=kubectl
time=2025-02-26T09:51:28.621-05:00 level=INFO msg="Refreshed snap" snap=lxd
Command: /snap/bin/k8s status
Output:
Error: The node is not part of a Kubernetes cluster. You can bootstrap a new cluster with:

  sudo k8s bootstrap
time=2025-02-26T09:51:33.206-05:00 level=INFO msg="Prepared provider" provider=lxd
time=2025-02-26T09:53:00.624-05:00 level=INFO msg="Prepared provider" provider=k8s
time=2025-02-26T09:53:19.510-05:00 level=INFO msg="Installed snap" snap=juju
Command: sudo -u ubuntu /snap/bin/juju show-controller concierge-k8s
Output:
{}
ERROR controller concierge-k8s not found
time=2025-02-26T09:53:25.349-05:00 level=INFO msg="Bootstrapping Juju" provider=k8s
Command: sudo -u ubuntu /snap/bin/juju show-controller concierge-lxd
Output:
{}
ERROR controller concierge-lxd not found
time=2025-02-26T09:53:27.397-05:00 level=INFO msg="Bootstrapping Juju" provider=lxd
time=2025-02-26T09:55:00.176-05:00 level=INFO msg="Bootstrapped Juju" provider=k8s
time=2025-02-26T09:56:18.206-05:00 level=INFO msg="Bootstrapped Juju" provider=lxd
~/CLionProjects/multipass/build$ ./bin/multipass exec juju-dev -- sudo concierge prepare -p dev --extra-snaps terraform
time=2025-02-26T09:56:59.249-05:00 level=INFO msg="Preset selected" preset=dev
time=2025-02-26T09:57:01.532-05:00 level=INFO msg="Refreshed snap" snap=jq
time=2025-02-26T09:57:02.270-05:00 level=INFO msg="Installed apt package" package=python3-pip
time=2025-02-26T09:57:02.522-05:00 level=INFO msg="Refreshed snap" snap=yq
time=2025-02-26T09:57:02.889-05:00 level=INFO msg="Installed apt package" package=python3-venv
time=2025-02-26T09:57:03.653-05:00 level=INFO msg="Refreshed snap" snap=rockcraft
time=2025-02-26T09:57:04.715-05:00 level=INFO msg="Refreshed snap" snap=snapcraft
time=2025-02-26T09:57:05.708-05:00 level=INFO msg="Refreshed snap" snap=jhack
time=2025-02-26T09:57:06.733-05:00 level=INFO msg="Refreshed snap" snap=charmcraft
time=2025-02-26T09:57:07.567-05:00 level=INFO msg="Refreshed snap" snap=terraform
time=2025-02-26T09:57:17.126-05:00 level=INFO msg="Refreshed snap" snap=k8s
time=2025-02-26T09:57:17.611-05:00 level=INFO msg="Refreshed snap" snap=lxd
time=2025-02-26T09:57:25.153-05:00 level=INFO msg="Refreshed snap" snap=kubectl
time=2025-02-26T09:57:27.131-05:00 level=INFO msg="Prepared provider" provider=lxd
time=2025-02-26T09:57:49.081-05:00 level=INFO msg="Prepared provider" provider=k8s
time=2025-02-26T09:57:50.248-05:00 level=INFO msg="Refreshed snap" snap=juju
time=2025-02-26T09:57:53.383-05:00 level=INFO msg="Previous Juju controller found" provider=lxd
time=2025-02-26T09:57:54.850-05:00 level=INFO msg="Previous Juju controller found" provider=k8s
~/CLionProjects/multipass/build$ ./bin/multipass exec juju-dev -- juju controllers
Use --refresh option with this command to see the latest information.

Controller      Model    User   Access     Cloud/Region         Models  Nodes    HA  Version
concierge-k8s   testing  admin  superuser  k8s                       2      -     -  3.6.2  
concierge-lxd*  testing  admin  superuser  localhost/localhost       2      1  none  3.6.2  
```

</details> 

In order to `cd` into directories we need to do `sudo sh -c` because `cd` cannot be run with `sudo`. This changes our SUDO_ user. We could use `sudo -E` to preserve the entire environment but that may cause unintended behavior. Instead we use `sudo -u` to restore the user. We know the user from the `ssh_info.username()`