### PR TITLE
[gh/wf/linux.yml] allow workflow cancellation

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,8 +23,8 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number && format('pr{0}', github.event.number) || github.run_id }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true #
 
 jobs:
   Lint:
@@ -64,6 +64,9 @@ jobs:
         echo "${MATRIX}" | jq -cs '{"include": . }' | awk '{ print "matrix=" $0 }' >> $GITHUB_OUTPUT
 
   BuildAndTest:
+    concurrency:
+      group: ${{ github.workflow }}-buildtest-${{ github.head_ref || github.run_id }}-${{ matrix.build-type }}
+      cancel-in-progress: true
     needs: [Lint, GetMatrix]
 
     # Allow skipped Lint

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,10 +68,16 @@ jobs:
 
     # Allow skipped Lint
     # Let Lint fail on pull requests
-    if: ${{ !cancelled() && (success() ||
-           needs.Lint.result == 'skipped' ||
-           (needs.Lint.result == 'failure' && github.event_name == 'pull_request')
-          )}}
+    if: ${{ !cancelled() &&
+            (
+              success() ||
+              needs.Lint.result == 'skipped' ||
+              (
+                needs.Lint.result == 'failure' &&
+                github.event_name == 'pull_request'
+              )
+            )
+        }}
 
     outputs:
       label: ${{ steps.build-params.outputs.label }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number && format('pr{0}', github.event.number) || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   Lint:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,13 +24,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true #
+  cancel-in-progress: true
 
 jobs:
   Lint:
     runs-on: ubuntu-latest
 
-    if: ${{ contains('pull_request merge_group', github.event_name) }}
+    if: ${{ !cancelled() && contains('pull_request merge_group', github.event_name) }}
 
     steps:
     - name: Check out code
@@ -64,20 +64,14 @@ jobs:
         echo "${MATRIX}" | jq -cs '{"include": . }' | awk '{ print "matrix=" $0 }' >> $GITHUB_OUTPUT
 
   BuildAndTest:
-    concurrency:
-      group: ${{ github.workflow }}-buildtest-${{ github.head_ref || github.run_id }}-${{ matrix.build-type }}
-      cancel-in-progress: true
     needs: [Lint, GetMatrix]
 
     # Allow skipped Lint
     # Let Lint fail on pull requests
-    if: |
-      ${{
-        success()
-        || needs.Lint.result == 'skipped'
-        || ( needs.Lint.result == 'failure'
-             && github.event_name == 'pull_request' )
-      }}
+    if: ${{ !cancelled() && (success() ||
+           needs.Lint.result == 'skipped' ||
+           (needs.Lint.result == 'failure' && github.event_name == 'pull_request')
+          )}}
 
     outputs:
       label: ${{ steps.build-params.outputs.label }}
@@ -312,9 +306,7 @@ jobs:
   Publish-Snap:
     needs: BuildAndTest
     # Need to explicitly continue on Lint getting skipped.
-    if: ${{
-      !failure()
-      && !cancelled()
+    if: ${{ !cancelled() && success()
       && needs.BuildAndTest.outputs.channel != ''
       && (github.event_name == 'push'
           || github.event_name == 'merge_group'
@@ -347,9 +339,7 @@ jobs:
 
     # Only dispatch if we have access to secrets.
     # Need to explicitly continue on Lint getting skipped.
-    if: ${{
-      !failure()
-      && !cancelled()
+    if: ${{ !cancelled() && success()
       && (github.event_name == 'push'
           || github.event_name == 'merge_group'
           || github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
Allow in-progress workflows to be canceled when an external event requests them (e.g., the workflow run has been superseded with a new commit).

MULTI-1939