### PR TITLE
[common_callbacks] fix make_confirmation_callback lifetime issue

### DIFF
--- a/src/client/cli/cmd/common_callbacks.h
+++ b/src/client/cli/cmd/common_callbacks.h
@@ -75,9 +75,9 @@ auto make_iterative_spinner_callback(AnimatedSpinner& spinner, Terminal& term)
 }
 
 template <typename Request, typename Reply>
-auto make_confirmation_callback(Terminal& term, const QString& key)
+auto make_confirmation_callback(Terminal& term, QString key)
 {
-    return [&key, &term](Reply& reply, grpc::ClientReaderWriterInterface<Request, Reply>* client) {
+    return [key = std::move(key), &term](Reply& reply, grpc::ClientReaderWriterInterface<Request, Reply>* client) {
         if (key.startsWith(daemon_settings_root) && key.endsWith(bridged_network_name) && reply.needs_authorization())
         {
             auto bridged_network = reply.reply_message();


### PR DESCRIPTION
The make_confirmation_callback function takes the key argument as const ref, meaning that it'll be bound to an existing QString when the arg is QString, but a temporary QString would be constructed and bound to it when the "key" is not a QString. This is fine during the make_confirmation_callback's scope since const& extend the lifetime of the temporary, but passing that "const&" to a capture list of a lambda that'll be executed later does not extend the lifetime, hence leading to undefined behavior.

I believe this was not causing any issues in release builds because of the optimization level. The compiler is probably inlining the whole thing, so the QString is directly constructed into the lambda's body. I could only trigger this while running the unit tests in Windows, built with the Debug configuration.

The patch fixes this issue by taking QString as a value and moving that into the lambda capture.

MULTI-1907