### PR TITLE
Harden bash completion security a little

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -21,9 +21,10 @@ _multipass_complete()
         local state=$1 cmd instances
 
         cmd="multipass list --format=csv --no-ipv4 | \tail -n +2"
-        [ -n "$state" ] && cmd="$cmd | \awk -F',' '\$2 == \"$state\"'"
+        instances=$( \eval $cmd )
 
-        instances=$( \eval $cmd | \cut -d',' -f 1  | \tr '\r\n' ' ')
+        [ -n "$state" ] && instances=$(awk -F',' "\$2 == \"$state\"" <<< "$instances")
+        instances=$(echo "$instances" | \cut -d',' -f 1  | \tr '\r\n' ' ')
 
         _add_nonrepeating_args "$instances"
     }
@@ -33,9 +34,10 @@ _multipass_complete()
         local instance=$1 cmd snapshots
 
         cmd="multipass list --snapshots --format=csv 2>/dev/null | \tail -n +2"
-        [ -n "$instance" ] && cmd="$cmd | \awk -F',' '\$1 == \"$instance\"'"
+        snapshots=$( \eval $cmd )
 
-        snapshots=$( \eval $cmd | \cut -d',' -f 1,2 | \tr ',' '.' | \tr '\r\n' ' ' )
+        [ -n "$instance" ] && snapshots=$(awk -F',' "\$1 == \"$instance\"" <<< "$snapshots")
+        snapshots=$(echo "$snapshots" | \cut -d',' -f 1,2 | \tr ',' '.' | \tr '\r\n' ' ')
 
         _add_nonrepeating_args "$snapshots"
     }

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -229,7 +229,7 @@ _multipass_complete()
         COMP_WORDBREAKS="${COMP_WORDBREAKS}="
     fi
 
