### PR TITLE
lxd libvirt deprecation warning docs

### DIFF
--- a/docs/explanation/driver.md
+++ b/docs/explanation/driver.md
@@ -1,6 +1,10 @@
 (explanation-driver)=
 # Driver
 
+```{warning}
+Support for libvirt and LXD will be deprecated and removed in a future release.
+```
+
 > See also: [How to set up the driver](/how-to-guides/customise-multipass/set-up-the-driver), [`local.driver`](/reference/settings/local-driver), [Instance](/explanation/instance), [Platform](/explanation/platform)
 
 A **driver** is the technology through which Multipass emulates a running machine. It corresponds to a hypervisor or intermediary technology to run virtual machines. The driver is sometimes also referred to as "backend".

--- a/docs/explanation/driver.md
+++ b/docs/explanation/driver.md
@@ -17,7 +17,7 @@ On some platforms, it is possible to select a driver during installation. Until 
 
 Different sets of drivers are available on different platforms:
 
-- On Linux, Multipass can be configured to use QEMU, LXD (deprecated), and libvirt (deprecated).
+- On Linux, Multipass can be configured to use QEMU, LXD, and libvirt. As of Multipass version 1.16, LXD and libvirt are no longer supported.
 - On macOS, the options are QEMU and VirtualBox. As of Multipass version 1.13, Hyperkit is no longer available.
 - On Windows, Multipass uses Hyper-V (only available on Windows Pro) or VirtualBox.
 

--- a/docs/explanation/driver.md
+++ b/docs/explanation/driver.md
@@ -42,7 +42,7 @@ Nonetheless, instances are preserved across drivers. After switching back to a p
 
 There are two exceptions to the above:
 
-  - On Linux, QEMU and libvirt share the same driver scope.
+  - On Linux, QEMU and libvirt (deprecated) share the same driver scope.
   - On macOS, stopped Hyperkit instances are automatically migrated to QEMU by Multipass's version 1.12 or later (see [How to migrate from Hyperkit to QEMU on macOS](/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos)).
 
 (driver-feature-disparities)=

--- a/docs/explanation/driver.md
+++ b/docs/explanation/driver.md
@@ -13,7 +13,7 @@ On some platforms, it is possible to select a driver during installation. Until 
 
 Different sets of drivers are available on different platforms:
 
-- On Linux, Multipass can be configured to use QEMU, LXD, and libvirt.
+- On Linux, Multipass can be configured to use QEMU, LXD (deprecated), and libvirt (deprecated).
 - On macOS, the options are QEMU and VirtualBox. As of Multipass version 1.13, Hyperkit is no longer available.
 - On Windows, Multipass uses Hyper-V (only available on Windows Pro) or VirtualBox.
 
@@ -23,7 +23,7 @@ When Multipass is installed, the following drivers are selected by default:
 
 - On Linux, the default driver depends on the host's architecture:
     + QEMU on AMD64
-    + LXD on other platforms.
+    + LXD (deprecated) on other platforms.
 - On macOS, QEMU is used.
 - On Windows, the default driver depends on the OS version:
   + Hyper-V on Windows Pro
@@ -52,8 +52,8 @@ While we strive to offer a uniform interface across the board, not all features 
 
 | Feature | Only supported on... | Notes |
 |--- | --- | --- |
-| **Native mounts** | <ul><li>Hyper-V</li><li>LXD</li><li>QEMU</li></ul> | This affects the `--type` option in the [`mount`](/reference/command-line-interface/mount) command). |
-| **Extra networks** | <ul><li>Hyper-V</li><li>LXD</li><li>QEMU</li><li>VirtualBox</li></ul> | This affects the [`networks`](/reference/command-line-interface/networks) command, as well as the `--network` and `--bridged` options in [`launch`](/reference/command-line-interface/launch). |
+| **Native mounts** | <ul><li>Hyper-V</li><li>LXD (deprecated)</li><li>QEMU</li></ul> | This affects the `--type` option in the [`mount`](/reference/command-line-interface/mount) command). |
+| **Extra networks** | <ul><li>Hyper-V</li><li>LXD (deprecated)</li><li>QEMU</li><li>VirtualBox</li></ul> | This affects the [`networks`](/reference/command-line-interface/networks) command, as well as the `--network` and `--bridged` options in [`launch`](/reference/command-line-interface/launch). |
 | **Snapshots** | <ul><li>Hyper-V</li><li>QEMU</li><li>VirtualBox</li></ul> |  |
 | **Clone** | <ul><li>Hyper-V</li><li>QEMU</li><li>VirtualBox</li></ul> |  This affects the [`clone`](/reference/command-line-interface/clone) command.|
 | **VM suspension** | <ul><li>Hyper-V</li><li>libvirt</li><li>QEMU</li><li>VirtualBox</li></ul> | This affects the [`suspend`](/reference/command-line-interface/suspend) command. |

