### PR TITLE
Flutter 3.29

### DIFF
--- a/src/client/gui/.metadata
+++ b/src/client/gui/.metadata
@@ -1,11 +1,11 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled.
+# This file should be version controlled and should not be manually edited.
 
 version:
-  revision: 4b12645012342076800eb701bcdfe18f87da21cf
-  channel: stable
+  revision: "09de023485e95e6d1225c2baa44b8feb85e0d45f"
+  channel: "[user-branch]"
 
 project_type: app
 
@@ -13,17 +13,17 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 4b12645012342076800eb701bcdfe18f87da21cf
-      base_revision: 4b12645012342076800eb701bcdfe18f87da21cf
+      create_revision: 09de023485e95e6d1225c2baa44b8feb85e0d45f
+      base_revision: 09de023485e95e6d1225c2baa44b8feb85e0d45f
     - platform: linux
-      create_revision: 4b12645012342076800eb701bcdfe18f87da21cf
-      base_revision: 4b12645012342076800eb701bcdfe18f87da21cf
+      create_revision: 09de023485e95e6d1225c2baa44b8feb85e0d45f
+      base_revision: 09de023485e95e6d1225c2baa44b8feb85e0d45f
     - platform: macos
-      create_revision: 4b12645012342076800eb701bcdfe18f87da21cf
-      base_revision: 4b12645012342076800eb701bcdfe18f87da21cf
+      create_revision: 09de023485e95e6d1225c2baa44b8feb85e0d45f
+      base_revision: 09de023485e95e6d1225c2baa44b8feb85e0d45f
     - platform: windows
-      create_revision: 4b12645012342076800eb701bcdfe18f87da21cf
-      base_revision: 4b12645012342076800eb701bcdfe18f87da21cf
+      create_revision: 09de023485e95e6d1225c2baa44b8feb85e0d45f
+      base_revision: 09de023485e95e6d1225c2baa44b8feb85e0d45f
 
   # User provided section
 

--- a/src/client/gui/lib/before_quit_dialog.dart
+++ b/src/client/gui/lib/before_quit_dialog.dart
@@ -24,17 +24,19 @@ class _BeforeQuitDialogState extends State<BeforeQuitDialog> {
   Widget build(BuildContext context) {
     return ConfirmationDialog(
       title: 'Before quitting',
-      body: Column(children: [
-        const Text(
-          'When quitting this application you can leave instances running in the background or choose to stop them completely.',
-        ),
-        const SizedBox(height: 12),
-        Switch(
-          value: remember,
-          label: 'Remember this setting',
-          onChanged: (value) => setState(() => remember = value),
-        ),
-      ]),
+      body: Column(
+        children: [
+          const Text(
+            'When quitting this application you can leave instances running in the background or choose to stop them completely.',
+          ),
+          const SizedBox(height: 12),
+          Switch(
+            value: remember,
+            label: 'Remember this setting',
+            onChanged: (value) => setState(() => remember = value),
+          ),
+        ],
+      ),
       actionText: 'Stop instances',
       onAction: () => widget.onStop(remember),
       inactionText: 'Leave instances running',

--- a/src/client/gui/lib/catalogue/catalogue.dart
+++ b/src/client/gui/lib/catalogue/catalogue.dart
@@ -73,24 +73,28 @@ class CatalogueScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final content = ref.watch(imagesProvider).when(
+    final content = ref
+        .watch(imagesProvider)
+        .when(
           skipLoadingOnRefresh: false,
           data: _buildCatalogue,
           error: (error, _) {
             final errorMessage = error is GrpcError ? error.message : error;
             return Center(
-              child: Column(children: [
-                const SizedBox(height: 32),
-                Text(
-                  'Failed to retrieve images: $errorMessage',
-                  style: const TextStyle(fontSize: 16),
-                ),
-                const SizedBox(height: 16),
-                TextButton(
-                  onPressed: () => ref.invalidate(imagesProvider),
-                  child: const Text('Refresh'),
-                ),
-              ]),
+              child: Column(
+                children: [
+                  const SizedBox(height: 32),
+                  Text(
+                    'Failed to retrieve images: $errorMessage',
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                  const SizedBox(height: 16),
+                  TextButton(
+                    onPressed: () => ref.invalidate(imagesProvider),
+                    child: const Text('Refresh'),
+                  ),
+                ],
+              ),
             );
           },
           loading: () => const Center(child: CircularProgressIndicator()),
@@ -119,11 +123,7 @@ class CatalogueScreen extends ConsumerWidget {
         padding: const EdgeInsets.symmetric(horizontal: 140).copyWith(top: 40),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            welcomeText,
-            const Divider(),
-            Expanded(child: content),
-          ],
+          children: [welcomeText, const Divider(), Expanded(child: content)],
         ),
       ),
     );
@@ -131,29 +131,34 @@ class CatalogueScreen extends ConsumerWidget {
 
   Widget _buildCatalogue(List<ImageInfo> images) {
     return SingleChildScrollView(
-      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        Container(
-          margin: const EdgeInsets.symmetric(vertical: 10),
-          child: const Text(
-            'Images',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            margin: const EdgeInsets.symmetric(vertical: 10),
+            child: const Text(
+              'Images',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
           ),
-        ),
-        LayoutBuilder(builder: (_, constraints) {
-          const minCardWidth = 285;
-          const spacing = 32.0;
-          final nCards = constraints.maxWidth ~/ minCardWidth;
-          final whiteSpace = spacing * (nCards - 1);
-          final cardWidth = (constraints.maxWidth - whiteSpace) / nCards;
-          return Wrap(
-            runSpacing: spacing,
-            spacing: spacing,
-            children:
-                images.map((image) => ImageCard(image, cardWidth)).toList(),
-          );
-        }),
-        const SizedBox(height: 32),
-      ]),
+          LayoutBuilder(
+            builder: (_, constraints) {
+              const minCardWidth = 285;
+              const spacing = 32.0;
+              final nCards = constraints.maxWidth ~/ minCardWidth;
+              final whiteSpace = spacing * (nCards - 1);
+              final cardWidth = (constraints.maxWidth - whiteSpace) / nCards;
+              return Wrap(
+                runSpacing: spacing,
+                spacing: spacing,
+                children:
+                    images.map((image) => ImageCard(image, cardWidth)).toList(),
+              );
+            },
+          ),
+          const SizedBox(height: 32),
+        ],
+      ),
     );
   }
 }

--- a/src/client/gui/lib/catalogue/image_card.dart
+++ b/src/client/gui/lib/catalogue/image_card.dart
@@ -46,7 +46,7 @@ class ImageCard extends ConsumerWidget {
                   'Canonical ',
                   style: TextStyle(color: Color(0xff666666)),
                 ),
-                SvgPicture.asset('assets/verified.svg')
+                SvgPicture.asset('assets/verified.svg'),
               ],
             ),
             Expanded(
@@ -55,40 +55,44 @@ class ImageCard extends ConsumerWidget {
                 child: Text(image.codename),
               ),
             ),
-            Row(children: [
-              OutlinedButton(
-                onPressed: () {
-                  final name = ref.read(randomNameProvider);
-                  final aliasInfo = image.aliasesInfo.first;
-                  final launchRequest = LaunchRequest(
-                    instanceName: name,
-                    image: aliasInfo.alias,
-                    numCores: defaultCpus,
-                    memSize: '${defaultRam}B',
-                    diskSpace: '${defaultDisk}B',
-                    remoteName:
-                        aliasInfo.hasRemoteName() ? aliasInfo.remoteName : null,
-                  );
+            Row(
+              children: [
+                OutlinedButton(
+                  onPressed: () {
+                    final name = ref.read(randomNameProvider);
+                    final aliasInfo = image.aliasesInfo.first;
+                    final launchRequest = LaunchRequest(
+                      instanceName: name,
+                      image: aliasInfo.alias,
+                      numCores: defaultCpus,
+                      memSize: '${defaultRam}B',
+                      diskSpace: '${defaultDisk}B',
+                      remoteName:
+                          aliasInfo.hasRemoteName()
+                              ? aliasInfo.remoteName
+                              : null,
+                    );
 
-                  initiateLaunchFlow(ref, launchRequest);
-                },
-                child: const Text('Launch'),
-              ),
-              const SizedBox(width: 16),
-              OutlinedButton(
-                onPressed: () {
-                  ref.read(launchingImageProvider.notifier).state = image;
-                  Scaffold.of(context).openEndDrawer();
-                },
-                child: SvgPicture.asset(
-                  'assets/settings.svg',
-                  colorFilter: const ColorFilter.mode(
-                    Colors.black,
-                    BlendMode.srcIn,
+                    initiateLaunchFlow(ref, launchRequest);
+                  },
+                  child: const Text('Launch'),
+                ),
+                const SizedBox(width: 16),
+                OutlinedButton(
+                  onPressed: () {
+                    ref.read(launchingImageProvider.notifier).state = image;
+                    Scaffold.of(context).openEndDrawer();
+                  },
+                  child: SvgPicture.asset(
+                    'assets/settings.svg',
+                    colorFilter: const ColorFilter.mode(
+                      Colors.black,
+                      BlendMode.srcIn,
+                    ),
                   ),
                 ),
-              ),
-            ]),
+              ],
+            ),
           ],
         ),
       ),

--- a/src/client/gui/lib/catalogue/launch_form.dart
+++ b/src/client/gui/lib/catalogue/launch_form.dart
@@ -78,8 +78,10 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
       helper: 'Names cannot be changed once an instance is created',
       hint: randomName,
       validator: nameValidator(vmNames, deletedVms),
-      onSaved: (value) => launchRequest.instanceName =
-          value.isNullOrBlank ? randomName : value!,
+      onSaved:
+          (value) =>
+              launchRequest.instanceName =
+                  value.isNullOrBlank ? randomName : value!,
       width: 360,
     );
 
@@ -109,14 +111,16 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
       initialValue: false,
       onSaved: (value) {
         if (value!) {
-          launchRequest.networkOptions
-              .add(LaunchRequest_NetworkOptions(id: 'bridged'));
+          launchRequest.networkOptions.add(
+            LaunchRequest_NetworkOptions(id: 'bridged'),
+          );
         }
       },
       builder: (field) {
-        final message = networks.isEmpty
-            ? 'No networks found.'
-            : validBridgedNetwork
+        final message =
+            networks.isEmpty
+                ? 'No networks found.'
+                : validBridgedNetwork
                 ? "Connect to the bridged network.\nOnce established, you won't be able to unset the connection."
                 : 'No valid bridged network is set.\nYou can set one in the Settings page.';
 
@@ -131,28 +135,34 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
 
     final mountPointsView = MountPointsView(
       allowDelete: true,
-      mounts: mountRequests.map((r) => MountPaths(
-            sourcePath: r.sourcePath,
-            targetPath: r.targetPaths.first.targetPath,
-          )),
-      onDelete: (mountPaths) => setState(() {
-        mountRequests.removeWhere((r) =>
-            r.sourcePath == mountPaths.sourcePath &&
-            r.targetPaths.first.targetPath == mountPaths.targetPath);
-      }),
+      mounts: mountRequests.map(
+        (r) => MountPaths(
+          sourcePath: r.sourcePath,
+          targetPath: r.targetPaths.first.targetPath,
+        ),
+      ),
+      onDelete:
+          (mountPaths) => setState(() {
+            mountRequests.removeWhere(
+              (r) =>
+                  r.sourcePath == mountPaths.sourcePath &&
+                  r.targetPaths.first.targetPath == mountPaths.targetPath,
+            );
+          }),
     );
 
     final addMountButton = OutlinedButton(
-      onPressed: () => setState(() {
-        addingMount = true;
-        Timer(100.milliseconds, () {
-          scrollController.animateTo(
-            scrollController.position.maxScrollExtent,
-            duration: 200.milliseconds,
-            curve: Curves.ease,
-          );
-        });
-      }),
+      onPressed:
+          () => setState(() {
+            addingMount = true;
+            Timer(100.milliseconds, () {
+              scrollController.animateTo(
+                scrollController.position.maxScrollExtent,
+                duration: 200.milliseconds,
+                curve: Curves.ease,
+              );
+            });
+          }),
       child: const Text('Add mount'),
     );
 
@@ -177,57 +187,64 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
           mountRequests.any((r) => r.sourcePath == mpPlatform.homeDirectory)
               ? null
               : mpPlatform.homeDirectory,
-      onSaved: (request) => setState(() {
-        mountRequests.add(request);
-        addingMount = false;
-      }),
+      onSaved:
+          (request) => setState(() {
+            mountRequests.add(request);
+            addingMount = false;
+          }),
     );
 
     final mountForm = Form(
       key: mountFormKey,
-      child: Column(children: [
-        editableMountPoint,
-        const SizedBox(height: 16),
-        Row(children: [
-          saveMountButton,
-          const SizedBox(width: 16),
-          cancelMountButton,
-        ]),
-      ]),
+      child: Column(
+        children: [
+          editableMountPoint,
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              saveMountButton,
+              const SizedBox(width: 16),
+              cancelMountButton,
+            ],
+          ),
+        ],
+      ),
     );
 
     final formBody = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(children: [
-          const Text('Configure instance', style: TextStyle(fontSize: 24)),
-          const Spacer(),
-          closeButton,
-        ]),
-        const SizedBox(height: 20),
-        const Text(
-          'Image',
-          style: TextStyle(fontSize: 18),
+        Row(
+          children: [
+            const Text('Configure instance', style: TextStyle(fontSize: 24)),
+            const Spacer(),
+            closeButton,
+          ],
         ),
+        const SizedBox(height: 20),
+        const Text('Image', style: TextStyle(fontSize: 18)),
         const SizedBox(height: 4),
         chosenImageName,
         const SizedBox(height: 16),
-        Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          nameInput,
-          const Spacer(),
-        ]),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [nameInput, const Spacer()],
+        ),
         const Divider(height: 60),
         const SizedBox(
           height: 50,
           child: Text('Resources', style: TextStyle(fontSize: 24)),
         ),
-        Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          Expanded(child: cpusSlider),
-          const SizedBox(width: 86),
-          Expanded(child: memorySlider),
-          const SizedBox(width: 86),
-          Expanded(child: diskSlider),
-        ]),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(child: cpusSlider),
+            const SizedBox(width: 86),
+            Expanded(child: memorySlider),
+            const SizedBox(width: 86),
+            Expanded(child: diskSlider),
+          ],
+        ),
         const Divider(height: 60),
         const SizedBox(
           height: 50,
@@ -255,42 +272,50 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
       child: const Text('Cancel'),
     );
 
-    return Stack(fit: StackFit.loose, children: [
-      Positioned.fill(
-        bottom: 80,
-        child: Container(
-          alignment: Alignment.topCenter,
-          color: Colors.white,
-          child: Form(
-            key: formKey,
-            autovalidateMode: AutovalidateMode.always,
-            child: SingleChildScrollView(
-              clipBehavior: Clip.none,
-              controller: scrollController,
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: formBody,
+    return Stack(
+      fit: StackFit.loose,
+      children: [
+        Positioned.fill(
+          bottom: 80,
+          child: Container(
+            alignment: Alignment.topCenter,
+            color: Colors.white,
+            child: Form(
+              key: formKey,
+              autovalidateMode: AutovalidateMode.always,
+              child: SingleChildScrollView(
+                clipBehavior: Clip.none,
+                controller: scrollController,
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: formBody,
+                ),
               ),
             ),
           ),
         ),
-      ),
-      Align(
-        alignment: Alignment.bottomCenter,
-        child: Container(
-          color: Colors.white,
-          padding: const EdgeInsets.all(16).copyWith(top: 4),
-          child: Column(mainAxisSize: MainAxisSize.min, children: [
-            const Divider(height: 30),
-            Row(children: [
-              launchButton,
-              const SizedBox(width: 16),
-              cancelButton,
-            ]),
-          ]),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: Container(
+            color: Colors.white,
+            padding: const EdgeInsets.all(16).copyWith(top: 4),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Divider(height: 30),
+                Row(
+                  children: [
+                    launchButton,
+                    const SizedBox(width: 16),
+                    cancelButton,
+                  ],
+                ),
+              ],
+            ),
+          ),
         ),
-      ),
-    ]);
+      ],
+    );
   }
 
   void launch(ImageInfo imageInfo) {

--- a/src/client/gui/lib/close_terminal_dialog.dart
+++ b/src/client/gui/lib/close_terminal_dialog.dart
@@ -26,15 +26,18 @@ class _CloseTerminalDialogState extends State<CloseTerminalDialog> {
   Widget build(BuildContext context) {
     return ConfirmationDialog(
       title: 'Are you sure you want to close this terminal?',
-      body: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        const Text('Its current state will be lost.'),
-        const SizedBox(height: 12),
-        Switch(
-          value: doNotAsk,
-          label: 'Do not ask me again.',
-          onChanged: (value) => setState(() => doNotAsk = value),
-        ),
-      ]),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Its current state will be lost.'),
+          const SizedBox(height: 12),
+          Switch(
+            value: doNotAsk,
+            label: 'Do not ask me again.',
+            onChanged: (value) => setState(() => doNotAsk = value),
+          ),
+        ],
+      ),
       actionText: 'Yes',
       onAction: () {
         widget.onYes();

--- a/src/client/gui/lib/confirmation_dialog.dart
+++ b/src/client/gui/lib/confirmation_dialog.dart
@@ -27,14 +27,16 @@ class ConfirmationDialog extends StatelessWidget {
       contentPadding: const EdgeInsets.symmetric(horizontal: 16),
       titlePadding: const EdgeInsets.symmetric(horizontal: 16).copyWith(top: 8),
       buttonPadding: const EdgeInsets.symmetric(horizontal: 16),
-      title: Row(children: [
-        Expanded(child: Text(title)),
-        IconButton(
-          onPressed: () => Navigator.pop(context),
-          splashRadius: 15,
-          icon: const Icon(Icons.close),
-        ),
-      ]),
+      title: Row(
+        children: [
+          Expanded(child: Text(title)),
+          IconButton(
+            onPressed: () => Navigator.pop(context),
+            splashRadius: 15,
+            icon: const Icon(Icons.close),
+          ),
+        ],
+      ),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -53,15 +55,10 @@ class ConfirmationDialog extends StatelessWidget {
       actions: [
         TextButton(
           onPressed: onAction,
-          style: TextButton.styleFrom(
-            backgroundColor: const Color(0xffC7162B),
-          ),
+          style: TextButton.styleFrom(backgroundColor: const Color(0xffC7162B)),
           child: Text(actionText),
         ),
-        OutlinedButton(
-          onPressed: onInaction,
-          child: Text(inactionText),
-        ),
+        OutlinedButton(onPressed: onInaction, child: Text(inactionText)),
       ],
     );
   }

--- a/src/client/gui/lib/daemon_unavailable.dart
+++ b/src/client/gui/lib/daemon_unavailable.dart
@@ -15,14 +15,17 @@ class DaemonUnavailable extends ConsumerWidget {
       decoration: const BoxDecoration(
         color: Colors.white,
         boxShadow: [
-          BoxShadow(color: Colors.black54, blurRadius: 10, spreadRadius: 5)
+          BoxShadow(color: Colors.black54, blurRadius: 10, spreadRadius: 5),
         ],
       ),
-      child: const Row(mainAxisSize: MainAxisSize.min, children: [
-        CircularProgressIndicator(color: Colors.orange),
-        SizedBox(width: 20),
-        Text('Waiting for daemon...'),
-      ]),
+      child: const Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CircularProgressIndicator(color: Colors.orange),
+          SizedBox(width: 20),
+          Text('Waiting for daemon...'),
+        ],
+      ),
     );
 
     return IgnorePointer(

--- a/src/client/gui/lib/dropdown.dart
+++ b/src/client/gui/lib/dropdown.dart
@@ -26,9 +26,10 @@ class Dropdown<T> extends StatelessWidget {
       underline: const SizedBox.shrink(),
       value: value,
       onChanged: onChanged,
-      items: items.entries
-          .map((e) => DropdownMenuItem(value: e.key, child: Text(e.value)))
-          .toList(),
+      items:
+          items.entries
+              .map((e) => DropdownMenuItem(value: e.key, child: Text(e.value)))
+              .toList(),
     );
 
     final styledDropdown = SizedBox(
@@ -51,11 +52,13 @@ class Dropdown<T> extends StatelessWidget {
       ),
     );
 
-    return Row(children: [
-      if (label != null) ...[
-        Expanded(child: Text(label!, style: const TextStyle(fontSize: 16))),
+    return Row(
+      children: [
+        if (label != null) ...[
+          Expanded(child: Text(label!, style: const TextStyle(fontSize: 16))),
+        ],
+        styledDropdown,
       ],
-      styledDropdown,
-    ]);
+    );
   }
 }

