### PR TITLE
Normalize mount targets

### DIFF
--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -65,12 +65,10 @@ constexpr auto cloud_init_file_name = "cloud-init-config.iso";
 
 [[maybe_unused]] // hands off clang-format
 constexpr auto key_examples = {petenv_key, driver_key, mounts_key};
-
 constexpr auto petenv_default = "primary";
-
 constexpr auto timeout_exit_code = 5;
-
 constexpr auto authenticated_certs_dir = "authenticated-certs";
+constexpr auto home_in_instance = "/home/ubuntu";
 } // namespace multipass
 
 #endif // MULTIPASS_CONSTANTS_H

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -73,6 +73,7 @@ QString backend_directory_path(const Path& path, const QString& subdirectory);
 std::string filename_for(const std::string& path);
 std::string contents_of(const multipass::Path& file_path);
 bool invalid_target_path(const QString& target_path);
+std::string make_abspath(const QString& input_path);
 QTemporaryFile create_temp_file_with_path(const QString& filename_template);
 void remove_directories(const std::vector<QString>& dirs);
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -72,7 +72,7 @@ bool is_dir(const std::string& path);
 QString backend_directory_path(const Path& path, const QString& subdirectory);
 std::string filename_for(const std::string& path);
 std::string contents_of(const multipass::Path& file_path);
-bool invalid_target_path(const QString& target_path);
+bool invalid_target_path(const QString& target_path); // input path should be normalized
 QTemporaryFile create_temp_file_with_path(const QString& filename_template);
 void remove_directories(const std::vector<QString>& dirs);
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -72,7 +72,6 @@ bool is_dir(const std::string& path);
 QString backend_directory_path(const Path& path, const QString& subdirectory);
 std::string filename_for(const std::string& path);
 std::string contents_of(const multipass::Path& file_path);
-bool invalid_target_path(const QString& target_path); // input path should be normalized
 QTemporaryFile create_temp_file_with_path(const QString& filename_template);
 void remove_directories(const std::vector<QString>& dirs);
 
@@ -239,6 +238,7 @@ public:
 
     virtual Path default_mount_target(const Path& source) const;
     virtual Path normalize_mount_target(Path target_mount_path) const;
+    virtual bool invalid_target_path(const Path& target_path) const; // input path must be normalized
 };
 } // namespace multipass
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -73,7 +73,6 @@ QString backend_directory_path(const Path& path, const QString& subdirectory);
 std::string filename_for(const std::string& path);
 std::string contents_of(const multipass::Path& file_path);
 bool invalid_target_path(const QString& target_path);
-QString make_abspath(QString target_mount_path);
 QTemporaryFile create_temp_file_with_path(const QString& filename_template);
 void remove_directories(const std::vector<QString>& dirs);
 
@@ -239,6 +238,7 @@ public:
     virtual bool is_ipv4_valid(const std::string& ipv4) const;
 
     virtual Path default_mount_target(const Path& source) const;
+    virtual Path make_abspath(Path target_mount_path) const;
 };
 } // namespace multipass
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -73,7 +73,7 @@ QString backend_directory_path(const Path& path, const QString& subdirectory);
 std::string filename_for(const std::string& path);
 std::string contents_of(const multipass::Path& file_path);
 bool invalid_target_path(const QString& target_path);
-std::string make_abspath(const QString& input_path);
+QString make_abspath(QString target_mount_path);
 QTemporaryFile create_temp_file_with_path(const QString& filename_template);
 void remove_directories(const std::vector<QString>& dirs);
 

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -238,7 +238,7 @@ public:
     virtual bool is_ipv4_valid(const std::string& ipv4) const;
 
     virtual Path default_mount_target(const Path& source) const;
-    virtual Path make_abspath(Path target_mount_path) const;
+    virtual Path normalize_mount_target(Path target_mount_path) const;
 };
 } // namespace multipass
 

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -233,11 +233,12 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
                                      "You can also use a shortcut of \"<name>\" to mean \"name=<name>\".",
                                      "spec");
     QCommandLineOption bridgedOption("bridged", "Adds one `--network bridged` network.");
