### PR TITLE
[exceptions] add FormattedExceptionBase type

### DIFF
--- a/include/multipass/exceptions/formatted_exception_base.h
+++ b/include/multipass/exceptions/formatted_exception_base.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_FORMATTED_EXCEPTION_BASE_H
+#define MULTIPASS_FORMATTED_EXCEPTION_BASE_H
+
+#include <fmt/format.h>
+
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace multipass
+{
+
+/**
+ * A templated exception base type that has formatting by default.
+ *
+ * This class is intended to be used as a base class to user-defined
+ * exception types. The user-defined exception type is either expected
+ * to inherit the constructors of FormattedExceptionBase, or call them
+ * explicitly.
+ *
+ * @tparam BaseExceptionType The exception type. Defaults to `std::runtime_error`.
+ * The exception type must be constructible with a std::string, and must derive from
+ * std::exception.
+ */
+template <typename BaseExceptionType = std::runtime_error>
+struct FormattedExceptionBase : public BaseExceptionType
+{
+    // These are here for giving nice and understandable compilation errors
+    // instead of a 1000 page of cryptic template wall of error message.
+    static_assert(
+        std::is_constructible<BaseExceptionType, std::string>::value ||
+            std::is_constructible<BaseExceptionType, std::error_code, std::string>::value,
+        "BaseExceptionType must either be constructible with (std::string) or (std::error_code, std::string).");
+    static_assert(std::is_base_of<std::exception, BaseExceptionType>::value,
+                  "BaseExceptionType must derive from std::exception");
+
+    /**
+     * Produces a formatted string using fmt and args.
+     *
+     * Possible format exceptions are handled gracefully.
+     *
+     * @tparam Args Format argument types
+     *
+     * @param [in] fmt Format string
+     * @param [in] args Format arguments
+     */
+    template <typename... Args>
+    FormattedExceptionBase(fmt::format_string<Args...> fmt, Args&&... args)
+        : BaseExceptionType(failsafe_format(fmt, std::forward<Args>(args)...))
+    {
+    }
+
+    /**
+     * Produces a formatted string using fmt and args.
+     *
+     * Possible format exceptions are handled gracefully.
+     *
+     * @tparam Args Format argument types
+     *
+     * @param [in] ec Error code
+     * @param [in] fmt Format string
+     * @param [in] args Format arguments
+     */
+    template <typename... Args>
+    FormattedExceptionBase(std::error_code ec, fmt::format_string<Args...> fmt, Args&&... args)
+        : BaseExceptionType(ec, failsafe_format(fmt, std::forward<Args>(args)...))
+    {
+    }
+
+private:
+    /**
+     * Exception catcher for fmt::format.
+     *
+     * Since this class is an exception class itself, it cannot simply throw
+     * exceptions on the constructor, otherwise it'll lead to `std::terminate()`
+     * and we definitely don't want to terminate just because of a recoverable
+     * format error.
+     *
+     * Instead, the code catches the exception and returns a string that indicate
+     * that there was a format error with the given format string, so it can be
+     * traced and fixed.
+     *
+     * The function is not marked as `noexcept` since in theory the std::string
+     * constructor could throw, and we're not handling that. The typical base exception
+     * types to this class do not give that guarantee either (.e.g, std::runtime_error)
+     * so the code does not bother.
+     *
+     * @tparam Args Format argument types
+     * @param [in] fmt Format string
+     * @param [in] args Format arguments
+     *
+     * @return std::string Format result
+     */
+    template <typename... Args>
+    static std::string failsafe_format(fmt::format_string<Args...> fmt, Args&&... args)
+    try
+    {
+        return fmt::format(fmt, std::forward<Args>(args)...);
+    }
+    catch (const std::exception& e)
+    {
+        std::string msg{"[Error while formatting the exception string]"};
+        msg += "\nFormat string: `";
+        msg += fmt.get().data();
+        msg += "`\nFormat error: `";
+        msg += e.what();
+        msg += '`';
+        return msg;
+    }
+    catch (...)
+    {
+        // In an unlikely event of fmt::format throwing a non-exception type.
+        std::string msg{"[Error while formatting the exception string]"};
+        msg += "\nFormat string: `";
+        msg += fmt.get().data();
+        msg += '`';
+        return msg;
+    }
+};
+
+} // namespace multipass
+
+#endif // MULTIPASS_FORMATTED_EXCEPTION_BASE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,6 +126,7 @@ add_executable(multipass_tests
   test_file_ops.cpp
   test_recursive_dir_iter.cpp
   test_log.cpp
