### PR TITLE
[ci] Fix description of custom checkout action

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,5 +1,5 @@
 name: Checkout
-description: Check out Multipass code along with tags and submodules
+description: Get tags and submodules for the Multipass repository
 
 runs:
   using: composite


### PR DESCRIPTION
The action claimed it checked out Multipass code, but that is actually
done elsewhere via the standard GitHub "checkout" action.
