### PR TITLE
[3rd-party/CMakeLists] Define CMAKE_POLICY_VERSION_MINIMUM=3.5

### DIFF
--- a/3rd-party/CMakeLists.txt
+++ b/3rd-party/CMakeLists.txt
@@ -4,6 +4,20 @@ if (MSVC)
   add_compile_options(-wd5045) #Disable warning about Spectre mitigation
 endif()
 
+function(add_subdirectory_compat)
+    #
+    # This is for CMake 4.0 compatibility.
+    #
+    # CMake 4.0 drops support CMake policies below 3.5 and some of our dependencies
+    # declare their minimum required version as 3.4, and CMake 4.0 is not happy
+    # with that. The CMAKE_POLICY_VERSION_MINIMUM option allows us to override that
+    # without having to touch the dependency's source code.
+    #
+    # https://cmake.org/cmake/help/latest/variable/CMAKE_POLICY_VERSION_MINIMUM.html
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+    add_subdirectory(${ARGV})
+endfunction()
+
 # Generates gRPC and protobuf C++ sources and headers from the given .proto files
 #
 # generate_grpc_cpp (<SRCS> <DEST> [<ARGN>...])
@@ -61,7 +75,7 @@ option(YAML_CPP_BUILD_TOOLS OFF)
 option(YAML_CPP_BUILD_CONTRIB OFF)
 option(YAML_CPP_BUILD_TESTS OFF)
 
-add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
+add_subdirectory_compat(yaml-cpp EXCLUDE_FROM_ALL)
 set_target_properties(yaml-cpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(yaml INTERFACE)
@@ -94,7 +108,7 @@ target_compile_definitions(scope_guard INTERFACE
   SG_REQUIRE_NOEXCEPT_IN_CPP17)
 
 # semver library
-add_subdirectory(semver EXCLUDE_FROM_ALL)
+add_subdirectory_compat(semver EXCLUDE_FROM_ALL)
 target_include_directories(semver INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/semver/include)
 set_target_properties(semver PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
With CMake 4.0, support for compatibility with versions older than 3.5 has been removed. One of our dependencies (yaml-cpp) defines its policy version as 3.4, so the build with CMake 4 fails for that reason.

There's an option to override that behavior, called CMAKE_POLICY_VERSION_MINIMUM. This flag suppresses the error and allows CMake to try building the project anyway. yaml-cpp builds without any issues when the option is in place. The upstream also updated the cmake_minimum_required() to `3.4...3.14` without making any code changes, so it's safe to assume that the project is compatible with the CMake 3.5 policies.

https://github.com/jbeder/yaml-cpp/commit/c2680200486572baf8221ba052ef50b58ecd816e

MULTI-1919