### PR TITLE
[daemon] register the signal handler immediately on start

### DIFF
--- a/include/multipass/signal.h
+++ b/include/multipass/signal.h
@@ -23,8 +23,6 @@
 
 namespace multipass
 {
-namespace test
-{
 struct Signal
 {
     template <typename T>
@@ -51,6 +49,5 @@ struct Signal
     std::condition_variable cv;
     bool signaled{false};
 };
-} // namespace test
 } // namespace multipass
 #endif // MULTIPASS_SIGNAL_TEST_FIXTURE_H

--- a/include/multipass/top_catch_all.h
+++ b/include/multipass/top_catch_all.h
@@ -99,7 +99,14 @@ inline auto multipass::top_catch_all(std::string_view log_category,
         detail::error(log_category);
     }
 
-    return std::forward<decltype(fallback_return)>(fallback_return);
+    if constexpr (std::is_invocable_v<T>)
+    {
+        return std::invoke(std::forward<decltype(fallback_return)>(fallback_return));
+    }
+    else
+    {
+        return std::forward<decltype(fallback_return)>(fallback_return);
+    }
 }
 
 template <typename Fun, typename... Args>

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -38,7 +38,6 @@
 #include "mock_vm_blueprint_provider.h"
 #include "mock_vm_image_vault.h"
 #include "path.h"
-#include "signal.h"
 #include "stub_virtual_machine.h"
 #include "tracking_url_downloader.h"
 
@@ -50,6 +49,7 @@
 #include <multipass/exceptions/blueprint_exceptions.h>
 #include <multipass/logging/log.h>
 #include <multipass/name_generator.h>
+#include <multipass/signal.h>
 #include <multipass/version.h>
 #include <multipass/virtual_machine_factory.h>
 #include <multipass/vm_image_host.h>
@@ -387,12 +387,12 @@ TEST_F(Daemon, ensure_that_on_restart_future_completes)
         .WillOnce(Return(mp::VirtualMachine::State::stopped));
     EXPECT_CALL(*mock_vm, start).Times(1);
 
-    mpt::Signal signal;
+    mp::Signal sig;
     // update_state is called by the finished() handler of the future. If it's called, then
     // everything's ok.
-    EXPECT_CALL(*mock_vm, update_state).WillOnce([&signal] {
+    EXPECT_CALL(*mock_vm, update_state).WillOnce([&sig] {
         // Ensure that update_state is delayed until daemon's destructor call.
-        signal.wait();
+        sig.wait();
         // Wait a bit to ensure that daemon's destructor has been run
         std::this_thread::sleep_for(std::chrono::milliseconds{50});
     });
@@ -401,7 +401,7 @@ TEST_F(Daemon, ensure_that_on_restart_future_completes)
 
     {
         mp::Daemon daemon{config_builder.build()};
-        signal.signal();
+        sig.signal();
     }
 }
 

--- a/tests/test_delayed_shutdown.cpp
+++ b/tests/test_delayed_shutdown.cpp
@@ -18,11 +18,11 @@
 #include "common.h"
 #include "mock_ssh_test_fixture.h"
 #include "mock_virtual_machine.h"
-#include "signal.h"
 #include "stub_virtual_machine.h"
 
 #include <multipass/delayed_shutdown_timer.h>
 #include <multipass/exceptions/ssh_exception.h>
+#include <multipass/signal.h>
 
 #include <QEventLoop>
 
@@ -49,7 +49,7 @@ struct DelayedShutdown : public Test
 
 TEST_F(DelayedShutdown, emits_finished_after_timer_expires)
 {
-    mpt::Signal finished;
+    mp::Signal finished;
     mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), [](const std::string&) {}};
 
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [this, &finished] {
@@ -90,7 +90,7 @@ TEST_F(DelayedShutdown, handlesExceptionWhenAttemptingToWall)
 
     EXPECT_CALL(vm, ssh_exec(HasSubstr("wall"), _)).Times(2).WillRepeatedly(Throw(mp::SSHException("nope")));
 
-    mpt::Signal finished;
+    mp::Signal finished;
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [this, &finished] {
         loop.quit();
         finished.signal();
@@ -104,7 +104,7 @@ TEST_F(DelayedShutdown, handlesExceptionWhenAttemptingToWall)
 
 TEST_F(DelayedShutdown, emits_finished_with_no_timer)
 {
-    mpt::Signal finished;
+    mp::Signal finished;
     mp::DelayedShutdownTimer delayed_shutdown_timer{vm.get(), [](const std::string&) {}};
 
     QObject::connect(&delayed_shutdown_timer, &mp::DelayedShutdownTimer::finished, [&finished] { finished.signal(); });

--- a/tests/test_sshfsmount.cpp
+++ b/tests/test_sshfsmount.cpp
@@ -19,13 +19,13 @@
 #include "mock_logger.h"
 #include "mock_ssh_process_exit_status.h"
 #include "sftp_server_test_fixture.h"
-#include "signal.h"
 #include "stub_ssh_key_provider.h"
 
 #include <src/sshfs_mount/sshfs_mount.h>
 
 #include <multipass/exceptions/sshfs_missing_error.h>
 #include <multipass/logging/log.h>
+#include <multipass/signal.h>
 #include <multipass/ssh/ssh_session.h>
 #include <multipass/utils.h>
 
@@ -386,7 +386,7 @@ TEST_F(SshfsMount, throws_when_sshfs_does_not_exist)
 
 TEST_F(SshfsMount, unblocks_when_sftpserver_exits)
 {
-    mpt::Signal client_message;
+    mp::Signal client_message;
     auto get_client_msg = [&client_message](sftp_session) {
         client_message.wait();
         return nullptr;


### PR DESCRIPTION
The signal handler should be the first thing to register since the controller (e.g. user, snapd) can send signals immediately. Right now, the daemon either freezes or crashes when it's being launched and then immediately killed via Ctrl-C, which can also observed via running `snap restart multipass` in quick succession.

The signal handler uses `QCoreApplication::quit()` to wrap everything up, but use of `QCoreApplication::quit()` requires proper initialization of the QT resources first, so the signal handler should wait until that's done.

In order to ensure that this patch does the following:

- signal.h is moved from test/ to multipass/
- Added a top-level mp::Signal object to facilitate communication between the signal handler thread and the main thread
- mp::top_catch_all can now accommodate a callable as a fallback_return, so the code can now execute additional logic when the wrappee throws
- Added `QThreadPool::globalInstance()->waitForDone()` to ensure that the tasks dispatched through QConcurrent::run() are waited for completion. (otherwise QCoreApplication's destructor might block)

MULTI-1918