### PR TITLE
[vm] Drop transition safety net for runtime errors

### DIFF
--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -123,11 +123,6 @@ std::optional<mp::SSHSession> wait_until_ssh_up_helper(mp::VirtualMachine* virtu
         {
             return log_and_retry(e, virtual_machine);
         }
-        catch (
-            const std::runtime_error& e) // transitioning away from catching generic runtime errors
-        {                                // TODO remove once we're confident this is an anomaly
-            return log_and_retry(e, virtual_machine, mpl::Level::warning);
-        }
     };
 
     auto on_timeout = [virtual_machine] {

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -1324,10 +1324,8 @@ TEST_F(BaseVM, waitForSSHUpThrowsOnTimeout)
                          mpt::match_what(HasSubstr("timed out waiting for response")));
 }
 
-using ExceptionParam = std::variant<std::runtime_error,
-                                    mp::IPUnavailableException,
-                                    mp::SSHException,
-                                    mp::InternalTimeoutException>;
+using ExceptionParam =
+    std::variant<mp::IPUnavailableException, mp::SSHException, mp::InternalTimeoutException>;
 class TestWaitForSSHExceptions : public BaseVM, public WithParamInterface<ExceptionParam>
 {
 };
@@ -1356,8 +1354,7 @@ TEST_P(TestWaitForSSHExceptions, waitForSSHUpRetriesOnExpectedException)
 
 INSTANTIATE_TEST_SUITE_P(TestWaitForSSHExceptions,
                          TestWaitForSSHExceptions,
-                         Values(std::runtime_error{"todo-remove-eventually"},
-                                mp::IPUnavailableException{"noip"},
+                         Values(mp::IPUnavailableException{"noip"},
                                 mp::SSHException{"nossh"},
                                 mp::InternalTimeoutException{"notime", std::chrono::seconds{1}}));
 

--- a/tests/test_base_virtual_machine.cpp
+++ b/tests/test_base_virtual_machine.cpp
@@ -1311,7 +1311,9 @@ TEST_F(BaseVM, waitForCloudInitErrorTimesOutThrows)
 TEST_F(BaseVM, waitForSSHUpThrowsOnTimeout)
 {
     vm.simulate_waiting_for_ssh();
-    EXPECT_CALL(vm, ssh_hostname(_)).WillOnce(Throw(std::runtime_error{"intentional"}));
+    constexpr auto action = "determine IP address";
+    EXPECT_CALL(vm, ssh_hostname(_))
+        .WillOnce(Throw(mp::InternalTimeoutException{action, std::chrono::milliseconds{0}}));
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
     auto& mock_utils = *mock_utils_ptr;


### PR DESCRIPTION
Remove safety-net catch for generic runtime errors when waiting for SSH.