-    local cur cmd opts prev prev2 prev_opts multipass_aliases unused_aliases
+    local cur cmd opts prev prev2 prev_opts multipass_aliases
     _get_comp_words_by_ref -n := -w WORDS -i CWORD cur prev
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -18,11 +18,9 @@ _multipass_complete()
 {
     _multipass_instances()
     {
-        local state=$1 cmd instances
+        local state=$1 instances
 
-        cmd="multipass list --format=csv --no-ipv4 | \tail -n +2"
-        instances=$( \eval "$cmd" )
-
+        instances=$(multipass list --format=csv --no-ipv4 | \tail -n +2)
         [ -n "$state" ] && instances=$(awk -F',' "\$2 == \"$state\"" <<< "$instances")
         instances=$(echo "$instances" | \cut -d',' -f 1  | \tr '\r\n' ' ')
 
@@ -31,11 +29,9 @@ _multipass_complete()
 
     _multipass_snapshots()
     {
-        local instance=$1 cmd snapshots
+        local instance=$1 snapshots
 
-        cmd="multipass list --snapshots --format=csv 2>/dev/null | \tail -n +2"
-        snapshots=$( \eval "$cmd" )
-
+        snapshots=$(multipass list --snapshots --format=csv 2>/dev/null | \tail -n +2)
         [ -n "$instance" ] && snapshots=$(awk -F',' "\$1 == \"$instance\"" <<< "$snapshots")
         snapshots=$(echo "$snapshots" | \cut -d',' -f 1,2 | \tr ',' '.' | \tr '\r\n' ' ')
 
@@ -65,10 +61,7 @@ _multipass_complete()
     # Set $opts to the list of available networks.
     _multipass_networks()
     {
-        local cmd
-        cmd="multipass networks --format=csv 2>/dev/null"
-
-        opts=$( \eval "$cmd" | \tail -n +2 | \cut -d',' -f 1 )
+        opts=$( multipass networks --format=csv 2>/dev/null | \tail -n +2 | \cut -d',' -f 1 )
     }
 
     _multipass_instances_with_colon()
@@ -87,10 +80,9 @@ _multipass_complete()
 
     _multipass_settings_keys()
     {
-        local cmd keys
+        local keys
 
-        cmd="multipass get --keys"
-        keys=$( \eval "$cmd" | \tr '\r\n' ' ' )
+        keys=$( multipass get --keys | \tr '\r\n' ' ' )
 
         for key in ${keys}; do
             if [[ "${COMP_WORDS[*]}" == *"${key}"* ]]; then
@@ -125,10 +117,7 @@ _multipass_complete()
     # Set $multipass_aliases to the list of available aliases.
     _multipass_aliases()
     {
-        local cmd
-        cmd="multipass aliases --format=csv 2>/dev/null"
-
-        multipass_aliases=$( \eval "$cmd" | \tail -n +2 | \cut -d',' -f 1 )
+        multipass_aliases=$( multipass aliases --format=csv 2>/dev/null | \tail -n +2 | \cut -d',' -f 1 )
     }
 
     # Removes the comma or equals sign at the end of $cur.

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -16,22 +16,24 @@ _multipass_complete()
 {
     _multipass_instances()
     {
-        local state=$1
+        local state=$1 cmd instances
 
-        local cmd="multipass list --format=csv --no-ipv4 | \tail -n +2"
+        cmd="multipass list --format=csv --no-ipv4 | \tail -n +2"
         [ -n "$state" ] && cmd="$cmd | \awk -F',' '\$2 == \"$state\"'"
 
-        local instances=$( \eval $cmd | \cut -d',' -f 1  | \tr '\r\n' ' ')
+        instances=$( \eval $cmd | \cut -d',' -f 1  | \tr '\r\n' ' ')
 
         _add_nonrepeating_args "$instances"
     }
 
     _multipass_snapshots()
     {
-        local instance=$1
-        local cmd="multipass list --snapshots --format=csv 2>/dev/null | \tail -n +2"
+        local instance=$1 cmd snapshots
+
+        cmd="multipass list --snapshots --format=csv 2>/dev/null | \tail -n +2"
         [ -n "$instance" ] && cmd="$cmd | \awk -F',' '\$1 == \"$instance\"'"
-        local snapshots=$( \eval $cmd | \cut -d',' -f 1,2 | \tr ',' '.' | \tr '\r\n' ' ' )
+
+        snapshots=$( \eval $cmd | \cut -d',' -f 1,2 | \tr ',' '.' | \tr '\r\n' ' ' )
 
         _add_nonrepeating_args "$snapshots"
     }
@@ -44,11 +46,12 @@ _multipass_complete()
 
     _multipass_restorable_snapshots()
     {
-        local instances=$( multipass info --no-runtime-information --format=csv \
-                           | \tail -n +2 \
-                           | \awk -F',|\r?\n' '$2 == "Stopped" && $16 > 0' \
-                           | \cut -d',' -f 1 \
-                           | \tr '\r\n' ' ')
+        local instances
+        instances=$( multipass info --no-runtime-information --format=csv \
+                     | \tail -n +2 \
+                     | \awk -F',|\r?\n' '$2 == "Stopped" && $16 > 0' \
+                     | \cut -d',' -f 1 \
+                     | \tr '\r\n' ' ')
 
         for instance in ${instances}; do
             _multipass_snapshots "${instance}"
@@ -58,7 +61,8 @@ _multipass_complete()
     # Set $opts to the list of available networks.
     _multipass_networks()
     {
-        local cmd="multipass networks --format=csv 2>/dev/null"
+        local cmd
+        cmd="multipass networks --format=csv 2>/dev/null"
 
         opts=$( \eval $cmd | \tail -n +2 | \cut -d',' -f 1 )
     }
@@ -79,8 +83,10 @@ _multipass_complete()
 
     _multipass_settings_keys()
     {
-        local cmd="multipass get --keys"
-        local keys=$( \eval $cmd | \tr '\r\n' ' ' )
+        local cmd keys
+
+        cmd="multipass get --keys"
+        keys=$( \eval $cmd | \tr '\r\n' ' ' )
 
         for key in ${keys}; do
             if [[ "${COMP_WORDS[*]}" == *"${key}"* ]]; then
@@ -115,7 +121,8 @@ _multipass_complete()
     # Set $multipass_aliases to the list of available aliases.
     _multipass_aliases()
     {
-        local cmd="multipass aliases --format=csv 2>/dev/null"
+        local cmd
+        cmd="multipass aliases --format=csv 2>/dev/null"
 
         multipass_aliases=$( \eval $cmd | \tail -n +2 | \cut -d',' -f 1 )
     }

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -12,6 +12,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+set -o pipefail
+
 _multipass_complete()
 {
     _multipass_instances()

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -21,7 +21,7 @@ _multipass_complete()
         local state=$1 cmd instances
 
         cmd="multipass list --format=csv --no-ipv4 | \tail -n +2"
-        instances=$( \eval $cmd )
+        instances=$( \eval "$cmd" )
 
         [ -n "$state" ] && instances=$(awk -F',' "\$2 == \"$state\"" <<< "$instances")
         instances=$(echo "$instances" | \cut -d',' -f 1  | \tr '\r\n' ' ')
@@ -34,7 +34,7 @@ _multipass_complete()
         local instance=$1 cmd snapshots
 
         cmd="multipass list --snapshots --format=csv 2>/dev/null | \tail -n +2"
-        snapshots=$( \eval $cmd )
+        snapshots=$( \eval "$cmd" )
 
         [ -n "$instance" ] && snapshots=$(awk -F',' "\$1 == \"$instance\"" <<< "$snapshots")
         snapshots=$(echo "$snapshots" | \cut -d',' -f 1,2 | \tr ',' '.' | \tr '\r\n' ' ')
@@ -68,7 +68,7 @@ _multipass_complete()
         local cmd
         cmd="multipass networks --format=csv 2>/dev/null"
 
-        opts=$( \eval $cmd | \tail -n +2 | \cut -d',' -f 1 )
+        opts=$( \eval "$cmd" | \tail -n +2 | \cut -d',' -f 1 )
     }
 
     _multipass_instances_with_colon()
@@ -90,7 +90,7 @@ _multipass_complete()
         local cmd keys
 
         cmd="multipass get --keys"
-        keys=$( \eval $cmd | \tr '\r\n' ' ' )
+        keys=$( \eval "$cmd" | \tr '\r\n' ' ' )
 
         for key in ${keys}; do
             if [[ "${COMP_WORDS[*]}" == *"${key}"* ]]; then
@@ -128,7 +128,7 @@ _multipass_complete()
         local cmd
         cmd="multipass aliases --format=csv 2>/dev/null"
 
-        multipass_aliases=$( \eval $cmd | \tail -n +2 | \cut -d',' -f 1 )
+        multipass_aliases=$( \eval "$cmd" | \tail -n +2 | \cut -d',' -f 1 )
     }
 
     # Removes the comma or equals sign at the end of $cur.
@@ -209,7 +209,7 @@ _multipass_complete()
         for item in $array; do
             found=0
             for ((i=2; i<CWORD; i++)); do
-                if [[ "${WORDS[i]}" == ${item} ]]; then
+                if [[ "${WORDS[i]}" == "${item}" ]]; then
                     found=1
                     break
                 fi
@@ -283,7 +283,7 @@ _multipass_complete()
         ;;
         "unalias")
             _multipass_aliases
-            _add_nonrepeating_args $multipass_aliases
+            _add_nonrepeating_args "$multipass_aliases"
         ;;
         "transfer"|"copy-files")
             _add_nonrepeating_args "--parents --recursive"


### PR DESCRIPTION
Improve the security of our bash completion in some respects, most notably by avoiding evaluating function input. See commit messages for further details.

MULTI-2010