### PR TITLE
[tests/mock_logger] Add substr as Description() for distinction

### DIFF
--- a/tests/mock_logger.cpp
+++ b/tests/mock_logger.cpp
@@ -17,6 +17,8 @@
 
 #include "mock_logger.h"
 
+#include <fmt/format.h>
+
 #include <type_traits>
 
 namespace mp = multipass;
@@ -50,7 +52,9 @@ mpt::MockLogger::Scope::~Scope()
 
 void mpt::MockLogger::expect_log(mpl::Level lvl, const std::string& substr, const Cardinality& times)
 {
-    EXPECT_CALL(*this, log(lvl, _, HasSubstr(substr))).Times(times).Description(substr);
+    EXPECT_CALL(*this, log(lvl, _, HasSubstr(substr)))
+        .Times(times)
+        .Description(fmt::format("log(level: {}, substr: '{}')", logging::as_string(lvl), substr));
 }
 
 void mpt::MockLogger::screen_logs(mpl::Level lvl)

--- a/tests/mock_logger.cpp
+++ b/tests/mock_logger.cpp
@@ -50,7 +50,7 @@ mpt::MockLogger::Scope::~Scope()
 
 void mpt::MockLogger::expect_log(mpl::Level lvl, const std::string& substr, const Cardinality& times)
 {
-    EXPECT_CALL(*this, log(lvl, _, HasSubstr(substr))).Times(times);
+    EXPECT_CALL(*this, log(lvl, _, HasSubstr(substr))).Times(times).Description(substr);
 }
 
 void mpt::MockLogger::screen_logs(mpl::Level lvl)


### PR DESCRIPTION
Right now, it's hard to tell which expect_log call is failed to be satisfied because the output is ambiguous:

```
 error: Actual function call count doesn't match EXPECT_CALL(*this, log(lvl, _, HasSubstr(substr)))...
         Expected: to be called once
           Actual: never called - unsatisfied and active
```
The patch fixes that by utilizing the matcher description:
````
 error: Actual function "my expected log string" call count doesn't match EXPECT_CALL(*this, log(lvl, _, HasSubstr(substr)))...
         Expected: to be called once
           Actual: never called - unsatisfied and active
```