### PR TITLE
[exceptions] add LoggedExceptionBase type

### DIFF
--- a/include/multipass/exceptions/logged_exception_base.h
+++ b/include/multipass/exceptions/logged_exception_base.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_LOGGED_EXCEPTION_BASE_H
+#define MULTIPASS_LOGGED_EXCEPTION_BASE_H
+
+#include <multipass/exceptions/formatted_exception_base.h>
+#include <multipass/logging/log.h>
+
+#include <stdexcept>
+#include <string_view>
+
+namespace multipass
+{
+
+/**
+ * A templated exception base type that has formatting and logging by default.
+ *
+ * The produced exception message would be logged automatically.
+ *
+ * This class is intended to be used as a base class to user-defined
+ * exception types. The user-defined exception type is either expected
+ * to inherit the constructors of LoggedExceptionBase, or call them
+ * explicitly.
+ *
+ * @tparam BaseExceptionType The exception type. Defaults to `std::runtime_error`.
+ * The exception type must be constructible with a std::string, implement a what() method
+ * that returns a type convertible to std::string_view, and must derive from std::exception.
+ */
+template <multipass::logging::Level level = multipass::logging::Level::error,
+          typename BaseExceptionType = std::runtime_error>
+struct LoggedExceptionBase : public FormattedExceptionBase<BaseExceptionType>
+{
+    /**
+     * Format @p args and log the resulting string
+     * upon construction
+     *
+     * @tparam Args Format argument types
+     *
+     * @param [in] category Log category
+     * @param [in] args Format arguments
+     */
+    template <typename... Args>
+    LoggedExceptionBase(std::string_view category, Args&&... args)
+        : FormattedExceptionBase<BaseExceptionType>(std::forward<Args>(args)...)
+    {
+        static_assert(sizeof...(Args) > 0,
+                      "LoggedExceptionBase requires at least the format argument in addition to the category.");
+        try
+        {
+            multipass::logging::log(level, category, this->what());
+        }
+        catch (...)
+        {
+        }
+    }
+};
+
+} // namespace multipass
+
+#endif // MULTIPASS_LOGGED_EXCEPTION_BASE_H

--- a/tests/test_exception.cpp
+++ b/tests/test_exception.cpp
@@ -16,19 +16,34 @@
  */
 
 #include <multipass/exceptions/formatted_exception_base.h>
+#include <multipass/exceptions/logged_exception_base.h>
 
-#include <gmock/gmock.h> // for EXPECT_THAT
-#include <gtest/gtest.h>
 #include <tests/common.h>
+#include <tests/mock_logger.h>
 
 namespace mpt = multipass::test;
 
-struct exception_tests : ::testing::Test
+struct AngryTypeThatThrowsUnexpectedThingsOnFormat
 {
 };
 
-using testing::HasSubstr;
+// This is a quick way to make fmt::format throw an "unexpected" thing,
+// so we can test the catch-all exception catcher.
+template <typename Char>
+struct fmt::formatter<AngryTypeThatThrowsUnexpectedThingsOnFormat, Char>
+{
+    constexpr auto parse(basic_format_parse_context<Char>& ctx)
+    {
+        return ctx.begin();
+    }
 
+    template <typename FormatContext>
+    fmt::context::iterator format(const AngryTypeThatThrowsUnexpectedThingsOnFormat& api, FormatContext& ctx) const
+    {
+        // What an unusual sight.
+        throw int{5};
+    }
+};
 struct custom_exception_type : std::exception
 {
 
@@ -45,80 +60,161 @@ private:
     std::string msg;
 };
 
-template <typename T>
-struct MockException : multipass::FormattedExceptionBase<T>
+struct formatted_exception_base_tests : ::testing::Test
 {
-    using multipass::FormattedExceptionBase<T>::FormattedExceptionBase;
-};
 
