### PR TITLE
Fix missing <tuple> include for std::tie in network_interface_info.h

### DIFF
--- a/include/multipass/network_interface_info.h
+++ b/include/multipass/network_interface_info.h
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace multipass


### PR DESCRIPTION
This PR adds a missing `#include <tuple>` to `network_interface_info.h`, which is required for the use of `std::tie`.

Without this include, builds fail on compilers/environments that do not implicitly include `<tuple>` via transitive headers. For example, GCC on Debian 12 produces:

```shell
error: ‘tie’ is not a member of ‘std’
note: ‘std::tie’ is defined in header ‘’; did you forget to ‘#include ’?
```

Tested by successfully building the project in a clean Debian 12 dev container with GCC. No other changes.