--- a/docs/explanation/mount.md
+++ b/docs/explanation/mount.md
@@ -23,7 +23,7 @@ Native mounts use driver-dependent technologies to achieve the high performance.
 
 - On **Hyper-V**, where they are implemented with [SMB/CIFS](https://learn.microsoft.com/en-us/windows/win32/fileio/microsoft-smb-protocol-and-cifs-protocol-overview).
 - On **QEMU**, where they are implemented with [9P](https://en.wikipedia.org/wiki/9P_(protocol)).
-- On **LXD**, using that backend's own mounts, which also rely on [9P](https://en.wikipedia.org/wiki/9P_(protocol)).
+- On **LXD** (deprecated), using that backend's own mounts, which also rely on [9P](https://en.wikipedia.org/wiki/9P_(protocol)).
 
 > See also: {ref}`driver-feature-disparities`.
 

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -34,7 +34,7 @@ By default, Multipass on Windows uses the `hyperv` driver.
 `````{tabs}
 
 ````{group-tab} Linux
-Warning! The libvirt driver is deprecated and will be removed in an upcoming release.
+**Warning!** The libvirt driver is deprecated and will be removed in an upcoming release.
 
 If you want more control over your VMs after they are launched, you can also use the experimental [libvirt](https://libvirt.org/) driver.
 

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -11,7 +11,7 @@ This document demonstrates how to choose, set up, and manage the drivers behind 
 
 ````{group-tab} Linux
 
-By default, Multipass on Linux uses the `qemu` or `lxd` (deprecated) driver (depending on the architecture).
+By default, Multipass on Linux uses the `qemu` driver.
 
 ````
 

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -11,7 +11,7 @@ This document demonstrates how to choose, set up, and manage the drivers behind 
 
 ````{group-tab} Linux
 
-By default, Multipass on Linux uses the `qemu` or `lxd` driver (depending on the architecture).
+By default, Multipass on Linux uses the `qemu` or `lxd` (deprecated) driver (depending on the architecture).
 
 ````
 

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -34,8 +34,9 @@ By default, Multipass on Windows uses the `hyperv` driver.
 `````{tabs}
 
 ````{group-tab} Linux
-**Warning!** The libvirt driver is deprecated and will be removed in an upcoming release.
-
+```{warning}
+Support for libvirt driver will be deprecated and removed in a future release.
+```
 If you want more control over your VMs after they are launched, you can also use the experimental [libvirt](https://libvirt.org/) driver.
 
 To install libvirt, run the following command (or use the equivalent for your Linux distribution):

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -35,7 +35,7 @@ By default, Multipass on Windows uses the `hyperv` driver.
 
 ````{group-tab} Linux
 Warning! The libvirt driver is deprecated and will be removed in an upcoming release.
- 
+
 If you want more control over your VMs after they are launched, you can also use the experimental [libvirt](https://libvirt.org/) driver.
 
 To install libvirt, run the following command (or use the equivalent for your Linux distribution):

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -34,8 +34,9 @@ By default, Multipass on Windows uses the `hyperv` driver.
 `````{tabs}
 
 ````{group-tab} Linux
-
-If you want more control over your VMs after they are launched, you can also use the experimental [libvirt](https://libvirt.org/) (deprecated) driver.
+Warning! The libvirt driver is deprecated and will be removed in an upcoming release.
+ 
+If you want more control over your VMs after they are launched, you can also use the experimental [libvirt](https://libvirt.org/) driver.
 
 To install libvirt, run the following command (or use the equivalent for your Linux distribution):
 

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -35,7 +35,7 @@ By default, Multipass on Windows uses the `hyperv` driver.
 
 ````{group-tab} Linux
 
-If you want more control over your VMs after they are launched, you can also use the experimental [libvirt](https://libvirt.org/) driver.
+If you want more control over your VMs after they are launched, you can also use the experimental [libvirt](https://libvirt.org/) (deprecated) driver.
 
 To install libvirt, run the following command (or use the equivalent for your Linux distribution):
 

--- a/docs/how-to-guides/manage-instances/create-an-instance.md
+++ b/docs/how-to-guides/manage-instances/create-an-instance.md
@@ -117,7 +117,7 @@ Multipass can create instances with additional network interfaces using the `mul
 
 This feature is only supported for images with [`cloud-init` support for v2 network config](https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html), which in turn requires [netplan](https://netplan.io/) to be installed, meaning that you'll require Ubuntu 17.10 and Ubuntu Core 16 (except `snapcraft:core16`) or later. More specifically, this feature is only supported in the following scenarios:
 
-* on Linux, with LXD (deprecated)
+* on Linux, with QEMU (*from Multipass 1.15 onward*)
 * on Windows, with both Hyper-V and VirtualBox
 * on macOS, with the QEMU and VirtualBox drivers
 

--- a/docs/how-to-guides/manage-instances/create-an-instance.md
+++ b/docs/how-to-guides/manage-instances/create-an-instance.md
@@ -117,7 +117,7 @@ Multipass can create instances with additional network interfaces using the `mul
 
 This feature is only supported for images with [`cloud-init` support for v2 network config](https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html), which in turn requires [netplan](https://netplan.io/) to be installed, meaning that you'll require Ubuntu 17.10 and Ubuntu Core 16 (except `snapcraft:core16`) or later. More specifically, this feature is only supported in the following scenarios:
 
-* on Linux, with LXD
+* on Linux, with LXD (deprecated)
 * on Windows, with both Hyper-V and VirtualBox
 * on macOS, with the QEMU and VirtualBox drivers
 

--- a/docs/reference/command-line-interface/networks.md
+++ b/docs/reference/command-line-interface/networks.md
@@ -7,7 +7,7 @@ The `multipass networks` command lists network interfaces that multipass can con
 
 At this time, `multipass networks` can only find interfaces in the following scenarios:
 
-- on Linux, with LXD (*and QEMU starting from Multipass version 1.15*)
+- on Linux, with QEMU (*from Multipass 1.15 onwards*) and LXD (deprecated) 
 - on Windows, with both Hyper-V and VirtualBox
 - on macOS, with the QEMU and VirtualBox drivers
 

--- a/docs/reference/command-line-interface/networks.md
+++ b/docs/reference/command-line-interface/networks.md
@@ -7,7 +7,7 @@ The `multipass networks` command lists network interfaces that multipass can con
 
 At this time, `multipass networks` can only find interfaces in the following scenarios:
 
-- on Linux, with QEMU (*from Multipass 1.15 onwards*) and LXD (deprecated) 
+- on Linux, with QEMU (*from Multipass 1.15 onward*) and LXD (deprecated)
 - on Windows, with both Hyper-V and VirtualBox
 - on macOS, with the QEMU and VirtualBox drivers
 

--- a/docs/reference/settings/local-driver.md
+++ b/docs/reference/settings/local-driver.md
@@ -13,7 +13,7 @@ A string identifying the hypervisor back-end in use.
 
 ## Possible values
 
-  - `qemu`, `libvirt` and `lxd` (deprecated) on Linux
+  - `qemu`, `libvirt` (deprecated) and `lxd` (deprecated) on Linux
   - `hyperv` and `virtualbox` on Windows
   - `qemu` and `virtualbox` on macOS 10.15+
   - *(deprecated)* `hyperkit` on Intel macOS 10.15+

--- a/docs/reference/settings/local-driver.md
+++ b/docs/reference/settings/local-driver.md
@@ -13,7 +13,7 @@ A string identifying the hypervisor back-end in use.
 
 ## Possible values
 
-  - `qemu`, `libvirt` and `lxd` on Linux
+  - `qemu`, `libvirt` and `lxd` (deprecated) on Linux
   - `hyperv` and `virtualbox` on Windows
   - `qemu` and `virtualbox` on macOS 10.15+
   - *(deprecated)* `hyperkit` on Intel macOS 10.15+
@@ -21,5 +21,5 @@ A string identifying the hypervisor back-end in use.
 ## Default values
 
   - `qemu` on macOS and AMD64 Linux
-  - `lxd` on non-AMD64 Linux
+  - `lxd` (deprecated) on non-AMD64 Linux
   - `hyperv` on Windows


### PR DESCRIPTION
[MULTI-1888](https://warthogs.atlassian.net/browse/MULTI-1888)
[MULTI-1893](https://warthogs.atlassian.net/browse/MULTI-1893)


[MULTI-1888]: https://warthogs.atlassian.net/browse/MULTI-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MULTI-1893]: https://warthogs.atlassian.net/browse/MULTI-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR is about adding the driver warning messages to all the lxd and libvirt related documentation pages. 