-    QCommandLineOption mountOption("mount",
-                                   "Mount a local directory inside the instance. If <target> is omitted, the "
-                                   "mount point will be under /home/ubuntu/<source-dir>, where <source-dir> is "
-                                   "the name of the <source> directory.",
-                                   "source>:<target");
+    QCommandLineOption mountOption(
+        "mount",
+        QStringLiteral("Mount a local directory inside the instance. If <target> is omitted, the mount point will be "
+                       "under %1/<source-dir>, where <source-dir> is the name of the <source> directory.")
+            .arg(home_in_instance),
+        "source>:<target");
 
     parser->addOptions({cpusOption, diskOption, memOption, memOptionDeprecated, nameOption, cloudInitOption,
                         networkOption, bridgedOption, mountOption});

--- a/src/client/cli/cmd/mount.cpp
+++ b/src/client/cli/cmd/mount.cpp
@@ -110,12 +110,13 @@ QString cmd::Mount::description() const
 mp::ParseCode cmd::Mount::parse_args(mp::ArgParser* parser)
 {
     parser->addPositionalArgument("source", "Path of the local directory to mount", "<source>");
-    parser->addPositionalArgument("target",
-                                  "Target mount points, in <name>[:<path>] format, where <name> "
-                                  "is an instance name, and optional <path> is the mount point. "
-                                  "If omitted, the mount point will be under /home/ubuntu/<source-dir>, "
-                                  "where <source-dir> is the name of the <source> directory.",
-                                  "<target> [<target> ...]");
+    parser->addPositionalArgument(
+        "target",
+        QStringLiteral("Target mount points, in <name>[:<path>] format, where <name> is an instance name, and optional "
+                       "<path> is the mount point. If omitted, the mount point will be under %1/<source-dir>, where "
+                       "<source-dir> is the name of the <source> directory.")
+            .arg(home_in_instance),
+        "<target> [<target> ...]");
 
     QCommandLineOption gid_mappings({"g", "gid-map"},
                                     "A mapping of group IDs for use in the mount. File and folder ownership will be "

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1928,7 +1928,7 @@ try // clang-format on
         const auto q_target_path = path_entry.target_path().empty()
                                        ? MP_UTILS.default_mount_target(QString::fromStdString(request->source_path()))
                                        : QDir::cleanPath(QString::fromStdString(path_entry.target_path()));
-        const auto target_path = q_target_path.toStdString();
+        const auto target_path = mp::utils::make_abspath(q_target_path);
 
         auto it = operative_instances.find(name);
         if (it == operative_instances.end())
@@ -1938,7 +1938,7 @@ try // clang-format on
         }
         auto& vm = it->second;
 
-        if (mp::utils::invalid_target_path(q_target_path))
+        if (mp::utils::invalid_target_path(QString::fromStdString(target_path)))
         {
             add_fmt_to(errors, "unable to mount to \"{}\"", target_path);
             continue;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1925,13 +1925,11 @@ try // clang-format on
     for (const auto& path_entry : request->target_paths())
     {
         const auto& name = path_entry.instance_name();
-        const auto target_path = [&path_entry, src_path = request->source_path()] {
-            auto q_target_path = QString::fromStdString(path_entry.target_path());
-            q_target_path = q_target_path.isEmpty() ? MP_UTILS.default_mount_target(QString::fromStdString(src_path))
-                                                    : MP_UTILS.make_abspath(q_target_path);
-
-            return q_target_path.toStdString();
-        }(); // TODO@ricab extract
+        auto q_target_path = QString::fromStdString(path_entry.target_path());
+        q_target_path = q_target_path.isEmpty()
+                            ? MP_UTILS.default_mount_target(QString::fromStdString(request->source_path()))
+                            : MP_UTILS.make_abspath(q_target_path);
+        auto target_path = q_target_path.toStdString();
 
         auto it = operative_instances.find(name);
         if (it == operative_instances.end())
@@ -1941,7 +1939,7 @@ try // clang-format on
         }
         auto& vm = it->second;
 
-        if (mp::utils::invalid_target_path(QString::fromStdString(target_path))) // TODO@ricab avoid cleanPath and conv
+        if (mp::utils::invalid_target_path(q_target_path)) // TODO@ricab avoid cleanPath
         {
             add_fmt_to(errors, "unable to mount to \"{}\"", target_path);
             continue;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1939,7 +1939,7 @@ try // clang-format on
         }
         auto& vm = it->second;
 
-        if (mp::utils::invalid_target_path(q_target_path)) // TODO@ricab avoid cleanPath
+        if (mp::utils::invalid_target_path(q_target_path))
         {
             add_fmt_to(errors, "unable to mount to \"{}\"", target_path);
             continue;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1930,7 +1930,7 @@ try // clang-format on
             if (q_target_path.isEmpty())
                 q_target_path = MP_UTILS.default_mount_target(QString::fromStdString(src_path));
             else
-                q_target_path = mpu::make_abspath(q_target_path);
+                q_target_path = MP_UTILS.make_abspath(q_target_path);
 
             return q_target_path.toStdString();
         }(); // TODO@ricab extract

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1925,10 +1925,15 @@ try // clang-format on
     for (const auto& path_entry : request->target_paths())
     {
         const auto& name = path_entry.instance_name();
-        const auto q_target_path = path_entry.target_path().empty()
-                                       ? MP_UTILS.default_mount_target(QString::fromStdString(request->source_path()))
-                                       : QDir::cleanPath(QString::fromStdString(path_entry.target_path()));
-        const auto target_path = mp::utils::make_abspath(q_target_path);
+        const auto target_path = [&path_entry, src_path = request->source_path()] {
+            auto q_target_path = QString::fromStdString(path_entry.target_path());
+            if (q_target_path.isEmpty())
+                q_target_path = MP_UTILS.default_mount_target(QString::fromStdString(src_path));
+            else
+                q_target_path = mpu::make_abspath(q_target_path);
+
+            return q_target_path.toStdString();
+        }(); // TODO@ricab extract
 
         auto it = operative_instances.find(name);
         if (it == operative_instances.end())
@@ -1938,7 +1943,7 @@ try // clang-format on
         }
         auto& vm = it->second;
 
-        if (mp::utils::invalid_target_path(QString::fromStdString(target_path)))
+        if (mp::utils::invalid_target_path(QString::fromStdString(target_path))) // TODO@ricab avoid cleanPath and conv
         {
             add_fmt_to(errors, "unable to mount to \"{}\"", target_path);
             continue;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1927,10 +1927,8 @@ try // clang-format on
         const auto& name = path_entry.instance_name();
         const auto target_path = [&path_entry, src_path = request->source_path()] {
             auto q_target_path = QString::fromStdString(path_entry.target_path());
-            if (q_target_path.isEmpty())
-                q_target_path = MP_UTILS.default_mount_target(QString::fromStdString(src_path));
-            else
-                q_target_path = MP_UTILS.make_abspath(q_target_path);
+            q_target_path = q_target_path.isEmpty() ? MP_UTILS.default_mount_target(QString::fromStdString(src_path))
+                                                    : MP_UTILS.make_abspath(q_target_path);
 
             return q_target_path.toStdString();
         }(); // TODO@ricab extract

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1928,7 +1928,7 @@ try // clang-format on
         auto q_target_path = QString::fromStdString(path_entry.target_path());
         q_target_path = q_target_path.isEmpty()
                             ? MP_UTILS.default_mount_target(QString::fromStdString(request->source_path()))
-                            : MP_UTILS.make_abspath(q_target_path);
+                            : MP_UTILS.normalize_mount_target(q_target_path);
         auto target_path = q_target_path.toStdString();
 
         auto it = operative_instances.find(name);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1939,7 +1939,7 @@ try // clang-format on
         }
         auto& vm = it->second;
 
-        if (mp::utils::invalid_target_path(q_target_path))
+        if (MP_UTILS.invalid_target_path(q_target_path))
         {
             add_fmt_to(errors, "unable to mount to \"{}\"", target_path);
             continue;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -41,7 +41,6 @@
 #include <array>
 #include <cassert>
 #include <cctype>
-#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <random>

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -41,6 +41,7 @@
 #include <array>
 #include <cassert>
 #include <cctype>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <random>
@@ -148,6 +149,18 @@ bool mp::utils::valid_hostname(const std::string& name_string)
     QRegularExpression matcher{QRegularExpression::anchoredPattern("^([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])")};
 
     return matcher.match(QString::fromStdString(name_string)).hasMatch();
+}
+
+std::string mp::utils::make_abspath(const QString& input_path)
+{
+    const fs::path base_path("/home/ubuntu");           // Base path for relative paths
+    const fs::path path_obj = input_path.toStdString(); // Convert QString to std::string
+
+    if (path_obj.is_absolute())
+    {
+        return path_obj.lexically_normal().string(); // Return as string if already absolute
+    }
+    return (fs::absolute(base_path / path_obj)).lexically_normal().string(); // Convert to absolute path
 }
 
 bool mp::utils::invalid_target_path(const QString& target_path)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -570,13 +570,13 @@ bool mp::Utils::is_ipv4_valid(const std::string& ipv4) const
 
 mp::Path mp::Utils::default_mount_target(const Path& source) const
 {
-    return source.isEmpty() ? "" : QDir{QDir::cleanPath(source)}.dirName().prepend("/home/ubuntu/");
+    return source.isEmpty() ? "" : QDir{QDir::cleanPath(source)}.dirName().prepend(QString{home_in_instance} + '/');
 }
 
 QString mp::Utils::normalize_mount_target(QString target_mount_path) const
 {
     if (QDir::isRelativePath(target_mount_path)) // relying on Qt to understand Linux paths on Windows
-        target_mount_path.prepend("/home/ubuntu/");
+        target_mount_path.prepend(QString{home_in_instance} + '/');
 
     return QDir::cleanPath(target_mount_path);
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -150,15 +150,6 @@ bool mp::utils::valid_hostname(const std::string& name_string)
     return matcher.match(QString::fromStdString(name_string)).hasMatch();
 }
 
-bool mp::utils::invalid_target_path(const QString& target_path)
-{
-    assert(target_path == QDir::cleanPath(target_path) && "target_path must be normalized");
-    static QRegularExpression matcher{
-        QRegularExpression::anchoredPattern("/+|/+(dev|proc|sys)(/.*)*|/+home(/*)(/ubuntu/*)*")};
-
-    return matcher.match(target_path).hasMatch();
-}
-
 QTemporaryFile mp::utils::create_temp_file_with_path(const QString& filename_template)
 {
     auto temp_folder = QFileInfo(filename_template).absoluteDir();
@@ -579,6 +570,15 @@ QString mp::Utils::normalize_mount_target(QString target_mount_path) const
         target_mount_path.prepend(QString{home_in_instance} + '/');
 
     return QDir::cleanPath(target_mount_path);
+}
+
+bool mp::Utils::invalid_target_path(const QString& target_path) const
+{
+    assert(target_path == QDir::cleanPath(target_path) && "target_path must be normalized");
+    static QRegularExpression matcher{
+        QRegularExpression::anchoredPattern("/+|/+(dev|proc|sys)(/.*)*|/+home(/*)(/ubuntu/*)*")};
+
+    return matcher.match(target_path).hasMatch();
 }
 
 auto mp::utils::find_bridge_with(const std::vector<mp::NetworkInterfaceInfo>& networks,

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -151,14 +151,6 @@ bool mp::utils::valid_hostname(const std::string& name_string)
     return matcher.match(QString::fromStdString(name_string)).hasMatch();
 }
 
-QString mp::utils::make_abspath(QString target_mount_path) // TODO@ricab move and rename
-{
-    if (QDir::isRelativePath(target_mount_path)) // relying on Qt to understand Linux paths on Windows
-        target_mount_path.prepend("/home/ubuntu/");
-
-    return QDir::cleanPath(target_mount_path);
-}
-
 bool mp::utils::invalid_target_path(const QString& target_path)
 {
     QString sanitized_path{QDir::cleanPath(target_path)};
@@ -579,6 +571,14 @@ bool mp::Utils::is_ipv4_valid(const std::string& ipv4) const
 mp::Path mp::Utils::default_mount_target(const Path& source) const
 {
     return source.isEmpty() ? "" : QDir{QDir::cleanPath(source)}.dirName().prepend("/home/ubuntu/");
+}
+
+QString mp::Utils::make_abspath(QString target_mount_path) const // TODO@ricab rename
+{
+    if (QDir::isRelativePath(target_mount_path)) // relying on Qt to understand Linux paths on Windows
+        target_mount_path.prepend("/home/ubuntu/");
+
+    return QDir::cleanPath(target_mount_path);
 }
 
 auto mp::utils::find_bridge_with(const std::vector<mp::NetworkInterfaceInfo>& networks,

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -573,7 +573,7 @@ mp::Path mp::Utils::default_mount_target(const Path& source) const
     return source.isEmpty() ? "" : QDir{QDir::cleanPath(source)}.dirName().prepend("/home/ubuntu/");
 }
 
-QString mp::Utils::make_abspath(QString target_mount_path) const // TODO@ricab rename
+QString mp::Utils::normalize_mount_target(QString target_mount_path) const
 {
     if (QDir::isRelativePath(target_mount_path)) // relying on Qt to understand Linux paths on Windows
         target_mount_path.prepend("/home/ubuntu/");

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -153,10 +153,11 @@ bool mp::utils::valid_hostname(const std::string& name_string)
 
 bool mp::utils::invalid_target_path(const QString& target_path)
 {
-    QString sanitized_path{QDir::cleanPath(target_path)};
-    QRegularExpression matcher{QRegularExpression::anchoredPattern("/+|/+(dev|proc|sys)(/.*)*|/+home(/*)(/ubuntu/*)*")};
+    assert(target_path == QDir::cleanPath(target_path) && "target_path must be normalized");
+    static QRegularExpression matcher{
+        QRegularExpression::anchoredPattern("/+|/+(dev|proc|sys)(/.*)*|/+home(/*)(/ubuntu/*)*")};
 
-    return matcher.match(sanitized_path).hasMatch();
+    return matcher.match(target_path).hasMatch();
 }
 
 QTemporaryFile mp::utils::create_temp_file_with_path(const QString& filename_template)

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -151,16 +151,12 @@ bool mp::utils::valid_hostname(const std::string& name_string)
     return matcher.match(QString::fromStdString(name_string)).hasMatch();
 }
 
-std::string mp::utils::make_abspath(const QString& input_path)
+QString mp::utils::make_abspath(QString target_mount_path) // TODO@ricab move and rename
 {
-    const fs::path base_path("/home/ubuntu");           // Base path for relative paths
-    const fs::path path_obj = input_path.toStdString(); // Convert QString to std::string
+    if (QDir::isRelativePath(target_mount_path)) // relying on Qt to understand Linux paths on Windows
+        target_mount_path.prepend("/home/ubuntu/");
 
-    if (path_obj.is_absolute())
-    {
-        return path_obj.lexically_normal().string(); // Return as string if already absolute
-    }
-    return (fs::absolute(base_path / path_obj)).lexically_normal().string(); // Convert to absolute path
+    return QDir::cleanPath(target_mount_path);
 }
 
 bool mp::utils::invalid_target_path(const QString& target_path)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -107,56 +107,56 @@ TEST(Utils, hostname_contains_special_character_is_invalid)
 
 TEST(Utils, path_root_invalid)
 {
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/")));
 }
 
 TEST(Utils, path_root_foo_valid)
 {
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/foo")));
+    EXPECT_FALSE(MP_UTILS.invalid_target_path(QString("/foo")));
 }
 
 TEST(Utils, path_dev_invalid)
 {
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/dev")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/dev/foo")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/dev")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/dev/foo")));
 }
 
 TEST(Utils, path_devpath_valid)
 {
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/devpath")));
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/devpath/foo")));
+    EXPECT_FALSE(MP_UTILS.invalid_target_path(QString("/devpath")));
+    EXPECT_FALSE(MP_UTILS.invalid_target_path(QString("/devpath/foo")));
 }
 
 TEST(Utils, path_proc_invalid)
 {
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/proc")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/proc/foo")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/proc")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/proc/foo")));
 }
 
 TEST(Utils, path_sys_invalid)
 {
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/sys")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/sys/foo")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/sys")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/sys/foo")));
 }
 
 TEST(Utils, path_home_proper_invalid)
 {
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/home")));
 }
 
 TEST(Utils, path_home_ubuntu_invalid)
 {
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home/ubuntu")));
+    EXPECT_TRUE(MP_UTILS.invalid_target_path(QString("/home/ubuntu")));
 }
 
 TEST(Utils, path_home_foo_valid)
 {
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/home/foo")));
+    EXPECT_FALSE(MP_UTILS.invalid_target_path(QString("/home/foo")));
 }
 
 TEST(Utils, path_home_ubuntu_foo_valid)
 {
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/home/ubuntu/foo")));
+    EXPECT_FALSE(MP_UTILS.invalid_target_path(QString("/home/ubuntu/foo")));
 }
 
 TEST(Utils, create_temp_file_with_path_does_not_throw_when_folder_exists)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -108,86 +108,55 @@ TEST(Utils, hostname_contains_special_character_is_invalid)
 TEST(Utils, path_root_invalid)
 {
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//")));
 }
 
 TEST(Utils, path_root_foo_valid)
 {
     EXPECT_FALSE(mp::utils::invalid_target_path(QString("/foo")));
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/foo/")));
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("//foo")));
 }
 
 TEST(Utils, path_dev_invalid)
 {
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/dev")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/dev/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//dev/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/dev//")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//dev//")));
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/dev/foo")));
 }
 
 TEST(Utils, path_devpath_valid)
 {
     EXPECT_FALSE(mp::utils::invalid_target_path(QString("/devpath")));
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/devpath/")));
     EXPECT_FALSE(mp::utils::invalid_target_path(QString("/devpath/foo")));
 }
 
 TEST(Utils, path_proc_invalid)
 {
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/proc")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/proc/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//proc/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/proc//")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//proc//")));
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/proc/foo")));
 }
 
 TEST(Utils, path_sys_invalid)
 {
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/sys")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/sys/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//sys/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/sys//")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//sys//")));
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/sys/foo")));
 }
 
 TEST(Utils, path_home_proper_invalid)
 {
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//home/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home//")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//home//")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home/foo/..")));
 }
 
 TEST(Utils, path_home_ubuntu_invalid)
 {
     EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home/ubuntu")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home/ubuntu/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//home/ubuntu/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home//ubuntu/")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home/ubuntu//")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("//home//ubuntu//")));
