### PR TITLE
Fix invalid macro definition in CMakeLists.txt

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -45,7 +45,7 @@ endfunction()
 option(MULTIPASS_ENABLE_SYSLOG "Use syslog for logging instead of journald" OFF)
 
 if(NOT MULTIPASS_ENABLE_SYSLOG)
-  add_compile_definitions(-DMULTIPASS_JOURNALD_ENABLED)
+  add_compile_definitions(MULTIPASS_JOURNALD_ENABLED)
 endif()
 
 add_target(platform)


### PR DESCRIPTION
This PR fixes an issue in `src/platform/CMakeLists.txt` where `add_compile_definitions()` is used with a `-D` prefix:

```cmake
add_compile_definitions(-DMULTIPASS_JOURNALD_ENABLED)
```

This results in a malformed macro definition `-D-DMULTIPASS_JOURNALD_ENABLED`, which causes a compiler error:

```shell
<command-line>: error: macro names must be identifiers
```

The fix is to pass only the macro name, as `add_compile_definitions()` automatically adds the `-D` prefix:

```cmake
add_compile_definitions(MULTIPASS_JOURNALD_ENABLED)
```

Tested in a clean Debian 12 environment using Make, where this issue was originally triggered.