### PR TITLE
[snapcraft.yaml] mimic github runner's sources.list

### DIFF
--- a/.github/workflows/linux.patch
+++ b/.github/workflows/linux.patch
@@ -1,16 +1,29 @@
 diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
-index 3fdefb04..f2ebe7b8 100644
+index d1c4cc1..c0d268c 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -127,6 +127,7 @@ parts:
+@@ -113,9 +113,9 @@ parts:
+       echo "Injecting custom APT mirror priorities..."
+
+       cat <<EOF > /etc/apt/apt-mirrors.txt
+-      https://archive.ubuntu.com/ubuntu/	priority:1
+-      https://security.ubuntu.com/ubuntu/	priority:2
+-      http://azure.archive.ubuntu.com/ubuntu/	priority:3
++      https://archive.ubuntu.com/ubuntu/	priority:2
++      https://security.ubuntu.com/ubuntu/	priority:3
++      http://azure.archive.ubuntu.com/ubuntu/	priority:1
+       EOF
+
+       codename=jammy
+@@ -159,6 +159,7 @@ parts:
+     build-packages:
      - on arm64: [libgles2-mesa-dev]
-     - on armhf: [libgles2-mesa-dev]
      - build-essential
 +    - ccache
      - git
      - libapparmor-dev
-     - libqt5x11extras5-dev
-@@ -159,6 +160,8 @@ parts:
+     - libgl1-mesa-dev
+@@ -240,6 +241,8 @@ parts:
      - -DMULTIPASS_ENABLE_TESTS=off
      - -DMULTIPASS_UPSTREAM=origin
      - -DMULTIPASS_ENABLE_FLUTTER_GUI=on

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -170,6 +170,7 @@ jobs:
         fi
 
         # Build the `multipass` part.
+        /snap/bin/snapcraft pull --use-lxd inject-apt-mirrors
         /snap/bin/snapcraft build --use-lxd multipass
 
     - name: Clear CCache stats

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,9 +113,9 @@ parts:
       echo "Injecting custom APT mirror priorities..."
 
       cat <<EOF > /etc/apt/apt-mirrors.txt
-      http://azure.archive.ubuntu.com/ubuntu/	priority:1
-      https://archive.ubuntu.com/ubuntu/	priority:2
-      https://security.ubuntu.com/ubuntu/	priority:3
+      https://archive.ubuntu.com/ubuntu/	priority:1
+      https://security.ubuntu.com/ubuntu/	priority:2
+      http://azure.archive.ubuntu.com/ubuntu/	priority:3
       EOF
 
       codename=jammy

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,26 @@ architectures:
   - build-on: amd64
   - build-on: arm64
 
+package-repositories:
+  # Use https:// endpoint by default
+  - type: apt
+    url: https://archive.ubuntu.com/ubuntu
+    formats: [deb]
+    architectures: [amd64, arm64]
+    key-server: keyserver.ubuntu.com
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    components: [main, multiverse, universe, restricted]
+    suites: [jammy, jammy-updates]
+  # Use http:// as fallback
+  - type: apt
+    url: http://archive.ubuntu.com/ubuntu/
+    formats: [deb]
+    architectures: [amd64, arm64]
+    key-server: keyserver.ubuntu.com
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    suites: [jammy, jammy-updates]
+    components: [main, multiverse, universe, restricted]
+
 layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,26 +17,6 @@ architectures:
   - build-on: amd64
   - build-on: arm64
 
-package-repositories:
-  # Use https:// endpoint by default
-  - type: apt
-    url: https://archive.ubuntu.com/ubuntu
-    formats: [deb]
-    architectures: [amd64, arm64]
-    key-server: keyserver.ubuntu.com
-    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
-    components: [main, multiverse, universe, restricted]
-    suites: [jammy, jammy-updates]
-  # Use http:// as fallback
-  - type: apt
-    url: http://archive.ubuntu.com/ubuntu/
-    formats: [deb]
-    architectures: [amd64, arm64]
-    key-server: keyserver.ubuntu.com
-    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
-    suites: [jammy, jammy-updates]
-    components: [main, multiverse, universe, restricted]
-
 layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qemu
@@ -126,6 +106,26 @@ apps:
       - x11
 
 parts:
+  inject-apt-mirrors:
+    plugin: nil
+    override-pull: |
+      # Based on https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/configure-apt-sources.sh
+      echo "Injecting custom APT mirror priorities..."
+
+      cat <<EOF > /etc/apt/apt-mirrors.txt
+      http://azure.archive.ubuntu.com/ubuntu/	priority:1
+      https://archive.ubuntu.com/ubuntu/	priority:2
+      https://security.ubuntu.com/ubuntu/	priority:3
+      EOF
+
+      codename=jammy
+      cat <<EOF > /etc/apt/sources.list
+      deb mirror+file:/etc/apt/apt-mirrors.txt $codename main restricted universe multiverse
+      deb mirror+file:/etc/apt/apt-mirrors.txt $codename-updates main restricted universe multiverse
+      deb mirror+file:/etc/apt/apt-mirrors.txt $codename-security main restricted universe multiverse
+      EOF
+
+      apt-get update
   libvirt:
     plugin: nil
     stage-packages:


### PR DESCRIPTION
... for reliability. GitHub runners use a mirror-based failover scheme. Multipass's build step happens inside an LXC container, which does not benefit from this. This PR adds a new part named "inject-apt-mirrors" to [replicate the runner behavior](https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/configure-apt-sources.sh).