### PR TITLE
[gui] vm_delete button uses normal buildButton styling

### DIFF
--- a/src/client/gui/lib/vm_action.dart
+++ b/src/client/gui/lib/vm_action.dart
@@ -75,9 +75,7 @@ class VmActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final enabled = action.allowedStatuses.containsAny(currentStatuses);
     final onPressed = enabled ? function : null;
-    return action == VmAction.delete
-        ? _buildDeleteButton(onPressed)
-        : _buildButton(onPressed);
+    return _buildButton(onPressed);
   }
 
   Widget _buildButton(VoidCallback? onPressed) {
@@ -91,16 +89,6 @@ class VmActionButton extends StatelessWidget {
             ),
           ),
         ),
-      ),
-      child: Text(action.name),
-    );
-  }
-
-  Widget _buildDeleteButton(VoidCallback? onPressed) {
-    return TextButton(
-      onPressed: onPressed,
-      style: TextButton.styleFrom(
-        backgroundColor: const Color(0xffC7162B),
       ),
       child: Text(action.name),
     );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9c7f37f3-bd46-4e87-9baf-9158abc9ed1d)

This pull request simplifies the `VmActionButton` widget in the `src/client/gui/lib/vm_action.dart` file by removing special styling related to the `delete` action. The Delete button previously was styled with a red background color, which was too strong of a call-to-action compared to the other Vm action buttons.
