### PR TITLE
Add --zone argument to launch command

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -233,14 +233,25 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
                                      "You can also use a shortcut of \"<name>\" to mean \"name=<name>\".",
                                      "spec");
     QCommandLineOption bridgedOption("bridged", "Adds one `--network bridged` network.");
+    QCommandLineOption zoneOption("zone", "The zone in which to launch the instance.", "zone");
     QCommandLineOption mountOption("mount",
                                    "Mount a local directory inside the instance. If <target> is omitted, the "
                                    "mount point will be under /home/ubuntu/<source-dir>, where <source-dir> is "
                                    "the name of the <source> directory.",
                                    "source>:<target");
 
-    parser->addOptions({cpusOption, diskOption, memOption, memOptionDeprecated, nameOption, cloudInitOption,
-                        networkOption, bridgedOption, mountOption});
+    parser->addOptions({
+        cpusOption,
+        diskOption,
+        memOption,
+        memOptionDeprecated,
+        nameOption,
+        cloudInitOption,
+        networkOption,
+        bridgedOption,
+        zoneOption,
+        mountOption,
+    });
 
     mp::cmd::add_timeout(parser);
 
@@ -426,8 +437,10 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
     try
     {
         if (parser->isSet(networkOption))
+        {
             for (const auto& net : parser->values(networkOption))
                 request.mutable_network_options()->Add(net_digest(net));
+        }
 
         request.set_timeout(mp::cmd::parse_timeout(parser));
     }
@@ -448,6 +461,17 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
     if (!spinner)
         spinner = std::make_unique<multipass::AnimatedSpinner>(
             cout); // Creating just in time to work around canonical/multipass#2075
+
+    if (parser->isSet("zone"))
+    {
+        auto zone = parser->value("zone").trimmed();
+        if (zone.isEmpty())
+        {
+            cerr << "Error: Empty zone specified with --zone option\n";
+            return ReturnCode::CommandLineError;
+        }
+        request.set_zone(zone.toStdString());
+    }
 
     if (timer)
         timer->resume();
@@ -507,7 +531,7 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
             }
         }
 