--- a/src/client/gui/lib/extensions.dart
+++ b/src/client/gui/lib/extensions.dart
@@ -11,54 +11,52 @@ final _hoveredLinkProvider = StateProvider.autoDispose<TextSpan?>((ref) {
 
 extension TextSpanFromStringExt on String {
   TextSpan get span => TextSpan(
-        text: this,
-        style: const TextStyle(
-          color: Colors.black,
-          fontFamily: 'Ubuntu',
-          fontFamilyFallback: ['NotoColorEmoji', 'FreeSans'],
-        ),
-      );
+    text: this,
+    style: const TextStyle(
+      color: Colors.black,
+      fontFamily: 'Ubuntu',
+      fontFamilyFallback: ['NotoColorEmoji', 'FreeSans'],
+    ),
+  );
 }
 
 extension TextSpanFromListExt on List<TextSpan> {
-  TextSpan get spans => TextSpan(
-        children: this,
-        style: const TextStyle(color: Colors.black),
-      );
+  TextSpan get spans =>
+      TextSpan(children: this, style: const TextStyle(color: Colors.black));
 }
 
 extension TextSpanExt on TextSpan {
   static const noStyle = TextStyle();
 
   TextSpan get bold => TextSpan(
-        text: text,
-        children: children,
-        style: (style ?? noStyle).copyWith(fontWeight: FontWeight.bold),
-      );
+    text: text,
+    children: children,
+    style: (style ?? noStyle).copyWith(fontWeight: FontWeight.bold),
+  );
 
   TextSpan size(double size) => TextSpan(
-        text: text,
-        children: children,
-        style: (style ?? noStyle).copyWith(fontSize: size),
-      );
+    text: text,
+    children: children,
+    style: (style ?? noStyle).copyWith(fontSize: size),
+  );
 
   TextSpan color(Color color) => TextSpan(
-        text: text,
-        children: children,
-        style: (style ?? noStyle).copyWith(color: color),
-      );
+    text: text,
+    children: children,
+    style: (style ?? noStyle).copyWith(color: color),
+  );
 
   TextSpan font(String fontFamily) => TextSpan(
-        text: text,
-        children: children,
-        style: (style ?? noStyle).copyWith(fontFamily: fontFamily),
-      );
+    text: text,
+    children: children,
+    style: (style ?? noStyle).copyWith(fontFamily: fontFamily),
+  );
 
   TextSpan backgroundColor(Color color) => TextSpan(
-        text: text,
-        children: children,
-        style: (style ?? noStyle).copyWith(backgroundColor: color),
-      );
+    text: text,
+    children: children,
+    style: (style ?? noStyle).copyWith(backgroundColor: color),
+  );
 
   TextSpan link(WidgetRef ref, VoidCallback callback) {
     final hovered = ref.watch(_hoveredLinkProvider) == this;

--- a/src/client/gui/lib/ffi.dart
+++ b/src/client/gui/lib/ffi.dart
@@ -19,71 +19,75 @@ extension on ffi.Pointer<Utf8> {
 
 final _lib = ffi.DynamicLibrary.open(mpPlatform.ffiLibraryName);
 
-final _multipassVersion = _lib.lookupFunction<ffi.Pointer<Utf8> Function(),
-    ffi.Pointer<Utf8> Function()>('multipass_version');
+final _multipassVersion = _lib
+    .lookupFunction<ffi.Pointer<Utf8> Function(), ffi.Pointer<Utf8> Function()>(
+      'multipass_version',
+    );
 
-final _generatePetname = _lib.lookupFunction<ffi.Pointer<Utf8> Function(),
-    ffi.Pointer<Utf8> Function()>('generate_petname');
+final _generatePetname = _lib
+    .lookupFunction<ffi.Pointer<Utf8> Function(), ffi.Pointer<Utf8> Function()>(
+      'generate_petname',
+    );
 
-final _getServerAddress = _lib.lookupFunction<ffi.Pointer<Utf8> Function(),
-    ffi.Pointer<Utf8> Function()>('get_server_address');
+final _getServerAddress = _lib
+    .lookupFunction<ffi.Pointer<Utf8> Function(), ffi.Pointer<Utf8> Function()>(
+      'get_server_address',
+    );
 
-enum _SettingsResult {
-  ok,
-  keyNotFound,
-  invalidValue,
-  unexpectedError,
-}
+enum _SettingsResult { ok, keyNotFound, invalidValue, unexpectedError }
 
 extension on int {
   _SettingsResult get settingsResult => _SettingsResult.values[this];
 }
 
-final _settingsFile = _lib.lookupFunction<ffi.Pointer<Utf8> Function(),
-    ffi.Pointer<Utf8> Function()>('settings_file');
+final _settingsFile = _lib
+    .lookupFunction<ffi.Pointer<Utf8> Function(), ffi.Pointer<Utf8> Function()>(
+      'settings_file',
+    );
 
 final _getSetting = _lib.lookupFunction<
-    ffi.Int32 Function(
-      ffi.Pointer<Utf8>,
-      ffi.Pointer<ffi.Pointer<Utf8>>,
-    ),
-    int Function(
-      ffi.Pointer<Utf8>,
-      ffi.Pointer<ffi.Pointer<Utf8>>,
-    )>('get_setting');
+  ffi.Int32 Function(ffi.Pointer<Utf8>, ffi.Pointer<ffi.Pointer<Utf8>>),
+  int Function(ffi.Pointer<Utf8>, ffi.Pointer<ffi.Pointer<Utf8>>)
+>('get_setting');
 
 final _setSetting = _lib.lookupFunction<
-    ffi.Int32 Function(
-      ffi.Pointer<Utf8>,
-      ffi.Pointer<Utf8>,
-      ffi.Pointer<ffi.Pointer<Utf8>>,
-    ),
-    int Function(
-      ffi.Pointer<Utf8>,
-      ffi.Pointer<Utf8>,
-      ffi.Pointer<ffi.Pointer<Utf8>>,
-    )>('set_setting');
+  ffi.Int32 Function(
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<ffi.Pointer<Utf8>>,
+  ),
+  int Function(
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<Utf8>,
+    ffi.Pointer<ffi.Pointer<Utf8>>,
+  )
+>('set_setting');
 
 final uid = _lib.lookupFunction<ffi.Int32 Function(), int Function()>('uid');
 final gid = _lib.lookupFunction<ffi.Int32 Function(), int Function()>('gid');
-final defaultId =
-    _lib.lookupFunction<ffi.Int32 Function(), int Function()>('default_id');
+final defaultId = _lib.lookupFunction<ffi.Int32 Function(), int Function()>(
+  'default_id',
+);
 
 final _memoryInBytes = _lib.lookupFunction<
-    ffi.LongLong Function(ffi.Pointer<Utf8>),
-    int Function(ffi.Pointer<Utf8>)>('memory_in_bytes');
+  ffi.LongLong Function(ffi.Pointer<Utf8>),
+  int Function(ffi.Pointer<Utf8>)
+>('memory_in_bytes');
 
 final _humanReadableMemory = _lib.lookupFunction<
-    ffi.Pointer<Utf8> Function(ffi.LongLong),
-    ffi.Pointer<Utf8> Function(int)>('human_readable_memory');
+  ffi.Pointer<Utf8> Function(ffi.LongLong),
+  ffi.Pointer<Utf8> Function(int)
+>('human_readable_memory');
 
-final getTotalDiskSize =
-    _lib.lookupFunction<ffi.LongLong Function(), int Function()>(
-        'get_total_disk_size');
+final getTotalDiskSize = _lib
+    .lookupFunction<ffi.LongLong Function(), int Function()>(
+      'get_total_disk_size',
+    );
 
 final _defaultMountTarget = _lib.lookupFunction<
-    ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>),
-    ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>)>('default_mount_target');
+  ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>),
+  ffi.Pointer<Utf8> Function(ffi.Pointer<Utf8>)
+>('default_mount_target');
 
 final class _NativeKeyCertificatePair extends ffi.Struct {
   // ignore: non_constant_identifier_names
@@ -100,8 +104,10 @@ class KeyCertificatePair {
   KeyCertificatePair(this.cert, this.key);
 }
 
-final _getCertPair = _lib.lookupFunction<_NativeKeyCertificatePair Function(),
-    _NativeKeyCertificatePair Function()>('get_cert_pair');
+final _getCertPair = _lib.lookupFunction<
+  _NativeKeyCertificatePair Function(),
+  _NativeKeyCertificatePair Function()
+>('get_cert_pair');
 
 String get multipassVersion => _multipassVersion().toDartString();
 
@@ -159,8 +165,11 @@ String getSetting(String key) {
 
 void setSetting(String key, String value) {
   final output = malloc<ffi.Pointer<Utf8>>();
-  switch (_setSetting(key.toNativeUtf8(), value.toNativeUtf8(), output)
-      .settingsResult) {
+  switch (_setSetting(
+    key.toNativeUtf8(),
+    value.toNativeUtf8(),
+    output,
+  ).settingsResult) {
     case _SettingsResult.ok:
       malloc.free(output);
     case _SettingsResult.keyNotFound:

--- a/src/client/gui/lib/grpc_client.dart
+++ b/src/client/gui/lib/grpc_client.dart
@@ -196,10 +196,7 @@ class GrpcClient {
   Future<FindReply> find({bool images = true, bool blueprints = true}) {
     return doRpc(
       _client.find,
-      FindRequest(
-        showImages: images,
-        showBlueprints: blueprints,
-      ),
+      FindRequest(showImages: images, showBlueprints: blueprints),
     ).then((r) => r!);
   }
 
@@ -247,11 +244,11 @@ class CustomChannelCredentials extends ChannelCredentials {
     super.authority,
     required List<int> certificate,
     required this.certificateKey,
-  })  : certificateChain = certificate,
-        super.secure(
-          certificates: certificate,
-          onBadCertificate: allowBadCertificates,
-        );
+  }) : certificateChain = certificate,
+       super.secure(
+         certificates: certificate,
+         onBadCertificate: allowBadCertificates,
+       );
 
   @override
   SecurityContext get securityContext {

--- a/src/client/gui/lib/logger.dart
+++ b/src/client/gui/lib/logger.dart
@@ -127,9 +127,9 @@ class MpPrettyPrinter extends LogPrinter {
     final match = _webStackTraceRegex.matchAsPrefix(line);
     if (match == null) return false;
     final segment = match.group(1)!;
-    if (segment.startsWith('packages/logger') ||
-        segment.startsWith('dart-sdk/lib')) return true;
-    return _isInExcludePaths(segment);
+    return segment.startsWith('packages/logger') ||
+        segment.startsWith('dart-sdk/lib') ||
+        _isInExcludePaths(segment);
   }
 
   bool _discardBrowserStacktraceLine(String line) {

--- a/src/client/gui/lib/logger.dart
+++ b/src/client/gui/lib/logger.dart
@@ -18,12 +18,7 @@ Future<void> setupLogger() async {
 
   logger = Logger(
     filter: NoFilter(),
-    printer: MpPrettyPrinter(
-      excludePaths: [
-        'dart:',
-        'package:flutter',
-      ],
-    ),
+    printer: MpPrettyPrinter(excludePaths: ['dart:', 'package:flutter']),
     output: MultiOutput([
       ConsoleOutput(),
       FileOutput(file: File('${logFilePath.path}/multipass_gui.log')),
@@ -38,11 +33,7 @@ Future<void> setupLogger() async {
     );
   };
   PlatformDispatcher.instance.onError = (error, stackTrace) {
-    logger.e(
-      'Dart error',
-      error: error,
-      stackTrace: stackTrace,
-    );
+    logger.e('Dart error', error: error, stackTrace: stackTrace);
     return true;
   };
 }
@@ -50,8 +41,9 @@ Future<void> setupLogger() async {
 class MpPrettyPrinter extends LogPrinter {
   static final _deviceStackTraceRegex = RegExp(r'#[0-9]+\s+(.+) \((\S+)\)');
   static final _webStackTraceRegex = RegExp(r'^((packages|dart-sdk)/\S+/)');
-  static final _browserStackTraceRegex =
-      RegExp(r'^(?:package:)?(dart:\S+|\S+)');
+  static final _browserStackTraceRegex = RegExp(
+    r'^(?:package:)?(dart:\S+|\S+)',
+  );
   final int stackTraceBeginIndex;
   final int? methodCount;
   final int? errorMethodCount;
@@ -91,12 +83,13 @@ class MpPrettyPrinter extends LogPrinter {
   }
 
   String? formatStackTrace(StackTrace? stackTrace, int? methodCount) {
-    final lines = stackTrace.toString().split('\n').where((line) {
-      return !_discardDeviceStacktraceLine(line) &&
-          !_discardWebStacktraceLine(line) &&
-          !_discardBrowserStacktraceLine(line) &&
-          line.isNotEmpty;
-    }).toList();
+    final lines =
+        stackTrace.toString().split('\n').where((line) {
+          return !_discardDeviceStacktraceLine(line) &&
+              !_discardWebStacktraceLine(line) &&
+              !_discardBrowserStacktraceLine(line) &&
+              line.isNotEmpty;
+        }).toList();
 
     final formatted = <String>[];
     final stackTraceLength =

--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -231,7 +231,7 @@ final theme = ThemeData(
   ),
   outlinedButtonTheme: OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(
-      disabledForegroundColor: Colors.black.withOpacity(0.5),
+      disabledForegroundColor: Colors.black.withAlpha(128),
       foregroundColor: Colors.black,
       padding: const EdgeInsets.all(16),
       shape: RoundedRectangleBorder(
@@ -245,7 +245,7 @@ final theme = ThemeData(
   textButtonTheme: TextButtonThemeData(
     style: TextButton.styleFrom(
       backgroundColor: const Color(0xff0E8620),
-      disabledForegroundColor: Colors.white.withOpacity(0.5),
+      disabledForegroundColor: Colors.white.withAlpha(128),
       foregroundColor: Colors.white,
       padding: const EdgeInsets.all(16),
       shape: RoundedRectangleBorder(

--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -47,11 +47,13 @@ void main() async {
 
   await hotKeyManager.unregisterAll();
 
-  providerContainer = ProviderContainer(overrides: [
-    guiSettingProvider.overrideWith(() {
-      return GuiSettingNotifier(sharedPreferences);
-    }),
-  ]);
+  providerContainer = ProviderContainer(
+    overrides: [
+      guiSettingProvider.overrideWith(() {
+        return GuiSettingNotifier(sharedPreferences);
+      }),
+    ],
+  );
   setupTrayMenu(providerContainer);
   runApp(
     UncontrolledProviderScope(
@@ -86,51 +88,55 @@ class _AppState extends ConsumerState<App> with WindowListener {
 
     final content = Stack(
       fit: StackFit.expand,
-      children: widgets.entries.map((e) {
-        final MapEntry(:key, value: widget) = e;
-        final isCurrent = key == currentKey;
-        var maintainState = key != SettingsScreen.sidebarKey;
-        if (key.startsWith('vm-')) {
-          maintainState = ref.read(vmVisitedProvider(key));
-        }
-        return Visibility(
-          key: Key(key),
-          maintainState: maintainState,
-          visible: isCurrent,
-          child: FocusScope(
-            autofocus: isCurrent,
-            canRequestFocus: isCurrent,
-            skipTraversal: !isCurrent,
-            child: widget,
-          ),
-        );
-      }).toList(),
+      children:
+          widgets.entries.map((e) {
+            final MapEntry(:key, value: widget) = e;
+            final isCurrent = key == currentKey;
+            var maintainState = key != SettingsScreen.sidebarKey;
+            if (key.startsWith('vm-')) {
+              maintainState = ref.read(vmVisitedProvider(key));
+            }
+            return Visibility(
+              key: Key(key),
+              maintainState: maintainState,
+              visible: isCurrent,
+              child: FocusScope(
+                autofocus: isCurrent,
+                canRequestFocus: isCurrent,
+                skipTraversal: !isCurrent,
+                child: widget,
+              ),
+            );
+          }).toList(),
     );
 
     final hotkey = ref.watch(hotkeyProvider);
 
-    return Stack(children: [
-      AnimatedPositioned(
-        duration: SideBar.animationDuration,
-        bottom: 0,
-        right: 0,
-        top: 0,
-        left: sidebarPushContent && sidebarExpanded
-            ? SideBar.expandedWidth
-            : SideBar.collapsedWidth,
-        child: content,
-      ),
-      CallbackGlobalShortcuts(
-        key: hotkey != null ? GlobalObjectKey(hotkey) : null,
-        bindings: {if (hotkey != null) hotkey: goToPrimary},
-        child: const SideBar(),
-      ),
-      const Align(
-        alignment: Alignment.bottomRight,
-        child: SizedBox(width: 400, child: NotificationList()),
-      ),
-      const DaemonUnavailable(),
-    ]);
+    return Stack(
+      children: [
+        AnimatedPositioned(
+          duration: SideBar.animationDuration,
+          bottom: 0,
+          right: 0,
+          top: 0,
+          left:
+              sidebarPushContent && sidebarExpanded
+                  ? SideBar.expandedWidth
+                  : SideBar.collapsedWidth,
+          child: content,
+        ),
+        CallbackGlobalShortcuts(
+          key: hotkey != null ? GlobalObjectKey(hotkey) : null,
+          bindings: {if (hotkey != null) hotkey: goToPrimary},
+          child: const SideBar(),
+        ),
+        const Align(
+          alignment: Alignment.bottomRight,
+          child: SizedBox(width: 400, child: NotificationList()),
+        ),
+        const DaemonUnavailable(),
+      ],
+    );
   }
 
   void goToPrimary() {
@@ -164,8 +170,10 @@ class _AppState extends ConsumerState<App> with WindowListener {
   void onWindowClose() async {
     if (!await windowManager.isPreventClose()) return;
     final daemonAvailable = ref.read(daemonAvailableProvider);
-    final vmsRunning =
-        ref.read(vmStatusesProvider).values.contains(Status.RUNNING);
+    final vmsRunning = ref
+        .read(vmStatusesProvider)
+        .values
+        .contains(Status.RUNNING);
     if (!daemonAvailable || !vmsRunning) windowManager.destroy();
 
     stopAllInstances() {
@@ -190,21 +198,22 @@ class _AppState extends ConsumerState<App> with WindowListener {
         showDialog(
           context: context,
           barrierDismissible: false,
-          builder: (context) => BeforeQuitDialog(
-            onStop: (remember) {
-              ref
-                  .read(guiSettingProvider(onAppCloseKey).notifier)
-                  .set(remember ? 'stop' : 'ask');
-              stopAllInstances();
-              Navigator.pop(context);
-            },
-            onKeep: (remember) {
-              ref
-                  .read(guiSettingProvider(onAppCloseKey).notifier)
-                  .set(remember ? 'nothing' : 'ask');
-              windowManager.destroy();
-            },
-          ),
+          builder:
+              (context) => BeforeQuitDialog(
+                onStop: (remember) {
+                  ref
+                      .read(guiSettingProvider(onAppCloseKey).notifier)
+                      .set(remember ? 'stop' : 'ask');
+                  stopAllInstances();
+                  Navigator.pop(context);
+                },
+                onKeep: (remember) {
+                  ref
+                      .read(guiSettingProvider(onAppCloseKey).notifier)
+                      .set(remember ? 'nothing' : 'ask');
+                  windowManager.destroy();
+                },
+              ),
         );
     }
   }
@@ -234,9 +243,7 @@ final theme = ThemeData(
       disabledForegroundColor: Colors.black.withAlpha(128),
       foregroundColor: Colors.black,
       padding: const EdgeInsets.all(16),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(2),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2)),
       side: const BorderSide(color: Color(0xff333333)),
       textStyle: const TextStyle(fontFamily: 'Ubuntu', fontSize: 16),
     ),
@@ -248,9 +255,7 @@ final theme = ThemeData(
       disabledForegroundColor: Colors.white.withAlpha(128),
       foregroundColor: Colors.white,
       padding: const EdgeInsets.all(16),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(2),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2)),
       textStyle: const TextStyle(fontFamily: 'Ubuntu', fontSize: 16),
     ),
   ),
@@ -265,10 +270,7 @@ final theme = ThemeData(
     ),
     indicatorSize: TabBarIndicatorSize.tab,
     labelColor: Colors.black,
-    labelStyle: TextStyle(
-      fontFamily: 'Ubuntu',
-      fontWeight: FontWeight.bold,
-    ),
+    labelStyle: TextStyle(fontFamily: 'Ubuntu', fontWeight: FontWeight.bold),
     unselectedLabelColor: Colors.black,
     unselectedLabelStyle: TextStyle(
       fontFamily: 'Ubuntu',

--- a/src/client/gui/lib/notifications/notification_entries.dart
+++ b/src/client/gui/lib/notifications/notification_entries.dart
@@ -32,41 +32,47 @@ class SimpleNotification extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-      RotatedBox(
-        quarterTurns: -1,
-        child: LinearProgressIndicator(
-          backgroundColor: Colors.transparent,
-          color: barColor,
-          value: barFullness,
-        ),
-      ),
-      const SizedBox(width: 8),
-      Expanded(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 10),
-          child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-            SizedBox(
-              width: 20,
-              height: 20,
-              child: FittedBox(fit: BoxFit.fill, child: icon),
-            ),
-            const SizedBox(width: 8),
-            Expanded(child: child),
-          ]),
-        ),
-      ),
-      if (closeable)
-        Material(
-          color: Colors.transparent,
-          child: IconButton(
-            splashRadius: 10,
-            iconSize: 20,
-            icon: const Icon(Icons.close),
-            onPressed: () => closeNotification(context),
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RotatedBox(
+          quarterTurns: -1,
+          child: LinearProgressIndicator(
+            backgroundColor: Colors.transparent,
+            color: barColor,
+            value: barFullness,
           ),
         ),
-    ]);
+        const SizedBox(width: 8),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 10),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: FittedBox(fit: BoxFit.fill, child: icon),
+                ),
+                const SizedBox(width: 8),
+                Expanded(child: child),
+              ],
+            ),
+          ),
+        ),
+        if (closeable)
+          Material(
+            color: Colors.transparent,
+            child: IconButton(
+              splashRadius: 10,
+              iconSize: 20,
+              icon: const Icon(Icons.close),
+              onPressed: () => closeNotification(context),
+            ),
+          ),
+      ],
+    );
   }
 }
 
@@ -120,36 +126,33 @@ class _TimeoutNotificationState extends State<TimeoutNotification>
       onExit: (_) => timeoutController.forward(),
       child: AnimatedBuilder(
         animation: timeoutController,
-        builder: (_, __) => SimpleNotification(
-          icon: widget.icon,
-          barColor: widget.barColor,
-          barFullness: 1.0 - timeoutController.value,
-          child: widget.child,
-        ),
+        builder:
+            (_, __) => SimpleNotification(
+              icon: widget.icon,
+              barColor: widget.barColor,
+              barFullness: 1.0 - timeoutController.value,
+              child: widget.child,
+            ),
       ),
     );
   }
 }
 
 class ErrorNotification extends SimpleNotification {
-  ErrorNotification({
-    super.key,
-    required String text,
-  }) : super(
-          child: Text(text),
-          barColor: Colors.red,
-          icon: const Icon(Icons.cancel_outlined, color: Colors.red),
-        );
+  ErrorNotification({super.key, required String text})
+    : super(
+        child: Text(text),
+        barColor: Colors.red,
+        icon: const Icon(Icons.cancel_outlined, color: Colors.red),
+      );
 }
 
 class SuccessNotification extends TimeoutNotification {
-  const SuccessNotification({
-    super.key,
-    required super.child,
-  }) : super(
-          barColor: Colors.green,
-          icon: const Icon(Icons.check_circle_outline, color: Colors.green),
-        );
+  const SuccessNotification({super.key, required super.child})
+    : super(
+        barColor: Colors.green,
+        icon: const Icon(Icons.check_circle_outline, color: Colors.green),
+      );
 }
 
 class OperationNotification extends StatelessWidget {
@@ -217,46 +220,47 @@ class LaunchingNotification extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text.rich([
-                  '$name is up and running\n'.span.bold,
-                  'You can start using it now'.span,
-                ].spans),
+                Text.rich(
+                  [
+                    '$name is up and running\n'.span.bold,
+                    'You can start using it now'.span,
+                  ].spans,
+                ),
                 Divider(),
-                Row(children: [
-                  const Spacer(),
-                  TextButton(
-                    onPressed: () {
-                      ref.read(sidebarKeyProvider.notifier).set('vm-$name');
-                      closeNotification(context);
-                    },
-                    child: Text('Go to instance'),
-                  ),
-                ]),
+                Row(
+                  children: [
+                    const Spacer(),
+                    TextButton(
+                      onPressed: () {
+                        ref.read(sidebarKeyProvider.notifier).set('vm-$name');
+                        closeNotification(context);
+                      },
+                      child: Text('Go to instance'),
+                    ),
+                  ],
+                ),
               ],
             ),
           );
         }
 
         // returns the message to be displayed and if the operation is cancelable
-        final data = snapshot.data?.match(
-          (l) {
-            switch (l.whichCreateOneof()) {
-              case LaunchReply_CreateOneof.launchProgress:
-                final progressType = l.launchProgress.type;
-                if (progressType == LaunchProgress_ProgressTypes.VERIFY) {
-                  return ('Verifying image', false);
-                }
+        final data = snapshot.data?.match((l) {
+          switch (l.whichCreateOneof()) {
+            case LaunchReply_CreateOneof.launchProgress:
+              final progressType = l.launchProgress.type;
+              if (progressType == LaunchProgress_ProgressTypes.VERIFY) {
+                return ('Verifying image', false);
+              }
 
-                final downloadPercentage = l.launchProgress.percentComplete;
-                return ('Downloading image $downloadPercentage%', true);
-              case LaunchReply_CreateOneof.createMessage:
-                return (l.createMessage, false);
-              default:
-                return (l.replyMessage, false);
-            }
-          },
-          (m) => (m.replyMessage, false),
-        );
+              final downloadPercentage = l.launchProgress.percentComplete;
+              return ('Downloading image $downloadPercentage%', true);
+            case LaunchReply_CreateOneof.createMessage:
+              return (l.createMessage, false);
+            default:
+              return (l.replyMessage, false);
+          }
+        }, (m) => (m.replyMessage, false));
 
         final (message, cancelable) = data ?? ('', false);
 
