### PR TITLE
[vcpkg] Update deps for compatibility with cmake 4.0

### DIFF
--- a/3rd-party/vcpkg-ports/poco/vcpkg.json
+++ b/3rd-party/vcpkg-ports/poco/vcpkg.json
@@ -8,7 +8,10 @@
   "supports": "!uwp",
   "dependencies": [
     "expat",
-    "pcre2",
+    {
+      "name": "pcre2",
+      "version>=": "10.43"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true


### PR DESCRIPTION
- Enforced pcre2 >= 10.43 for [cmake minimum version](https://github.com/PCRE2Project/pcre2/blob/3864abdb713f78831dd12d898ab31bbb0fa630b6/CMakeLists.txt#L108) compatibility with cmake 4.0