### PR TITLE
Enabling qemu driver on linux arm cpu 

### DIFF
--- a/BUILD.linux.md
+++ b/BUILD.linux.md
@@ -59,6 +59,20 @@ sudo apt install libgl1 libpng16-16 libqt6core6 libqt6gui6 \
     dnsmasq-utils qemu-system-x86 qemu-utils libslang2 iproute2 \
     iptables iputils-ping libatm1 libxtables12 xterm
 ```
+On ARM64 architecture, you can do this by running:
+
+```
+sudo apt update
+sudo apt install libgl1 libpng16-16 libqt6core6 libqt6gui6 \
+    libqt6network6 libqt6widgets6 libxml2 libvirt0 dnsmasq-base \
+    dnsmasq-utils qemu-system-arm qemu-efi-aarch64 qemu-utils \
+    libslang2 iproute2 iptables iputils-ping libatm1 libxtables12 \
+    xterm
+```
+Additionally, on ARM64 architecture, there is an extra step to set up the `QEMU_EFI.fd` file:
+```
+sudo cp /usr/share/qemu-efi-aarch64/QEMU_EFI.fd /usr/share/qemu/QEMU_EFI.fd
+```
 
 Then run the Multipass daemon:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,11 +302,7 @@ else()
     endif()
 
     add_definitions(-DMULTIPASS_PLATFORM_LINUX)
-    set(MULTIPASS_BACKENDS libvirt lxd)
-
-    if (${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "x86_64")
-      list(APPEND MULTIPASS_BACKENDS qemu)
-    endif()
+    set(MULTIPASS_BACKENDS libvirt lxd qemu)
 
     set(MULTIPASS_PLATFORM linux)
     set(LINUX TRUE)

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -189,7 +189,9 @@ QStringList mp::QemuPlatformDetail::vm_platform_args(const VirtualMachineDescrip
              << "OVMF.fd";
 #elif defined Q_PROCESSOR_ARM
         opts << "-bios"
-             << "QEMU_EFI.fd";
+             << "QEMU_EFI.fd"
+             << "-machine"
+             << "virt,gic-version=3";
 #endif
     }
 

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -189,7 +189,7 @@ QStringList mp::QemuPlatformDetail::vm_platform_args(const VirtualMachineDescrip
              << "OVMF.fd";
 #elif defined Q_PROCESSOR_ARM
         opts << "-bios"
-             << "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd"
+             << "QEMU_EFI.fd"
              << "-machine"
              << "virt,gic-version=3";
 #endif

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -191,7 +191,7 @@ QStringList mp::QemuPlatformDetail::vm_platform_args(const VirtualMachineDescrip
         opts << "-bios"
              << "QEMU_EFI.fd"
              << "-machine"
-             << "virt,gic-version=3";
+             << "virt";
 #endif
     }
 

--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -189,7 +189,7 @@ QStringList mp::QemuPlatformDetail::vm_platform_args(const VirtualMachineDescrip
              << "OVMF.fd";
 #elif defined Q_PROCESSOR_ARM
         opts << "-bios"
-             << "QEMU_EFI.fd"
+             << "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd"
              << "-machine"
              << "virt,gic-version=3";
 #endif

--- a/src/platform/backends/qemu/qemu_vmstate_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vmstate_process_spec.cpp
@@ -29,17 +29,13 @@ QStringList mp::QemuVmStateProcessSpec::arguments() const
 {
     QStringList args;
 
-    args << platform_args;
-
-#if defined Q_PROCESSOR_X86
-    args << "-nographic"
-         << "-dump-vmstate" << file_name;
-#elif defined Q_PROCESSOR_ARM
-    args << "-machine"
+    args << platform_args
+#if defined Q_PROCESSOR_ARM
+         << "-machine"
          << "virt"
+#endif
          << "-nographic"
          << "-dump-vmstate" << file_name;
-#endif
 
     return args;
 }

--- a/src/platform/backends/qemu/qemu_vmstate_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vmstate_process_spec.cpp
@@ -31,8 +31,15 @@ QStringList mp::QemuVmStateProcessSpec::arguments() const
 
     args << platform_args;
 
+#if defined Q_PROCESSOR_X86
     args << "-nographic"
          << "-dump-vmstate" << file_name;
+#elif defined Q_PROCESSOR_ARM
+    args << "-machine"
+         << "virt,gic-version=3"
+         << "-nographic"
+         << "-dump-vmstate" << file_name;
+#endif
 
     return args;
 }

--- a/src/platform/backends/qemu/qemu_vmstate_process_spec.cpp
+++ b/src/platform/backends/qemu/qemu_vmstate_process_spec.cpp
@@ -36,7 +36,7 @@ QStringList mp::QemuVmStateProcessSpec::arguments() const
          << "-dump-vmstate" << file_name;
 #elif defined Q_PROCESSOR_ARM
     args << "-machine"
-         << "virt,gic-version=3"
+         << "virt"
          << "-nographic"
          << "-dump-vmstate" << file_name;
 #endif

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -32,10 +32,7 @@
 
 #include "backends/libvirt/libvirt_virtual_machine_factory.h"
 #include "backends/lxd/lxd_virtual_machine_factory.h"
-
-#ifdef QEMU_ENABLED
 #include "backends/qemu/qemu_virtual_machine_factory.h"
-#endif
 
 #ifdef VIRTUALBOX_ENABLED
 #include "backends/virtualbox/virtualbox_virtual_machine_factory.h"
@@ -276,14 +273,11 @@ mp::platform::Platform::get_network_interfaces_info() const
 
 bool mp::platform::Platform::is_backend_supported(const QString& backend) const
 {
-    return
-#ifdef QEMU_ENABLED
-        backend == "qemu" ||
-#endif
+    return backend == "qemu" ||
 #ifdef VIRTUALBOX_ENABLED
-        backend == "virtualbox" ||
+           backend == "virtualbox" ||
 #endif
-        backend == "libvirt" || backend == "lxd";
+           backend == "libvirt" || backend == "lxd";
 }
 
 bool mp::platform::Platform::link(const char* target, const char* link) const
@@ -361,13 +355,7 @@ QString mp::platform::Platform::daemon_config_home() const // temporary
 
 QString mp::platform::Platform::default_driver() const
 {
-    return QStringLiteral(
-#ifdef QEMU_ENABLED
-        "qemu"
-#else
-        "lxd"
-#endif
-    );
+    return QStringLiteral("qemu");
 }
 
 QString mp::platform::Platform::default_privileged_mounts() const
@@ -428,10 +416,8 @@ std::string mp::platform::default_server_address()
 mp::VirtualMachineFactory::UPtr mp::platform::vm_backend(const mp::Path& data_dir)
 {
     const auto& driver = MP_SETTINGS.get(mp::driver_key);
-#ifdef QEMU_ENABLED
     if (driver == QStringLiteral("qemu"))
         return std::make_unique<QemuVirtualMachineFactory>(data_dir);
-#endif
 
     if (driver == QStringLiteral("libvirt"))
         return std::make_unique<LibVirtVirtualMachineFactory>(data_dir);

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -31,15 +31,10 @@
 #include <src/platform/backends/libvirt/libvirt_wrapper.h>
 #include <src/platform/backends/lxd/lxd_virtual_machine_factory.h>
 
-#ifdef QEMU_ENABLED
 #include "tests/qemu/linux/mock_dnsmasq_server.h"
 #include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
 #define DEFAULT_FACTORY mp::QemuVirtualMachineFactory
 #define DEFAULT_DRIVER "qemu"
-#else
-#define DEFAULT_FACTORY mp::LXDVirtualMachineFactory
-#define DEFAULT_DRIVER "lxd"
-#endif
 
 #include <src/platform/platform_linux_detail.h>
 
@@ -72,10 +67,8 @@ struct PlatformLinux : public mpt::TestWithMockedBinPath
     template <typename VMFactoryType>
     void aux_test_driver_factory(const QString& driver)
     {
-#ifdef QEMU_ENABLED
         const mpt::MockDNSMasqServerFactory::GuardedMock dnsmasq_server_factory_attr{
             mpt::MockDNSMasqServerFactory::inject<NiceMock>()};
-#endif
 
         auto factory = mpt::MockProcessFactory::Inject();
         setup_driver_settings(driver);
@@ -146,12 +139,10 @@ TEST_F(PlatformLinux, testDefaultDriverProducesCorrectFactory)
     aux_test_driver_factory<DEFAULT_FACTORY>(DEFAULT_DRIVER);
 }
 
-#ifdef QEMU_ENABLED
 TEST_F(PlatformLinux, testExplicitQemuDriverProducesCorrectFactory)
 {
     aux_test_driver_factory<mp::QemuVirtualMachineFactory>("qemu");
 }
-#endif
 
 TEST_F(PlatformLinux, testLibvirtDriverProducesCorrectFactory)
 {

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -33,9 +33,6 @@
 
 #include "tests/qemu/linux/mock_dnsmasq_server.h"
 #include <src/platform/backends/qemu/qemu_virtual_machine_factory.h>
-#define DEFAULT_FACTORY mp::QemuVirtualMachineFactory
-#define DEFAULT_DRIVER "qemu"
-
 #include <src/platform/platform_linux_detail.h>
 
 #include <multipass/constants.h>
@@ -136,11 +133,6 @@ TEST_F(PlatformLinux, testDefaultPrivilegedMounts)
 
 TEST_F(PlatformLinux, testDefaultDriverProducesCorrectFactory)
 {
-    aux_test_driver_factory<DEFAULT_FACTORY>(DEFAULT_DRIVER);
-}
-
-TEST_F(PlatformLinux, testExplicitQemuDriverProducesCorrectFactory)
-{
     aux_test_driver_factory<mp::QemuVirtualMachineFactory>("qemu");
 }
 
@@ -165,7 +157,7 @@ TEST_F(PlatformLinux, testQemuInEnvVarIsIgnored)
 TEST_F(PlatformLinux, testLibvirtInEnvVarIsIgnored)
 {
     mpt::SetEnvScope env(mp::driver_env_var, "LIBVIRT");
-    aux_test_driver_factory<DEFAULT_FACTORY>(DEFAULT_DRIVER);
+    aux_test_driver_factory<mp::QemuVirtualMachineFactory>("qemu");
 }
 
 TEST_F(PlatformLinux, testSnapReturnsExpectedDefaultAddress)

--- a/tests/qemu/linux/test_qemu_platform_detail.cpp
+++ b/tests/qemu/linux/test_qemu_platform_detail.cpp
@@ -181,7 +181,7 @@ TEST_F(QemuPlatformDetail, platformArgsGenerateNetResourcesRemovesWorksAsExpecte
 #if defined Q_PROCESSOR_X86
         "-bios", "OVMF.fd",
 #elif defined Q_PROCESSOR_ARM
-        "-bios", "QEMU_EFI.fd",
+        "-bios", "QEMU_EFI.fd", "-machine", "virt",
 #endif
             "--enable-kvm", "-cpu", "host", "-nic",
             QString::fromStdString(

--- a/tests/qemu/test_qemu_vmstate_process_spec.cpp
+++ b/tests/qemu/test_qemu_vmstate_process_spec.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "tests/common.h"
-#include "tests/mock_environment_helpers.h"
 
 #include <src/platform/backends/qemu/qemu_vmstate_process_spec.h>
 
@@ -33,6 +32,14 @@ struct TestQemuVmStateProcessSpec : public Test
 TEST_F(TestQemuVmStateProcessSpec, defaultArgumentsCorrect)
 {
     mp::QemuVmStateProcessSpec spec{file_name};
-
-    EXPECT_EQ(spec.arguments(), QStringList({"-nographic", "-dump-vmstate", file_name}));
+#if defined Q_PROCESSOR_X86
+    const QStringList default_arguments = {"-nographic", "-dump-vmstate", file_name};
+#elif defined Q_PROCESSOR_ARM
+    const QStringList default_arguments = {"-machine",
+                                           "virt",
+                                           "-nographic",
+                                           "-dump-vmstate",
+                                           file_name};
+#endif
+    EXPECT_EQ(spec.arguments(), default_arguments);
 }


### PR DESCRIPTION
https://warthogs.atlassian.net/browse/MULTI-1933

In the development environment, `qemu-system-arm` and `qemu-efi-aarch64` need to be installed and `sudo cp /usr/share/qemu-efi-aarch64/QEMU_EFI.fd /usr/share/qemu/QEMU_EFI.fd` need to be run in order to make `qemu-system-arm -bios QEMU_EFI.fd ...` find the `QEMU_EFI.fd` file and access it with the right permission. On the other side, the snapcraft [copies](https://github.com/canonical/multipass/blob/3d329cb5a94056953785580149c5536baeadc1b0/snap/snapcraft.yaml#L338) the file into a snap confined folder, so there above-mentioned issues do not exist in deployment. 

The snap file can be downloaded [here](https://www.dropbox.com/scl/fi/z6rgdmnqi0ksu4odormao/multipass_1.16.0-dev.3744-gaad30415_arm64.snap?rlkey=w0d88ywq1ujbv7c3xri69szss&st=vio2wmpw&dl=0). 

Regarding to how to get the an arm + ubuntu machine to test, [testflinger](https://certification.canonical.com/search/v2/physicalmachines/?term=in_testflinger%3Atrue+arch%3Aarm64) machine is a good option. You will need to install testfinger cmd via snap and [reserve](https://certification.canonical.com/docs/ops/tel-labs-docs/how-to/reserve_system_on_testflinger/) a machine for an interactive session. 