### PR TITLE
[tics] fix TICS CI sub command

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -2,8 +2,8 @@ name: TICS
 
 on:
   schedule:
-  # 04:11 UTC every Sunday
-  - cron: 11 4 * * 0
+  # 04:11 UTC every Tuesday
+  - cron: 11 4 * * 2
 
 jobs:
   build:


### PR DESCRIPTION
Fixed the `apt-get` command as well as the cron schedule comment.