### PR TITLE
Fix invalid macro definition and add <tuple> include

### DIFF
--- a/include/multipass/network_interface_info.h
+++ b/include/multipass/network_interface_info.h
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace multipass

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -45,7 +45,7 @@ endfunction()
 option(MULTIPASS_ENABLE_SYSLOG "Use syslog for logging instead of journald" OFF)
 
 if(NOT MULTIPASS_ENABLE_SYSLOG)
-  add_compile_definitions(-DMULTIPASS_JOURNALD_ENABLED)
+  add_compile_definitions(MULTIPASS_JOURNALD_ENABLED)
 endif()
 
 add_target(platform)


### PR DESCRIPTION
Author: @rshrj

This MP contains two external MPs:

https://github.com/canonical/multipass/pull/4008:
> This PR fixes an issue in `src/platform/CMakeLists.txt` where `add_compile_definitions()` is used with a `-D` prefix:
> 
> ```cmake
> add_compile_definitions(-DMULTIPASS_JOURNALD_ENABLED)
> ```
> 
> This results in a malformed macro definition `-D-DMULTIPASS_JOURNALD_ENABLED`, which causes a compiler error:
> 
> ```shell
> <command-line>: error: macro names must be identifiers
> ```
> 
> The fix is to pass only the macro name, as `add_compile_definitions()` automatically adds the `-D` prefix:
> 
> ```cmake
> add_compile_definitions(MULTIPASS_JOURNALD_ENABLED)
> ```
>
> Tested in a clean Debian 12 environment using Make, where this issue was originally triggered.

https://github.com/canonical/multipass/pull/4009:

> This PR adds a missing `#include <tuple>` to `network_interface_info.h`, which is required for the use of `std::tie`.
> 
> Without this include, builds fail on compilers/environments that do not implicitly include `<tuple>` via transitive headers. For example, GCC on Debian 12 produces:
> 
> ```shell
> error: ‘tie’ is not a member of ‘std’
> note: ‘std::tie’ is defined in header ‘’; did you forget to ‘#include ’?
> ```
> 
> Tested by successfully building the project in a clean Debian 12 dev container with GCC. No other changes.