-    EXPECT_TRUE(mp::utils::invalid_target_path(QString("/home/ubuntu/foo/..")));
 }
 
 TEST(Utils, path_home_foo_valid)
 {
     EXPECT_FALSE(mp::utils::invalid_target_path(QString("/home/foo")));
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/home/foo/")));
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("//home/foo/")));
 }
 
 TEST(Utils, path_home_ubuntu_foo_valid)
 {
     EXPECT_FALSE(mp::utils::invalid_target_path(QString("/home/ubuntu/foo")));
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("/home/ubuntu/foo/")));
-    EXPECT_FALSE(mp::utils::invalid_target_path(QString("//home/ubuntu/foo")));
 }
 
 TEST(Utils, create_temp_file_with_path_does_not_throw_when_folder_exists)


### PR DESCRIPTION
Fixes #3733. 

Co-authored by @ntorresalberto (thanks!)

This takes #3908 and applies some changes on top. The main thing was to update path normalization to rely on Qt for mounts. This resolves a few problems:

1. Target paths were not correctly processed on Windows: the previous implementation used `std::filesystem` which would treat target paths as Windows paths on that platform, whereas they are meant for Linux VMs. In particular, that meant that a) paths were not correctly identified as relative or absolute; b) they were not normalized correctly. Qt, on the other hand, seems to understand Linux paths even on Windows. See https://gist.github.com/ricab/312893d71ad09c6271107eb902f48fdd and
https://godbolt.org/z/j5f7657v4.

2. Target paths weren't fully normalized. In particular, trailing slashes were not removed or added. The underlying call to `std::filesystem::path::lexically_normal` kept `/foo/bar/` and `/foo/bar` unchanged ¯\_(ツ)_/¯

It also streamlines the code around this a little and extracts a constant for `/home/ubuntu`. We should actually have one for the `ubuntu` user instead, but I didn't feel like replacing that all over in here.

See commit messages for further details.
