### PR TITLE
[project/cmake] add auto linker selection based on availability

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -160,6 +160,10 @@ jobs:
           sed -i "/build-environment:/a \    - VCPKG_BINARY_SOURCES: ${VCPKG_BINARY_SOURCES}" snap/snapcraft.yaml
         fi
 
+        if [ -n "${GITHUB_ACTIONS}" ]; then
+          sed -i "/build-environment:/a \    - GITHUB_ACTIONS: \"${GITHUB_ACTIONS}\"" snap/snapcraft.yaml
+        fi
+
         # Build the `multipass` part.
         /snap/bin/snapcraft build --use-lxd multipass
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -149,14 +149,14 @@ jobs:
         sed -i "/cmake-parameters:/a \    - -DMULTIPASS_BUILD_LABEL=${{ steps.build-params.outputs.label }}" snap/snapcraft.yaml
 
         # Inject vcpkg GH Actions cache env vars if they exist
-        if [ -n "$ACTIONS_CACHE_URL" ]; then
+        if [ -n "${ACTIONS_CACHE_URL}" ]; then
           sed -i "/build-environment:/a \    - ACTIONS_CACHE_URL: ${ACTIONS_CACHE_URL}" snap/snapcraft.yaml
         fi
-        if [ -n "ACTIONS_RUNTIME_TOKEN" ]; then
+        if [ -n "${ACTIONS_RUNTIME_TOKEN}" ]; then
           sed -i "/build-environment:/a \    - ACTIONS_RUNTIME_TOKEN: ${ACTIONS_RUNTIME_TOKEN}" snap/snapcraft.yaml
         fi
 
-        if [ -n "VCPKG_BINARY_SOURCES" ]; then
+        if [ -n "${VCPKG_BINARY_SOURCES}" ]; then
           sed -i "/build-environment:/a \    - VCPKG_BINARY_SOURCES: ${VCPKG_BINARY_SOURCES}" snap/snapcraft.yaml
         fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,16 @@
 cmake_minimum_required(VERSION 3.17)
 cmake_policy(SET CMP0079 NEW) # Allow target_link_libraries() in subdirs
 
+include(src/cmake/environment-utils.cmake)
+is_running_in_ci(IS_RUNNING_IN_CI)
+
+message(STATUS "Running in CI environment? ${IS_RUNNING_IN_CI}")
+
+if(NOT ${IS_RUNNING_IN_CI})
+  include(src/cmake/configure-linker.cmake)
+  configure_linker()
+endif()
+
 cmake_host_system_information(RESULT HOST_OS_NAME QUERY OS_NAME)
 
 if("${HOST_OS_NAME}" STREQUAL "macOS")

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ make
 
 Please note that if you're working on a forked repository that you created using the "Copy the main branch only" option, the repository will not include the necessary git tags to determine the Multipass version during CMake configuration. In this case, you need to manually fetch the tags from the upstream by running `git fetch --tags https://github.com/canonical/multipass.git` in the `<multipass>` source code directory. 
 
+### Automatic linker selection
+
+***Requires (>= CMake 3.29)***
+
+To accelerate the build, the build system will attempt to locate and utilize `mold` or `lld` (respectively) in place of the default linker of the toolchain. To override, set [CMAKE_LINKER_TYPE](https://cmake.org/cmake/help/latest/variable/CMAKE_LINKER_TYPE.html#cmake-linker-type) at CMake configure step.
+
 ## Run the Multipass daemon and client
 
 First, install Multipass's runtime dependencies. On AMD64 architecture, you can do this with:

--- a/src/cmake/configure-linker.cmake
+++ b/src/cmake/configure-linker.cmake
@@ -1,0 +1,45 @@
+# Copyright (C) Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+function(configure_linker)
+    if(${CMAKE_VERSION} VERSION_LESS "3.29")
+        message(STATUS "configure_linker is only supported in CMake 3.29 and above.")
+        return()
+    endif()
+
+    if(NOT DEFINED CMAKE_LINKER_TYPE)
+        if (WIN32)
+            set (LLD_LINKER_NAMES lld-link)
+        else()
+            set(LLD_LINKER_NAMES ld.lld ld64.lld)
+            set(MOLD_LINKER_NAMES mold sold)
+            find_program(MOLD_LINKER NAMES ${MOLD_LINKER_NAMES})
+        endif()
+
+        find_program(LLD_LINKER NAMES ${LLD_LINKER_NAMES})
+
+        if(MOLD_LINKER)
+            message(STATUS "configure_linker: `mold` found in environment, will use it as default.")
+            set(CMAKE_LINKER_TYPE MOLD PARENT_SCOPE)
+        elseif(LLD_LINKER)
+            message(STATUS "configure_linker: `lld` found in environment, will use it as default.")
+            set(CMAKE_LINKER_TYPE LDD PARENT_SCOPE)
+        else()
+            message(STATUS "configure_linker: neither `mold` or `lld` is present in the environment, will use the toolchain default.")
+        endif()
+    else()
+        message(STATUS "configure_linker: will use the user specified linker: `${CMAKE_LINKER_TYPE}`")
+    endif()
+endfunction()

--- a/src/cmake/environment-utils.cmake
+++ b/src/cmake/environment-utils.cmake
@@ -1,0 +1,21 @@
+# Copyright (C) Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function(is_running_in_ci OUT_VAR)
+    if(DEFINED ENV{GITHUB_ACTIONS} AND "$ENV{GITHUB_ACTIONS}" STREQUAL "true")
+        set(${OUT_VAR} TRUE PARENT_SCOPE)
+    else()
+        set(${OUT_VAR} FALSE PARENT_SCOPE)
+    endif()
+endfunction()


### PR DESCRIPTION
`mold` and `lld` are usually several magnitudes faster compared to the default linker of the toolchains. This PR adds the configure_linker CMake function to automatically configure which linker to use based on availability of the "mold" and "lld" in the environment. The function is no-op below CMake 3.29 since the current implementation depends on a rather recent CMake variable, CMAKE_LINKER_TYPE.

The user can disable the auto linker selection by explicitly specifying the CMAKE_LINKER_TYPE at configure step, i.e.,:

cmake -DCMAKE_LINKER_TYPE=DEFAULT -S . -B build

The `configure_linker` is intended to be only run in non-CI environments. The `is_running_in_ci` determines whether the project is being built in a CI environment.

MULTI-1912