### PR TITLE
Honour the close settings when quitting from the tray

### DIFF
--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -166,7 +166,18 @@ class _AppState extends ConsumerState<App> with WindowListener {
     final daemonAvailable = ref.read(daemonAvailableProvider);
     final vmsRunning =
         ref.read(vmStatusesProvider).values.contains(Status.RUNNING);
-    if (!daemonAvailable || !vmsRunning) windowManager.destroy();
+    final closeJob = ref.read(guiSettingProvider(onAppCloseKey));
+
+    // nothing to do
+    if (!daemonAvailable || !vmsRunning || closeJob == 'nothing') {
+      windowManager.destroy();
+      return;
+    }
+
+    // checking the need to restore the window
+    if (!await windowManager.isVisible() || await windowManager.isMinimized()) {
+      windowManager.showAndRestore();
+    }
 
     stopAllInstances() {
       final notificationsNotifier = ref.read(notificationsProvider.notifier);
@@ -181,31 +192,28 @@ class _AppState extends ConsumerState<App> with WindowListener {
       );
     }
 
-    switch (ref.read(guiSettingProvider(onAppCloseKey))) {
-      case 'nothing':
-        windowManager.destroy();
-      case 'stop':
-        stopAllInstances();
-      default:
-        showDialog(
-          context: context,
-          barrierDismissible: false,
-          builder: (context) => BeforeQuitDialog(
-            onStop: (remember) {
-              ref
-                  .read(guiSettingProvider(onAppCloseKey).notifier)
-                  .set(remember ? 'stop' : 'ask');
-              stopAllInstances();
-              Navigator.pop(context);
-            },
-            onKeep: (remember) {
-              ref
-                  .read(guiSettingProvider(onAppCloseKey).notifier)
-                  .set(remember ? 'nothing' : 'ask');
-              windowManager.destroy();
-            },
-          ),
-        );
+    if (closeJob == 'ask') {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => BeforeQuitDialog(
+          onStop: (remember) {
+            ref
+                .read(guiSettingProvider(onAppCloseKey).notifier)
+                .set(remember ? 'stop' : 'ask');
+            stopAllInstances();
+            Navigator.pop(context);
+          },
+          onKeep: (remember) {
+            ref
+                .read(guiSettingProvider(onAppCloseKey).notifier)
+                .set(remember ? 'nothing' : 'ask');
+            windowManager.destroy();
+          },
+        ),
+      );
+    } else {
+      stopAllInstances();
     }
   }
 }

--- a/src/client/gui/lib/tray_menu.dart
+++ b/src/client/gui/lib/tray_menu.dart
@@ -95,7 +95,7 @@ Future<void> setupTrayMenu(ProviderContainer providerContainer) async {
   await TrayMenu.instance.addLabel(
     'quit',
     label: 'Quit',
-    callback: (_, __) => windowManager.destroy(),
+    callback: (_, __) => windowManager.close(),
   );
 
   await TrayMenu.instance.show(await _iconFilePath());


### PR DESCRIPTION
Closes: #3919
Previously, the tray menu action **'Quit'** caused a function to immediately destroy the window. Now the usual process of closing window is taking place. This allows to consider the settings and perform the necessary tasks before closing.

Additionally, the restoration functionality of a hidden/minimized window has been added if there is a setting of the need to show a dialog before closing (**'Ask about running instances'**).

**To reproduce:**
Set setting _'Stop running instances'_ or _'Ask about running instances'_
![settings](https://github.com/user-attachments/assets/8a45ad93-c709-4a58-95d2-6bbed591a482)

Launch instance:
![run1_gui](https://github.com/user-attachments/assets/26d10c8a-142c-4260-917b-720eaa7792f9)

**Don't close the app Window, but Quit from the tray.**

Before:
![multipass_#3919_before](https://github.com/user-attachments/assets/3ae1ad07-f969-4c7e-be05-0cd67545b973)

After:
![multipass_#3919_after](https://github.com/user-attachments/assets/5fb41772-f24d-40a8-9634-6d493f09dcc5)
