### PR TITLE
[cloud-init] replace Qt with C++ stl

### DIFF
--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -20,7 +20,6 @@
 #ifndef MULTIPASS_CLOUD_INIT_ISO_H
 #define MULTIPASS_CLOUD_INIT_ISO_H
 
-#include <multipass/path.h>
 #include <multipass/singleton.h>
 
 #include <filesystem>

--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -21,12 +21,11 @@
 #define MULTIPASS_CLOUD_INIT_ISO_H
 
 #include <multipass/path.h>
+#include <multipass/singleton.h>
 
 #include <filesystem>
 #include <string>
 #include <vector>
-
-#include <multipass/singleton.h>
 
 #define MP_CLOUD_INIT_FILE_OPS multipass::CloudInitFileOps::instance()
 
@@ -42,7 +41,7 @@ public:
     std::string& operator[](const std::string& name);
     bool erase(const std::string& name);
 
-    void write_to(const Path& path);
+    void write_to(const std::filesystem& path);
     void read_from(const std::filesystem::path& path);
 
     friend bool operator==(const CloudInitIso& lhs, const CloudInitIso& rhs)

--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -41,7 +41,7 @@ public:
     std::string& operator[](const std::string& name);
     bool erase(const std::string& name);
 
-    void write_to(const std::filesystem& path);
+    void write_to(const std::filesystem::path& path);
     void read_from(const std::filesystem::path& path);
 
     friend bool operator==(const CloudInitIso& lhs, const CloudInitIso& rhs)

--- a/src/iso/CMakeLists.txt
+++ b/src/iso/CMakeLists.txt
@@ -19,5 +19,4 @@ add_library(iso STATIC
 
 target_link_libraries(iso
   fmt::fmt-header-only
-  utils
-  Qt6::Core)
+  utils)

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -22,8 +22,6 @@
 #include <multipass/format.h>
 #include <multipass/yaml_node_utils.h>
 
-#include <QFile>
-
 #include <array>
 #include <cctype>
 #include <stdexcept>
@@ -130,7 +128,7 @@ void set_at(T& t, SizeType offset, const V& value)
 }
 
 template <typename T>
-void write(const T& t, QFile& f)
+void write(const T& t, std::ofstream& f)
 {
     f.write(reinterpret_cast<const char*>(t.data.data()), t.data.size());
 }
@@ -459,22 +457,21 @@ struct RootPathTable
     std::array<uint8_t, 10> data{};
 };
 
-template <typename Size>
-Size num_blocks(Size num_bytes)
+std::size_t num_blocks(std::size_t num_bytes)
 {
     return ((num_bytes + logical_block_size - 1) / logical_block_size);
 }
 
-void seek_to_next_block(QFile& f)
+void seek_to_next_block(std::ofstream& f)
 {
-    const auto next_block_pos = num_blocks(f.pos()) * logical_block_size;
-    f.seek(next_block_pos);
+    const auto next_block_pos = num_blocks(f.tellp()) * logical_block_size;
+    f.seekp(next_block_pos);
 }
 
-void pad_to_end(QFile& f)
+void pad_to_end(std::ofstream& f)
 {
     seek_to_next_block(f);
-    f.seek(f.pos() - 1);
+    f.seekp(-1, std::ios::cur);
     char end = 0;
     f.write(&end, 1);
 }
@@ -545,18 +542,17 @@ bool mp::CloudInitIso::erase(const std::string& name)
     return false;
 }
 
-void mp::CloudInitIso::write_to(const std::filesystem& path)
+void mp::CloudInitIso::write_to(const std::filesystem::path& path)
 {
-    QFile f{QString::fromStdString(path.string())};
-    if (!f.open(QIODevice::WriteOnly))
-        throw std::runtime_error{fmt::format(
-            "Failed to open file for writing during cloud-init generation: {}; path: {}",
-            f.errorString(),
-            path.string())};
+    std::ofstream f{path, std::ios::binary | std::ios::out};
+    if (!f.is_open())
+        throw std::runtime_error{
+            fmt::format("Failed to open file for writing during cloud-init generation; path: {}",
+                        path.string())};
 
     const uint32_t num_reserved_bytes = 32768u;
     const uint32_t num_reserved_blocks = num_blocks(num_reserved_bytes);
-    f.seek(num_reserved_bytes);
+    f.seekp(num_reserved_bytes);
 
     PrimaryVolumeDescriptor prim_desc;
     JolietVolumeDescriptor joliet_desc;

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -545,14 +545,14 @@ bool mp::CloudInitIso::erase(const std::string& name)
     return false;
 }
 
