### PR TITLE
Remove libvirt driver from GUI

### DIFF
--- a/src/client/gui/lib/platform/linux.dart
+++ b/src/client/gui/lib/platform/linux.dart
@@ -15,7 +15,6 @@ class LinuxPlatform extends MpPlatform {
   Map<String, String> get drivers => const {
         'qemu': 'QEMU',
         'lxd': 'LXD',
-        'libvirt': 'libvirt',
       };
 
   @override

--- a/src/client/gui/lib/providers.dart
+++ b/src/client/gui/lib/providers.dart
@@ -7,6 +7,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:grpc/grpc.dart';
+import 'package:multipass_gui/platform/platform.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'ffi.dart';
@@ -318,4 +319,13 @@ final networksProvider = Provider.autoDispose((ref) {
     }).ignore();
   }
   return BuiltSet<String>();
+});
+
+final driversProvider = Provider.autoDispose((ref) {
+  final driver = ref.watch(daemonSettingProvider(driverKey)).valueOrNull;
+  if (driver != null && !mpPlatform.drivers.containsKey(driver)) {
+    return Map<String, String>.from(mpPlatform.drivers)
+      ..addAll({driver: driver});
+  }
+  return mpPlatform.drivers;
 });

--- a/src/client/gui/lib/providers.dart
+++ b/src/client/gui/lib/providers.dart
@@ -7,7 +7,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:grpc/grpc.dart';
-import 'package:multipass_gui/platform/platform.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'ffi.dart';
@@ -319,13 +318,4 @@ final networksProvider = Provider.autoDispose((ref) {
     }).ignore();
   }
   return BuiltSet<String>();
-});
-
-final driversProvider = Provider.autoDispose((ref) {
-  final driver = ref.watch(daemonSettingProvider(driverKey)).valueOrNull;
-  if (driver != null && !mpPlatform.drivers.containsKey(driver)) {
-    return Map<String, String>.from(mpPlatform.drivers)
-      ..addAll({driver: driver});
-  }
-  return mpPlatform.drivers;
 });

--- a/src/client/gui/lib/settings/virtualization_settings.dart
+++ b/src/client/gui/lib/settings/virtualization_settings.dart
@@ -17,6 +17,7 @@ class VirtualizationSettings extends ConsumerWidget {
     final driver = ref.watch(driverProvider).valueOrNull;
     final bridgedNetwork = ref.watch(bridgedNetworkProvider).valueOrNull;
     final networks = ref.watch(networksProvider);
+    final drivers = ref.watch(driversProvider);
 
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       const Text(
@@ -28,7 +29,7 @@ class VirtualizationSettings extends ConsumerWidget {
         label: 'Driver',
         width: 260,
         value: driver,
-        items: mpPlatform.drivers,
+        items: drivers,
         onChanged: (value) {
           if (value == driver) return;
           ref

--- a/src/client/gui/lib/settings/virtualization_settings.dart
+++ b/src/client/gui/lib/settings/virtualization_settings.dart
@@ -17,7 +17,6 @@ class VirtualizationSettings extends ConsumerWidget {
     final driver = ref.watch(driverProvider).valueOrNull;
     final bridgedNetwork = ref.watch(bridgedNetworkProvider).valueOrNull;
     final networks = ref.watch(networksProvider);
-    final drivers = ref.watch(driversProvider);
 
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       const Text(
@@ -29,7 +28,10 @@ class VirtualizationSettings extends ConsumerWidget {
         label: 'Driver',
         width: 260,
         value: driver,
-        items: drivers,
+        items: {
+          if (driver != null) driver: driver,
+          ...mpPlatform.drivers,
+        },
         onChanged: (value) {
           if (value == driver) return;
           ref


### PR DESCRIPTION
This PR removes libvirt from the list of drivers in the GUI. If a user has libvirt they will still be on libvirt, however, once they switch to a different driver libvirt will no-longer be selectable.

MULTI-1889