### PR TITLE
Update daemon permissions

### DIFF
--- a/packaging/macos/postinstall-multipassd.sh.in
+++ b/packaging/macos/postinstall-multipassd.sh.in
@@ -14,6 +14,9 @@ fi
 # Create log dir and ensure correct permissions
 mkdir -p "$3/Library/Logs/Multipass" -m 755
 
+# Ensure correct daemon permissions
+chown root:wheel "$3@CPACK_PACKAGING_INSTALL_PREFIX@/bin/multipassd"
+
 # Install launch agent
 cp -v "$LAUNCH_AGENT_SRC" "$LAUNCH_AGENT_DEST"
 launchctl load -w "$LAUNCH_AGENT_DEST"


### PR DESCRIPTION
With our recent changes to permissions, it doesn't make sense for the daemon binary to not have similar restrictions applied to it. This PR applies those restrictions by making the daemon owned by root similar to how the storage directory is now owned by root.

MULTI-1998