-void mp::CloudInitIso::write_to(const Path& path)
+void mp::CloudInitIso::write_to(const std::filesystem& path)
 {
-    QFile f{path};
+    QFile f{QString::fromStdString(path.string())};
     if (!f.open(QIODevice::WriteOnly))
         throw std::runtime_error{fmt::format(
             "Failed to open file for writing during cloud-init generation: {}; path: {}",
             f.errorString(),
-            path)};
+            path.string())};
 
     const uint32_t num_reserved_bytes = 32768u;
     const uint32_t num_reserved_blocks = num_blocks(num_reserved_bytes);
@@ -750,7 +750,7 @@ void mp::CloudInitFileOps::update_cloud_init_with_new_extra_interfaces_and_new_i
     // overwrite the whole network-config file content
     iso_file["network-config"] = mpu::emit_cloud_config(
         mpu::make_cloud_init_network_config(default_mac_addr, extra_interfaces));
-    iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
+    iso_file.write_to(cloud_init_path);
 }
 
 void mp::CloudInitFileOps::update_identifiers(const std::string& default_mac_addr,
@@ -771,7 +771,7 @@ void mp::CloudInitFileOps::update_identifiers(const std::string& default_mac_add
                                                                    extra_interfaces,
                                                                    network_config_file_content));
 
-    iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
+    iso_file.write_to(cloud_init_path);
 }
 
 void mp::CloudInitFileOps::add_extra_interface_to_cloud_init(
@@ -789,7 +789,7 @@ void mp::CloudInitFileOps::add_extra_interface_to_cloud_init(
         mpu::add_extra_interface_to_network_config(default_mac_addr,
                                                    extra_interface,
                                                    iso_file["network-config"]));
-    iso_file.write_to(QString::fromStdString(cloud_init_path.string()));
+    iso_file.write_to(cloud_init_path);
 }
 
 std::string mp::CloudInitFileOps::get_instance_id_from_cloud_init(

--- a/src/iso/cloud_init_iso.cpp
+++ b/src/iso/cloud_init_iso.cpp
@@ -472,8 +472,7 @@ void pad_to_end(std::ofstream& f)
 {
     seek_to_next_block(f);
     f.seekp(-1, std::ios::cur);
-    char end = 0;
-    f.write(&end, 1);
+    f.put('\0');
 }
 } // namespace
 

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -48,7 +48,7 @@ void mp::BaseVirtualMachineFactory::configure(VirtualMachineDescription& vm_desc
         if (!vm_desc.network_data_config.IsNull())
             iso.add_file("network-config", mpu::emit_cloud_config(vm_desc.network_data_config));
 
-        iso.write_to(cloud_init_iso);
+        iso.write_to(cloud_init_iso.toStdString());
     }
 
     vm_desc.cloud_init_iso = cloud_init_iso;

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -71,10 +71,10 @@ struct CloudInitIso : public Test
 {
     CloudInitIso()
     {
-        iso_path = QDir{temp_dir.path()}.filePath("test.iso");
+        iso_path = QDir{temp_dir.path()}.filePath("test.iso").toStdString();
     }
     mpt::TempDir temp_dir;
-    QString iso_path;
+    std::filesystem iso_path;
 };
 
 TEST_F(CloudInitIso, check_contains_false)
@@ -141,9 +141,9 @@ TEST_F(CloudInitIso, creates_iso_file)
     iso.add_file("test", "test data");
     iso.write_to(iso_path);
 
-    QFile file{iso_path};
-    EXPECT_TRUE(file.exists());
-    EXPECT_THAT(file.size(), Ge(0));
+    std::ofstream file{iso_path, std::ios::binary};
+    EXPECT_TRUE(file.is_open());
+    EXPECT_THAT(fs::file_size(iso_path), Ge(0));
 }
 
 TEST_F(CloudInitIso, reads_iso_file_failed_to_open_file)
@@ -154,7 +154,7 @@ TEST_F(CloudInitIso, reads_iso_file_failed_to_open_file)
     const auto [mock_file_ops, _] = mpt::MockFileOps::inject();
     EXPECT_CALL(*mock_file_ops, is_open(An<const std::ifstream&>())).WillOnce(Return(false));
     mp::CloudInitIso new_iso;