@@ -274,17 +278,19 @@ class LaunchingNotification extends ConsumerWidget {
               Text.rich(['Launching $name\n'.span.bold, message.span].spans),
               if (cancelable) ...[
                 const Divider(),
-                Row(children: [
-                  const Spacer(),
-                  OutlinedButton(
-                    onPressed: () {
-                      closeNotification(context);
-                      cancelCompleter.complete();
-                    },
-                    child: Text('Cancel'),
-                  ),
-                  const SizedBox(width: 20),
-                ])
+                Row(
+                  children: [
+                    const Spacer(),
+                    OutlinedButton(
+                      onPressed: () {
+                        closeNotification(context);
+                        cancelCompleter.complete();
+                      },
+                      child: Text('Cancel'),
+                    ),
+                    const SizedBox(width: 20),
+                  ],
+                ),
               ],
             ],
           ),

--- a/src/client/gui/lib/notifications/notifications_list.dart
+++ b/src/client/gui/lib/notifications/notifications_list.dart
@@ -52,10 +52,9 @@ class _NotificationListState extends ConsumerState<NotificationList> {
         initialItemCount: notifications.length,
         itemBuilder: (_, index, animation) {
           return SlideTransition(
-            position: animation.drive(Tween(
-              begin: const Offset(1, 0),
-              end: Offset.zero,
-            )),
+            position: animation.drive(
+              Tween(begin: const Offset(1, 0), end: Offset.zero),
+            ),
             child: NotificationTile(notifications[index]),
           );
         },
@@ -72,7 +71,7 @@ class NotificationTile extends ConsumerWidget {
   final Widget notification;
 
   NotificationTile(this.notification)
-      : super(key: GlobalObjectKey(notification));
+    : super(key: GlobalObjectKey(notification));
 
   void removeSelf(WidgetRef ref) {
     ref.read(notificationsProvider.notifier).remove(notification);

--- a/src/client/gui/lib/notifications/notifications_provider.dart
+++ b/src/client/gui/lib/notifications/notifications_provider.dart
@@ -35,20 +35,22 @@ class NotificationsNotifier extends AutoDisposeNotifier<BuiltList<Widget>> {
     required String Function(T) onSuccess,
     required String Function(Object?) onError,
   }) {
-    add(OperationNotification(
-      text: loading,
-      future: op.then(onSuccess).onError((error, _) {
-        if (error is GrpcError) error = error.message;
-        throw onError(error);
-      }),
-    ));
+    add(
+      OperationNotification(
+        text: loading,
+        future: op.then(onSuccess).onError((error, _) {
+          if (error is GrpcError) error = error.message;
+          throw onError(error);
+        }),
+      ),
+    );
   }
 }
 
 final notificationsProvider =
     NotifierProvider.autoDispose<NotificationsNotifier, BuiltList<Widget>>(
-  NotificationsNotifier.new,
-);
+      NotificationsNotifier.new,
+    );
 
 extension ErrorNotificationWidgetRefExtension on WidgetRef {
   void Function(Object?, StackTrace) notifyError(

--- a/src/client/gui/lib/platform/linux.dart
+++ b/src/client/gui/lib/platform/linux.dart
@@ -13,10 +13,10 @@ class LinuxPlatform extends MpPlatform {
 
   @override
   Map<String, String> get drivers => const {
-        'qemu': 'QEMU',
-        'lxd': 'LXD',
-        'libvirt': 'libvirt',
-      };
+    'qemu': 'QEMU',
+    'lxd': 'LXD',
+    'libvirt': 'libvirt',
+  };
 
   @override
   String get ffiLibraryName => 'libdart_ffi.so';
@@ -29,31 +29,35 @@ class LinuxPlatform extends MpPlatform {
 
   @override
   Map<SingleActivator, Intent> get terminalShortcuts => const {
-        SingleActivator(LogicalKeyboardKey.keyC, control: true, shift: true):
-            CopySelectionTextIntent.copy,
-        SingleActivator(LogicalKeyboardKey.insert, control: true):
-            CopySelectionTextIntent.copy,
-        SingleActivator(LogicalKeyboardKey.keyV, control: true, shift: true):
-            PasteTextIntent(SelectionChangedCause.keyboard),
-        SingleActivator(LogicalKeyboardKey.insert, shift: true):
-            PasteTextIntent(SelectionChangedCause.keyboard),
-        SingleActivator(LogicalKeyboardKey.equal, control: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.add, control: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.add, control: true, shift: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.numpadAdd, control: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.minus, control: true):
-            DecreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.numpadSubtract, control: true):
-            DecreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.digit0, control: true):
-            ResetTerminalFontIntent(),
-      };
+    SingleActivator(LogicalKeyboardKey.keyC, control: true, shift: true):
+        CopySelectionTextIntent.copy,
+    SingleActivator(LogicalKeyboardKey.insert, control: true):
+        CopySelectionTextIntent.copy,
+    SingleActivator(
+      LogicalKeyboardKey.keyV,
+      control: true,
+      shift: true,
+    ): PasteTextIntent(SelectionChangedCause.keyboard),
+    SingleActivator(LogicalKeyboardKey.insert, shift: true): PasteTextIntent(
+      SelectionChangedCause.keyboard,
+    ),
+    SingleActivator(LogicalKeyboardKey.equal, control: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.add, control: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.add, control: true, shift: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.numpadAdd, control: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.minus, control: true):
+        DecreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.numpadSubtract, control: true):
+        DecreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.digit0, control: true):
+        ResetTerminalFontIntent(),
+  };
 
   @override
   String get trayIconFile => 'icon.png';
@@ -62,9 +66,10 @@ class LinuxPlatform extends MpPlatform {
   String get metaKey => 'Super';
 
   @override
-  String? get homeDirectory => Platform.environment['SNAP'] == null
-      ? Platform.environment['HOME']
-      : Platform.environment['SNAP_REAL_HOME'];
+  String? get homeDirectory =>
+      Platform.environment['SNAP'] == null
+          ? Platform.environment['HOME']
+          : Platform.environment['SNAP_REAL_HOME'];
 }
 
 class LinuxAutostartNotifier extends AutostartNotifier {

--- a/src/client/gui/lib/platform/macos.dart
+++ b/src/client/gui/lib/platform/macos.dart
@@ -13,9 +13,9 @@ class MacOSPlatform extends MpPlatform {
 
   @override
   Map<String, String> get drivers => const {
-        'qemu': 'QEMU',
-        'virtualbox': 'VirtualBox',
-      };
+    'qemu': 'QEMU',
+    'virtualbox': 'VirtualBox',
+  };
 
   @override
   String get ffiLibraryName => 'libdart_ffi.dylib';
@@ -28,25 +28,26 @@ class MacOSPlatform extends MpPlatform {
 
   @override
   Map<SingleActivator, Intent> get terminalShortcuts => const {
-        SingleActivator(LogicalKeyboardKey.keyC, meta: true):
-            CopySelectionTextIntent.copy,
-        SingleActivator(LogicalKeyboardKey.keyV, meta: true):
-            PasteTextIntent(SelectionChangedCause.keyboard),
-        SingleActivator(LogicalKeyboardKey.equal, meta: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.equal, meta: true, shift: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.add, meta: true, shift: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.numpadAdd, meta: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.minus, meta: true):
-            DecreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.numpadSubtract, meta: true):
-            DecreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.digit0, meta: true):
-            ResetTerminalFontIntent(),
-      };
+    SingleActivator(LogicalKeyboardKey.keyC, meta: true):
+        CopySelectionTextIntent.copy,
+    SingleActivator(LogicalKeyboardKey.keyV, meta: true): PasteTextIntent(
+      SelectionChangedCause.keyboard,
+    ),
+    SingleActivator(LogicalKeyboardKey.equal, meta: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.equal, meta: true, shift: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.add, meta: true, shift: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.numpadAdd, meta: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.minus, meta: true):
+        DecreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.numpadSubtract, meta: true):
+        DecreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.digit0, meta: true):
+        ResetTerminalFontIntent(),
+  };
 
   @override
   String get trayIconFile => 'icon_template.png';

--- a/src/client/gui/lib/platform/windows.dart
+++ b/src/client/gui/lib/platform/windows.dart
@@ -16,9 +16,9 @@ class WindowsPlatform extends MpPlatform {
 
   @override
   Map<String, String> get drivers => const {
-        'hyperv': 'Hyper-V',
-        'virtualbox': 'VirtualBox',
-      };
+    'hyperv': 'Hyper-V',
+    'virtualbox': 'VirtualBox',
+  };
 
   @override
   String get ffiLibraryName => 'dart_ffi.dll';
@@ -31,31 +31,35 @@ class WindowsPlatform extends MpPlatform {
 
   @override
   Map<SingleActivator, Intent> get terminalShortcuts => const {
-        SingleActivator(LogicalKeyboardKey.keyC, control: true, shift: true):
-            CopySelectionTextIntent.copy,
-        SingleActivator(LogicalKeyboardKey.insert, control: true):
-            CopySelectionTextIntent.copy,
-        SingleActivator(LogicalKeyboardKey.keyV, control: true, shift: true):
-            PasteTextIntent(SelectionChangedCause.keyboard),
-        SingleActivator(LogicalKeyboardKey.insert, shift: true):
-            PasteTextIntent(SelectionChangedCause.keyboard),
-        SingleActivator(LogicalKeyboardKey.equal, control: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.add, control: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.add, control: true, shift: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.numpadAdd, control: true):
-            IncreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.minus, control: true):
-            DecreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.numpadSubtract, control: true):
-            DecreaseTerminalFontIntent(),
-        SingleActivator(LogicalKeyboardKey.digit0, control: true):
-            ResetTerminalFontIntent(),
-      };
+    SingleActivator(LogicalKeyboardKey.keyC, control: true, shift: true):
+        CopySelectionTextIntent.copy,
+    SingleActivator(LogicalKeyboardKey.insert, control: true):
+        CopySelectionTextIntent.copy,
+    SingleActivator(
+      LogicalKeyboardKey.keyV,
+      control: true,
+      shift: true,
+    ): PasteTextIntent(SelectionChangedCause.keyboard),
+    SingleActivator(LogicalKeyboardKey.insert, shift: true): PasteTextIntent(
+      SelectionChangedCause.keyboard,
+    ),
+    SingleActivator(LogicalKeyboardKey.equal, control: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.equal, control: true, shift: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.add, control: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.add, control: true, shift: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.numpadAdd, control: true):
+        IncreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.minus, control: true):
+        DecreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.numpadSubtract, control: true):
+        DecreaseTerminalFontIntent(),
+    SingleActivator(LogicalKeyboardKey.digit0, control: true):
+        ResetTerminalFontIntent(),
+  };
 
   @override
   String get trayIconFile => 'icon.ico';

--- a/src/client/gui/lib/settings/autostart_notifiers.dart
+++ b/src/client/gui/lib/settings/autostart_notifiers.dart
@@ -6,7 +6,8 @@ import '../platform/platform.dart';
 
 final autostartProvider =
     AsyncNotifierProvider.autoDispose<AutostartNotifier, bool>(
-        mpPlatform.autostartNotifier);
+      mpPlatform.autostartNotifier,
+    );
 
 abstract class AutostartNotifier extends AutoDisposeAsyncNotifier<bool> {
   Future<void> set(bool value) async {

--- a/src/client/gui/lib/settings/general_settings.dart
+++ b/src/client/gui/lib/settings/general_settings.dart
@@ -20,40 +20,44 @@ class GeneralSettings extends ConsumerWidget {
     final autostart = ref.watch(autostartProvider).valueOrNull ?? false;
     final onAppClose = ref.watch(onAppCloseProvider);
 
-    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-      const Text(
-        'General',
-        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-      ),
-      const SizedBox(height: 20),
-      if (update.version.isNotBlank) ...[
-        UpdateAvailable(update),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'General',
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
         const SizedBox(height: 20),
+        if (update.version.isNotBlank) ...[
+          UpdateAvailable(update),
+          const SizedBox(height: 20),
+        ],
+        Switch(
+          label: 'Open the Multipass GUI on startup',
+          value: autostart,
+          trailingSwitch: true,
+          size: 30,
+          onChanged: (value) {
+            ref
+                .read(autostartProvider.notifier)
+                .set(value)
+                .onError(ref.notifyError((e) => 'Failed to set autostart: $e'));
+          },
+        ),
+        const SizedBox(height: 20),
+        Dropdown(
+          label: 'When closing Multipass',
+          width: 260,
+          value: onAppClose ?? 'ask',
+          onChanged:
+              (value) => ref.read(onAppCloseProvider.notifier).set(value!),
+          items: const {
+            'ask': 'Ask about running instances',
+            'stop': 'Stop running instances',
+            'nothing': 'Do not stop running instances',
+          },
+        ),
       ],
-      Switch(
-        label: 'Open the Multipass GUI on startup',
-        value: autostart,
-        trailingSwitch: true,
-        size: 30,
-        onChanged: (value) {
-          ref
-              .read(autostartProvider.notifier)
-              .set(value)
-              .onError(ref.notifyError((e) => 'Failed to set autostart: $e'));
-        },
-      ),
-      const SizedBox(height: 20),
-      Dropdown(
-        label: 'When closing Multipass',
-        width: 260,
-        value: onAppClose ?? 'ask',
-        onChanged: (value) => ref.read(onAppCloseProvider.notifier).set(value!),
-        items: const {
-          'ask': 'Ask about running instances',
-          'stop': 'Stop running instances',
-          'nothing': 'Do not stop running instances',
-        },
-      ),
-    ]);
+    );
   }
 }

--- a/src/client/gui/lib/settings/hotkey.dart
+++ b/src/client/gui/lib/settings/hotkey.dart
@@ -15,8 +15,9 @@ class HotkeyNotifier extends Notifier<SingleActivator?> {
     final hotkeyString = ref.read(hotkeySettingProvider);
     if (hotkeyString == null) return null;
     final components = hotkeyString.toLowerCase().split('+');
-    final keyId =
-        components.map(int.tryParse).firstWhereOrNull((e) => e != null);
+    final keyId = components
+        .map(int.tryParse)
+        .firstWhereOrNull((e) => e != null);
     if (keyId == null) return null;
     final key = LogicalKeyboardKey.findKeyByKeyId(keyId);
     if (key == null) return null;
@@ -50,8 +51,9 @@ class HotkeyNotifier extends Notifier<SingleActivator?> {
   }
 }
 
-final hotkeyProvider =
-    NotifierProvider<HotkeyNotifier, SingleActivator?>(HotkeyNotifier.new);
+final hotkeyProvider = NotifierProvider<HotkeyNotifier, SingleActivator?>(
+  HotkeyNotifier.new,
+);
 
 class HotkeyRecorder extends StatefulWidget {
   final SingleActivator? value;
@@ -144,16 +146,17 @@ class HotkeyRecorderState extends State<HotkeyRecorder> {
       } else if (shouldSave) {
         shouldSave = false;
         final trigger = key;
-        final activator = trigger != null
-            ? SingleActivator(
-                trigger,
-                alt: alt,
-                control: control,
-                meta: meta,
-                shift: shift,
-                includeRepeats: false,
-              )
-            : null;
+        final activator =
+            trigger != null
+                ? SingleActivator(
+                  trigger,
+                  alt: alt,
+                  control: control,
+                  meta: meta,
+                  shift: shift,
+                  includeRepeats: false,
+                )
+                : null;
         widget.onSave?.call(activator);
       } else {
         set(widget.value);
@@ -170,9 +173,10 @@ class HotkeyRecorderState extends State<HotkeyRecorder> {
       if (shift) 'Shift',
       if (meta) mpPlatform.metaKey,
     ].join('+');
-    final keyCombination = modifiers.isNotEmpty
-        ? '$modifiers+$keyLabel'
-        : hasFocus
+    final keyCombination =
+        modifiers.isNotEmpty
+            ? '$modifiers+$keyLabel'
+            : hasFocus
             ? 'Input...'
             : '';
 

--- a/src/client/gui/lib/settings/usage_settings.dart
+++ b/src/client/gui/lib/settings/usage_settings.dart
@@ -22,70 +22,82 @@ class UsageSettings extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final primaryName = ref.watch(primaryNameProvider);
-    final hasPassphrase = ref.watch(passphraseProvider.select((value) {
-      return value.valueOrNull.isNotNullOrBlank;
-    }));
-    final privilegedMounts = ref.watch(privilegedMountsProvider.select((value) {
-      return value.valueOrNull?.toBoolOption.toNullable() ?? false;
-    }));
+    final hasPassphrase = ref.watch(
+      passphraseProvider.select((value) {
+        return value.valueOrNull.isNotNullOrBlank;
+      }),
+    );
+    final privilegedMounts = ref.watch(
+      privilegedMountsProvider.select((value) {
+        return value.valueOrNull?.toBoolOption.toNullable() ?? false;
+      }),
+    );
     final hotkey = ref.watch(hotkeyProvider);
-    final askTerminalClose = ref.watch(askTerminalCloseProvider.select((value) {
-      return value?.toBoolOption.toNullable() ?? true;
-    }));
+    final askTerminalClose = ref.watch(
+      askTerminalCloseProvider.select((value) {
+        return value?.toBoolOption.toNullable() ?? true;
+      }),
+    );
 
-    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-      const Text(
-        'Usage',
-        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-      ),
-      const SizedBox(height: 20),
-      PrimaryNameField(
-        value: primaryName,
-        onSave: (value) {
-          ref.read(primaryNameProvider.notifier).set(value);
-        },
-      ),
-      const SizedBox(height: 20),
-      HotkeyField(
-        value: hotkey,
-        onSave: (newHotkey) => ref.read(hotkeyProvider.notifier).set(newHotkey),
-      ),
-      const SizedBox(height: 20),
-      PassphraseField(
-        hasPassphrase: hasPassphrase,
-        onSave: (value) {
-          ref
-              .read(passphraseProvider.notifier)
-              .set(value)
-              .onError(ref.notifyError((e) => 'Failed to set passphrase: $e'));
-        },
-      ),
-      const SizedBox(height: 20),
-      Switch(
-        label: 'Allow privileged mounts',
-        value: privilegedMounts,
-        trailingSwitch: true,
-        size: 30,
-        onChanged: (value) {
-          ref
-              .read(privilegedMountsProvider.notifier)
-              .set(value.toString())
-              .onError(
-                ref.notifyError((e) => 'Failed to set privileged mounts: $e'),
-              );
-        },
-      ),
-      const SizedBox(height: 20),
-      Switch(
-        label: 'Ask before closing terminal',
-        value: askTerminalClose,
-        trailingSwitch: true,
-        size: 30,
-        onChanged: (value) {
-          ref.read(askTerminalCloseProvider.notifier).set(value.toString());
-        },
-      ),
-    ]);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Usage',
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 20),
+        PrimaryNameField(
+          value: primaryName,
+          onSave: (value) {
+            ref.read(primaryNameProvider.notifier).set(value);
+          },
+        ),
+        const SizedBox(height: 20),
+        HotkeyField(
+          value: hotkey,
+          onSave:
+              (newHotkey) => ref.read(hotkeyProvider.notifier).set(newHotkey),
+        ),
+        const SizedBox(height: 20),
+        PassphraseField(
+          hasPassphrase: hasPassphrase,
+          onSave: (value) {
+            ref
+                .read(passphraseProvider.notifier)
+                .set(value)
+                .onError(
+                  ref.notifyError((e) => 'Failed to set passphrase: $e'),
+                );
+          },
+        ),
+        const SizedBox(height: 20),
+        Switch(
+          label: 'Allow privileged mounts',
+          value: privilegedMounts,
+          trailingSwitch: true,
+          size: 30,
+          onChanged: (value) {
+            ref
+                .read(privilegedMountsProvider.notifier)
+                .set(value.toString())
+                .onError(
+                  ref.notifyError((e) => 'Failed to set privileged mounts: $e'),
+                );
+          },
+        ),
+        const SizedBox(height: 20),
+        Switch(
+          label: 'Ask before closing terminal',
+          value: askTerminalClose,
+          trailingSwitch: true,
+          size: 30,
+          onChanged: (value) {
+            ref.read(askTerminalCloseProvider.notifier).set(value.toString());
+          },
+        ),
+      ],
+    );
   }
 }
 
@@ -155,7 +167,7 @@ class _PrimaryNameFieldState extends State<PrimaryNameField> {
           return null;
         },
         inputFormatters: [
-          FilteringTextInputFormatter.allow(RegExp('[-A-Za-z0-9]'))
+          FilteringTextInputFormatter.allow(RegExp('[-A-Za-z0-9]')),
         ],
       ),
     );
@@ -166,11 +178,7 @@ class HotkeyField extends StatefulWidget {
   final SingleActivator? value;
   final ValueChanged<SingleActivator?> onSave;
 
-  const HotkeyField({
-    super.key,
-    required this.value,
-    required this.onSave,
-  });
+  const HotkeyField({super.key, required this.value, required this.onSave});
 
   @override
   State<HotkeyField> createState() => _HotkeyFieldState();
@@ -204,18 +212,20 @@ class _HotkeyFieldState extends State<HotkeyField> {
     return SettingField(
       label: 'Primary instance hotkey',
       onSave: () => widget.onSave(value),
-      onDiscard: () => setState(() {
-        recorderState.currentState?.set(widget.value);
-        changed = false;
-      }),
+      onDiscard:
+          () => setState(() {
+            recorderState.currentState?.set(widget.value);
+            changed = false;
+          }),
       changed: changed,
       child: HotkeyRecorder(
         key: recorderState,
         value: value,
-        onSave: (newHotkey) => setState(() {
-          value = newHotkey;
-          changed = components(value) != components(widget.value);
-        }),
+        onSave:
+            (newHotkey) => setState(() {
+              value = newHotkey;
+              changed = components(value) != components(widget.value);
+            }),
       ),
     );
   }
@@ -250,7 +260,8 @@ class _PassphraseFieldState extends State<PassphraseField> {
   void hasChanged() {
     Timer(100.milliseconds, () {
       setState(() {
-        changed = (focus.hasFocus && widget.hasPassphrase) ||
+        changed =
+            (focus.hasFocus && widget.hasPassphrase) ||
             controller.text.isNotEmpty;
       });
     });
@@ -300,22 +311,25 @@ class SettingField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-      Expanded(child: Text(label, style: const TextStyle(fontSize: 16))),
-      const SizedBox(width: 12),
-      if (changed) ...[
-        OutlinedButton(
-          onPressed: onSave,
-          child: const Icon(Icons.check, color: Color(0xff0E8620)),
-        ),
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(child: Text(label, style: const TextStyle(fontSize: 16))),
         const SizedBox(width: 12),
-        OutlinedButton(
-          onPressed: onDiscard,
-          child: const Icon(Icons.close, color: Color(0xffC7162B)),
-        ),
-        const SizedBox(width: 12),
+        if (changed) ...[
+          OutlinedButton(
+            onPressed: onSave,
+            child: const Icon(Icons.check, color: Color(0xff0E8620)),
+          ),
+          const SizedBox(width: 12),
+          OutlinedButton(
+            onPressed: onDiscard,
+            child: const Icon(Icons.close, color: Color(0xffC7162B)),
+          ),
+          const SizedBox(width: 12),
+        ],
+        SizedBox(width: 260, child: child),
       ],
-      SizedBox(width: 260, child: child),
-    ]);
+    );
   }
 }

