### PR TITLE
update xz-embedded submodule url in gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	url = https://github.com/CanonicalLtd/libssh.git
 [submodule "3rd-party/xz-decoder/xz-embedded"]
 	path = 3rd-party/xz-decoder/xz-embedded
-	url = https://git.tukaani.org/xz-embedded.git
+	url = https://github.com/tukaani-project/xz-embedded.git
 [submodule "3rd-party/semver"]
 	path = 3rd-party/semver
 	url = https://github.com/CanonicalLtd/semver.git

--- a/3rd-party/submodule_info.md
+++ b/3rd-party/submodule_info.md
@@ -32,8 +32,8 @@ Version: 1.1.0 (+[our patches](https://github.com/CanonicalLtd/semver/compare/1.
 <https://github.com/zmarko/semver/releases>
 
 ### xz-embedded
-Version: v20240322 |
-<https://git.tukaani.org/xz-embedded.git> |
+Version: v2024-12-30 |
+<https://github.com/tukaani-project/xz-embedded.git> |
 <https://tukaani.org/xz/embedded.html>
 
 ### yaml-cpp


### PR DESCRIPTION
This pull request updates the URL for the `xz-embedded` submodule to point to the GitHub repository for xz-embedded, which is more stable than the git.tukaani.org link that points to the GitHub repo anyways.

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L10-R10): Updated the URL for the `xz-embedded` submodule from `https://git.tukaani.org/xz-embedded.git` to `https://github.com/tukaani-project/xz-embedded.git`.