### PR TITLE
[log] introduce mpl::<level-name>(...) log functions

### DIFF
--- a/include/multipass/logging/log.h
+++ b/include/multipass/logging/log.h
@@ -30,6 +30,11 @@ namespace multipass
 namespace logging
 {
 
+void log(Level level, CString category, CString message);
+void set_logger(std::shared_ptr<Logger> logger);
+Level get_logging_level();
+Logger* get_logger(); // for tests, don't rely on it lasting
+
 /**
  * Log with formatting support
  *
@@ -54,13 +59,105 @@ constexpr void
 log(Level level, const std::string& category, fmt::format_string<Arg0, Args...> fmt, Arg0&& arg0, Args&&... args)
 {
     const auto formatted_log_msg = fmt::format(fmt, std::forward<Arg0>(arg0), std::forward<Args>(args)...);
-    log(level, category, formatted_log_msg);
+    logging::log(level, category, formatted_log_msg);
 }
 
-void log(Level level, CString category, CString message);
-void set_logger(std::shared_ptr<Logger> logger);
-Level get_logging_level();
-Logger* get_logger(); // for tests, don't rely on it lasting
+/**
+ * Log function with templated log level.
+ *
+ * This function acts as an dispatch point for the templated
+ * and non-templated log overloads, based on argument count.
+ * We cannot simply use the templated overload since it requires
+ * at least 1 arguments.
+ *
+ * @tparam level Log level
+ * @tparam Args Format argument types
+ * @param category Log category
+ * @param fmt Format string
+ * @param args Format arguments, if any
+ */
+template <Level level, typename... Args>
+constexpr void log(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
+{
+    if constexpr (sizeof...(Args) > 0)
+    {
+        // Needs formatting
+        logging::log(level, category, fmt, std::forward<Args>(args)...);
+        return;
+    }
+    logging::log(level, category, CString{fmt.get().data()});
+}
+
+/**
+ * Log an error message.
+ *
+ * @tparam Args Format argument types
+ * @param category Log category
+ * @param fmt Format string
+ * @param args Format arguments
+ */
+template <typename... Args>
+constexpr void error(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
+{
+    logging::log<Level::error>(category, fmt, std::forward<Args>(args)...);
+}
+
+/**
+ * Log a warning message.
+ *
+ * @tparam Args List of types for format arguments
+ * @param category Log category
+ * @param fmt Format string
+ * @param args Format arguments
+ */
+template <typename... Args>
+constexpr void warn(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
+{
+    logging::log<Level::warning>(category, fmt, std::forward<Args>(args)...);
+}
+
+/**
+ * Log a info message.
+ *
+ * @tparam Args List of types for format arguments
+ * @param category Log category
+ * @param fmt Format string
+ * @param args Format arguments
+ */
+template <typename... Args>
+constexpr void info(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
+{
+    logging::log<Level::info>(category, fmt, std::forward<Args>(args)...);
+}
+
+/**
+ * Log a debug message.
+ *
+ * @tparam Args List of types for format arguments
+ * @param category Log category
+ * @param fmt Format string
+ * @param args Format arguments
+ */
+template <typename... Args>
+constexpr void debug(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
+{
+    logging::log<Level::debug>(category, fmt, std::forward<Args>(args)...);
+}
+
+/**
+ * Log a trace message.
+ *
+ * @tparam Args List of types for format arguments
+ * @param category Log category
+ * @param fmt Format string
+ * @param args Format arguments
+ */
+template <typename... Args>
+constexpr void trace(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
+{
+    logging::log<Level::trace>(category, fmt, std::forward<Args>(args)...);
+}
+
 } // namespace logging
 } // namespace multipass
 #endif // MULTIPASS_LOG_H

--- a/include/multipass/logging/log.h
+++ b/include/multipass/logging/log.h
@@ -48,11 +48,11 @@ Logger* get_logger(); // for tests, don't rely on it lasting
  *
  * @tparam Arg0 Type of the first format argument
  * @tparam Args Type of the rest of the format arguments
- * @param level Log level
- * @param category Log category
- * @param fmt Format string
- * @param arg0 The first format argument
- * @param args Rest of the format arguments
+ * @param [in] level Log level
+ * @param [in] category Log category
+ * @param [in] fmt Format string
+ * @param [in] arg0 The first format argument
+ * @param [in] args Rest of the format arguments
  */
 template <typename Arg0, typename... Args>
 constexpr void
@@ -72,9 +72,9 @@ log(Level level, const std::string& category, fmt::format_string<Arg0, Args...> 
  *
  * @tparam level Log level
  * @tparam Args Format argument types
- * @param category Log category
- * @param fmt Format string
- * @param args Format arguments, if any
+ * @param [in] category Log category
+ * @param [in] fmt Format string
+ * @param [in] args Format arguments, if any
  */
 template <Level level, typename... Args>
 constexpr void log(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
@@ -92,9 +92,9 @@ constexpr void log(const std::string& category, fmt::format_string<Args...> fmt,
  * Log an error message.
  *
  * @tparam Args Format argument types
- * @param category Log category
- * @param fmt Format string
- * @param args Format arguments
+ * @param [in] category Log category
+ * @param [in] fmt Format string
+ * @param [in] args Format arguments
  */
 template <typename... Args>
 constexpr void error(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
@@ -105,10 +105,10 @@ constexpr void error(const std::string& category, fmt::format_string<Args...> fm
 /**
  * Log a warning message.
  *
- * @tparam Args List of types for format arguments
- * @param category Log category
- * @param fmt Format string
- * @param args Format arguments
+ * @tparam Args Format argument types
+ * @param [in] category Log category
+ * @param [in] fmt Format string
+ * @param [in] args Format arguments
  */
 template <typename... Args>
 constexpr void warn(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
@@ -119,10 +119,10 @@ constexpr void warn(const std::string& category, fmt::format_string<Args...> fmt
 /**
  * Log a info message.
  *
- * @tparam Args List of types for format arguments
- * @param category Log category
- * @param fmt Format string
- * @param args Format arguments
+ * @tparam Args Format argument types
+ * @param [in] category Log category
+ * @param [in] fmt Format string
+ * @param [in] args Format arguments
  */
 template <typename... Args>
 constexpr void info(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
@@ -133,10 +133,10 @@ constexpr void info(const std::string& category, fmt::format_string<Args...> fmt
 /**
  * Log a debug message.
  *
- * @tparam Args List of types for format arguments
- * @param category Log category
- * @param fmt Format string
- * @param args Format arguments
+ * @tparam Args Format argument types
+ * @param [in] category Log category
+ * @param [in] fmt Format string
+ * @param [in] args Format arguments
  */
 template <typename... Args>
 constexpr void debug(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)
@@ -147,10 +147,10 @@ constexpr void debug(const std::string& category, fmt::format_string<Args...> fm
 /**
  * Log a trace message.
  *
- * @tparam Args List of types for format arguments
- * @param category Log category
- * @param fmt Format string
- * @param args Format arguments
+ * @tparam Args Format argument types
+ * @param [in] category Log category
+ * @param [in] fmt Format string
+ * @param [in] args Format arguments
  */
 template <typename... Args>
 constexpr void trace(const std::string& category, fmt::format_string<Args...> fmt, Args&&... args)

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -70,3 +70,67 @@ TEST_F(log_tests, test_format_overload_multiple_args_missing)
     // time error with the C++20
     EXPECT_THROW({ mpl::log(mpl::Level::error, "test_category", "with formatting {} {}", 1); }, fmt::format_error);
 }
+
+// ------------------------------------------------------------------------------
+
+TEST_F(log_tests, test_log_error_function)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::error, "with formatting 1");
+    mpl::error("test_category", "with formatting {}", 1);
+}
+
+TEST_F(log_tests, test_log_warn_function)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::warning, "with formatting 1");
+    mpl::warn("test_category", "with formatting {}", 1);
+}
+
+TEST_F(log_tests, test_log_info_function)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::info, "with formatting 1");
+    mpl::info("test_category", "with formatting {}", 1);
+}
+
+TEST_F(log_tests, test_log_debug_function)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::debug, "with formatting 1");
+    mpl::debug("test_category", "with formatting {}", 1);
+}
+
+TEST_F(log_tests, test_log_trace_function)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::trace, "with formatting 1");
+    mpl::trace("test_category", "with formatting {}", 1);
+}
+
+// ------------------------------------------------------------------------------
+
+TEST_F(log_tests, test_log_error_function_noargs)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::error, "without formatting {}");
+    mpl::error("test_category", "without formatting {}");
+}
+
+TEST_F(log_tests, test_log_warn_function_noargs)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::warning, "without formatting {}");
+    mpl::warn("test_category", "without formatting {}");
+}
+
+TEST_F(log_tests, test_log_info_function_noargs)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::info, "without formatting {}");
+    mpl::info("test_category", "without formatting {}");
+}
+
+TEST_F(log_tests, test_log_debug_function_noargs)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::debug, "without formatting {}");
+    mpl::debug("test_category", "without formatting {}");
+}
+
+TEST_F(log_tests, test_log_trace_function_noargs)
+{
+    logger_scope.mock_logger->expect_log(mpl::Level::trace, "without formatting {}");
+    mpl::trace("test_category", "without formatting {}");
+}


### PR DESCRIPTION
Added the following templated log functions: error, warn, info, debug, trace.

Added a templated log overload, which takes the log level as a template parameter. This function acts as a dispatcher for calls with/without a format.

Moved non-templated function declarations to the top.

Unit tests were added for the new log-level functions.

Prefixed all log() calls with logging:: namespace so log() from math library does not get pulled into overload resolution candidates.

MULTI-1853