--- a/src/client/gui/lib/settings/virtualization_settings.dart
+++ b/src/client/gui/lib/settings/virtualization_settings.dart
@@ -18,37 +18,44 @@ class VirtualizationSettings extends ConsumerWidget {
     final bridgedNetwork = ref.watch(bridgedNetworkProvider).valueOrNull;
     final networks = ref.watch(networksProvider);
 
-    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-      const Text(
-        'Virtualization',
-        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-      ),
-      const SizedBox(height: 20),
-      Dropdown(
-        label: 'Driver',
-        width: 260,
-        value: driver,
-        items: mpPlatform.drivers,
-        onChanged: (value) {
-          if (value == driver) return;
-          ref
-              .read(driverProvider.notifier)
-              .set(value!)
-              .onError(ref.notifyError((e) => 'Failed to set driver: $e'));
-        },
-      ),
-      const SizedBox(height: 20),
-      if (networks.isNotEmpty)
-        Dropdown<String>(
-          label: 'Bridged network',
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Virtualization',
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 20),
+        Dropdown(
+          label: 'Driver',
           width: 260,
-          value: networks.contains(bridgedNetwork) ? bridgedNetwork : '',
-          items: {'': 'None', ...Map.fromIterable(networks)},
+          value: driver,
+          items: mpPlatform.drivers,
           onChanged: (value) {
-            ref.read(bridgedNetworkProvider.notifier).set(value!).onError(
-                ref.notifyError((e) => 'Failed to set bridged network: $e'));
+            if (value == driver) return;
+            ref
+                .read(driverProvider.notifier)
+                .set(value!)
+                .onError(ref.notifyError((e) => 'Failed to set driver: $e'));
           },
         ),
-    ]);
+        const SizedBox(height: 20),
+        if (networks.isNotEmpty)
+          Dropdown<String>(
+            label: 'Bridged network',
+            width: 260,
+            value: networks.contains(bridgedNetwork) ? bridgedNetwork : '',
+            items: {'': 'None', ...Map.fromIterable(networks)},
+            onChanged: (value) {
+              ref
+                  .read(bridgedNetworkProvider.notifier)
+                  .set(value!)
+                  .onError(
+                    ref.notifyError((e) => 'Failed to set bridged network: $e'),
+                  );
+            },
+          ),
+      ],
+    );
   }
 }

--- a/src/client/gui/lib/sidebar.dart
+++ b/src/client/gui/lib/sidebar.dart
@@ -187,7 +187,7 @@ class SideBar extends ConsumerWidget {
             catalogue,
             instances,
             Expanded(child: ListView(children: vmEntries.toList())),
-            Divider(color: Colors.white.withOpacity(0.3)),
+            Divider(color: Colors.white.withAlpha(77)),
             help,
             settings,
           ],

--- a/src/client/gui/lib/sidebar.dart
+++ b/src/client/gui/lib/sidebar.dart
@@ -74,7 +74,8 @@ class SideBar extends ConsumerWidget {
 
     final instances = SidebarEntry(
       icon: SvgPicture.asset('assets/instances.svg'),
-      selected: isSelected(VmTableScreen.sidebarKey) ||
+      selected:
+          isSelected(VmTableScreen.sidebarKey) ||
           !expanded && selectedSidebarKey.startsWith('vm-'),
       label: 'Instances',
       badge: vmNames.length.toString(),
@@ -110,48 +111,51 @@ class SideBar extends ConsumerWidget {
           pushContent ? Icons.chevron_left : Icons.chevron_right,
           color: Colors.white,
         ),
-        onPressed: () => ref
-            .read(sidebarPushContentProvider.notifier)
-            .update((state) => !state),
+        onPressed:
+            () => ref
+                .read(sidebarPushContentProvider.notifier)
+                .update((state) => !state),
       ),
     );
 
