### PR TITLE
[tests/simple_streams] add test case for no image-downloads

### DIFF
--- a/tests/test_data/no_image_downloads_in_datatype.json
+++ b/tests/test_data/no_image_downloads_in_datatype.json
@@ -1,0 +1,7 @@
+{
+  "index": {
+    "com.ubuntu.cloud:released:download": {
+      "datatype": "image-uploads"
+    }
+  }
+}

--- a/tests/test_simple_streams_index.cpp
+++ b/tests/test_simple_streams_index.cpp
@@ -70,3 +70,9 @@ TEST(SimpleStreamsIndex, throws_on_invalid_top_level_type)
     auto json = mpt::load_test_file("invalid_top_level.json");
     EXPECT_THROW(mp::SimpleStreamsIndex::fromJson(json), std::runtime_error);
 }
+
+TEST(SimpleStreamsIndex, throws_on_no_image_with_image_downloads)
+{
+    auto json = mpt::load_test_file("no_image_downloads_in_datatype.json");
+    EXPECT_THROW(mp::SimpleStreamsIndex::fromJson(json), std::runtime_error);
+}


### PR DESCRIPTION
It is causing spurious coverage-related CI failures, such as: https://app.codecov.io/gh/canonical/multipass/pull/4090/indirect-changes

MULTI-2005