### PR TITLE
[ci/BuildAndTest] pull the coredump folder as a whole

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -232,7 +232,9 @@ jobs:
         bash <(curl -s https://codecov.io/bash) -Z -s ${{ steps.coverage-setup.outputs.build }}
 
     - name: Pull coredump and executable from LXC container
-      if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE == '139'}}
+      if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE != '0'}}
+      # do not cause job to fail if there are no coredumps available.
+      continue-on-error: true
       run: |
 
         set -o xtrace
@@ -254,7 +256,7 @@ jobs:
 
     - name: Upload test coredump
       uses: actions/upload-artifact@v4
-      if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE == '139' }}
+      if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE != '0' }}
       with:
         name: buildandtest-test-crash-${{ runner.os }}-${{ matrix.build-type }}
         path: /tmp/coredump/**

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -245,21 +245,11 @@ jobs:
         mkdir -p /tmp/coredump
         instance_name=`/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass`
         # Pull the crashed executable from the container
-        /snap/bin/lxc --project snapcraft file pull "$instance_name/root/parts/multipass/build/bin/multipass_tests" /tmp/multipass_tests
+        /snap/bin/lxc --project snapcraft file pull -p -r "$instance_name/root/parts/multipass/build/bin/multipass_tests" /tmp/coredump/multipass_tests
         echo "Pulled the executable."
-        # List the coredump files into a variable
-        files=`/snap/bin/lxc --project snapcraft exec $instance_name -- bash -c "ls /coredump 2>/dev/null"`
-        echo "$files"
-        # If there's `any`, we need to pull them.
-        if [ ! -z "$files" ]
-        then
-          ARRAY=($files)
-          COREDUMP_FILES=(`printf "$instance_name/coredump/%s " "${ARRAY[@]}"`)
-          /snap/bin/lxc --project snapcraft file pull "${COREDUMP_FILES[@]}" /tmp/coredump
-          echo "Pulled ${#COREDUMP_FILES[@]} coredump(s) from the snap build container"
-        else
-          echo "Executable crashed, but no coredump file found!"
-        fi
+        # Pull the coredump folder
+        /snap/bin/lxc --project snapcraft file pull -p -r "$instance_name/coredump" /tmp/coredump
+        echo "Pulled the coredumps folder."
         set +o xtrace
 
     - name: Upload test coredump


### PR DESCRIPTION
one-by-one file pulling was breaking when the file included whitespace characters. this patch switches to pulling the whole coredumps folder to simplify the code. 

also added a fix for pull coredump step not triggering when the segfault happens in the coverage step.

MULTI-1875