### PR TITLE
[gui] add 'Launch & Configure next' button to launch form

### DIFF
--- a/src/client/gui/lib/catalogue/launch_form.dart
+++ b/src/client/gui/lib/catalogue/launch_form.dart
@@ -251,9 +251,9 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
       child: const Text('Launch'),
     );
 
-    final launchAndConfigureNextButton = TextButton(
+    final launchAndConfigureNextButton = OutlinedButton(
       onPressed: () => launch(imageInfo, configureNext: true),
-      child: const Text('Launch & Configure Next'),
+      child: const Text('Launch & Configure next'),
     );
 
     final cancelButton = OutlinedButton(

--- a/src/client/gui/lib/catalogue/launch_form.dart
+++ b/src/client/gui/lib/catalogue/launch_form.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:basics/basics.dart';
 import 'package:flutter/material.dart' hide Switch, ImageInfo;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:protobuf/protobuf.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../ffi.dart';

--- a/src/client/gui/lib/catalogue/launch_form.dart
+++ b/src/client/gui/lib/catalogue/launch_form.dart
@@ -250,6 +250,11 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
       child: const Text('Launch'),
     );
 
+    final launchAndConfigureNextButton = TextButton(
+      onPressed: () => launch(imageInfo, configureNext: true),
+      child: const Text('Launch & Configure Next'),
+    );
+
     final cancelButton = OutlinedButton(
       onPressed: () => Scaffold.of(context).closeEndDrawer(),
       child: const Text('Cancel'),
@@ -285,6 +290,8 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
             Row(children: [
               launchButton,
               const SizedBox(width: 16),
+              launchAndConfigureNextButton,
+              const SizedBox(width: 16),
               cancelButton,
             ]),
           ]),
@@ -293,9 +300,7 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
     ]);
   }
 
-  void launch(ImageInfo imageInfo) {
-    launchRequest.clear();
-
+  void launch(ImageInfo imageInfo, {bool configureNext = false}) {
     final formState = formKey.currentState;
     if (formState == null) return;
     final mountFormState = mountFormKey.currentState;
@@ -316,8 +321,18 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
       mountRequest.targetPaths.first.instanceName = launchRequest.instanceName;
     }
 
-    initiateLaunchFlow(ref, launchRequest, mountRequests);
-    Scaffold.of(context).closeEndDrawer();
+    initiateLaunchFlow(
+      ref,
+      launchRequest.deepCopy(),
+      mountRequests.map((r) => r.deepCopy()).toList(),
+    );
+
+    if (!configureNext) {
+      Scaffold.of(context).closeEndDrawer();
+      ref
+          .read(sidebarKeyProvider.notifier)
+          .set('vm-${launchRequest.instanceName}');
+    }
   }
 }
 
@@ -346,7 +361,6 @@ void initiateLaunchFlow(
   );
 
   ref.read(notificationsProvider.notifier).add(notification);
-  ref.read(sidebarKeyProvider.notifier).set('vm-${launchRequest.instanceName}');
 }
 
 FormFieldValidator<String> nameValidator(


### PR DESCRIPTION
resolves #4028 

![image](https://github.com/user-attachments/assets/02b6ee97-0290-4c40-bec8-cd45c0a218cd)


This pull request introduces a new feature to the `LaunchForm` in the `src/client/gui/lib/catalogue/launch_form.dart` file, allowing users to launch and configure the next item without closing the form. The most important changes include adding a new button, modifying the launch method to support the new functionality, and adjusting the form reset behavior.

New feature for launching and configuring the next item:

* Added a `launchAndConfigureNextButton` to the form, which allows users to launch the current item and immediately configure the next one. [[1]](diffhunk://#diff-1859f216fc901caa87909945aef29585a3d98e3b5e265a7e804870ae8a3a652fR253-R257) [[2]](diffhunk://#diff-1859f216fc901caa87909945aef29585a3d98e3b5e265a7e804870ae8a3a652fR293-R294)

Modifications to the launch method:

* Updated the `launch` method to accept an optional `configureNext` parameter, which controls whether the form should reset after launching.

Form reset behavior:

* Adjusted the form reset logic to only reset the form and close the drawer if `configureNext` is `false`. [[1]](diffhunk://#diff-1859f216fc901caa87909945aef29585a3d98e3b5e265a7e804870ae8a3a652fR326-R336) [[2]](diffhunk://#diff-1859f216fc901caa87909945aef29585a3d98e3b5e265a7e804870ae8a3a652fL349)