-        cout << "Launched: " << reply.vm_instance_name() << "\n";
+        cout << "Launched: " << reply.vm_instance_name() << " in " << reply.zone() << "\n";
 
         if (term->is_live() && update_available(reply.update_info()))
         {
@@ -553,6 +577,14 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
                 // TODO: show the option which triggered the error only. This will need a refactor in the
                 // LaunchError proto.
                 error_details = "Invalid network options supplied";
+            }
+            else if (error == LaunchError::INVALID_ZONE)
+            {
+                error_details = fmt::format("Invalid zone name supplied: {}", request.zone());
+            }
+            else if (error == LaunchError::ZONE_UNAVAILABLE)
+            {
+                error_details = fmt::format("Unavailable zone name supplied: {}", request.zone());
             }
         }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2969,7 +2969,8 @@ void mp::Daemon::release_resources(const std::string& instance)
 
 void mp::Daemon::create_vm(const CreateRequest* request,
                            grpc::ServerReaderWriterInterface<CreateReply, CreateRequest>* server,
-                           std::promise<grpc::Status>* status_promise, bool start)
+                           std::promise<grpc::Status>* status_promise,
+                           bool start)
 {
     typedef typename std::pair<VirtualMachineDescription, ClientLaunchData> VMFullDescription;
 
@@ -2977,7 +2978,8 @@ void mp::Daemon::create_vm(const CreateRequest* request,
 
     if (!checked_args.option_errors.error_codes().empty())
     {
-        return status_promise->set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid arguments supplied",
+        return status_promise->set_value(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                                                      "Invalid arguments supplied",
                                                       checked_args.option_errors.SerializeAsString()));
     }
     else if (auto& nets = checked_args.nets_need_bridging; !nets.empty() && !request->permission_to_bridge())
@@ -3026,7 +3028,8 @@ void mp::Daemon::create_vm(const CreateRequest* request,
     auto log_level = mpl::level_from(request->verbosity_level());
 
     QObject::connect(
-        prepare_future_watcher, &QFutureWatcher<VMFullDescription>::finished,
+        prepare_future_watcher,
+        &QFutureWatcher<VMFullDescription>::finished,
         [this, server, status_promise, name, timeout, start, prepare_future_watcher, log_level] {
             mpl::ClientLogger<CreateReply, CreateRequest> logger{log_level, *config->logger, server};
 
@@ -3066,33 +3069,38 @@ void mp::Daemon::create_vm(const CreateRequest* request,
 
                     operative_instances[name]->start();
 
-                    auto future_watcher = create_future_watcher([this, server, name, vm_aliases, vm_workspaces] {
-                        LaunchReply reply;
-                        reply.set_vm_instance_name(name);
-                        config->update_prompt->populate_if_time_to_show(reply.mutable_update_info());
+                    auto future_watcher =
+                        create_future_watcher([this, server, name, vm_aliases, vm_workspaces, zone = vm_desc.zone] {
+                            LaunchReply reply;
+                            reply.set_vm_instance_name(name);
+                            config->update_prompt->populate_if_time_to_show(reply.mutable_update_info());
 
-                        // Attach the aliases to be created by the CLI to the last message.
-                        for (const auto& blueprint_alias : vm_aliases)
-                        {
-                            mpl::log(mpl::Level::debug, category,
-                                     fmt::format("Adding alias '{}' to RPC reply", blueprint_alias.first));
-                            auto alias = reply.add_aliases_to_be_created();
-                            alias->set_name(blueprint_alias.first);
-                            alias->set_instance(blueprint_alias.second.instance);
-                            alias->set_command(blueprint_alias.second.command);
-                            alias->set_working_directory(blueprint_alias.second.working_directory);
-                        }
+                            reply.set_zone(zone);
 
-                        // Now attach the workspaces.
-                        for (const auto& blueprint_workspace : vm_workspaces)
-                        {
-                            mpl::log(mpl::Level::debug, category,
-                                     fmt::format("Adding workspace '{}' to RPC reply", blueprint_workspace));
-                            reply.add_workspaces_to_be_created(blueprint_workspace);
-                        }
+                            // Attach the aliases to be created by the CLI to the last message.
+                            for (const auto& blueprint_alias : vm_aliases)
+                            {
+                                mpl::log(mpl::Level::debug,
+                                         category,
+                                         fmt::format("Adding alias '{}' to RPC reply", blueprint_alias.first));
+                                auto alias = reply.add_aliases_to_be_created();
+                                alias->set_name(blueprint_alias.first);
+                                alias->set_instance(blueprint_alias.second.instance);
+                                alias->set_command(blueprint_alias.second.command);
+                                alias->set_working_directory(blueprint_alias.second.working_directory);
+                            }
 
-                        server->Write(reply);
-                    });
+                            // Now attach the workspaces.
+                            for (const auto& blueprint_workspace : vm_workspaces)
+                            {
+                                mpl::log(mpl::Level::debug,
+                                         category,
+                                         fmt::format("Adding workspace '{}' to RPC reply", blueprint_workspace));
+                                reply.add_workspaces_to_be_created(blueprint_workspace);
+                            }
+
+                            server->Write(reply);
+                        });
                     future_watcher->setFuture(
                         QtConcurrent::run(&Daemon::async_wait_for_ready_all<LaunchReply, LaunchRequest>,
                                           this,
@@ -3130,7 +3138,7 @@ void mp::Daemon::create_vm(const CreateRequest* request,
         try
         {
             CreateReply reply;
-            reply.set_create_message("Creating " + name);
+            reply.set_create_message(fmt::format("Creating {} in {}", name, zone_name));
             server->Write(reply);
 
             Query query;
@@ -3716,8 +3724,9 @@ void mp::Daemon::populate_instance_info(VirtualMachine& vm,
     const auto& name = vm.vm_name;
     info->set_name(name);
     const auto zone = info->mutable_zone();
-    zone->set_name(vm.get_zone().get_name());
-    zone->set_available(vm.get_zone().is_available());
+    const auto& az = vm.get_zone();
+    zone->set_name(az.get_name());
+    zone->set_available(az.is_available());
 
     if (deleted)
         info->mutable_instance_status()->set_status(mp::InstanceStatus::DELETED);

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -128,6 +128,7 @@ message LaunchReply {
     repeated Alias aliases_to_be_created = 10;
     repeated string workspaces_to_be_created = 11;
     bool password_requested = 12;
+    string zone = 13;
 }
 
 message PurgeRequest {


### PR DESCRIPTION
```
$     multipass list
No instances found.
$     multipass launch
Launched: frisky-sturgeon in zone zone1
$     multipass launch --zone zone1,zone3
launch failed: Invalid arguments supplied
$     multipass launch --zone zone1,
launch failed: Invalid arguments supplied
$     multipass launch --zone zone
launch failed: Invalid arguments supplied
$     multipass launch --zone zone3
Launched: quiet-lapwing in zone zone3
$     multipass list
Name                    State             IPv4             Image               Zone
frisky-sturgeon         Running           10.127.101.158   Ubuntu 24.04 LTS    zone1(a)
quiet-lapwing           Running           10.127.101.19    Ubuntu 24.04 LTS    zone3(a)

```


This pull request includes several changes to improve the `launch` command functionality in the `src/client/cli/cmd/launch.cpp` file, focusing on code formatting and adding a new `--zone` option. Additionally, it includes updates to the daemon and tests to support the new functionality.

### New `--zone` option:
* [`src/client/cli/cmd/launch.cpp`](diffhunk://#diff-273c7f46120011e4630f6400f3a20b56b3121f7cac91de5749fe63cf59f112c5R245-R261): Added a new `--zone` option to specify the availability zone during the launch command. This includes parsing the new option and setting the zone in the request. [[1]](diffhunk://#diff-273c7f46120011e4630f6400f3a20b56b3121f7cac91de5749fe63cf59f112c5R245-R261) [[2]](diffhunk://#diff-273c7f46120011e4630f6400f3a20b56b3121f7cac91de5749fe63cf59f112c5R474-R492)
* [`src/daemon/daemon.cpp`](diffhunk://#diff-d93d28344d209ab944d30f1b5438025d11fdcf98a15cb00588e0c219f46d08fbR3073-R3075): Updated the daemon to handle the new zone information and include it in the response. [[1]](diffhunk://#diff-d93d28344d209ab944d30f1b5438025d11fdcf98a15cb00588e0c219f46d08fbR3073-R3075) [[2]](diffhunk://#diff-d93d28344d209ab944d30f1b5438025d11fdcf98a15cb00588e0c219f46d08fbL3132-R3135)
* [`src/rpc/multipass.proto`](diffhunk://#diff-8f3345af7a851812a78ed26c3595542c317bc8120404a37c38594d86b708ff84R131): Added a new `zone_name` field to the `LaunchReply` message to communicate the zone information.

### Test updates:
* [`tests/test_cli_client.cpp`](diffhunk://#diff-966c5ac143e04c376d361c1755d1963a29c7b8800d954742b940d1deec14cb07R1011-R1035): Added new tests to verify the functionality of the `--zone` option, including tests for valid, empty, and nonexistent zone values.