-    MP_EXPECT_THROW_THAT(new_iso.read_from(std::filesystem::path(iso_path.toStdString())),
+    MP_EXPECT_THROW_THAT(new_iso.read_from(iso_path),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Failed to open file")));
 }
@@ -173,7 +173,7 @@ TEST_F(CloudInitIso, reads_iso_file_failed_to_read_single_bytes)
     // failed on the first read_single_byte call
     mp::CloudInitIso new_iso;
     MP_EXPECT_THROW_THAT(
-        new_iso.read_from(std::filesystem::path(iso_path.toStdString())),
+        new_iso.read_from(iso_path),
         std::runtime_error,
         mpt::match_what(HasSubstr("Can not read the next byte data from file at")));
 }
@@ -197,7 +197,7 @@ TEST_F(CloudInitIso, reads_iso_file_failed_to_check_it_has_Joliet_volume_descrip
         .WillOnce(read_returns_one_byte_value_one);
 
     mp::CloudInitIso new_iso;
-    MP_EXPECT_THROW_THAT(new_iso.read_from(std::filesystem::path(iso_path.toStdString())),
+    MP_EXPECT_THROW_THAT(new_iso.read_from(iso_path),
                          std::runtime_error,
                          mpt::match_what(StrEq("The Joliet volume descriptor is not in place.")));
 }
@@ -223,7 +223,7 @@ TEST_F(CloudInitIso, reads_iso_file_Joliet_volume_descriptor_malformed)
         .WillOnce(read_returns_five_bytes_string);
 
     mp::CloudInitIso new_iso;
-    MP_EXPECT_THROW_THAT(new_iso.read_from(std::filesystem::path(iso_path.toStdString())),
+    MP_EXPECT_THROW_THAT(new_iso.read_from(iso_path),
                          std::runtime_error,
                          mpt::match_what(StrEq("The Joliet descriptor is malformed.")));
 }
@@ -244,7 +244,7 @@ TEST_F(CloudInitIso, reads_iso_file_failed_to_read_array)
         .WillOnce(read_returns_failed_ifstream);
 
     mp::CloudInitIso new_iso;
-    MP_EXPECT_THROW_THAT(new_iso.read_from(std::filesystem::path(iso_path.toStdString())),
+    MP_EXPECT_THROW_THAT(new_iso.read_from(iso_path),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("bytes data from file at")));
 }
@@ -271,7 +271,7 @@ TEST_F(CloudInitIso, reads_iso_file_failed_to_check_root_dir_record_data)
         .WillOnce(read_return_default_buffer);
 
     mp::CloudInitIso new_iso;
-    MP_EXPECT_THROW_THAT(new_iso.read_from(std::filesystem::path(iso_path.toStdString())),
+    MP_EXPECT_THROW_THAT(new_iso.read_from(iso_path),
                          std::runtime_error,
                          mpt::match_what(StrEq("The root directory record data is malformed.")));
 }
@@ -296,7 +296,7 @@ TEST_F(CloudInitIso, reads_iso_file_failed_to_read_vec)
         .WillOnce(read_returns_failed_ifstream);
 
     mp::CloudInitIso new_iso;
-    MP_EXPECT_THROW_THAT(new_iso.read_from(std::filesystem::path(iso_path.toStdString())),
+    MP_EXPECT_THROW_THAT(new_iso.read_from(iso_path),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("bytes data from file at")));
 }
@@ -332,7 +332,7 @@ TEST_F(CloudInitIso, reads_iso_file_encoded_file_name_is_not_even_length)
 
     mp::CloudInitIso new_iso;
     MP_EXPECT_THROW_THAT(
-        new_iso.read_from(std::filesystem::path(iso_path.toStdString())),
+        new_iso.read_from(iso_path),
         std::runtime_error,
         mpt::match_what(HasSubstr("is not even, which does not conform to u16 name format")));
 }
@@ -350,7 +350,7 @@ TEST_F(CloudInitIso, reads_iso_file_with_random_string_data)
     original_iso.write_to(iso_path);
 
     mp::CloudInitIso new_iso;
-    new_iso.read_from(iso_path.toStdString());
+    new_iso.read_from(iso_path);
     EXPECT_EQ(original_iso, new_iso);
 }
 
@@ -385,7 +385,7 @@ write_files:
     original_iso.write_to(iso_path);
 
     mp::CloudInitIso new_iso;
-    new_iso.read_from(iso_path.toStdString());
+    new_iso.read_from(iso_path);
     EXPECT_EQ(original_iso, new_iso);
 }
 
@@ -403,7 +403,7 @@ TEST_F(CloudInitIso, updateCloudInitWithNewNonEmptyExtraInterfaces)
         default_mac_addr,
         extra_interfaces,
         "vm2",
-        iso_path.toStdString()));
+        iso_path));
 
     const std::string expected_modified_meta_data_content =
         fmt::format(meta_data_content_template, "vm2", "vm1");
