### PR TITLE
Fix flakey SFTP server test

### DIFF
--- a/tests/test_sftpserver.cpp
+++ b/tests/test_sftpserver.cpp
@@ -1671,7 +1671,7 @@ TEST_F(SftpServer, handles_readdir_attributes_preserved)
     EXPECT_EQ(test_file_attrs.size, (uint64_t)test_file_info.size());
     EXPECT_EQ(test_file_attrs.gid, test_file_info.groupId());
     EXPECT_EQ(test_file_attrs.uid, test_file_info.ownerId());
-    EXPECT_EQ(test_file_attrs.atime,
+    EXPECT_EQ(test_file_attrs.mtime,
               (uint32_t)test_file_info.lastModified().toSecsSinceEpoch()); // atime64 is zero, expected?
 
     EXPECT_TRUE(compare_permission(test_file_attrs.permissions, test_file_info, Permission::Owner));


### PR DESCRIPTION
The test was expecting returned lastRead to be the same as the expected lastModified, which has a really small chance of not being true. Changed it to check the returned lastModified to be the same as the expected lastModified.

Resolves #4086 