+  test_exception.cpp
 )
 
 target_include_directories(multipass_tests

--- a/tests/test_exception.cpp
+++ b/tests/test_exception.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/exceptions/formatted_exception_base.h>
+
+#include <gmock/gmock.h> // for EXPECT_THAT
+#include <gtest/gtest.h>
+#include <tests/common.h>
+
+namespace mpt = multipass::test;
+
+struct exception_tests : ::testing::Test
+{
+};
+
+using testing::HasSubstr;
+
+struct custom_exception_type : std::exception
+{
+
+    custom_exception_type(const std::string& v) : msg(v)
+    {
+    }
+
+    const char* what() const noexcept override
+    {
+        return msg.c_str();
+    }
+
+private:
+    std::string msg;
+};
+
+template <typename T>
+struct MockException : multipass::FormattedExceptionBase<T>
+{
+    using multipass::FormattedExceptionBase<T>::FormattedExceptionBase;
+};
+
+struct AngryTypeThatThrowsUnexpectedThings
+{
+};
+
+// This is a quick way to make fmt::format throw an "unexpected" thing,
+// so we can test the catch-all exception catcher.
+template <typename Char>
+struct fmt::formatter<AngryTypeThatThrowsUnexpectedThings, Char>
+{
+    constexpr auto parse(basic_format_parse_context<Char>& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    fmt::context::iterator format(const AngryTypeThatThrowsUnexpectedThings& api, FormatContext& ctx) const
+    {
+        // What an unusual sight.
+        throw int{5};
+    }
+};
+
+TEST_F(exception_tests, throw_default)
+{
+    MP_EXPECT_THROW_THAT(throw multipass::FormattedExceptionBase<>("message {}", 1),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr("message 1")));
+}
+
+TEST_F(exception_tests, throw_non_default_std)
+{
+    MP_EXPECT_THROW_THAT(throw MockException<std::overflow_error>("message {}", 1),
+                         std::overflow_error,
+                         mpt::match_what(HasSubstr("message 1")));
+}
+
+TEST_F(exception_tests, throw_std_system_error)
+{
+    MP_EXPECT_THROW_THAT(
+        throw MockException<std::system_error>(std::make_error_code(std::errc::operation_canceled), "message {}", 1),
+        std::system_error,
+        mpt::match_what(HasSubstr("message 1")));
+}
+
+TEST_F(exception_tests, throw_user_defined_exception)
+{
+    MP_EXPECT_THROW_THAT(throw MockException<custom_exception_type>("message {}", 1),
+                         custom_exception_type,
+                         mpt::match_what(HasSubstr("message 1")));
+}
+
+TEST_F(exception_tests, throw_format_error)
+{
+    constexpr auto expected_error_msg = R"([Error while formatting the exception string]
+Format string: `message {}`
+Format error: `argument not found`)";
+
+    MP_EXPECT_THROW_THAT(throw MockException<std::runtime_error>("message {}"),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr(expected_error_msg)));
+}
+
+TEST_F(exception_tests, throw_unexpected_error)
+{
+    constexpr auto expected_error_msg = R"([Error while formatting the exception string]
+Format string: `message {}`)";
+
+    MP_EXPECT_THROW_THAT(throw MockException<std::runtime_error>("message {}", AngryTypeThatThrowsUnexpectedThings{}),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr(expected_error_msg)));
+}


### PR DESCRIPTION
FormattedExceptionBase is a generic base class type that produces a formatted string and passes it to the base class. This is a common occurrence in the codebase, so this class is designed to address that.

FormattedExceptionBase can be used with any type that derives from std::exception and has a std::string constructor.

The class gracefully handles format errors to not incur a `std::terminate()`.

MULTI-1854