### PR TITLE
Added the return of the inner shell exit code

### DIFF
--- a/include/multipass/ssh/ssh_client.h
+++ b/include/multipass/ssh/ssh_client.h
@@ -47,7 +47,7 @@ public:
 
     int exec(const std::vector<std::string>& args);
     int exec(const std::vector<std::vector<std::string>>& args_list);
-    void connect();
+    int connect();
 
 private:
     void handle_ssh_events();

--- a/src/client/cli/cmd/shell.cpp
+++ b/src/client/cli/cmd/shell.cpp
@@ -76,7 +76,10 @@ mp::ReturnCode cmd::Shell::run(mp::ArgParser* parser)
         {
             auto console_creator = [this](auto channel) { return term->make_console(channel); };
             mp::SSHClient ssh_client{host, port, username, priv_key_blob, console_creator};
-            ssh_client.connect();
+            const int exit_code = ssh_client.connect();
+
+            if (exit_code != 0)
+                return ReturnCode::CommandFail;
         }
         catch (const std::exception& e)
         {

--- a/src/ssh/ssh_client.cpp
+++ b/src/ssh/ssh_client.cpp
@@ -63,9 +63,9 @@ mp::SSHClient::SSHClient(SSHSessionUPtr ssh_session, ConsoleCreator console_crea
 {
 }
 
-void mp::SSHClient::connect()
+int mp::SSHClient::connect()
 {
-    exec(std::vector<std::string>{});
+    return exec(std::vector<std::string>{});
 }
 
 int mp::SSHClient::exec(const std::vector<std::string>& args)


### PR DESCRIPTION
Closes: #3054
Previously, with a successful exit from the instance’s shell, the exit code was always 0. Now the shell returns integer 'exit_code'. If this value goes beyond the 'ReturnCode' range (0-3), will be returned the default 0 (ReturnCode::Ok).

**To reproduce:**
Start service:
`sudo /usr/local/bin/multipassd`

Open another terminal/tab. List of existing instances:
`multipass ls`

Start some instance:
`multipass start 'instance_name'`

Switch to instance’s shell:
`multipass shell 'instance_name'`

Exit the instance's shell with some exit code:
`exit 1`

Try to get this code from the main shell:
`echo $?`

**Before:**
get result: `0`

**After:**
get result: `1` (custom exit code value in 0-3 range)