### PR TITLE
[sshfs-mount-handler] ensure signals are disconnected upon destruction

### DIFF
--- a/include/multipass/qt_delete_later_unique_ptr.h
+++ b/include/multipass/qt_delete_later_unique_ptr.h
@@ -31,7 +31,7 @@ namespace multipass
 
 struct QtDeleteLater {
     void operator()(QObject *o) {
-        // Detach the signal handlers since this object don't live in a QT object
+        // Detach the signal handlers since this object doesn't live in a QT object
         // hierarchy, and that might cause lifetime related issues, especially
         // if signals are involved.
         o->disconnect();

--- a/include/multipass/qt_delete_later_unique_ptr.h
+++ b/include/multipass/qt_delete_later_unique_ptr.h
@@ -31,6 +31,11 @@ namespace multipass
 
 struct QtDeleteLater {
     void operator()(QObject *o) {
+        // Detach the signal handlers since this object don't live in a QT object
+        // hierarchy, and that might cause lifetime related issues, especially
+        // if signals are involved.
+        o->disconnect();
+        // Qt requires that a QObject be deleted from the thread it lives in.
         o->deleteLater();
     }
 };

--- a/include/multipass/sshfs_mount/sshfs_mount_handler.h
+++ b/include/multipass/sshfs_mount/sshfs_mount_handler.h
@@ -36,7 +36,6 @@ public:
 
     void activate_impl(ServerVariant server, std::chrono::milliseconds timeout) override;
     void deactivate_impl(bool force) override;
-    bool is_active() override;
 
 private:
     qt_delete_later_unique_ptr<Process> process;

--- a/tests/test_sshfs_mount_handler.cpp
+++ b/tests/test_sshfs_mount_handler.cpp
@@ -120,9 +120,9 @@ TEST_F(SSHFSMountHandlerTest, mount_creates_sshfs_process)
     factory->register_callback(sshfs_server_callback(sshfs_prints_connected));
 
     mpt::MockVirtualMachine mock_vm{"my_instance"};
-    EXPECT_CALL(mock_vm, ssh_port()).Times(3);
-    EXPECT_CALL(mock_vm, ssh_hostname()).Times(3);
-    EXPECT_CALL(mock_vm, ssh_username()).Times(3);
+    EXPECT_CALL(mock_vm, ssh_port()).Times(2);
+    EXPECT_CALL(mock_vm, ssh_hostname()).Times(2);
+    EXPECT_CALL(mock_vm, ssh_username()).Times(2);
 
     mp::SSHFSMountHandler sshfs_mount_handler{&mock_vm, &key_provider, target_path, mount};
     sshfs_mount_handler.activate(&server);


### PR DESCRIPTION
Currently, the signal handlers outlast the process and the mount handler, which leads to undefined behavior.  

This resulted in a crash when I attempted to unmount an sshfs mount in Windows.  

This patch resolves the issue by ensuring that all connected signals are disconnected in the destructor.

Also modernized the mpl::log calls while at it.

MULTI-1873