### PR TITLE
Added more Bash-complete instances in multipass stop --force (clone of  #4072)

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -348,7 +348,21 @@ _multipass_complete()
 
     if [[ "$prev_opts" = false ]]; then
         case "${cmd}" in
-            "exec"|"stop"|"suspend"|"restart")
+            "exec"|"suspend"|"restart")
+                _multipass_instances "Running"
+            ;;
+            "stop")
+                _get_comp_words_by_ref -n := -w WORDS -i CWORD cur prev
+                for ((i=2; i<CWORD; i++)); do
+                    if [[ "${WORDS[i]}" == "--force" ]]; then
+                        _multipass_instances "Starting"
+                        _multipass_instances "Restarting"
+                        _multipass_instances "Suspending"
+                        _multipass_instances "Suspended"
+                        break
+                    fi
+                done
+
                 _multipass_instances "Running"
             ;;
             "connect"|"sh"|"shell")


### PR DESCRIPTION
Clone of https://github.com/canonical/multipass/pull/4072. Fixes #3682. See original for details.

Authored by [Artem-OSSRevival](https://github.com/Artem-OSSRevival).