-struct AngryTypeThatThrowsUnexpectedThings
-{
-};
-
-// This is a quick way to make fmt::format throw an "unexpected" thing,
-// so we can test the catch-all exception catcher.
-template <typename Char>
-struct fmt::formatter<AngryTypeThatThrowsUnexpectedThings, Char>
-{
-    constexpr auto parse(basic_format_parse_context<Char>& ctx)
+    template <typename T>
+    struct MockFormattedException : multipass::FormattedExceptionBase<T>
     {
-        return ctx.begin();
-    }
-
-    template <typename FormatContext>
-    fmt::context::iterator format(const AngryTypeThatThrowsUnexpectedThings& api, FormatContext& ctx) const
-    {
-        // What an unusual sight.
-        throw int{5};
-    }
+        using multipass::FormattedExceptionBase<T>::FormattedExceptionBase;
+    };
 };
 
-TEST_F(exception_tests, throw_default)
+using testing::HasSubstr;
+
+TEST_F(formatted_exception_base_tests, throw_default)
 {
     MP_EXPECT_THROW_THAT(throw multipass::FormattedExceptionBase<>("message {}", 1),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("message 1")));
 }
 
-TEST_F(exception_tests, throw_non_default_std)
+TEST_F(formatted_exception_base_tests, throw_non_default_std)
 {
-    MP_EXPECT_THROW_THAT(throw MockException<std::overflow_error>("message {}", 1),
+    MP_EXPECT_THROW_THAT(throw MockFormattedException<std::overflow_error>("message {}", 1),
                          std::overflow_error,
                          mpt::match_what(HasSubstr("message 1")));
 }
 
-TEST_F(exception_tests, throw_std_system_error)
+TEST_F(formatted_exception_base_tests, throw_std_system_error)
 {
     MP_EXPECT_THROW_THAT(
-        throw MockException<std::system_error>(std::make_error_code(std::errc::operation_canceled), "message {}", 1),
+        throw MockFormattedException<std::system_error>(std::make_error_code(std::errc::operation_canceled),
+                                                        "message {}",
+                                                        1),
         std::system_error,
         mpt::match_what(HasSubstr("message 1")));
 }
 
-TEST_F(exception_tests, throw_user_defined_exception)
+TEST_F(formatted_exception_base_tests, throw_user_defined_exception)
 {
-    MP_EXPECT_THROW_THAT(throw MockException<custom_exception_type>("message {}", 1),
+    MP_EXPECT_THROW_THAT(throw MockFormattedException<custom_exception_type>("message {}", 1),
                          custom_exception_type,
                          mpt::match_what(HasSubstr("message 1")));
 }
 
-TEST_F(exception_tests, throw_format_error)
+TEST_F(formatted_exception_base_tests, throw_format_error)
 {
     constexpr auto expected_error_msg = R"([Error while formatting the exception string]
 Format string: `message {}`
 Format error: `argument not found`)";
 
-    MP_EXPECT_THROW_THAT(throw MockException<std::runtime_error>("message {}"),
+    MP_EXPECT_THROW_THAT(throw MockFormattedException<std::runtime_error>("message {}"),
                          std::runtime_error,
                          mpt::match_what(HasSubstr(expected_error_msg)));
 }
 
-TEST_F(exception_tests, throw_unexpected_error)
+TEST_F(formatted_exception_base_tests, throw_unexpected_error)
 {
     constexpr auto expected_error_msg = R"([Error while formatting the exception string]
 Format string: `message {}`)";
 
-    MP_EXPECT_THROW_THAT(throw MockException<std::runtime_error>("message {}", AngryTypeThatThrowsUnexpectedThings{}),
+    MP_EXPECT_THROW_THAT(
+        throw MockFormattedException<std::runtime_error>("message {}", AngryTypeThatThrowsUnexpectedThingsOnFormat{}),
+        std::runtime_error,
+        mpt::match_what(HasSubstr(expected_error_msg)));
+}
+
+struct logged_exception_base_tests : ::testing::Test
+{
+    template <multipass::logging::Level L, typename T>
+    struct MockLoggedException : multipass::LoggedExceptionBase<L, T>
+    {
+        using multipass::LoggedExceptionBase<L, T>::LoggedExceptionBase;
+    };
+
+    mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject();
+
+    using lvl = multipass::logging::Level;
+};
+
+TEST_F(logged_exception_base_tests, throw_default)
+{
+    using uut_t = multipass::LoggedExceptionBase<>;
+    logger_scope.mock_logger->expect_log(lvl::error, "message 1");
+    // Log error
+    MP_EXPECT_THROW_THAT(throw uut_t("category", "message {}", 1),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr("message 1")));
+}
+
+TEST_F(logged_exception_base_tests, throw_non_default_std)
+{
+    using uut_t = multipass::LoggedExceptionBase<lvl::warning, std::overflow_error>;
+    logger_scope.mock_logger->expect_log(lvl::warning, "message 1");
+    MP_EXPECT_THROW_THAT(throw uut_t("category", "message {}", 1),
+                         std::overflow_error,
+                         mpt::match_what(HasSubstr("message 1")));
+}
+
+TEST_F(logged_exception_base_tests, throw_std_system_error)
+{
+    using uut_t = MockLoggedException<lvl::error, std::system_error>;
+    logger_scope.mock_logger->expect_log(lvl::error, "message 1");
+    MP_EXPECT_THROW_THAT(throw uut_t("category", std::make_error_code(std::errc::operation_canceled), "message {}", 1),
+                         std::system_error,
+                         mpt::match_what(HasSubstr("message 1")));
+}
+
+TEST_F(logged_exception_base_tests, throw_user_defined_exception)
+{
+    using uut_t = MockLoggedException<lvl::error, custom_exception_type>;
+    logger_scope.mock_logger->expect_log(lvl::error, "message 1");
+
+    MP_EXPECT_THROW_THAT(throw uut_t("category", "message {}", 1),
+                         custom_exception_type,
+                         mpt::match_what(HasSubstr("message 1")));
+}
+
+TEST_F(logged_exception_base_tests, throw_format_error)
+{
+    constexpr auto expected_error_msg = R"([Error while formatting the exception string]
+Format string: `message {}`
+Format error: `argument not found`)";
+
+    using uut_t = MockLoggedException<lvl::error, std::runtime_error>;
+    logger_scope.mock_logger->expect_log(lvl::error, expected_error_msg);
+    MP_EXPECT_THROW_THAT(throw uut_t("category", "message {}"),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr(expected_error_msg)));
+}
+
+TEST_F(logged_exception_base_tests, throw_log_error)
+{
+
+    constexpr auto expected_error_msg = R"([Error while formatting the exception string]
+Format string: `message {}`)";
+
+    ON_CALL(*logger_scope.mock_logger, log(lvl::error, "category", testing::_)).WillByDefault([] {
+        throw std::runtime_error{"serious logging issue"};
+    });
+
+    logger_scope.mock_logger->expect_log(lvl::error, expected_error_msg);
+    using uut_t = MockLoggedException<lvl::error, std::runtime_error>;
+
+    MP_EXPECT_THROW_THAT(throw uut_t("category", "message {}"),
+                         std::runtime_error,
+                         mpt::match_what(HasSubstr(expected_error_msg)));
+}
+
+TEST_F(logged_exception_base_tests, throw_unexpected_error)
+{
+    constexpr auto expected_error_msg = R"([Error while formatting the exception string]
+Format string: `message {}`)";
+    using uut_t = MockLoggedException<lvl::error, std::runtime_error>;
+
+    logger_scope.mock_logger->expect_log(lvl::error, expected_error_msg);
+    MP_EXPECT_THROW_THAT(throw uut_t("category", "message {}", AngryTypeThatThrowsUnexpectedThingsOnFormat{}),
                          std::runtime_error,
                          mpt::match_what(HasSubstr(expected_error_msg)));
 }


### PR DESCRIPTION
LoggedExceptionBase is an extension to FormattedExceptionBase where the produced exception message would be logged too. This streamlines the scenario where the exception message is also desired to be logged.