### PR TITLE
Added more Bash-complete instances in multipass stop --force

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -348,7 +348,21 @@ _multipass_complete()
 
     if [[ "$prev_opts" = false ]]; then
         case "${cmd}" in
-            "exec"|"stop"|"suspend"|"restart")
+            "exec"|"suspend"|"restart")
+                _multipass_instances "Running"
+            ;;
+            "stop")
+                _get_comp_words_by_ref -n := -w WORDS -i CWORD cur prev
+                for ((i=2; i<CWORD; i++)); do
+                    if [[ "${WORDS[i]}" == "--force" ]]; then
+                        _multipass_instances "Starting"
+                        _multipass_instances "Restarting"
+                        _multipass_instances "Suspending"
+                        _multipass_instances "Suspended"
+                        break
+                    fi
+                done
+
                 _multipass_instances "Running"
             ;;
             "connect"|"sh"|"shell")


### PR DESCRIPTION
Closes: #3682
Previously, when the TAB pressed, only ‘Running’ instances were completed.
Now, if the `--force` flag is provided, additionally taken into account 'Starting', 'Restarting', 'Suspending' and 'Suspended' ones.

**To reproduce:**
Run service:
`sudo /usr/local/bin/multipassd`

Run GUI:
`/usr/local/bin/multipass.gui`

start and then **suspend the instance**

**OR** start/stop/suspend tasks can be done from the CLI:
`multipass start --all`
`multipass suspend --all`

**Before:**
Open Bash and add the script:
`source <multipass>/completions/bash/multipass`

Check the instance is suspended:
`multipass ls`

Try the bash-completion (**'n'** is the first letter of the instance’s name):
`multipass stop --force n[TAB]`

_Nothing happens._

**After:**
Reopen Bash and add the script:
`source <multipass>/completions/bash/multipass`
`multipass ls`
`multipass stop --force n[TAB]`

`natty-nilgai` (real instance name) will be completed.