### PR TITLE
Remove lxd driver from GUI

### DIFF
--- a/src/client/gui/lib/platform/linux.dart
+++ b/src/client/gui/lib/platform/linux.dart
@@ -14,7 +14,6 @@ class LinuxPlatform extends MpPlatform {
   @override
   Map<String, String> get drivers => const {
         'qemu': 'QEMU',
-        'lxd': 'LXD',
       };
 
   @override


### PR DESCRIPTION
This PR removes lxd from the list of drivers in the GUI. If a user has lxd they will still be on lxd, however, once they switch to a different driver lxd will no-longer be selectable.

MULTI-1894