-    final header = Row(crossAxisAlignment: CrossAxisAlignment.end, children: [
-      Container(
-        alignment: Alignment.bottomCenter,
-        color: const Color(0xffE95420),
-        height: 50,
-        margin: const EdgeInsets.symmetric(horizontal: 8),
-        padding: const EdgeInsets.all(4),
-        child: SvgPicture.asset('assets/multipass.svg', width: 20),
-      ),
-      Expanded(
-        flex: 3,
-        child: AnimatedOpacity(
-          opacity: expanded ? 1 : 0,
-          duration: SideBar.animationDuration,
-          child: Text.rich([
-            'Canonical\n'.span.size(12).color(Colors.white),
-            'Multipass'.span.size(24).color(Colors.white),
-          ].spans),
+    final header = Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Container(
+          alignment: Alignment.bottomCenter,
+          color: const Color(0xffE95420),
+          height: 50,
+          margin: const EdgeInsets.symmetric(horizontal: 8),
+          padding: const EdgeInsets.all(4),
+          child: SvgPicture.asset('assets/multipass.svg', width: 20),
         ),
-      ),
-      Flexible(child: pinSidebarButton),
-    ]);
+        Expanded(
+          flex: 3,
+          child: AnimatedOpacity(
+            opacity: expanded ? 1 : 0,
+            duration: SideBar.animationDuration,
+            child: Text.rich(
+              [
+                'Canonical\n'.span.size(12).color(Colors.white),
+                'Multipass'.span.size(24).color(Colors.white),
+              ].spans,
+            ),
+          ),
+        ),
+        Flexible(child: pinSidebarButton),
+      ],
+    );
 
     final vmEntries = vmNames.map((name) {
       final key = 'vm-$name';
-      final hasShells =
-          ref.watch(runningShellsProvider(name).select((n) => n > 0));
+      final hasShells = ref.watch(
+        runningShellsProvider(name).select((n) => n > 0),
+      );
       return SidebarEntry(
         key: ValueKey(key),
         icon: Opacity(
           opacity: hasShells ? 1 : 0,
-          child: SvgPicture.asset(
-            'assets/shell.svg',
-            width: 15,
-            height: 15,
-          ),
+          child: SvgPicture.asset('assets/shell.svg', width: 15, height: 15),
         ),
         selected: isSelected(key) && expanded,
         label: name,
@@ -232,9 +236,10 @@ class SidebarEntry extends ConsumerWidget {
       margin: const EdgeInsets.symmetric(vertical: 4),
       decoration: BoxDecoration(
         border: Border(
-          left: selected
-              ? const BorderSide(color: Colors.white, width: 2)
-              : BorderSide.none,
+          left:
+              selected
+                  ? const BorderSide(color: Colors.white, width: 2)
+                  : BorderSide.none,
         ),
       ),
       child: TextButton(
@@ -244,36 +249,38 @@ class SidebarEntry extends ConsumerWidget {
           backgroundColor:
               selected ? const Color(0xff444444) : Colors.transparent,
         ),
-        child: Row(children: [
-          badge == null
-              ? icon
-              : Badge(
+        child: Row(
+          children: [
+            badge == null
+                ? icon
+                : Badge(
                   backgroundColor: const Color(0xff333333),
                   isLabelVisible: !expanded,
                   label: Text(badge!),
                   offset: const Offset(10, -6),
                   child: icon,
                 ),
-          Expanded(
-            flex: 5,
-            child: AnimatedOpacity(
-              duration: SideBar.animationDuration,
-              opacity: expanded ? 1 : 0,
-              child: Text('    $label', softWrap: false),
-            ),
-          ),
-          if (badge != null && expanded)
-            Flexible(
-              child: Container(
-                decoration: const BoxDecoration(
-                  color: Color(0xff333333),
-                  shape: BoxShape.circle,
-                ),
-                alignment: Alignment.center,
-                child: Text(badge!, softWrap: false),
+            Expanded(
+              flex: 5,
+              child: AnimatedOpacity(
+                duration: SideBar.animationDuration,
+                opacity: expanded ? 1 : 0,
+                child: Text('    $label', softWrap: false),
               ),
             ),
-        ]),
+            if (badge != null && expanded)
+              Flexible(
+                child: Container(
+                  decoration: const BoxDecoration(
+                    color: Color(0xff333333),
+                    shape: BoxShape.circle,
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(badge!, softWrap: false),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/src/client/gui/lib/switch.dart
+++ b/src/client/gui/lib/switch.dart
@@ -35,15 +35,13 @@ class Switch extends StatelessWidget {
     final labelText = Text(label, style: const TextStyle(fontSize: 16));
 
     return trailingSwitch
-        ? Row(children: [
+        ? Row(
+          children: [
             Expanded(child: labelText),
             const SizedBox(width: 8),
             switchBox,
-          ])
-        : Row(children: [
-            switchBox,
-            const SizedBox(width: 8),
-            labelText,
-          ]);
+          ],
+        )
+        : Row(children: [switchBox, const SizedBox(width: 8), labelText]);
   }
 }

--- a/src/client/gui/lib/tray_menu.dart
+++ b/src/client/gui/lib/tray_menu.dart
@@ -62,9 +62,11 @@ Future<void> setupTrayMenu(ProviderContainer providerContainer) async {
     await TrayMenu.instance.addLabel(
       'toggle-window',
       label: 'Toggle window',
-      callback: (_, __) async => await windowManager.isVisible()
-          ? windowManager.hide()
-          : windowManager.showAndRestore(),
+      callback:
+          (_, __) async =>
+              await windowManager.isVisible()
+                  ? windowManager.hide()
+                  : windowManager.showAndRestore(),
     );
   }
 
@@ -101,22 +103,22 @@ Future<void> setupTrayMenu(ProviderContainer providerContainer) async {
   await TrayMenu.instance.show(await _iconFilePath());
 
   final lock = Lock();
-  providerContainer.listen(
-    trayMenuDataProvider,
-    (previousVmData, nextVmData) async {
-      lock.synchronized(() async {
-        if (nextVmData == null) {
-          await _setTrayMenuError();
-        } else {
-          await _updateTrayMenu(
-            providerContainer,
-            previousVmData?.toMap() ?? {},
-            nextVmData.toMap(),
-          );
-        }
-      });
-    },
-  );
+  providerContainer.listen(trayMenuDataProvider, (
+    previousVmData,
+    nextVmData,
+  ) async {
+    lock.synchronized(() async {
+      if (nextVmData == null) {
+        await _setTrayMenuError();
+      } else {
+        await _updateTrayMenu(
+          providerContainer,
+          previousVmData?.toMap() ?? {},
+          nextVmData.toMap(),
+        );
+      }
+    });
+  });
 }
 
 Future<void> _setTrayMenuError() async {
@@ -204,12 +206,10 @@ Future<void> _updateTrayMenu(
               .read(vmScreenLocationProvider(name).notifier)
               .state = VmDetailsLocation.shells;
           providerContainer.read(sidebarKeyProvider.notifier).set(key);
-          final (:ids, :currentIndex) =
-              providerContainer.read(shellIdsProvider(name));
-          final terminalIdentifier = (
-            vmName: name,
-            shellId: ids[currentIndex],
+          final (:ids, :currentIndex) = providerContainer.read(
+            shellIdsProvider(name),
           );
+          final terminalIdentifier = (vmName: name, shellId: ids[currentIndex]);
           final provider = terminalProvider(terminalIdentifier);
           if (providerContainer.exists(provider)) {
             providerContainer.read(provider.notifier).start();

--- a/src/client/gui/lib/update_available.dart
+++ b/src/client/gui/lib/update_available.dart
@@ -93,13 +93,15 @@ class UpdateAvailable extends StatelessWidget {
     return Container(
       color: const Color(0xffF7F7F7),
       padding: const EdgeInsets.all(12),
-      child: Row(children: [
-        icon,
-        const SizedBox(width: 12),
-        text,
-        const Spacer(),
-        button,
-      ]),
+      child: Row(
+        children: [
+          icon,
+          const SizedBox(width: 12),
+          text,
+          const Spacer(),
+          button,
+        ],
+      ),
     );
   }
 }
@@ -118,21 +120,24 @@ class UpdateAvailableNotification extends StatelessWidget {
         width: 30,
         colorFilter: const ColorFilter.mode(_color, BlendMode.srcIn),
       ),
-      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        Text(
-          'Multipass ${updateInfo.version} is available',
-          style: const TextStyle(fontSize: 16),
-        ),
-        const SizedBox(height: 12),
-        TextButton(
-          onPressed: () async {
-            await launchInstallUrl();
-            if (!context.mounted) return;
-            closeNotification(context);
-          },
-          child: const Text('Upgrade now', style: TextStyle(fontSize: 14)),
-        ),
-      ]),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Multipass ${updateInfo.version} is available',
+            style: const TextStyle(fontSize: 16),
+          ),
+          const SizedBox(height: 12),
+          TextButton(
+            onPressed: () async {
+              await launchInstallUrl();
+              if (!context.mounted) return;
+              closeNotification(context);
+            },
+            child: const Text('Upgrade now', style: TextStyle(fontSize: 14)),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/src/client/gui/lib/vm_action.dart
+++ b/src/client/gui/lib/vm_action.dart
@@ -84,10 +84,10 @@ class VmActionButton extends StatelessWidget {
     return OutlinedButton(
       onPressed: onPressed,
       style: ButtonStyle(
-        side: MaterialStateBorderSide.resolveWith(
+        side: WidgetStateBorderSide.resolveWith(
           (states) => BorderSide(
-            color: const Color(0xff333333).withOpacity(
-              states.contains(MaterialState.disabled) ? 0.5 : 1,
+            color: const Color(0xff333333).withAlpha(
+              states.contains(WidgetState.disabled) ? 128 : 255,
             ),
           ),
         ),

--- a/src/client/gui/lib/vm_action.dart
+++ b/src/client/gui/lib/vm_action.dart
@@ -11,52 +11,51 @@ enum VmAction {
   delete,
   recover,
   purge,
-  edit,
-  ;
+  edit;
 
   String get name => switch (this) {
-        start => 'Start',
-        stop => 'Stop',
-        suspend => 'Suspend',
-        restart => 'Restart',
-        delete => 'Delete',
-        recover => 'Recover',
-        purge => 'Purge',
-        edit => 'Edit',
-      };
+    start => 'Start',
+    stop => 'Stop',
+    suspend => 'Suspend',
+    restart => 'Restart',
+    delete => 'Delete',
+    recover => 'Recover',
+    purge => 'Purge',
+    edit => 'Edit',
+  };
 
   String get pastTense => switch (this) {
-        start => 'Started',
-        stop => 'Stopped',
-        suspend => 'Suspended',
-        restart => 'Restarted',
-        delete => 'Deleted',
-        recover => 'Recovered',
-        purge => 'Purged',
-        edit => 'Edited',
-      };
+    start => 'Started',
+    stop => 'Stopped',
+    suspend => 'Suspended',
+    restart => 'Restarted',
+    delete => 'Deleted',
+    recover => 'Recovered',
+    purge => 'Purged',
+    edit => 'Edited',
+  };
 
   String get continuousTense => switch (this) {
-        start => 'Starting',
-        stop => 'Stopping',
-        suspend => 'Suspending',
-        restart => 'Restarting',
-        delete => 'Deleting',
-        recover => 'Recovering',
-        purge => 'Purging',
-        edit => 'Editing',
-      };
+    start => 'Starting',
+    stop => 'Stopping',
+    suspend => 'Suspending',
+    restart => 'Restarting',
+    delete => 'Deleting',
+    recover => 'Recovering',
+    purge => 'Purging',
+    edit => 'Editing',
+  };
 
   Set<Status> get allowedStatuses => switch (this) {
-        start => const {Status.STOPPED, Status.SUSPENDED},
-        stop => const {Status.RUNNING},
-        suspend => const {Status.RUNNING},
-        restart => const {Status.RUNNING},
-        delete => const {Status.STOPPED, Status.SUSPENDED, Status.RUNNING},
-        recover => const {Status.DELETED},
-        purge => const {Status.DELETED},
-        edit => const {Status.STOPPED},
-      };
+    start => const {Status.STOPPED, Status.SUSPENDED},
+    stop => const {Status.RUNNING},
+    suspend => const {Status.RUNNING},
+    restart => const {Status.RUNNING},
+    delete => const {Status.STOPPED, Status.SUSPENDED, Status.RUNNING},
+    recover => const {Status.DELETED},
+    purge => const {Status.DELETED},
+    edit => const {Status.STOPPED},
+  };
 }
 
 class VmActionButton extends StatelessWidget {
@@ -86,9 +85,9 @@ class VmActionButton extends StatelessWidget {
       style: ButtonStyle(
         side: WidgetStateBorderSide.resolveWith(
           (states) => BorderSide(
-            color: const Color(0xff333333).withAlpha(
-              states.contains(WidgetState.disabled) ? 128 : 255,
-            ),
+            color: const Color(
+              0xff333333,
+            ).withAlpha(states.contains(WidgetState.disabled) ? 128 : 255),
           ),
         ),
       ),
@@ -99,9 +98,7 @@ class VmActionButton extends StatelessWidget {
   Widget _buildDeleteButton(VoidCallback? onPressed) {
     return TextButton(
       onPressed: onPressed,
-      style: TextButton.styleFrom(
-        backgroundColor: const Color(0xffC7162B),
-      ),
+      style: TextButton.styleFrom(backgroundColor: const Color(0xffC7162B)),
       child: Text(action.name),
     );
   }

--- a/src/client/gui/lib/vm_details/cpu_sparkline.dart
+++ b/src/client/gui/lib/vm_details/cpu_sparkline.dart
@@ -22,10 +22,11 @@ class CpuSparkline extends ConsumerWidget {
       color: const Color(0xff666666),
       dotData: const FlDotData(show: false),
       preventCurveOverShooting: true,
-      spots: values.indexed.map((e) {
-        final (index, value) = e;
-        return FlSpot(index.toDouble(), value);
-      }).toList(),
+      spots:
+          values.indexed.map((e) {
+            final (index, value) = e;
+            return FlSpot(index.toDouble(), value);
+          }).toList(),
     );
 
     return LineChart(
@@ -54,15 +55,16 @@ class CpuUsagesNotifier
   @override
   Queue<double> build(String arg) {
     final usages = stateOrNull ?? Queue.of(Iterable.generate(50, (_) => 0.0));
-    final cpuTimes = ref
-        .watch(vmInfoProvider(arg))
-        .instanceInfo
-        .cpuTimes
-        .split(' ')
-        .skip(2)
-        .take(8)
-        .map(int.parse)
-        .toList();
+    final cpuTimes =
+        ref
+            .watch(vmInfoProvider(arg))
+            .instanceInfo
+            .cpuTimes
+            .split(' ')
+            .skip(2)
+            .take(8)
+            .map(int.parse)
+            .toList();
 
     if (cpuTimes.isEmpty) {
       return usages

--- a/src/client/gui/lib/vm_details/cpus_slider.dart
+++ b/src/client/gui/lib/vm_details/cpus_slider.dart
@@ -10,11 +10,7 @@ class CpusSlider extends ConsumerStatefulWidget {
   final int? initialValue;
   final FormFieldSetter<int> onSaved;
 
-  const CpusSlider({
-    super.key,
-    this.initialValue,
-    required this.onSaved,
-  });
+  const CpusSlider({super.key, this.initialValue, required this.onSaved});
 
   @override
   ConsumerState<CpusSlider> createState() => _CpusSliderState();
@@ -79,43 +75,51 @@ class _CpusSliderState extends ConsumerState<CpusSlider> {
       initialValue: widget.initialValue,
       onSaved: widget.onSaved,
       builder: (field) {
-        return Column(children: [
-          Slider(
-            min: min.toDouble(),
-            max: max.toDouble(),
-            divisions: divisions,
-            value: (field.value ?? min).toDouble(),
-            onChanged: (value) {
-              final intValue = value.toInt();
-              field.didChange(intValue);
-              controller.text = intValue.toString();
-            },
-          ),
-          const SizedBox(height: 5),
-          Row(children: [Text('$min'), Spacer(), Text('$max')]),
-          if ((field.value ?? min) > cores) ...[
-            const SizedBox(height: 25),
-            const Row(children: [
-              Icon(Icons.warning_rounded, color: Color(0xffCC7900)),
-              SizedBox(width: 5),
-              Text(
-                'Over-provisioning of cores',
-                style: TextStyle(fontSize: 16),
+        return Column(
+          children: [
+            Slider(
+              min: min.toDouble(),
+              max: max.toDouble(),
+              divisions: divisions,
+              value: (field.value ?? min).toDouble(),
+              onChanged: (value) {
+                final intValue = value.toInt();
+                field.didChange(intValue);
+                controller.text = intValue.toString();
+              },
+            ),
+            const SizedBox(height: 5),
+            Row(children: [Text('$min'), Spacer(), Text('$max')]),
+            if ((field.value ?? min) > cores) ...[
+              const SizedBox(height: 25),
+              const Row(
+                children: [
+                  Icon(Icons.warning_rounded, color: Color(0xffCC7900)),
+                  SizedBox(width: 5),
+                  Text(
+                    'Over-provisioning of cores',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ],
               ),
-            ]),
+            ],
           ],
-        ]);
+        );
       },
     );
 
-    return Column(children: [
-      Row(children: [
-        Text('CPUs', style: TextStyle(fontSize: 16)),
-        const Spacer(),
-        SizedBox(width: 65, child: textField),
-      ]),
-      const SizedBox(height: 25),
-      sliderFormField,
-    ]);
+    return Column(
+      children: [
+        Row(
+          children: [
+            Text('CPUs', style: TextStyle(fontSize: 16)),
+            const Spacer(),
+            SizedBox(width: 65, child: textField),
+          ],
+        ),
+        const SizedBox(height: 25),
+        sliderFormField,
+      ],
+    );
   }
 }

--- a/src/client/gui/lib/vm_details/disk_slider.dart
+++ b/src/client/gui/lib/vm_details/disk_slider.dart
@@ -13,12 +13,8 @@ class DiskSlider extends ConsumerWidget {
   final int min;
   final FormFieldSetter<int> onSaved;
 
-  DiskSlider({
-    super.key,
-    int? min,
-    this.initialValue,
-    required this.onSaved,
-  }) : min = min ?? 1.gibi;
+  DiskSlider({super.key, int? min, this.initialValue, required this.onSaved})
+    : min = min ?? 1.gibi;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/src/client/gui/lib/vm_details/disk_slider.dart
+++ b/src/client/gui/lib/vm_details/disk_slider.dart
@@ -13,7 +13,7 @@ class DiskSlider extends ConsumerWidget {
   final int min;
   final FormFieldSetter<int> onSaved;
 
-  const DiskSlider({
+  DiskSlider({
     super.key,
     int? min,
     this.initialValue,

--- a/src/client/gui/lib/vm_details/ip_addresses.dart
+++ b/src/client/gui/lib/vm_details/ip_addresses.dart
@@ -12,28 +12,31 @@ class IpAddresses extends StatelessWidget {
     final firstIp = ips.firstOrNull ?? '-';
     final restIps = ips.skip(1).toList();
 
-    return Row(children: [
-      Expanded(child: CopyableText(firstIp)),
-      if (restIps.isNotEmpty)
-        Badge.count(
-          count: restIps.length,
-          alignment: const AlignmentDirectional(-1.5, 0.4),
-          textStyle: const TextStyle(fontSize: 10),
-          largeSize: 14,
-          child: PopupMenuButton<void>(
-            icon: const Icon(Icons.keyboard_arrow_down),
-            position: PopupMenuPosition.under,
-            tooltip: 'Other IP addresses',
-            splashRadius: 10,
-            itemBuilder: (_) => [
-              const PopupMenuItem(
-                enabled: false,
-                child: Text('Other IP addresses'),
-              ),
-              ...restIps.map((ip) => PopupMenuItem(child: Text(ip))),
-            ],
+    return Row(
+      children: [
+        Expanded(child: CopyableText(firstIp)),
+        if (restIps.isNotEmpty)
+          Badge.count(
+            count: restIps.length,
+            alignment: const AlignmentDirectional(-1.5, 0.4),
+            textStyle: const TextStyle(fontSize: 10),
+            largeSize: 14,
+            child: PopupMenuButton<void>(
+              icon: const Icon(Icons.keyboard_arrow_down),
+              position: PopupMenuPosition.under,
+              tooltip: 'Other IP addresses',
+              splashRadius: 10,
+              itemBuilder:
+                  (_) => [
+                    const PopupMenuItem(
+                      enabled: false,
+                      child: Text('Other IP addresses'),
+                    ),
+                    ...restIps.map((ip) => PopupMenuItem(child: Text(ip))),
+                  ],
+            ),
           ),
-        ),
-    ]);
+      ],
+    );
   }
 }

--- a/src/client/gui/lib/vm_details/ip_addresses.dart
+++ b/src/client/gui/lib/vm_details/ip_addresses.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart' hide Tooltip;
 
 import '../copyable_text.dart';
-import '../extensions.dart';
-import '../tooltip.dart';
 
 class IpAddresses extends StatelessWidget {
   final Iterable<String> ips;

--- a/src/client/gui/lib/vm_details/mapping_slider.dart
+++ b/src/client/gui/lib/vm_details/mapping_slider.dart
@@ -35,9 +35,10 @@ class MappingSlider extends StatelessWidget {
       max: (scaledMax + extraMaxStep).toDouble(),
       divisions: enabled ? scaledMax - scaledMin + extraMaxStep : null,
       value: mapping(value).toDouble(),
-      onChanged: enabled
-          ? (mappedValue) => onChanged(inverseMapping(mappedValue.toInt()))
-          : null,
+      onChanged:
+          enabled
+              ? (mappedValue) => onChanged(inverseMapping(mappedValue.toInt()))
+              : null,
     );
   }
 }

--- a/src/client/gui/lib/vm_details/memory_slider.dart
+++ b/src/client/gui/lib/vm_details/memory_slider.dart
@@ -62,9 +62,10 @@ class _MemorySliderState extends State<MemorySlider> {
     TextEditingValue newValue,
   ) {
     if (newValue.text.isEmpty) return newValue;
-    final parsedValue = (unitToBytes == bytesToBytes)
-        ? int.tryParse(newValue.text)
-        : double.tryParse(newValue.text);
+    final parsedValue =
+        (unitToBytes == bytesToBytes)
+            ? int.tryParse(newValue.text)
+            : double.tryParse(newValue.text);
     return parsedValue == null ? oldValue : newValue;
   }
 
@@ -95,16 +96,17 @@ class _MemorySliderState extends State<MemorySlider> {
         (bytesToMebi, mebiToBytes): 'MiB',
         (bytesToGibi, gibiToBytes): 'GiB',
       },
-      onChanged: (convertors) => setState(() {
-        final (fromBytes, toBytes) = convertors!;
-        bytesToUnit = fromBytes;
-        unitToBytes = toBytes;
-        final value = formKey.currentState?.value;
-        if (value != null) {
-          final clampedValue = value.clamp(widget.min, widget.max);
-          controller.text = bytesToUnit(clampedValue).toNiceString();
-        }
-      }),
+      onChanged:
+          (convertors) => setState(() {
+            final (fromBytes, toBytes) = convertors!;
+            bytesToUnit = fromBytes;
+            unitToBytes = toBytes;
+            final value = formKey.currentState?.value;
+            if (value != null) {
+              final clampedValue = value.clamp(widget.min, widget.max);
+              controller.text = bytesToUnit(clampedValue).toNiceString();
+            }
+          }),
     );
 
     final sliderFormField = FormField<int>(
@@ -112,52 +114,62 @@ class _MemorySliderState extends State<MemorySlider> {
       initialValue: widget.initialValue,
       onSaved: (value) => widget.onSaved(value!.clamp(widget.min, widget.max)),
       builder: (field) {
-        return Column(children: [
-          MappingSlider(
-            min: widget.min,
-            max: widget.max,
-            enabled: widget.enabled,
-            value: field.value ?? widget.min,
-            onChanged: (value) {
-              field.didChange(value);
-              final clampedValue = value.clamp(widget.min, widget.max);
-              controller.text = bytesToUnit(clampedValue).toNiceString();
-            },
-          ),
-          const SizedBox(height: 5),
-          Row(children: [
-            Text(humanReadableMemory(widget.min)),
-            Spacer(),
-            Text(humanReadableMemory(widget.max)),
-          ]),
-          if ((field.value ?? widget.min) > widget.sysMax) ...[
-            const SizedBox(height: 25),
-            Row(children: [
-              const Icon(Icons.warning_rounded, color: Color(0xffCC7900)),
-              const SizedBox(width: 5),
-              Text(
-                'Over-provisioning of ${widget.label.toLowerCase()}',
-                style: const TextStyle(fontSize: 16),
+        return Column(
+          children: [
+            MappingSlider(
+              min: widget.min,
+              max: widget.max,
+              enabled: widget.enabled,
+              value: field.value ?? widget.min,
+              onChanged: (value) {
+                field.didChange(value);
+                final clampedValue = value.clamp(widget.min, widget.max);
+                controller.text = bytesToUnit(clampedValue).toNiceString();
+              },
+            ),
+            const SizedBox(height: 5),
+            Row(
+              children: [
+                Text(humanReadableMemory(widget.min)),
+                Spacer(),
+                Text(humanReadableMemory(widget.max)),
+              ],
+            ),
+            if ((field.value ?? widget.min) > widget.sysMax) ...[
+              const SizedBox(height: 25),
+              Row(
+                children: [
+                  const Icon(Icons.warning_rounded, color: Color(0xffCC7900)),
+                  const SizedBox(width: 5),
+                  Text(
+                    'Over-provisioning of ${widget.label.toLowerCase()}',
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ],
               ),
-            ]),
+            ],
           ],
-        ]);
+        );
       },
     );
 
-    return Column(children: [
-      Row(children: [
-        Text(widget.label, style: TextStyle(fontSize: 16)),
-        Spacer(),
-        ConstrainedBox(
-          constraints: BoxConstraints(minWidth: 65),
-          child: IntrinsicWidth(child: textField),
+    return Column(
+      children: [
+        Row(
+          children: [
+            Text(widget.label, style: TextStyle(fontSize: 16)),
+            Spacer(),
+            ConstrainedBox(
+              constraints: BoxConstraints(minWidth: 65),
+              child: IntrinsicWidth(child: textField),
+            ),
+            SizedBox(width: 8),
+            unitDropdown,
+          ],
         ),
-        SizedBox(width: 8),
-        unitDropdown,
-      ]),
-      const SizedBox(height: 25),
-      sliderFormField,
-    ]);
+        const SizedBox(height: 25),
+        sliderFormField,
+      ],
+    );
   }
 }

--- a/src/client/gui/lib/vm_details/mount_points.dart
+++ b/src/client/gui/lib/vm_details/mount_points.dart
@@ -35,9 +35,11 @@ class _EditableMountPointState extends State<EditableMountPoint> {
   @override
   void initState() {
     super.initState();
-    sourceController.addListener(() => setState(() {
-          targetHint = defaultMountTarget(source: sourceController.text);
-        }));
+    sourceController.addListener(
+      () => setState(() {
+        targetHint = defaultMountTarget(source: sourceController.text);
+      }),
+    );
     sourceController.text = widget.initialSource ?? '';
   }
 
@@ -65,32 +67,38 @@ class _EditableMountPointState extends State<EditableMountPoint> {
   Widget build(BuildContext context) {
     final headers = DefaultTextStyle.merge(
       style: const TextStyle(color: Colors.black),
-      child: const Row(children: [
-        Expanded(
-          child: Row(children: [
-            Text('HOST DIRECTORY'),
-            SizedBox(width: 8),
-            Tooltip(
-              message:
-                  'A directory on your local machine that will be shared with the instance',
-              child: Icon(Icons.info_outline, size: 20),
+      child: const Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                Text('HOST DIRECTORY'),
+                SizedBox(width: 8),
+                Tooltip(
+                  message:
+                      'A directory on your local machine that will be shared with the instance',
+                  child: Icon(Icons.info_outline, size: 20),
+                ),
+              ],
             ),
-          ]),
-        ),
-        SizedBox(width: 24),
-        Expanded(
-          child: Row(children: [
-            Text('GUEST DIRECTORY'),
-            SizedBox(width: 8),
-            Tooltip(
-              message:
-                  'A destination inside the instance for the shared directory.\n'
-                  'If the destination directory already exists, its contents will not be visible until unmounting.',
-              child: Icon(Icons.info_outline, size: 20),
+          ),
+          SizedBox(width: 24),
+          Expanded(
+            child: Row(
+              children: [
+                Text('GUEST DIRECTORY'),
+                SizedBox(width: 8),
+                Tooltip(
+                  message:
+                      'A destination inside the instance for the shared directory.\n'
+                      'If the destination directory already exists, its contents will not be visible until unmounting.',
+                  child: Icon(Icons.info_outline, size: 20),
+                ),
+              ],
             ),
-          ]),
-        ),
-      ]),
+          ),
+        ],
+      ),
     );
 
     final sourceField = ClippingTextField(
@@ -105,9 +113,10 @@ class _EditableMountPointState extends State<EditableMountPoint> {
         final chosenSource = sourceController.text;
         final source = await getDirectoryPath(
           confirmButtonText: 'Select',
-          initialDirectory: await Directory(chosenSource).exists()
-              ? chosenSource
-              : mpPlatform.homeDirectory,
+          initialDirectory:
+              await Directory(chosenSource).exists()
+                  ? chosenSource
+                  : mpPlatform.homeDirectory,
         );
         if (source == null) return;
         sourceController.text = source;
@@ -127,21 +136,29 @@ class _EditableMountPointState extends State<EditableMountPoint> {
       },
     );
 
-    return Column(children: [
-      headers,
-      const SizedBox(height: 8),
-      Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        Expanded(
-          child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-            Expanded(child: sourceField),
-            const SizedBox(width: 10),
-            SizedBox(height: 42, child: filePicker),
-          ]),
+    return Column(
+      children: [
+        headers,
+        const SizedBox(height: 8),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(child: sourceField),
+                  const SizedBox(width: 10),
+                  SizedBox(height: 42, child: filePicker),
+                ],
+              ),
+            ),
+            const SizedBox(width: 24),
+            Expanded(child: targetField), // deleteButton,
+          ],
         ),
-        const SizedBox(width: 24),
-        Expanded(child: targetField), // deleteButton,
-      ]),
-    ]);
+      ],
+    );
   }
 }
 
@@ -171,28 +188,23 @@ class MountPointsView extends StatelessWidget {
 
     final headers = DefaultTextStyle.merge(
       style: const TextStyle(color: Colors.black),
-      child: const Row(children: [
-        Expanded(child: Text('HOST DIRECTORY')),
-        SizedBox(width: 24),
-        Expanded(child: Text('GUEST DIRECTORY')),
-      ]),
+      child: const Row(
+        children: [
+          Expanded(child: Text('HOST DIRECTORY')),
+          SizedBox(width: 24),
+          Expanded(child: Text('GUEST DIRECTORY')),
+        ],
+      ),
     );
 
-    const divider = Divider(
-      height: 15,
-      color: Colors.black38,
-    );
+    const divider = Divider(height: 15, color: Colors.black38);
 
-    return Column(children: [
-      if (mounts.isNotEmpty) ...[
-        headers,
-        divider,
+    return Column(
+      children: [
+        if (mounts.isNotEmpty) ...[headers, divider],
+        for (final mount in mounts) ...[buildEntry(mount), divider],
       ],
-      for (final mount in mounts) ...[
-        buildEntry(mount),
-        divider,
-      ],
-    ]);
+    );
   }
 
   Widget buildEntry(MountPaths mount) {
@@ -212,28 +224,32 @@ class MountPointsView extends StatelessWidget {
       style: const TextStyle(fontSize: 16),
       child: SizedBox(
         height: 30,
-        child: Row(children: [
-          Expanded(
-            child: ExtendedText(
-              mount.sourcePath,
-              maxLines: 1,
-              overflowWidget: middleOverflow,
-            ),
-          ),
-          const SizedBox(width: 24),
-          Expanded(
-            child: Row(children: [
-              Expanded(
-                child: ExtendedText(
-                  mount.targetPath,
-                  maxLines: 1,
-                  overflowWidget: middleOverflow,
-                ),
+        child: Row(
+          children: [
+            Expanded(
+              child: ExtendedText(
+                mount.sourcePath,
+                maxLines: 1,
+                overflowWidget: middleOverflow,
               ),
-              if (allowDelete) button,
-            ]),
-          ),
-        ]),
+            ),
+            const SizedBox(width: 24),
+            Expanded(
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ExtendedText(
+                      mount.targetPath,
+                      maxLines: 1,
+                      overflowWidget: middleOverflow,
+                    ),
+                  ),
+                  if (allowDelete) button,
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -286,12 +302,11 @@ class _ClippingTextFieldState extends State<ClippingTextField> {
 
       final clippedTextFormField = FormField<String>(
         validator: (_) => widget.validator?.call(widget.controller.text),
-        builder: (field) => InputDecorator(
-          decoration: InputDecoration(
-            errorText: field.errorText,
-          ),
-          child: clippedText,
-        ),
+        builder:
+            (field) => InputDecorator(
+              decoration: InputDecoration(errorText: field.errorText),
+              child: clippedText,
+            ),
       );
 
       return GestureDetector(

--- a/src/client/gui/lib/vm_details/ram_slider.dart
+++ b/src/client/gui/lib/vm_details/ram_slider.dart
@@ -12,12 +12,8 @@ class RamSlider extends ConsumerWidget {
   final int min;
   final FormFieldSetter<int> onSaved;
 
-  RamSlider({
-    super.key,
-    int? min,
-    this.initialValue,
-    required this.onSaved,
-  }) : min = min ?? 512.mebi;
+  RamSlider({super.key, int? min, this.initialValue, required this.onSaved})
+    : min = min ?? 512.mebi;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/src/client/gui/lib/vm_details/ram_slider.dart
+++ b/src/client/gui/lib/vm_details/ram_slider.dart
@@ -12,7 +12,7 @@ class RamSlider extends ConsumerWidget {
   final int min;
   final FormFieldSetter<int> onSaved;
 
-  const RamSlider({
+  RamSlider({
     super.key,
     int? min,
     this.initialValue,

--- a/src/client/gui/lib/vm_details/spec_input.dart
+++ b/src/client/gui/lib/vm_details/spec_input.dart
@@ -35,36 +35,39 @@ class SpecInput extends StatelessWidget {
   Widget build(BuildContext context) {
     return SizedBox(
       width: width,
-      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        if (label != null) ...[
-          Text(
-            label!,
-            style: const TextStyle(fontSize: 16, color: Colors.black),
-          ),
-          const SizedBox(height: 8),
-        ],
-        TextFormField(
-          autofocus: autofocus,
-          controller: controller,
-          decoration: InputDecoration(
-            hintText: hint,
-            helperText: helper,
-            helperMaxLines: 3,
-            helperStyle: const TextStyle(color: Colors.black),
-            disabledBorder: const OutlineInputBorder(
-              borderSide: BorderSide(color: Colors.black12),
-              borderRadius: BorderRadius.zero,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (label != null) ...[
+            Text(
+              label!,
+              style: const TextStyle(fontSize: 16, color: Colors.black),
             ),
+            const SizedBox(height: 8),
+          ],
+          TextFormField(
+            autofocus: autofocus,
+            controller: controller,
+            decoration: InputDecoration(
+              hintText: hint,
+              helperText: helper,
+              helperMaxLines: 3,
+              helperStyle: const TextStyle(color: Colors.black),
+              disabledBorder: const OutlineInputBorder(
+                borderSide: BorderSide(color: Colors.black12),
+                borderRadius: BorderRadius.zero,
+              ),
+            ),
+            enabled: enabled,
+            focusNode: focusNode,
+            initialValue: initialValue,
+            inputFormatters: inputFormatters,
+            onSaved: onSaved,
+            style: const TextStyle(color: Colors.black),
+            validator: validator,
           ),
-          enabled: enabled,
-          focusNode: focusNode,
-          initialValue: initialValue,
-          inputFormatters: inputFormatters,
-          onSaved: onSaved,
-          style: const TextStyle(color: Colors.black),
-          validator: validator,
-        ),
-      ]),
+        ],
+      ),
     );
   }
 }

--- a/src/client/gui/lib/vm_details/terminal.dart
+++ b/src/client/gui/lib/vm_details/terminal.dart
@@ -234,11 +234,11 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
   final buttonStyle = ButtonStyle(
     foregroundColor: WidgetStateColor.resolveWith((states) {
       final disabled = states.contains(WidgetState.disabled);
-      return Colors.white.withOpacity(disabled ? 0.5 : 1.0);
+      return Colors.white.withAlpha(disabled ? 128 : 255);
     }),
     side: WidgetStateBorderSide.resolveWith((states) {
       final disabled = states.contains(WidgetState.disabled);
-      var color = Colors.white.withOpacity(disabled ? 0.5 : 1.0);
+      var color = Colors.white.withAlpha(disabled ? 128 : 255);
       return BorderSide(color: color);
     }),
   );

--- a/src/client/gui/lib/vm_details/terminal.dart
+++ b/src/client/gui/lib/vm_details/terminal.dart
@@ -18,8 +18,10 @@ import '../platform/platform.dart';
 import '../providers.dart';
 import '../vm_action.dart';
 
-final runningShellsProvider =
-    StateProvider.autoDispose.family<int, String>((_, __) {
+final runningShellsProvider = StateProvider.autoDispose.family<int, String>((
+  _,
+  __,
+) {
   return 0;
 });
 
@@ -146,19 +148,15 @@ class TerminalNotifier
 
 final terminalProvider = NotifierProvider.autoDispose
     .family<TerminalNotifier, Terminal?, TerminalIdentifier>(
-        TerminalNotifier.new);
+      TerminalNotifier.new,
+    );
 
 class VmTerminal extends ConsumerStatefulWidget {
   final String name;
   final ShellId id;
   final bool isCurrent;
 
-  const VmTerminal(
-    this.name,
-    this.id, {
-    super.key,
-    this.isCurrent = false,
-  });
+  const VmTerminal(this.name, this.id, {super.key, this.isCurrent = false});
 
   @override
   ConsumerState<VmTerminal> createState() => _VmTerminalState();
@@ -215,7 +213,9 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
     final name = widget.name;
     final action = VmAction.start;
     final operation = ref.read(grpcClientProvider).start([name]);
-    ref.read(notificationsProvider.notifier).addOperation(
+    ref
+        .read(notificationsProvider.notifier)
+        .addOperation(
           operation,
           loading: '${action.continuousTense} $name',
           onSuccess: (_) => '${action.pastTense} $name',
@@ -275,10 +275,7 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
         label: 'Copy',
         onPressed: () {
           ContextMenuController.removeAny();
-          Actions.maybeInvoke(
-            context,
-            CopySelectionTextIntent.copy,
-          );
+          Actions.maybeInvoke(context, CopySelectionTextIntent.copy);
         },
       ),
       ContextMenuButtonItem(
@@ -294,30 +291,33 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
     ];
 
     final style = Theme.of(context).textButtonTheme.style?.copyWith(
-          backgroundColor: WidgetStatePropertyAll(Colors.transparent),
-        );
+      backgroundColor: WidgetStatePropertyAll(Colors.transparent),
+    );
 
     contextMenuController.show(
       context: context,
-      contextMenuBuilder: (_) => TapRegion(
-        onTapOutside: (_) => ContextMenuController.removeAny(),
-        child: TextButtonTheme(
-          data: TextButtonThemeData(style: style),
-          child: AdaptiveTextSelectionToolbar.buttonItems(
-            anchors: TextSelectionToolbarAnchors(primaryAnchor: offset),
-            buttonItems: buttonItems,
+      contextMenuBuilder:
+          (_) => TapRegion(
+            onTapOutside: (_) => ContextMenuController.removeAny(),
+            child: TextButtonTheme(
+              data: TextButtonThemeData(style: style),
+              child: AdaptiveTextSelectionToolbar.buttonItems(
+                anchors: TextSelectionToolbarAnchors(primaryAnchor: offset),
+                buttonItems: buttonItems,
+              ),
+            ),
           ),
-        ),
-      ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
     final terminal = ref.watch(terminalProvider(terminalIdentifier));
-    final vmStatus = ref.watch(vmInfoProvider(widget.name).select((info) {
-      return info.instanceStatus.status;
-    }));
+    final vmStatus = ref.watch(
+      vmInfoProvider(widget.name).select((info) {
+        return info.instanceStatus.status;
+      }),
+    );
     final vmRunning = vmStatus == Status.RUNNING;
     final canStartVm = [Status.STOPPED, Status.SUSPENDED].contains(vmStatus);
 
@@ -334,9 +334,11 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
             const SizedBox(height: 12),
             OutlinedButton(
               style: buttonStyle,
-              onPressed: canStartVm || vmRunning
-                  ? () => startVmIfNeeded(vmRunning).then((_) => openShell())
-                  : null,
+              onPressed:
+                  canStartVm || vmRunning
+                      ? () =>
+                          startVmIfNeeded(vmRunning).then((_) => openShell())
+                      : null,
               child: const Text('Open shell'),
             ),
             const SizedBox(height: 32),
@@ -347,24 +349,27 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
 
     // we need a builder so that we introduce a new BuildContext that will end up
     // being below the BuildContext of the Actions widget so that the events can propagate
-    final terminalView = Builder(builder: (context) {
-      return TerminalView(
-        terminal,
-        controller: terminalController,
-        focusNode: focusNode,
-        hardwareKeyboardOnly: true,
-        onSecondaryTapUp: (d, _) => openContextMenu(d.globalPosition, context),
-        padding: const EdgeInsets.all(4),
-        scrollController: scrollController,
-        shortcuts: mpPlatform.terminalShortcuts,
-        theme: terminalTheme,
-        textStyle: TerminalStyle(
-          fontFamily: 'UbuntuMono',
-          fontFamilyFallback: ['NotoColorEmoji', 'FreeSans'],
-          fontSize: fontSize,
-        ),
-      );
-    });
+    final terminalView = Builder(
+      builder: (context) {
+        return TerminalView(
+          terminal,
+          controller: terminalController,
+          focusNode: focusNode,
+          hardwareKeyboardOnly: true,
+          onSecondaryTapUp:
+              (d, _) => openContextMenu(d.globalPosition, context),
+          padding: const EdgeInsets.all(4),
+          scrollController: scrollController,
+          shortcuts: mpPlatform.terminalShortcuts,
+          theme: terminalTheme,
+          textStyle: TerminalStyle(
+            fontFamily: 'UbuntuMono',
+            fontFamilyFallback: ['NotoColorEmoji', 'FreeSans'],
+            fontSize: fontSize,
+          ),
+        );
+      },
+    );
 
     final scrollableTerminal = RawScrollbar(
       controller: scrollController,
@@ -374,14 +379,16 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
 
     final terminalActions = {
       IncreaseTerminalFontIntent: CallbackAction<IncreaseTerminalFontIntent>(
-        onInvoke: (_) => setState(() {
-          fontSize = min(fontSize + fontSizeStep, maxFontSize);
-        }),
+        onInvoke:
+            (_) => setState(() {
+              fontSize = min(fontSize + fontSizeStep, maxFontSize);
+            }),
       ),
       DecreaseTerminalFontIntent: CallbackAction<DecreaseTerminalFontIntent>(
-        onInvoke: (_) => setState(() {
-          fontSize = max(fontSize - fontSizeStep, minFontSize);
-        }),
+        onInvoke:
+            (_) => setState(() {
+              fontSize = max(fontSize - fontSizeStep, minFontSize);
+            }),
       ),
       ResetTerminalFontIntent: CallbackAction<ResetTerminalFontIntent>(
         onInvoke: (_) => setState(() => fontSize = defaultFontSize),
@@ -407,10 +414,7 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
       ),
     };
 
-    return Actions(
-      actions: terminalActions,
-      child: scrollableTerminal,
-    );
+    return Actions(actions: terminalActions, child: scrollableTerminal);
   }
 }
 

--- a/src/client/gui/lib/vm_details/terminal_tabs.dart
+++ b/src/client/gui/lib/vm_details/terminal_tabs.dart
@@ -10,11 +10,12 @@ import '../close_terminal_dialog.dart';
 import '../providers.dart';
 import 'terminal.dart';
 
-typedef ShellIds = ({
-  BuiltList<ShellId> ids,
-// this is the index of the currently selected shell id
-  int currentIndex,
-});
+typedef ShellIds =
+    ({
+      BuiltList<ShellId> ids,
+      // this is the index of the currently selected shell id
+      int currentIndex,
+    });
 
 class ShellIdsNotifier extends AutoDisposeFamilyNotifier<ShellIds, String> {
   @override
@@ -106,11 +107,12 @@ class Tab extends StatelessWidget {
 
     final decoration = BoxDecoration(
       color: Color(selected ? 0xff2B2B2B : 0xff222222),
-      border: selected
-          ? const Border(
-              bottom: BorderSide(color: Color(0xffE95420), width: 2.5),
-            )
-          : null,
+      border:
+          selected
+              ? const Border(
+                bottom: BorderSide(color: Color(0xffE95420), width: 2.5),
+              )
+              : null,
     );
 
     return GestureDetector(
@@ -118,11 +120,9 @@ class Tab extends StatelessWidget {
       child: Container(
         width: 190,
         decoration: decoration,
-        child: Row(children: [
-          ubuntuIcon,
-          Expanded(child: tabTitle),
-          closeButton,
-        ]),
+        child: Row(
+          children: [ubuntuIcon, Expanded(child: tabTitle), closeButton],
+        ),
       ),
     );
   }
@@ -140,52 +140,56 @@ class TerminalTabs extends ConsumerWidget {
     final (:ids, :currentIndex) = ref.watch(provider);
     final askTerminalCloseProvider = guiSettingProvider(askTerminalCloseKey);
 
-    final tabsAndShells = ids.mapIndexed((index, shellId) {
-      final tab = ReorderableDragStartListener(
-        key: ValueKey(shellId.id),
-        index: index,
-        child: Tab(
-          title: 'Shell ${shellId.id}',
-          selected: index == currentIndex,
-          onTap: () => ref.read(notifier).setCurrent(index),
-          onClose: () {
-            final ask = ref.read(askTerminalCloseProvider.select((ask) {
-              return ask?.toBoolOption.toNullable() ?? true;
-            }));
-            final terminalKey = (vmName: name, shellId: shellId);
-            if (!ask || ref.read(terminalProvider(terminalKey)) == null) {
-              ref.read(notifier).remove(index);
-              return;
-            }
-            showDialog(
-              context: context,
-              barrierDismissible: false,
-              builder: (context) {
-                return CloseTerminalDialog(
-                  onYes: () {
-                    Navigator.pop(context);
-                    ref.read(notifier).remove(index);
+    final tabsAndShells =
+        ids.mapIndexed((index, shellId) {
+          final tab = ReorderableDragStartListener(
+            key: ValueKey(shellId.id),
+            index: index,
+            child: Tab(
+              title: 'Shell ${shellId.id}',
+              selected: index == currentIndex,
+              onTap: () => ref.read(notifier).setCurrent(index),
+              onClose: () {
+                final ask = ref.read(
+                  askTerminalCloseProvider.select((ask) {
+                    return ask?.toBoolOption.toNullable() ?? true;
+                  }),
+                );
+                final terminalKey = (vmName: name, shellId: shellId);
+                if (!ask || ref.read(terminalProvider(terminalKey)) == null) {
+                  ref.read(notifier).remove(index);
+                  return;
+                }
+                showDialog(
+                  context: context,
+                  barrierDismissible: false,
+                  builder: (context) {
+                    return CloseTerminalDialog(
+                      onYes: () {
+                        Navigator.pop(context);
+                        ref.read(notifier).remove(index);
+                      },
+                      onNo: () => Navigator.pop(context),
+                      onDoNotAsk:
+                          (doNotAsk) => ref
+                              .read(askTerminalCloseProvider.notifier)
+                              .set('${!doNotAsk}'),
+                    );
                   },
-                  onNo: () => Navigator.pop(context),
-                  onDoNotAsk: (doNotAsk) => ref
-                      .read(askTerminalCloseProvider.notifier)
-                      .set('${!doNotAsk}'),
                 );
               },
-            );
-          },
-        ),
-      );
+            ),
+          );
 
-      final shell = VmTerminal(
-        key: GlobalObjectKey(shellId),
-        name,
-        shellId,
-        isCurrent: index == currentIndex,
-      );
+          final shell = VmTerminal(
+            key: GlobalObjectKey(shellId),
+            name,
+            shellId,
+            isCurrent: index == currentIndex,
+          );
 
-      return (tab: tab, shell: shell);
-    }).toList();
+          return (tab: tab, shell: shell);
+        }).toList();
 
     final addShellButton = Material(
       color: Colors.transparent,
@@ -216,13 +220,11 @@ class TerminalTabs extends ConsumerWidget {
       ),
     );
 
-    return Column(children: [
-      Container(
-        color: const Color(0xff222222),
-        height: 35,
-        child: tabList,
-      ),
-      Expanded(child: shellStack),
-    ]);
+    return Column(
+      children: [
+        Container(color: const Color(0xff222222), height: 35, child: tabList),
+        Expanded(child: shellStack),
+      ],
+    );
   }
 }

--- a/src/client/gui/lib/vm_details/vm_action_buttons.dart
+++ b/src/client/gui/lib/vm_details/vm_action_buttons.dart
@@ -39,10 +39,11 @@ class VmActionButtons extends ConsumerWidget {
         showDialog(
           context: context,
           barrierDismissible: false,
-          builder: (_) => DeleteInstanceDialog(
-            multiple: false,
-            onDelete: () => wrapInNotification(client.purge)(action),
-          ),
+          builder:
+              (_) => DeleteInstanceDialog(
+                multiple: false,
+                onDelete: () => wrapInNotification(client.purge)(action),
+              ),
         );
       },
     };
@@ -88,9 +89,11 @@ class ActionTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final enabled = ref.watch(vmInfoProvider(name).select((info) {
-      return action.allowedStatuses.contains(info.instanceStatus.status);
-    }));
+    final enabled = ref.watch(
+      vmInfoProvider(name).select((info) {
+        return action.allowedStatuses.contains(info.instanceStatus.status);
+      }),
+    );
 
     return ListTile(
       enabled: enabled,

--- a/src/client/gui/lib/vm_details/vm_details.dart
+++ b/src/client/gui/lib/vm_details/vm_details.dart
@@ -10,30 +10,30 @@ import 'vm_details_resources.dart';
 
 enum VmDetailsLocation { shells, details }
 
-final vmScreenLocationProvider =
-    StateProvider.autoDispose.family<VmDetailsLocation, String>((_, __) {
-  return VmDetailsLocation.shells;
-});
+final vmScreenLocationProvider = StateProvider.autoDispose
+    .family<VmDetailsLocation, String>((_, __) {
+      return VmDetailsLocation.shells;
+    });
 
 enum ActiveEditPage { resources, bridge, mounts }
 
-final activeEditPageProvider =
-    StateProvider.autoDispose.family<ActiveEditPage?, String>((ref, name) {
-  ref.listen(
-    vmInfoProvider(name).select((info) => info.instanceStatus.status),
-    (_, status) {
-      final isBridgeOrResources = [
-        ActiveEditPage.bridge,
-        ActiveEditPage.resources,
-      ].contains(ref.controller.state);
+final activeEditPageProvider = StateProvider.autoDispose
+    .family<ActiveEditPage?, String>((ref, name) {
+      ref.listen(
+        vmInfoProvider(name).select((info) => info.instanceStatus.status),
+        (_, status) {
+          final isBridgeOrResources = [
+            ActiveEditPage.bridge,
+            ActiveEditPage.resources,
+          ].contains(ref.controller.state);
 
-      if (isBridgeOrResources && status != Status.STOPPED) {
-        ref.invalidateSelf();
-      }
-    },
-  );
-  return null;
-});
+          if (isBridgeOrResources && status != Status.STOPPED) {
+            ref.invalidateSelf();
+          }
+        },
+      );
+      return null;
+    });
 
 class VmDetailsScreen extends ConsumerWidget {
   final String name;
@@ -45,22 +45,27 @@ class VmDetailsScreen extends ConsumerWidget {
     final location = ref.watch(vmScreenLocationProvider(name));
 
     return Scaffold(
-      body: Column(children: [
-        VmDetailsHeader(name),
-        Expanded(
-          child: Stack(fit: StackFit.expand, children: [
-            Visibility(
-              visible: location == VmDetailsLocation.shells,
-              maintainState: true,
-              child: TerminalTabs(name),
+      body: Column(
+        children: [
+          VmDetailsHeader(name),
+          Expanded(
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                Visibility(
+                  visible: location == VmDetailsLocation.shells,
+                  maintainState: true,
+                  child: TerminalTabs(name),
+                ),
+                Visibility(
+                  visible: location == VmDetailsLocation.details,
+                  child: VmDetails(name),
+                ),
+              ],
             ),
-            Visibility(
-              visible: location == VmDetailsLocation.details,
-              child: VmDetails(name),
-            ),
-          ]),
-        ),
-      ]),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -77,31 +82,34 @@ class VmDetails extends ConsumerWidget {
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(20),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          DisableSection(
-            active: activeEditPage,
-            letEnabledFor: const [],
-            child: GeneralDetails(name),
-          ),
-          const Divider(height: 60),
-          DisableSection(
-            active: activeEditPage,
-            letEnabledFor: const [ActiveEditPage.resources],
-            child: ResourcesDetails(name),
-          ),
-          const Divider(height: 60),
-          DisableSection(
-            active: activeEditPage,
-            letEnabledFor: const [ActiveEditPage.bridge],
-            child: BridgedDetails(name),
-          ),
-          const Divider(height: 60),
-          DisableSection(
-            active: activeEditPage,
-            letEnabledFor: const [ActiveEditPage.mounts],
-            child: MountDetails(name),
-          ),
-        ]),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            DisableSection(
+              active: activeEditPage,
+              letEnabledFor: const [],
+              child: GeneralDetails(name),
+            ),
+            const Divider(height: 60),
+            DisableSection(
+              active: activeEditPage,
+              letEnabledFor: const [ActiveEditPage.resources],
+              child: ResourcesDetails(name),
+            ),
+            const Divider(height: 60),
+            DisableSection(
+              active: activeEditPage,
+              letEnabledFor: const [ActiveEditPage.bridge],
+              child: BridgedDetails(name),
+            ),
+            const Divider(height: 60),
+            DisableSection(
+              active: activeEditPage,
+              letEnabledFor: const [ActiveEditPage.mounts],
+              child: MountDetails(name),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -124,10 +132,7 @@ class DisableSection extends StatelessWidget {
     final disabled = active != null && !letEnabledFor.contains(active);
     return IgnorePointer(
       ignoring: disabled,
-      child: Opacity(
-        opacity: disabled ? 0.5 : 1.0,
-        child: child,
-      ),
+      child: Opacity(opacity: disabled ? 0.5 : 1.0, child: child),
     );
   }
 }

--- a/src/client/gui/lib/vm_details/vm_details_bridge.dart
+++ b/src/client/gui/lib/vm_details/vm_details_bridge.dart
@@ -30,12 +30,16 @@ class _BridgedDetailsState extends ConsumerState<BridgedDetails> {
   Widget build(BuildContext context) {
     final networks = ref.watch(networksProvider);
     final bridgedNetworkSetting = ref.watch(bridgedNetworkProvider).valueOrNull;
-    final bridged = ref.watch(bridgedProvider.select((value) {
-      return value.valueOrNull?.toBoolOption.toNullable();
-    }));
-    final stopped = ref.watch(vmInfoProvider(widget.name).select((info) {
-      return info.instanceStatus.status == Status.STOPPED;
-    }));
+    final bridged = ref.watch(
+      bridgedProvider.select((value) {
+        return value.valueOrNull?.toBoolOption.toNullable();
+      }),
+    );
+    final stopped = ref.watch(
+      vmInfoProvider(widget.name).select((info) {
+        return info.instanceStatus.status == Status.STOPPED;
+      }),
+    );
 
     if (!stopped) editing = false;
 
@@ -44,16 +48,20 @@ class _BridgedDetailsState extends ConsumerState<BridgedDetails> {
       initialValue: bridged ?? false,
       onSaved: (value) {
         if (value!) {
-          ref.read(bridgedProvider.notifier).set(value.toString()).onError(
+          ref
+              .read(bridgedProvider.notifier)
+              .set(value.toString())
+              .onError(
                 ref.notifyError((e) => 'Failed to set bridged network: $e'),
               );
         }
       },
       builder: (field) {
         final validBridgedNetwork = networks.contains(bridgedNetworkSetting);
-        final message = networks.isEmpty
-            ? 'No networks found.'
-            : validBridgedNetwork
+        final message =
+            networks.isEmpty
+                ? 'No networks found.'
+                : validBridgedNetwork
                 ? "Once established, you won't be able to unset the connection."
                 : 'No valid bridged network is set.';
 
@@ -108,28 +116,27 @@ class _BridgedDetailsState extends ConsumerState<BridgedDetails> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(children: [
-            const SizedBox(
-              height: 50,
-              child: Text('Bridged network', style: TextStyle(fontSize: 24)),
-            ),
-            const Spacer(),
-            if (editing)
-              cancelButton
-            else if (!(bridged ?? false))
-              configureButton,
-          ]),
+          Row(
+            children: [
+              const SizedBox(
+                height: 50,
+                child: Text('Bridged network', style: TextStyle(fontSize: 24)),
+              ),
+              const Spacer(),
+              if (editing)
+                cancelButton
+              else if (!(bridged ?? false))
+                configureButton,
+            ],
+          ),
           editing
               ? SizedBox(width: 300, child: bridgedCheckbox)
               : Text(
-                  'Status: ${bridged ?? false ? '' : 'not'} connected',
-                  style: const TextStyle(fontSize: 16),
-                ),
+                'Status: ${bridged ?? false ? '' : 'not'} connected',
+                style: const TextStyle(fontSize: 16),
+              ),
           if (editing)
-            Padding(
-              padding: const EdgeInsets.only(top: 16),
-              child: saveButton,
-            ),
+            Padding(padding: const EdgeInsets.only(top: 16), child: saveButton),
         ],
       ),
     );

--- a/src/client/gui/lib/vm_details/vm_details_general.dart
+++ b/src/client/gui/lib/vm_details/vm_details_general.dart
@@ -6,7 +6,6 @@ import 'package:intl/intl.dart';
 import '../copyable_text.dart';
 import '../extensions.dart';
 import '../providers.dart';
-import '../tooltip.dart';
 import 'cpu_sparkline.dart';
 import 'memory_usage.dart';
 import 'vm_action_buttons.dart';

--- a/src/client/gui/lib/vm_details/vm_details_general.dart
+++ b/src/client/gui/lib/vm_details/vm_details_general.dart
@@ -54,12 +54,12 @@ class VmDetailsHeader extends ConsumerWidget {
 
     OutlinedButton locationButton(VmDetailsLocation location) {
       final style = buttonStyle?.copyWith(
-        shape: const MaterialStatePropertyAll(RoundedRectangleBorder()),
+        shape: const WidgetStatePropertyAll(RoundedRectangleBorder()),
         backgroundColor: location == currentLocation
-            ? const MaterialStatePropertyAll(Color(0xff333333))
+            ? const WidgetStatePropertyAll(Color(0xff333333))
             : null,
         foregroundColor: location == currentLocation
-            ? const MaterialStatePropertyAll(Colors.white)
+            ? const WidgetStatePropertyAll(Colors.white)
             : null,
       );
       return OutlinedButton(

--- a/src/client/gui/lib/vm_details/vm_details_general.dart
+++ b/src/client/gui/lib/vm_details/vm_details_general.dart
@@ -54,12 +54,14 @@ class VmDetailsHeader extends ConsumerWidget {
     OutlinedButton locationButton(VmDetailsLocation location) {
       final style = buttonStyle?.copyWith(
         shape: const WidgetStatePropertyAll(RoundedRectangleBorder()),
-        backgroundColor: location == currentLocation
-            ? const WidgetStatePropertyAll(Color(0xff333333))
-            : null,
-        foregroundColor: location == currentLocation
-            ? const WidgetStatePropertyAll(Colors.white)
-            : null,
+        backgroundColor:
+            location == currentLocation
+                ? const WidgetStatePropertyAll(Color(0xff333333))
+                : null,
+        foregroundColor:
+            location == currentLocation
+                ? const WidgetStatePropertyAll(Colors.white)
+                : null,
       );
       return OutlinedButton(
         style: style,
@@ -70,10 +72,13 @@ class VmDetailsHeader extends ConsumerWidget {
       );
     }
 
-    final locationButtons = Row(mainAxisSize: MainAxisSize.min, children: [
-      locationButton(VmDetailsLocation.shells),
-      locationButton(VmDetailsLocation.details),
-    ]);
+    final locationButtons = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        locationButton(VmDetailsLocation.shells),
+        locationButton(VmDetailsLocation.details),
+      ],
+    );
 
     final list = [
       Expanded(
@@ -116,13 +121,16 @@ class VmStat extends StatelessWidget {
     return SizedBox(
       width: textScaler.scale(width),
       height: textScaler.scale(height),
-      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-        Text(
-          label,
-          style: const TextStyle(fontSize: 10, fontWeight: FontWeight.bold),
-        ),
-        Expanded(child: Align(alignment: Alignment.centerLeft, child: child)),
-      ]),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(fontSize: 10, fontWeight: FontWeight.bold),
+          ),
+          Expanded(child: Align(alignment: Alignment.centerLeft, child: child)),
+        ],
+      ),
     );
   }
 }
@@ -171,8 +179,9 @@ class GeneralDetails extends ConsumerWidget {
       height: baseVmStatHeight,
       label: 'CREATED',
       child: CopyableText(
-        DateFormat('yyyy-MM-dd HH:mm:ss')
-            .format(info.instanceInfo.creationTimestamp.toDateTime()),
+        DateFormat(
+          'yyyy-MM-dd HH:mm:ss',
+        ).format(info.instanceInfo.creationTimestamp.toDateTime()),
       ),
     );
 
@@ -191,14 +200,11 @@ class GeneralDetails extends ConsumerWidget {
           height: baseVmStatHeight,
           child: Text('General', style: TextStyle(fontSize: 24)),
         ),
-        Wrap(spacing: 50, runSpacing: 25, children: [
-          status,
-          image,
-          privateIp,
-          publicIp,
-          created,
-          uptime,
-        ]),
+        Wrap(
+          spacing: 50,
+          runSpacing: 25,
+          children: [status, image, privateIp, publicIp, created, uptime],
+        ),
       ],
     );
   }

--- a/src/client/gui/lib/vm_details/vm_details_mounts.dart
+++ b/src/client/gui/lib/vm_details/vm_details_mounts.dart
@@ -27,9 +27,11 @@ class _MountDetailsState extends ConsumerState<MountDetails> {
 
   @override
   Widget build(BuildContext context) {
-    final mounts = ref.watch(vmInfoProvider(widget.name).select((info) {
-      return info.mountInfo.mountPaths.build();
-    }));
+    final mounts = ref.watch(
+      vmInfoProvider(widget.name).select((info) {
+        return info.mountInfo.mountPaths.build();
+      }),
+    );
 
     final mountPointsView = MountPointsView(
       mounts: mounts,
@@ -39,9 +41,10 @@ class _MountDetailsState extends ConsumerState<MountDetails> {
 
     final editableMountPoint = EditableMountPoint(
       existingTargets: mounts.map((m) => m.targetPath).toList(),
-      initialSource: mounts.any((m) => m.sourcePath == mpPlatform.homeDirectory)
-          ? null
-          : mpPlatform.homeDirectory,
+      initialSource:
+          mounts.any((m) => m.sourcePath == mpPlatform.homeDirectory)
+              ? null
+              : mpPlatform.homeDirectory,
       onSaved: doMount,
     );
 
@@ -79,9 +82,10 @@ class _MountDetailsState extends ConsumerState<MountDetails> {
       child: const Text('Add mount'),
     );
 
-    final topRightButton = phase == MountDetailsPhase.idle
-        ? (mounts.isEmpty ? addMountButton : configureButton)
-        : cancelButton;
+    final topRightButton =
+        phase == MountDetailsPhase.idle
+            ? (mounts.isEmpty ? addMountButton : configureButton)
+            : cancelButton;
 
     return Form(
       key: formKey,
@@ -89,23 +93,22 @@ class _MountDetailsState extends ConsumerState<MountDetails> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(children: [
-            const SizedBox(
-              height: 50,
-              child: Text('Mounts', style: TextStyle(fontSize: 24)),
-            ),
-            const Spacer(),
-            topRightButton,
-          ]),
+          Row(
+            children: [
+              const SizedBox(
+                height: 50,
+                child: Text('Mounts', style: TextStyle(fontSize: 24)),
+              ),
+              const Spacer(),
+              topRightButton,
+            ],
+          ),
           mountPointsView,
           const SizedBox(height: 20),
           if (phase == MountDetailsPhase.configure) addMountButton,
           if (phase == MountDetailsPhase.adding) ...[
             editableMountPoint,
-            Padding(
-              padding: const EdgeInsets.only(top: 16),
-              child: saveButton,
-            ),
+            Padding(padding: const EdgeInsets.only(top: 16), child: saveButton),
           ],
         ],
       ),
@@ -137,28 +140,31 @@ class _MountDetailsState extends ConsumerState<MountDetails> {
     showDialog(
       context: context,
       barrierDismissible: false,
-      builder: (context) => ConfirmationDialog(
-        title: 'Delete mount',
-        body: Text.rich([
-          'Are you sure you want to remove the mount\n'.span,
-          '${mountPaths.sourcePath} ⭢ $target'.span.font('UbuntuMono'),
-          ' from ${widget.name}?'.span,
-        ].spans),
-        actionText: 'Delete',
-        onAction: () {
-          Navigator.pop(context);
-          notificationsNotifier.addOperation(
-            grpcClient.umount(widget.name, target),
-            loading: "Unmounting '$target' from ${widget.name}",
-            onSuccess: (_) => "Unmounted '$target' from ${widget.name}",
-            onError: (error) {
-              return "Failed to unmount '$target' from ${widget.name}: $error";
+      builder:
+          (context) => ConfirmationDialog(
+            title: 'Delete mount',
+            body: Text.rich(
+              [
+                'Are you sure you want to remove the mount\n'.span,
+                '${mountPaths.sourcePath} ⭢ $target'.span.font('UbuntuMono'),
+                ' from ${widget.name}?'.span,
+              ].spans,
+            ),
+            actionText: 'Delete',
+            onAction: () {
+              Navigator.pop(context);
+              notificationsNotifier.addOperation(
+                grpcClient.umount(widget.name, target),
+                loading: "Unmounting '$target' from ${widget.name}",
+                onSuccess: (_) => "Unmounted '$target' from ${widget.name}",
+                onError: (error) {
+                  return "Failed to unmount '$target' from ${widget.name}: $error";
+                },
+              );
             },
-          );
-        },
-        inactionText: 'Cancel',
-        onInaction: () => Navigator.pop(context),
-      ),
+            inactionText: 'Cancel',
+            onInaction: () => Navigator.pop(context),
+          ),
     );
   }
 }

--- a/src/client/gui/lib/vm_details/vm_details_resources.dart
+++ b/src/client/gui/lib/vm_details/vm_details_resources.dart
@@ -42,57 +42,74 @@ class _ResourcesDetailsState extends ConsumerState<ResourcesDetails> {
     final cpus = ref.watch(cpusProvider).whenOrNull(data: int.tryParse);
     final ram = ref.watch(ramProvider).whenOrNull(data: memoryInBytes);
     final disk = ref.watch(diskProvider).whenOrNull(data: memoryInBytes);
-    final stopped = ref.watch(vmInfoProvider(widget.name).select((info) {
-      return info.instanceStatus.status == Status.STOPPED;
-    }));
+    final stopped = ref.watch(
+      vmInfoProvider(widget.name).select((info) {
+        return info.instanceStatus.status == Status.STOPPED;
+      }),
+    );
 
     if (!stopped) editing = false;
 
-    final cpusResource = !editing
-        ? Text(
-            'CPUs ${cpus?.toString() ?? '…'}',
-            style: TextStyle(fontSize: 16),
-          )
-        : CpusSlider(
-            key: Key('cpus-$cpus'),
-            initialValue: cpus,
-            onSaved: (value) {
-              if (value == null || value == cpus) return;
-              ref.read(cpusProvider.notifier).set('$value').onError(
-                  ref.notifyError((error) => 'Failed to set CPUs : $error'));
-            },
-          );
+    final cpusResource =
+        !editing
+            ? Text(
+              'CPUs ${cpus?.toString() ?? '…'}',
+              style: TextStyle(fontSize: 16),
+            )
+            : CpusSlider(
+              key: Key('cpus-$cpus'),
+              initialValue: cpus,
+              onSaved: (value) {
+                if (value == null || value == cpus) return;
+                ref
+                    .read(cpusProvider.notifier)
+                    .set('$value')
+                    .onError(
+                      ref.notifyError((error) => 'Failed to set CPUs : $error'),
+                    );
+              },
+            );
 
-    final ramResource = !editing
-        ? Text(
-            'Memory ${ram.map(humanReadableMemory) ?? '…'}',
-            style: TextStyle(fontSize: 16),
-          )
-        : RamSlider(
-            key: Key('ram-$ram'),
-            initialValue: ram,
-            onSaved: (value) {
-              if (value == null || value == ram) return;
-              ref.read(ramProvider.notifier).set('${value}B').onError(
-                  ref.notifyError((e) => 'Failed to set memory size: $e'));
-            },
-          );
+    final ramResource =
+        !editing
+            ? Text(
+              'Memory ${ram.map(humanReadableMemory) ?? '…'}',
+              style: TextStyle(fontSize: 16),
+            )
+            : RamSlider(
+              key: Key('ram-$ram'),
+              initialValue: ram,
+              onSaved: (value) {
+                if (value == null || value == ram) return;
+                ref
+                    .read(ramProvider.notifier)
+                    .set('${value}B')
+                    .onError(
+                      ref.notifyError((e) => 'Failed to set memory size: $e'),
+                    );
+              },
+            );
 
-    final diskResource = !editing
-        ? Text(
-            'Disk ${disk.map(humanReadableMemory) ?? '…'}',
-            style: TextStyle(fontSize: 16),
-          )
-        : DiskSlider(
-            key: Key('disk-$disk'),
-            min: disk,
-            initialValue: disk,
-            onSaved: (value) {
-              if (value == null || value == disk) return;
-              ref.read(diskProvider.notifier).set('${value}B').onError(
-                  ref.notifyError((e) => 'Failed to set disk size: $e'));
-            },
-          );
+    final diskResource =
+        !editing
+            ? Text(
+              'Disk ${disk.map(humanReadableMemory) ?? '…'}',
+              style: TextStyle(fontSize: 16),
+            )
+            : DiskSlider(
+              key: Key('disk-$disk'),
+              min: disk,
+              initialValue: disk,
+              onSaved: (value) {
+                if (value == null || value == disk) return;
+                ref
+                    .read(diskProvider.notifier)
+                    .set('${value}B')
+                    .onError(
+                      ref.notifyError((e) => 'Failed to set disk size: $e'),
+                    );
+              },
+            );
 
     final saveButton = TextButton(
       onPressed: () {
@@ -135,27 +152,29 @@ class _ResourcesDetailsState extends ConsumerState<ResourcesDetails> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(children: [
-            const SizedBox(
-              height: 50,
-              child: Text('Resources', style: TextStyle(fontSize: 24)),
-            ),
-            const Spacer(),
-            editing ? cancelButton : configureButton,
-          ]),
+          Row(
+            children: [
+              const SizedBox(
+                height: 50,
+                child: Text('Resources', style: TextStyle(fontSize: 24)),
+              ),
+              const Spacer(),
+              editing ? cancelButton : configureButton,
+            ],
+          ),
           const SizedBox(height: 10),
-          Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
-            Expanded(child: cpusResource),
-            const SizedBox(width: 86),
-            Expanded(child: ramResource),
-            const SizedBox(width: 86),
-            Expanded(child: diskResource),
-          ]),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(child: cpusResource),
+              const SizedBox(width: 86),
+              Expanded(child: ramResource),
+              const SizedBox(width: 86),
+              Expanded(child: diskResource),
+            ],
+          ),
           if (editing)
-            Padding(
-              padding: const EdgeInsets.only(top: 16),
-              child: saveButton,
-            ),
+            Padding(padding: const EdgeInsets.only(top: 16), child: saveButton),
         ],
       ),
     );

--- a/src/client/gui/lib/vm_details/vm_status_icon.dart
+++ b/src/client/gui/lib/vm_details/vm_status_icon.dart
@@ -13,8 +13,11 @@ const icons = {
   Status.STARTING: Icon(Icons.more_horiz, color: Color(0xff757575), size: 15),
   Status.SUSPENDING: Icon(Icons.more_horiz, color: Color(0xff757575), size: 15),
   Status.DELETED: Icon(Icons.close, color: Colors.redAccent, size: 15),
-  Status.DELAYED_SHUTDOWN:
-      Icon(Icons.circle, color: Color(0xff0C8420), size: 10),
+  Status.DELAYED_SHUTDOWN: Icon(
+    Icons.circle,
+    color: Color(0xff0C8420),
+    size: 10,
+  ),
 };
 
 class VmStatusIcon extends StatelessWidget {
@@ -25,30 +28,37 @@ class VmStatusIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final statusName = !isLaunching
-        ? status.name.toLowerCase().replaceAll('_', ' ')
-        : 'launching';
+    final statusName =
+        !isLaunching
+            ? status.name.toLowerCase().replaceAll('_', ' ')
+            : 'launching';
 
-    final icon = !isLaunching
-        ? icons[status] ?? unknownIcon
-        : SizedBox(
-            width: 10,
-            height: 10,
-            child: FittedBox(
-              fit: BoxFit.fill,
-              child: CircularProgressIndicator(),
+    final icon =
+        !isLaunching
+            ? icons[status] ?? unknownIcon
+            : SizedBox(
+              width: 10,
+              height: 10,
+              child: FittedBox(
+                fit: BoxFit.fill,
+                child: CircularProgressIndicator(),
+              ),
+            );
+
+    return Row(
+      children: [
+        icon,
+        const SizedBox(width: 8),
+        Expanded(
+          child: Tooltip(
+            message: statusName,
+            child: Text(
+              statusName.nonBreaking,
+              overflow: TextOverflow.ellipsis,
             ),
-          );
-
-    return Row(children: [
-      icon,
-      const SizedBox(width: 8),
-      Expanded(
-        child: Tooltip(
-          message: statusName,
-          child: Text(statusName.nonBreaking, overflow: TextOverflow.ellipsis),
+          ),
         ),
-      ),
-    ]);
+      ],
+    );
   }
 }

--- a/src/client/gui/lib/vm_table/bulk_actions.dart
+++ b/src/client/gui/lib/vm_table/bulk_actions.dart
@@ -16,20 +16,22 @@ class BulkActionsBar extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final client = ref.watch(grpcClientProvider);
     final selectedVms = ref.watch(selectedVmsProvider);
-    final statuses = ref
-        .watch(vmStatusesProvider)
-        .asMap()
-        .whereKey(selectedVms.contains)
-        .values
-        .toSet();
+    final statuses =
+        ref
+            .watch(vmStatusesProvider)
+            .asMap()
+            .whereKey(selectedVms.contains)
+            .values
+            .toSet();
 
     Function(VmAction) wrapInNotification(
       Future<void> Function(Iterable<String>) function,
     ) {
       return (action) {
-        final object = selectedVms.length == 1
-            ? selectedVms.first
-            : '${selectedVms.length} instances';
+        final object =
+            selectedVms.length == 1
+                ? selectedVms.first
+                : '${selectedVms.length} instances';
 
         final notificationsNotifier = ref.read(notificationsProvider.notifier);
         notificationsNotifier.addOperation(
@@ -51,10 +53,11 @@ class BulkActionsBar extends ConsumerWidget {
         showDialog(
           context: context,
           barrierDismissible: false,
-          builder: (_) => DeleteInstanceDialog(
-            multiple: selectedVms.length > 1,
-            onDelete: () => wrapInNotification(client.purge)(action),
-          ),
+          builder:
+              (_) => DeleteInstanceDialog(
+                multiple: selectedVms.length > 1,
+                onDelete: () => wrapInNotification(client.purge)(action),
+              ),
         );
       },
     };

--- a/src/client/gui/lib/vm_table/header_selection.dart
+++ b/src/client/gui/lib/vm_table/header_selection.dart
@@ -22,9 +22,12 @@ class HeaderSelectionTile extends ConsumerWidget {
       controlAffinity: ListTileControlAffinity.leading,
       title: Text(name, style: const TextStyle(color: Colors.black)),
       value: enabledHeaders[name],
-      onChanged: (isSelected) => ref
-          .read(enabledHeadersProvider.notifier)
-          .update((state) => state.rebuild((set) => set[name] = isSelected!)),
+      onChanged:
+          (isSelected) => ref
+              .read(enabledHeadersProvider.notifier)
+              .update(
+                (state) => state.rebuild((set) => set[name] = isSelected!),
+              ),
     );
   }
 }
@@ -36,30 +39,36 @@ class HeaderSelection extends StatelessWidget {
   Widget build(BuildContext context) {
     return PopupMenuButton(
       position: PopupMenuPosition.under,
-      itemBuilder: (_) => headers.skip(2).map((h) {
-        return PopupMenuItem<void>(
-          padding: EdgeInsets.zero,
-          enabled: false,
-          child: HeaderSelectionTile(h.name),
-        );
-      }).toList(),
+      itemBuilder:
+          (_) =>
+              headers.skip(2).map((h) {
+                return PopupMenuItem<void>(
+                  padding: EdgeInsets.zero,
+                  enabled: false,
+                  child: HeaderSelectionTile(h.name),
+                );
+              }).toList(),
       child: Container(
         width: 120,
         height: 42,
         padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          border: Border.all(color: Colors.grey),
-        ),
-        child: Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
-          SvgPicture.asset(
-            'assets/settings.svg',
-            colorFilter: const ColorFilter.mode(
-              Color(0xff333333),
-              BlendMode.srcIn,
+        decoration: BoxDecoration(border: Border.all(color: Colors.grey)),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            SvgPicture.asset(
+              'assets/settings.svg',
+              colorFilter: const ColorFilter.mode(
+                Color(0xff333333),
+                BlendMode.srcIn,
+              ),
             ),
-          ),
-          const Text('Columns', style: TextStyle(fontWeight: FontWeight.bold)),
-        ]),
+            const Text(
+              'Columns',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/src/client/gui/lib/vm_table/no_vms.dart
+++ b/src/client/gui/lib/vm_table/no_vms.dart
@@ -14,10 +14,7 @@ class NoVms extends ConsumerWidget {
     final multipassLogo = SvgPicture.asset(
       'assets/multipass.svg',
       width: 40,
-      colorFilter: const ColorFilter.mode(
-        Color(0xffD9D9D9),
-        BlendMode.srcIn,
-      ),
+      colorFilter: const ColorFilter.mode(Color(0xffD9D9D9), BlendMode.srcIn),
     );
 
     goToCatalogue() {
@@ -35,12 +32,14 @@ class NoVms extends ConsumerWidget {
             const SizedBox(height: 22),
             const Text('Zero Instances', style: TextStyle(fontSize: 21)),
             const SizedBox(height: 8),
-            Text.rich([
-              'Return to the '.span,
-              'Catalogue'.span.color(Colors.blue).link(ref, goToCatalogue),
-              ' to choose your instance or get started with the primary Ubuntu Image'
-                  .span,
-            ].spans.size(16)),
+            Text.rich(
+              [
+                'Return to the '.span,
+                'Catalogue'.span.color(Colors.blue).link(ref, goToCatalogue),
+                ' to choose your instance or get started with the primary Ubuntu Image'
+                    .span,
+              ].spans.size(16),
+            ),
           ],
         ),
       ),

--- a/src/client/gui/lib/vm_table/table.dart
+++ b/src/client/gui/lib/vm_table/table.dart
@@ -26,10 +26,7 @@ class TableHeader<T> {
     return Container(
       alignment: Alignment.centerLeft,
       margin: const EdgeInsets.only(left: 10),
-      child: Text(name,
-          style: const TextStyle(
-            fontWeight: FontWeight.bold,
-          )),
+      child: Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
     );
   }
 }
@@ -69,10 +66,7 @@ class _TableState<T> extends State<Table<T>> {
   Widget addScrollbars(TableView table) {
     return Scrollbar(
       controller: vertical,
-      child: Scrollbar(
-        controller: horizontal,
-        child: table,
-      ),
+      child: Scrollbar(controller: horizontal, child: table),
     );
   }
 
@@ -90,29 +84,34 @@ class _TableState<T> extends State<Table<T>> {
           ),
         ),
         onHorizontalDragStart: (_) => setState(() => isResizingColumn++),
-        onHorizontalDragUpdate: (d) => setState(() {
-          header.width = max(
-            header.minWidth,
-            header._oldWidth + d.localPosition.dx,
-          );
-        }),
-        onHorizontalDragEnd: (_) => setState(() {
-          header._oldWidth = header.width;
-          isResizingColumn--;
-        }),
+        onHorizontalDragUpdate:
+            (d) => setState(() {
+              header.width = max(
+                header.minWidth,
+                header._oldWidth + d.localPosition.dx,
+              );
+            }),
+        onHorizontalDragEnd:
+            (_) => setState(() {
+              header._oldWidth = header.width;
+              isResizingColumn--;
+            }),
       ),
     );
 
-    final title = Stack(children: [
-      Positioned.fill(child: header.childBuilder(header.name)),
-      if (index == sortIndex)
-        Align(
-          alignment: Alignment.centerRight,
-          child: sortAscending
-              ? const Icon(Icons.arrow_drop_up_rounded)
-              : const Icon(Icons.arrow_drop_down_rounded),
-        ),
-    ]);
+    final title = Stack(
+      children: [
+        Positioned.fill(child: header.childBuilder(header.name)),
+        if (index == sortIndex)
+          Align(
+            alignment: Alignment.centerRight,
+            child:
+                sortAscending
+                    ? const Icon(Icons.arrow_drop_up_rounded)
+                    : const Icon(Icons.arrow_drop_down_rounded),
+          ),
+      ],
+    );
 
     setSorting() {
       setState(() {
@@ -126,10 +125,14 @@ class _TableState<T> extends State<Table<T>> {
       });
     }
 
-    return Stack(children: [
-      header.sortKey != null ? InkWell(onTap: setSorting, child: title) : title,
-      Align(alignment: Alignment.centerRight, child: resizeHandle),
-    ]);
+    return Stack(
+      children: [
+        header.sortKey != null
+            ? InkWell(onTap: setSorting, child: title)
+            : title,
+        Align(alignment: Alignment.centerRight, child: resizeHandle),
+      ],
+    );
   }
 
   List<Widget> buildRow(T entry) {
@@ -146,9 +149,10 @@ class _TableState<T> extends State<Table<T>> {
   @override
   Widget build(BuildContext context) {
     Iterable<T> data = widget.data;
-    final sortKey = widget.headers
-        .elementAtOrNull(sortIndex ?? widget.headers.length)
-        ?.sortKey;
+    final sortKey =
+        widget.headers
+            .elementAtOrNull(sortIndex ?? widget.headers.length)
+            ?.sortKey;
     if (sortKey != null) {
       final sortedData = data.sortedBy(sortKey);
       data = sortAscending ? sortedData : sortedData.reversed;
@@ -157,11 +161,7 @@ class _TableState<T> extends State<Table<T>> {
     final headerCells = [
       for (final (i, header) in widget.headers.indexed) buildHeader(i, header),
     ];
-    final cells = [
-      headerCells,
-      ...data.map(buildRow),
-      widget.finalRow,
-    ];
+    final cells = [headerCells, ...data.map(buildRow), widget.finalRow];
 
     final table = TableView.builder(
       horizontalDetails: ScrollableDetails.horizontal(controller: horizontal),
@@ -170,27 +170,32 @@ class _TableState<T> extends State<Table<T>> {
       rowCount: cells.length,
       columnCount: widget.headers.length + 1,
       rowBuilder: (_) => const TableSpan(extent: FixedTableSpanExtent(50)),
-      columnBuilder: (i) => TableSpan(
-        extent: i == widget.headers.length
-            ? const RemainingTableSpanExtent()
-            : FixedTableSpanExtent(widget.headers[i].width),
-      ),
-      cellBuilder: (_, v) => TableViewCell(
-        child: Container(
-          decoration: BoxDecoration(
-            border: Border(
-              bottom: v.row < cells.length - 1 ? borderSide : BorderSide.none,
+      columnBuilder:
+          (i) => TableSpan(
+            extent:
+                i == widget.headers.length
+                    ? const RemainingTableSpanExtent()
+                    : FixedTableSpanExtent(widget.headers[i].width),
+          ),
+      cellBuilder:
+          (_, v) => TableViewCell(
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border(
+                  bottom:
+                      v.row < cells.length - 1 ? borderSide : BorderSide.none,
+                ),
+              ),
+              child: cells.elementAtOrNull(v.row)?.elementAtOrNull(v.column),
             ),
           ),
-          child: cells.elementAtOrNull(v.row)?.elementAtOrNull(v.column),
-        ),
-      ),
     );
 
     return MouseRegion(
-      cursor: isResizingColumn == 0
-          ? MouseCursor.defer
-          : SystemMouseCursors.resizeColumn,
+      cursor:
+          isResizingColumn == 0
+              ? MouseCursor.defer
+              : SystemMouseCursors.resizeColumn,
       child: DecoratedBox(
         decoration: const BoxDecoration(
           border: Border.fromBorderSide(borderSide),

--- a/src/client/gui/lib/vm_table/vm_table_headers.dart
+++ b/src/client/gui/lib/vm_table/vm_table_headers.dart
@@ -36,12 +36,14 @@ final headers = <TableHeader<VmInfo>>[
     width: 110,
     minWidth: 70,
     sortKey: (info) => info.instanceStatus.status.name,
-    cellBuilder: (info) => Consumer(
-      builder: (_, ref, __) => VmStatusIcon(
-        info.instanceStatus.status,
-        isLaunching: ref.watch(isLaunchingProvider(info.name)),
-      ),
-    ),
+    cellBuilder:
+        (info) => Consumer(
+          builder:
+              (_, ref, __) => VmStatusIcon(
+                info.instanceStatus.status,
+                isLaunching: ref.watch(isLaunchingProvider(info.name)),
+              ),
+        ),
   ),
   TableHeader(
     name: 'CPU USAGE',
@@ -53,19 +55,21 @@ final headers = <TableHeader<VmInfo>>[
     name: 'MEMORY USAGE',
     width: 140,
     minWidth: 130,
-    cellBuilder: (info) => MemoryUsage(
-      used: info.instanceInfo.memoryUsage,
-      total: info.memoryTotal,
-    ),
+    cellBuilder:
+        (info) => MemoryUsage(
+          used: info.instanceInfo.memoryUsage,
+          total: info.memoryTotal,
+        ),
   ),
   TableHeader(
     name: 'DISK USAGE',
     width: 130,
     minWidth: 100,
-    cellBuilder: (info) => MemoryUsage(
-      used: info.instanceInfo.diskUsage,
-      total: info.diskTotal,
-    ),
+    cellBuilder:
+        (info) => MemoryUsage(
+          used: info.instanceInfo.diskUsage,
+          total: info.diskTotal,
+        ),
   ),
   TableHeader(
     name: 'IMAGE',
@@ -98,12 +102,15 @@ class SelectAllCheckbox extends ConsumerWidget {
     final selectedVms = ref.watch(selectedVmsProvider);
     final searchName = ref.watch(searchNameProvider);
     final runningOnly = ref.watch(runningOnlyProvider);
-    final vmNames = ref
-        .watch(vmInfosProvider)
-        .where((i) => !runningOnly || i.instanceStatus.status == Status.RUNNING)
-        .where((i) => i.name.contains(searchName))
-        .map((i) => i.name)
-        .toList();
+    final vmNames =
+        ref
+            .watch(vmInfosProvider)
+            .where(
+              (i) => !runningOnly || i.instanceStatus.status == Status.RUNNING,
+            )
+            .where((i) => i.name.contains(searchName))
+            .map((i) => i.name)
+            .toList();
     final allSelected = selectedVms.containsAll(vmNames);
 
     void toggleSelectedAll(bool isSelected) {
@@ -128,9 +135,11 @@ class SelectVmCheckbox extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selected = ref.watch(selectedVmsProvider.select((selectedVms) {
-      return selectedVms.contains(name);
-    }));
+    final selected = ref.watch(
+      selectedVmsProvider.select((selectedVms) {
+        return selectedVms.contains(name);
+      }),
+    );
 
     void toggleSelected(bool isSelected) {
       ref.read(selectedVmsProvider.notifier).update((state) {

--- a/src/client/gui/lib/vm_table/vms.dart
+++ b/src/client/gui/lib/vm_table/vms.dart
@@ -41,44 +41,48 @@ class Vms extends ConsumerWidget {
       ref.read(sidebarKeyProvider.notifier).set(CatalogueScreen.sidebarKey);
     }
 
-    final heading = Row(children: [
-      const Expanded(
-        child: Text(
-          'All Instances',
-          style: TextStyle(fontSize: 37, fontWeight: FontWeight.w300),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+    final heading = Row(
+      children: [
+        const Expanded(
+          child: Text(
+            'All Instances',
+            style: TextStyle(fontSize: 37, fontWeight: FontWeight.w300),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
-      ),
-      TextButton(
-        onPressed: goToCatalogue,
-        child: const Text('Launch'),
-      )
-    ]);
+        TextButton(onPressed: goToCatalogue, child: const Text('Launch')),
+      ],
+    );
 
     final searchName = ref.watch(searchNameProvider);
     final runningOnly = ref.watch(runningOnlyProvider);
-    final vmFilters = Row(children: [
-      Switch(
-        label: 'Show running instances only',
-        value: runningOnly,
-        onChanged: (v) => ref.read(runningOnlyProvider.notifier).state = v,
-      ),
-      const Spacer(),
-      const SearchBox(),
-      const SizedBox(width: 8),
-      const HeaderSelection(),
-    ]);
+    final vmFilters = Row(
+      children: [
+        Switch(
+          label: 'Show running instances only',
+          value: runningOnly,
+          onChanged: (v) => ref.read(runningOnlyProvider.notifier).state = v,
+        ),
+        const Spacer(),
+        const SearchBox(),
+        const SizedBox(width: 8),
+        const HeaderSelection(),
+      ],
+    );
 
     final enabledHeaderNames = ref.watch(enabledHeadersProvider).asMap();
     final enabledHeaders =
         headers.where((h) => enabledHeaderNames[h.name]!).toList();
 
-    final infos = ref
-        .watch(vmInfosProvider)
-        .where((i) => !runningOnly || i.instanceStatus.status == Status.RUNNING)
-        .where((i) => i.name.contains(searchName))
-        .toList();
+    final infos =
+        ref
+            .watch(vmInfosProvider)
+            .where(
+              (i) => !runningOnly || i.instanceStatus.status == Status.RUNNING,
+            )
+            .where((i) => i.name.contains(searchName))
+            .toList();
 
     int total(Iterable<String> it) => it.map((e) => int.tryParse(e) ?? 0).sum;
     final totalUsedMemory = total(infos.map((i) => i.instanceInfo.memoryUsage));
@@ -118,23 +122,25 @@ class Vms extends ConsumerWidget {
 
     return Padding(
       padding: const EdgeInsets.all(20).copyWith(top: 52),
-      child: Column(children: [
-        heading,
-        const SizedBox(height: 35),
-        vmFilters,
-        const BulkActionsBar(),
-        const SizedBox(height: 10),
-        Flexible(
-          child: SizedBox(
-            height: (infos.length + 2) * 50,
-            child: Table<VmInfo>(
-              headers: enabledHeaders,
-              data: infos.toList(),
-              finalRow: totalUsageRow,
+      child: Column(
+        children: [
+          heading,
+          const SizedBox(height: 35),
+          vmFilters,
+          const BulkActionsBar(),
+          const SizedBox(height: 10),
+          Flexible(
+            child: SizedBox(
+              height: (infos.length + 2) * 50,
+              child: Table<VmInfo>(
+                headers: enabledHeaders,
+                data: infos.toList(),
+                finalRow: totalUsageRow,
+              ),
             ),
           ),
-        ),
-      ]),
+        ],
+      ),
     );
   }
 }

--- a/src/client/gui/lib/window_size.dart
+++ b/src/client/gui/lib/window_size.dart
@@ -48,9 +48,10 @@ Future<Size> deriveWindowSize(SharedPreferences sharedPreferences) async {
   final prefix = resolutionString(screenSize);
   final lastWidth = sharedPreferences.getDouble('$prefix$windowWidthKey');
   final lastHeight = sharedPreferences.getDouble('$prefix$windowHeightKey');
-  final size = lastWidth != null && lastHeight != null
-      ? Size(lastWidth, lastHeight)
-      : null;
+  final size =
+      lastWidth != null && lastHeight != null
+          ? Size(lastWidth, lastHeight)
+          : null;
   logger.d('Got last window size: ${size?.s()}');
   return size ?? computeDefaultWindowSize(screenSize);
 }
@@ -69,9 +70,10 @@ Size computeDefaultWindowSize(Size? screenSize) {
   final defaultHeight = switch (screenHeight) {
     null || <= 576 => 450.0,
     >= 900 => 822.0,
-    _ => aspectRatioFactor != null
-        ? defaultWidth * aspectRatioFactor
-        : screenHeight * windowSizeFactor,
+    _ =>
+      aspectRatioFactor != null
+          ? defaultWidth * aspectRatioFactor
+          : screenHeight * windowSizeFactor,
   };
 
   final size = Size(defaultWidth, defaultHeight);

--- a/src/client/gui/macos/Flutter/Flutter-Debug.xcconfig
+++ b/src/client/gui/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/src/client/gui/macos/Flutter/Flutter-Release.xcconfig
+++ b/src/client/gui/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/src/client/gui/macos/Podfile
+++ b/src/client/gui/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/src/client/gui/macos/Podfile.lock
+++ b/src/client/gui/macos/Podfile.lock
@@ -1,0 +1,85 @@
+PODS:
+  - file_selector_macos (0.0.1):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - HotKey (0.2.0)
+  - hotkey_manager_macos (0.0.1):
+    - FlutterMacOS
+    - HotKey
+  - local_notifier (0.1.0):
+    - FlutterMacOS
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - screen_retriever_macos (0.0.1):
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - tray_menu (0.0.1):
+    - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+  - window_manager (0.2.0):
+    - FlutterMacOS
+  - window_size (0.0.2):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - hotkey_manager_macos (from `Flutter/ephemeral/.symlinks/plugins/hotkey_manager_macos/macos`)
+  - local_notifier (from `Flutter/ephemeral/.symlinks/plugins/local_notifier/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - tray_menu (from `Flutter/ephemeral/.symlinks/plugins/tray_menu/macos`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+  - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
+  - window_size (from `Flutter/ephemeral/.symlinks/plugins/window_size/macos`)
+
+SPEC REPOS:
+  trunk:
+    - HotKey
+
+EXTERNAL SOURCES:
+  file_selector_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  hotkey_manager_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/hotkey_manager_macos/macos
+  local_notifier:
+    :path: Flutter/ephemeral/.symlinks/plugins/local_notifier/macos
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  screen_retriever_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  tray_menu:
+    :path: Flutter/ephemeral/.symlinks/plugins/tray_menu/macos
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+  window_manager:
+    :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
+  window_size:
+    :path: Flutter/ephemeral/.symlinks/plugins/window_size/macos
+
+SPEC CHECKSUMS:
+  file_selector_macos: cc3858c981fe6889f364731200d6232dac1d812d
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  HotKey: e96d8a2ddbf4591131e2bb3f54e69554d90cdca6
+  hotkey_manager_macos: 1e2edb0c7ae4fe67108af44a9d3445de41404160
+  local_notifier: e9506bc66fc70311e8bc7291fb70f743c081e4ff
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  screen_retriever_macos: 776e0fa5d42c6163d2bf772d22478df4b302b161
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  tray_menu: 388c475404aa4fc1563a6ed002bef6677d467905
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
+  window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
+  window_size: 339dafa0b27a95a62a843042038fa6c3c48de195
+
+PODFILE CHECKSUM: 7eb978b976557c8c1cd717d8185ec483fd090a82
+
+COCOAPODS: 1.16.2

--- a/src/client/gui/macos/Runner.xcodeproj/project.pbxproj
+++ b/src/client/gui/macos/Runner.xcodeproj/project.pbxproj
@@ -21,14 +21,24 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		5B05DA7ABC36447C694702B7 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47C236D472EF54B6BE825075 /* Pods_Runner.framework */; };
+		88D4864415FFD81FF557BF0A /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C4BB1219B19D2D45110362 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		331C80D9294CF71000263BE5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 33CC10E52044A3C60003C045 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 33CC10EC2044A3C60003C045;
+			remoteInfo = Runner;
+		};
 		33CC111F2044C79F0003C045 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 33CC10E52044A3C60003C045 /* Project object */;
@@ -52,6 +62,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
 		33CC10ED2044A3C60003C045 /* Multipass.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Multipass.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -66,21 +78,60 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		47C236D472EF54B6BE825075 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		63C4BB1219B19D2D45110362 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8BF926972FAEF4471555C1B8 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		8E257F6423CD8793A44B284E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		9553F3714BAA2571404D1CA7 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		9F89BDF0FB70203901A362D3 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		ABBAA748535FB053B8EAAE71 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		AEA974E9535CFC0401D8A6AE /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		331C80D2294CF70F00263BE5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				88D4864415FFD81FF557BF0A /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		33CC10EA2044A3C60003C045 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B05DA7ABC36447C694702B7 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		268411E0FA100A9EEBB546B1 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				ABBAA748535FB053B8EAAE71 /* Pods-Runner.debug.xcconfig */,
+				AEA974E9535CFC0401D8A6AE /* Pods-Runner.release.xcconfig */,
+				8E257F6423CD8793A44B284E /* Pods-Runner.profile.xcconfig */,
+				9F89BDF0FB70203901A362D3 /* Pods-RunnerTests.debug.xcconfig */,
+				9553F3714BAA2571404D1CA7 /* Pods-RunnerTests.release.xcconfig */,
+				8BF926972FAEF4471555C1B8 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		331C80D6294CF71000263BE5 /* RunnerTests */ = {
+			isa = PBXGroup;
+			children = (
+				331C80D7294CF71000263BE5 /* RunnerTests.swift */,
+			);
+			path = RunnerTests;
+			sourceTree = "<group>";
+		};
 		33BA886A226E78AF003329D5 /* Configs */ = {
 			isa = PBXGroup;
 			children = (
@@ -97,8 +148,10 @@
 			children = (
 				33FAB671232836740065AC1E /* Runner */,
 				33CEB47122A05771004F2AC0 /* Flutter */,
+				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				268411E0FA100A9EEBB546B1 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -106,6 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				33CC10ED2044A3C60003C045 /* Multipass.app */,
+				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -148,6 +202,8 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				47C236D472EF54B6BE825075 /* Pods_Runner.framework */,
+				63C4BB1219B19D2D45110362 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -155,15 +211,36 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		331C80D4294CF70F00263BE5 /* RunnerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
+			buildPhases = (
+				152D56A405A7B53C8A8DD751 /* [CP] Check Pods Manifest.lock */,
+				331C80D1294CF70F00263BE5 /* Sources */,
+				331C80D2294CF70F00263BE5 /* Frameworks */,
+				331C80D3294CF70F00263BE5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				331C80DA294CF71000263BE5 /* PBXTargetDependency */,
+			);
+			name = RunnerTests;
+			productName = RunnerTests;
+			productReference = 331C80D5294CF71000263BE5 /* RunnerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		33CC10EC2044A3C60003C045 /* Runner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				26FE05DB3DDAACDD8E29DA88 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				A7F2622FC01771CF2BA72311 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -181,10 +258,15 @@
 		33CC10E52044A3C60003C045 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
+					331C80D4294CF70F00263BE5 = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = 33CC10EC2044A3C60003C045;
+					};
 					33CC10EC2044A3C60003C045 = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
@@ -215,12 +297,20 @@
 			projectRoot = "";
 			targets = (
 				33CC10EC2044A3C60003C045 /* Runner */,
+				331C80D4294CF70F00263BE5 /* RunnerTests */,
 				33CC111A2044C6BA0003C045 /* Flutter Assemble */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		331C80D3294CF70F00263BE5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		33CC10EB2044A3C60003C045 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -233,6 +323,50 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		152D56A405A7B53C8A8DD751 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		26FE05DB3DDAACDD8E29DA88 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -271,9 +405,34 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		A7F2622FC01771CF2BA72311 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		331C80D1294CF70F00263BE5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		33CC10E92044A3C60003C045 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -287,6 +446,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		331C80DA294CF71000263BE5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 33CC10EC2044A3C60003C045 /* Runner */;
+			targetProxy = 331C80D9294CF71000263BE5 /* PBXContainerItemProxy */;
+		};
 		33CC11202044C79F0003C045 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 33CC111A2044C6BA0003C045 /* Flutter Assemble */;
@@ -307,11 +471,57 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		331C80DB294CF71000263BE5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9F89BDF0FB70203901A362D3 /* Pods-RunnerTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.multipassGui.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/multipass_gui.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/multipass_gui";
+			};
+			name = Debug;
+		};
+		331C80DC294CF71000263BE5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9553F3714BAA2571404D1CA7 /* Pods-RunnerTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.multipassGui.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/multipass_gui.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/multipass_gui";
+			};
+			name = Release;
+		};
+		331C80DD294CF71000263BE5 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8BF926972FAEF4471555C1B8 /* Pods-RunnerTests.profile.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.multipassGui.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/multipass_gui.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/multipass_gui";
+			};
+			name = Profile;
+		};
 		338D0CE9231458BD00FA5F75 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -335,9 +545,11 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -386,6 +598,7 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -409,9 +622,11 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -439,6 +654,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -462,9 +678,11 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -540,6 +758,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				331C80DB294CF71000263BE5 /* Debug */,
+				331C80DC294CF71000263BE5 /* Release */,
+				331C80DD294CF71000263BE5 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/src/client/gui/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/src/client/gui/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,6 +37,17 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C80D4294CF70F00263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -48,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/src/client/gui/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/src/client/gui/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/src/client/gui/macos/Runner/AppDelegate.swift
+++ b/src/client/gui/macos/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return false
+  }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+    return true
   }
 }

--- a/src/client/gui/macos/Runner/MainFlutterWindow.swift
+++ b/src/client/gui/macos/Runner/MainFlutterWindow.swift
@@ -3,7 +3,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/src/client/gui/macos/RunnerTests/RunnerTests.swift
+++ b/src/client/gui/macos/RunnerTests/RunnerTests.swift
@@ -1,0 +1,12 @@
+import Cocoa
+import FlutterMacOS
+import XCTest
+
+class RunnerTests: XCTestCase {
+
+  func testExample() {
+    // If you add code to the Runner application, consider adding tests here.
+    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  }
+
+}

--- a/src/client/gui/pubspec.lock
+++ b/src/client/gui/pubspec.lock
@@ -13,18 +13,18 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "4bae5ae63e6d6dd17c4aac8086f3dec26c0236f6a0f03416c6c19d830c367cf5"
+      sha256: "068190d6c99c436287936ba5855af2e1fa78d8083ae65b4db6a281780da727ae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.8"
+    version: "1.6.0"
   async:
     dependency: "direct main"
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   basics:
     dependency: "direct main"
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -101,11 +101,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2.11.0+mp"
-      resolved-ref: a2830134265c61fa1f8973c42761e0faf349b2db
+      ref: "2.12.0+mp"
+      resolved-ref: "1d924a068e4a4fa8ca51706192f91221a392144a"
       url: "https://github.com/andrei-toterman/dartssh2.git"
     source: git
-    version: "2.11.0"
+    version: "2.12.0"
   equatable:
     dependency: transitive
     description:
@@ -118,10 +118,10 @@ packages:
     dependency: "direct main"
     description:
       name: extended_text
-      sha256: d8d8c9aaf5a97590a2ed249c896eda4f3e761cfc60d3edf0cbe1384348e38466
+      sha256: "0468bbeae01cefcabb40de97a7cea137a454bdf27bcaa24fcda199bdebbe026e"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.0"
+    version: "15.0.0"
   extended_text_library:
     dependency: transitive
     description:
@@ -134,10 +134,10 @@ packages:
     dependency: "direct main"
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -158,10 +158,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_android
-      sha256: "98ac58e878b05ea2fdb204e7f4fc4978d90406c9881874f901428e01d3b18fbc"
+      sha256: f3a3d48a36d1640b4dca22a086f26b426c246925a80eddc2953120775fbcf86a
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1+12"
+    version: "0.5.1+13"
   file_selector_ios:
     dependency: transitive
     description:
@@ -206,10 +206,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   fixnum:
     dependency: transitive
     description:
@@ -337,10 +337,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http2:
     dependency: transitive
     description:
@@ -361,18 +361,18 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "00f33b908655e606b86d2ade4710a231b802eec6f11e87e4ea3783fd72077a50"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.1"
+    version: "0.20.2"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -425,10 +425,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -457,10 +457,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
+      sha256: "0ca7359dad67fd7063cb2892ab0c0737b2daafd807cf1acecd62374c8fae6c12"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.15"
+    version: "2.2.16"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.1.0"
   pinenacl:
     dependency: transitive
     description:
@@ -609,18 +609,18 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: a752ce92ea7540fc35a0d19722816e04d0e72828a4200e83a98cf1a1eb524c9a
+      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.5.2"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: bf808be89fe9dc467475e982c1db6c2faf3d2acf54d526cd5ec37d86c99dbd84
+      sha256: "3ec7210872c4ba945e3244982918e502fa2bfb5230dff6832459ca0e1879b7ad"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.8"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -649,10 +649,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -718,10 +718,10 @@ packages:
     dependency: "direct main"
     description:
       name: synchronized
-      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0+3"
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -783,10 +783,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
+      sha256: "1d0eae19bd7606ef60fe69ef3b312a437a16549476c42321d5dc1506c9ca3bf4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.14"
+    version: "6.3.15"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -847,10 +847,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "27d5fefe86fb9aace4a9f8375b56b3c292b64d8c04510df230f849850d912cb7"
+      sha256: "44cc7104ff32563122a929e4620cf3efd584194eec6d1d913eb5ba593dbcf6de"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.15"
+    version: "1.1.18"
   vector_graphics_codec:
     dependency: transitive
     description:
@@ -879,18 +879,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   win32:
     dependency: "direct main"
     description:
       name: win32
-      sha256: "154360849a56b7b67331c21f09a386562d88903f90a1099c5987afc1912e1f29"
+      sha256: b89e6e24d1454e149ab20fbb225af58660f0c0bf4475544650700d8e2da54aef
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "5.11.0"
   window_manager:
     dependency: "direct main"
     description:
@@ -942,5 +942,5 @@ packages:
     source: hosted
     version: "0.0.6"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/src/client/gui/pubspec.yaml
+++ b/src/client/gui/pubspec.yaml
@@ -6,16 +6,16 @@ environment:
   sdk: '>=3.0.3 <4.0.0'
 
 dependencies:
-  async: ^2.12.0
+  async: ^2.13.0
   basics: ^0.10.0
   built_collection: ^5.1.1
-  collection: ^1.19.0
+  collection: ^1.19.1
   dartssh2:
     git:
       url: https://github.com/andrei-toterman/dartssh2.git
-      ref: 2.11.0+mp
-  extended_text: ^14.2.0
-  ffi: ^2.1.3
+      ref: 2.12.0+mp
+  extended_text: ^15.0.0
+  ffi: ^2.1.4
   file_selector: ^1.0.3
   fl_chart: ^0.70.2
   flutter:
@@ -25,21 +25,21 @@ dependencies:
   fpdart: ^1.1.1
   grpc: ^4.0.1
   hotkey_manager: ^0.2.3
-  intl: ^0.20.1
+  intl: ^0.20.2
   local_notifier: ^0.1.6
   logger: ^2.5.0
   path_provider: ^2.1.5
   protobuf: ^3.1.0
   rxdart: ^0.28.0
-  shared_preferences: ^2.3.5
-  synchronized: ^3.3.0+3
+  shared_preferences: ^2.5.2
+  synchronized: ^3.3.1
   tray_menu:
     git:
       url: https://github.com/andrei-toterman/tray_menu.git
       ref: cef5b8f
   two_dimensional_scrollables: ^0.3.3
   url_launcher: ^6.3.1
-  win32: ^5.10.0
+  win32: ^5.11.0
   window_manager: ^0.4.3
   window_size:
     git:

--- a/src/client/gui/windows/CMakeLists.txt
+++ b/src/client/gui/windows/CMakeLists.txt
@@ -8,7 +8,7 @@ set(BINARY_NAME "multipass.gui")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.
-cmake_policy(SET CMP0063 NEW)
+cmake_policy(VERSION 3.14...3.25)
 
 # Define build configuration option.
 get_property(IS_MULTICONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
@@ -52,6 +52,7 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 # Application build; see runner/CMakeLists.txt.
 add_subdirectory("runner")
 
+
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
 include(flutter/generated_plugins.cmake)
@@ -85,6 +86,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
     COMPONENT Runtime)
 endif()
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/src/client/gui/windows/flutter/CMakeLists.txt
+++ b/src/client/gui/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/src/client/gui/windows/runner/flutter_window.cpp
+++ b/src/client/gui/windows/runner/flutter_window.cpp
@@ -33,6 +33,11 @@ bool FlutterWindow::OnCreate() {
     this->Show();
   });
 
+  // Flutter can complete the first frame before the "show window" callback is
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
+  flutter_controller_->ForceRedraw();
+
   return true;
 }
 

--- a/src/client/gui/windows/runner/runner.exe.manifest
+++ b/src/client/gui/windows/runner/runner.exe.manifest
@@ -9,12 +9,6 @@
     <application>
       <!-- Windows 10 and Windows 11 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-      <!-- Windows 8.1 -->
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-      <!-- Windows 8 -->
-      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
     </application>
   </compatibility>
 </assembly>

--- a/src/client/gui/windows/runner/utils.cpp
+++ b/src/client/gui/windows/runner/utils.cpp
@@ -45,9 +45,11 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
+  int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -55,8 +57,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/src/client/gui/windows/runner/win32_window.cpp
+++ b/src/client/gui/windows/runner/win32_window.cpp
@@ -60,7 +60,7 @@ class WindowClassRegistrar {
  public:
   ~WindowClassRegistrar() = default;
 
-  // Returns the singleton registar instance.
+  // Returns the singleton registrar instance.
   static WindowClassRegistrar* GetInstance() {
     if (!instance_) {
       instance_ = new WindowClassRegistrar();

--- a/src/client/gui/windows/runner/win32_window.h
+++ b/src/client/gui/windows/runner/win32_window.h
@@ -77,7 +77,7 @@ class Win32Window {
   // OS callback called by message pump. Handles the WM_NCCREATE message which
   // is passed when the non-client area is being created and enables automatic
   // non-client DPI scaling so that the non-client area automatically
-  // responsponds to changes in DPI. All other messages are handled by
+  // responds to changes in DPI. All other messages are handled by
   // MessageHandler.
   static LRESULT CALLBACK WndProc(HWND const window,
                                   UINT const message,


### PR DESCRIPTION
This PR does the following:
- updates the version of Flutter we use to 3.29.1
- fixes deprecation warnings
- fixes other small warnings, like needless includes
- re-formats all the Dart files. this new version of Flutter also comes with a new version of Dart i.e. 3.7, and according to this https://github.com/dart-lang/dart_style/releases/tag/v3.0.0, it means that new formatting rules are introduced, which made our Lint action fail, so the formatting had to be fixed now

All of the changes under the `linux`, `windows` and `macos` dirs were things automatically generated by Flutter itself.

private pr: canonical/multipass-private#732

MULTI-1848