### PR TITLE
[daemon] trigger on_restart for a running VM after daemon boot

### DIFF
--- a/tests/daemon_test_fixture.h
+++ b/tests/daemon_test_fixture.h
@@ -43,6 +43,17 @@ namespace multipass
 {
 namespace test
 {
+
+struct fake_vm_properties
+{
+    std::string name{"real-zebraphant"};
+    std::string default_mac{};
+    std::vector<mp::NetworkInterface> extra_ifaces;
+    std::unordered_map<std::string, mp::VMMount> mounts;
+    bool deleted = false;
+    VirtualMachine::State state = VirtualMachine::State::starting;
+};
+
 struct DaemonTestFixture : public ::Test
 {
     DaemonTestFixture();
@@ -62,6 +73,8 @@ struct DaemonTestFixture : public ::Test
     std::string fake_json_contents(const std::string& default_mac,
                                    const std::vector<mp::NetworkInterface>& extra_ifaces,
                                    const std::unordered_map<std::string, mp::VMMount>& mounts = {});
+
+    std::string fake_json_contents(const fake_vm_properties& vm_properties);
 
     std::pair<std::unique_ptr<TempDir>, QString> // unique_ptr bypasses missing move ctor
     plant_instance_json(const std::string& contents);

--- a/tests/daemon_test_fixture.h
+++ b/tests/daemon_test_fixture.h
@@ -48,8 +48,8 @@ struct fake_vm_properties
 {
     std::string name{"real-zebraphant"};
     std::string default_mac{};
-    std::vector<mp::NetworkInterface> extra_ifaces;
-    std::unordered_map<std::string, mp::VMMount> mounts;
+    std::vector<mp::NetworkInterface> extra_ifaces{};
+    std::unordered_map<std::string, mp::VMMount> mounts{};
     bool deleted = false;
     VirtualMachine::State state = VirtualMachine::State::starting;
 };

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -382,8 +382,7 @@ TEST_F(Daemon, ensure_that_on_restart_future_completes)
 
     // This VM was running before, but not now.
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>("yakety-yak");
-    EXPECT_CALL(*mock_vm, current_state)
-        .WillOnce(Return(mp::VirtualMachine::State::stopped));
+    EXPECT_CALL(*mock_vm, current_state).WillOnce(Return(mp::VirtualMachine::State::stopped));
     EXPECT_CALL(*mock_vm, start).Times(1);
 
     mpt::Signal signal;
@@ -2536,7 +2535,7 @@ TEST_P(DaemonIsBridged, is_bridged_works)
     mp::VMSpecs specs{};
     specs.extra_interfaces = extra_interfaces;
 
-    auto [mock_platform, platform_guard] = mpt::MockPlatform::inject();
+    auto [mock_platform, platform_guard] = mpt::MockPlatform::inject<NiceMock>();
     EXPECT_CALL(*mock_platform, bridge_nomenclature).WillRepeatedly(Return("generic"));
 
     auto mock_factory = use_a_mock_vm_factory();

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -383,7 +383,6 @@ TEST_F(Daemon, ensure_that_on_restart_future_completes)
     // This VM was running before, but not now.
     auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>("yakety-yak");
     EXPECT_CALL(*mock_vm, current_state)
-        .WillOnce(Return(mp::VirtualMachine::State::stopped))
         .WillOnce(Return(mp::VirtualMachine::State::stopped));
     EXPECT_CALL(*mock_vm, start).Times(1);
 
@@ -403,6 +402,80 @@ TEST_F(Daemon, ensure_that_on_restart_future_completes)
         mp::Daemon daemon{config_builder.build()};
         signal.signal();
     }
+}
+
+TEST_F(Daemon, starts_previously_running_vms_back)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    multipass::test::fake_vm_properties vm_props{};
+    vm_props.default_mac = "52:54:00:73:76:28";
+    vm_props.state = multipass::VirtualMachine::State::running;
+    const auto [temp_dir, _] = plant_instance_json(fake_json_contents(vm_props));
+    config_builder.data_directory = temp_dir->path();
+    config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+
+    // This VM was running before, but not now.
+    auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(vm_props.name);
+    EXPECT_CALL(*mock_vm, current_state).WillOnce(Return(mp::VirtualMachine::State::stopped));
+    EXPECT_CALL(*mock_vm, start).Times(1);
+    EXPECT_CALL(*mock_vm, update_state).Times(1);
+    EXPECT_CALL(*mock_vm, wait_until_ssh_up).Times(1);
+    EXPECT_CALL(*mock_factory, create_virtual_machine).WillOnce(Return(std::move(mock_vm)));
+
+    mp::Daemon daemon{config_builder.build()};
+}
+
+TEST_F(Daemon, calls_on_restart_for_already_running_vms_on_construction)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    multipass::test::fake_vm_properties vm_props{};
+    vm_props.default_mac = "52:54:00:73:76:28";
+    vm_props.state = multipass::VirtualMachine::State::running;
+    const auto [temp_dir, _] = plant_instance_json(fake_json_contents(vm_props));
+    config_builder.data_directory = temp_dir->path();
+    config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+
+    // This VM was running before, but not now.
+    auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(vm_props.name);
+    EXPECT_CALL(*mock_vm, current_state).WillOnce(Return(mp::VirtualMachine::State::running));
+    EXPECT_CALL(*mock_vm, start).Times(0);
+    // This will need another patch to be landed first. Otherwise the test'll be flaky.
+    // EXPECT_CALL(*mock_vm, update_state).Times(1);
+    EXPECT_CALL(*mock_vm, wait_until_ssh_up).Times(1);
+    EXPECT_CALL(*mock_factory, create_virtual_machine).WillOnce(Return(std::move(mock_vm)));
+
+    mp::Daemon daemon{config_builder.build()};
+}
+
+TEST_F(Daemon, updates_the_deleted_but_non_stopped_vm_state)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    multipass::test::fake_vm_properties vm_props{};
+    vm_props.default_mac = "52:54:00:73:76:28";
+    vm_props.deleted = true;
+    vm_props.state = multipass::VirtualMachine::State::running;
+    const auto [temp_dir, _] = plant_instance_json(fake_json_contents(vm_props));
+    config_builder.data_directory = temp_dir->path();
+    config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+
+    // This VM was running before, but not now.
+    auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>(vm_props.name);
+    EXPECT_CALL(*mock_vm, current_state).Times(0);
+    EXPECT_CALL(*mock_vm, start).Times(0);
+    // This will need another patch to be landed first. Otherwise the test'll be flaky.
+    // EXPECT_CALL(*mock_vm, update_state).Times(1);
+    EXPECT_CALL(*mock_vm, wait_until_ssh_up).Times(0);
+
+    EXPECT_CALL(*mock_factory, create_virtual_machine).WillOnce(Return(std::move(mock_vm)));
+
+    auto cfg = config_builder.build();
+    // It's important that inject() happens AFTER the build, because
+    // build() is also overwriting the global logger.
+    auto logger_scope = mpt::MockLogger::inject();
+    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
+    logger_scope.mock_logger->expect_log(mpl::Level::warning,
+                                         fmt::format("{} is deleted but has incompatible state", vm_props.name));
+    mp::Daemon daemon{std::move(cfg)};
 }
 
 namespace


### PR DESCRIPTION
on_restart re-initializes some daemon-side resources needed for the VM functionality, such as non-backend mounts like sshfs. this patch ensures that on_restart is executed for the VM's that are already running, or starting.

Closes: #4005

MULTI-1908