@@ -411,7 +411,7 @@ TEST_F(CloudInitIso, updateCloudInitWithNewNonEmptyExtraInterfaces)
         fmt::format(network_config_data_content_template, "52:54:00:56:78:90", "52:54:00:56:78:91");
 
     mp::CloudInitIso new_iso;
-    new_iso.read_from(iso_path.toStdString());
+    new_iso.read_from(iso_path);
     EXPECT_EQ(new_iso.at("meta-data"), expected_modified_meta_data_content);
     EXPECT_EQ(new_iso.at("network-config"), expected_generated_network_config_data_content);
 }
@@ -429,9 +429,9 @@ TEST_F(CloudInitIso, updateCloudInitWithNewEmptyExtraInterfaces)
         default_mac_addr,
         empty_extra_interfaces,
         std::string(),
-        iso_path.toStdString()));
+        iso_path));
     mp::CloudInitIso new_iso;
-    new_iso.read_from(iso_path.toStdString());
+    new_iso.read_from(iso_path);
     EXPECT_TRUE(new_iso.contains("network-config"));
 }
 
@@ -452,7 +452,7 @@ TEST_F(CloudInitIso, updateCloneCloudInitSrcFileWithExtraInterfaces)
     EXPECT_NO_THROW(MP_CLOUD_INIT_FILE_OPS.update_identifiers(default_mac_addr,
                                                               extra_interfaces,
                                                               "vm1-clone1",
-                                                              iso_path.toStdString()));
+                                                              iso_path));
 
     const std::string expected_modified_meta_data_content =
         fmt::format(meta_data_content_template, "vm1-clone1_e_e", "vm1-clone1");
@@ -460,7 +460,7 @@ TEST_F(CloudInitIso, updateCloneCloudInitSrcFileWithExtraInterfaces)
         fmt::format(network_config_data_content_template, "52:54:00:56:78:90", "52:54:00:56:78:91");
 
     mp::CloudInitIso new_iso;
-    new_iso.read_from(iso_path.toStdString());
+    new_iso.read_from(iso_path);
     EXPECT_EQ(new_iso.at("meta-data"), expected_modified_meta_data_content);
     EXPECT_EQ(new_iso.at("network-config"), expected_generated_network_config_data_content);
 }
@@ -472,10 +472,9 @@ TEST_F(CloudInitIso, addExtraInterfaceToCloudInit)
     original_iso.write_to(iso_path);
 
     const mp::NetworkInterface dummy_extra_interface{};
-    EXPECT_NO_THROW(
-        MP_CLOUD_INIT_FILE_OPS.add_extra_interface_to_cloud_init("",
-                                                                 dummy_extra_interface,
-                                                                 iso_path.toStdString()));
+    EXPECT_NO_THROW(MP_CLOUD_INIT_FILE_OPS.add_extra_interface_to_cloud_init("",
+                                                                             dummy_extra_interface,
+                                                                             iso_path));
 }
 
 TEST_F(CloudInitIso, getInstanceIdFromCloudInit)
@@ -484,6 +483,5 @@ TEST_F(CloudInitIso, getInstanceIdFromCloudInit)
     original_iso.add_file("meta-data", default_meta_data_content);
     original_iso.write_to(iso_path);
 
-    EXPECT_EQ(MP_CLOUD_INIT_FILE_OPS.get_instance_id_from_cloud_init(iso_path.toStdString()),
-              "vm1");
+    EXPECT_EQ(MP_CLOUD_INIT_FILE_OPS.get_instance_id_from_cloud_init(iso_path), "vm1");
 }

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -74,7 +74,7 @@ struct CloudInitIso : public Test
         iso_path = QDir{temp_dir.path()}.filePath("test.iso").toStdString();
     }
     mpt::TempDir temp_dir;
-    std::filesystem iso_path;
+    std::filesystem::path iso_path;
 };
 
 TEST_F(CloudInitIso, check_contains_false)
@@ -143,7 +143,7 @@ TEST_F(CloudInitIso, creates_iso_file)
 
     std::ofstream file{iso_path, std::ios::binary};
     EXPECT_TRUE(file.is_open());
-    EXPECT_THAT(fs::file_size(iso_path), Ge(0));
+    EXPECT_THAT(std::filesystem::file_size(iso_path), Ge(0));
 }
 
 TEST_F(CloudInitIso, reads_iso_file_failed_to_open_file)


### PR DESCRIPTION
- Removes some unnecessary conversions between `QString` and `std::string`
- Reduces the binary size by a few percentages of a `KB`