### PR TITLE
[feat] Add wait-ready command to check Multipass daemon readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cmake-build-*
 .DS_Store
 CMakeLists.txt.user
 build
+Testing
 
 # package build artifacts
 *.deb

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ cmake-build-*
 .DS_Store
 CMakeLists.txt.user
 build
-Testing
 
 # package build artifacts
 *.deb

--- a/src/client/cli/client.cpp
+++ b/src/client/cli/client.cpp
@@ -46,6 +46,7 @@
 #include "cmd/umount.h"
 #include "cmd/unalias.h"
 #include "cmd/version.h"
+#include "cmd/wait_ready.h"
 
 #include <multipass/cli/argparser.h>
 #include <multipass/cli/client_common.h>
@@ -111,6 +112,7 @@ mp::Client::Client(ClientConfig& config)
     add_command<cmd::Umount>();
     add_command<cmd::Version>();
     add_command<cmd::Clone>();
+    add_command<cmd::WaitReady>();
 
     sort_commands();
 

--- a/src/client/cli/cmd/CMakeLists.txt
+++ b/src/client/cli/cmd/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(commands STATIC
   umount.cpp
   unalias.cpp
   version.cpp
+  wait_ready.cpp
 )
 
 target_link_libraries(commands

--- a/src/client/cli/cmd/common_cli.cpp
+++ b/src/client/cli/cmd/common_cli.cpp
@@ -177,18 +177,34 @@ QString multipass::cmd::describe_common_settings_keys()
            " get --keys` to obtain the full list of available settings at any given time.";
 }
 
-void multipass::cmd::add_timeout(multipass::ArgParser* parser)
+namespace
+{
+void add_timeout_option(multipass::ArgParser* parser, const QString& extra_description = {})
 {
     QCommandLineOption timeout_option(
         "timeout",
         QString("Maximum time, in seconds, to wait for the command to complete. "
-                "Note that some background operations may continue beyond that. "
-                "By default, instance startup and initialization is limited to "
-                "%1 minutes each.")
-            .arg(std::chrono::duration_cast<std::chrono::minutes>(multipass::default_timeout)
-                     .count()),
+                "Note that some background operations may continue beyond that.") +
+            extra_description,
         "timeout");
     parser->addOption(timeout_option);
+}
+} // namespace
+
+void multipass::cmd::add_instance_timeout(multipass::ArgParser* parser)
+{
+    const auto instance_timeout_str =
+        QString (" By default, instance startup and initialization is limited to "
+                 "%1 minutes each.")
+            .arg(std::chrono::duration_cast<std::chrono::minutes>(multipass::default_timeout)
+                .count());
+    
+    add_timeout_option(parser, instance_timeout_str);
+}
+
+void multipass::cmd::add_timeout(multipass::ArgParser* parser)
+{
+    add_timeout_option(parser);
 }
 
 int multipass::cmd::parse_timeout(const multipass::ArgParser* parser)

--- a/src/client/cli/cmd/common_cli.cpp
+++ b/src/client/cli/cmd/common_cli.cpp
@@ -194,11 +194,11 @@ void add_timeout_option(multipass::ArgParser* parser, const QString& extra_descr
 void multipass::cmd::add_instance_timeout(multipass::ArgParser* parser)
 {
     const auto instance_timeout_str =
-        QString (" By default, instance startup and initialization is limited to "
-                 "%1 minutes each.")
+        QString(" By default, instance startup and initialization is limited to "
+                "%1 minutes each.")
             .arg(std::chrono::duration_cast<std::chrono::minutes>(multipass::default_timeout)
-                .count());
-    
+                     .count());
+
     add_timeout_option(parser, instance_timeout_str);
 }
 

--- a/src/client/cli/cmd/common_cli.h
+++ b/src/client/cli/cmd/common_cli.h
@@ -62,6 +62,7 @@ ReturnCode return_code_from(const SettingsException& e);
 QString describe_common_settings_keys();
 
 // parser helpers
+void add_instance_timeout(multipass::ArgParser*);
 void add_timeout(multipass::ArgParser*);
 int parse_timeout(const multipass::ArgParser* parser);
 std::unique_ptr<multipass::utils::Timer> make_timer(int timeout,

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -265,7 +265,7 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
                         bridgedOption,
                         mountOption});
 
-    mp::cmd::add_timeout(parser);
+    mp::cmd::add_instance_timeout(parser);
 
     auto status = parser->commandParse(this);
 

--- a/src/client/cli/cmd/restart.cpp
+++ b/src/client/cli/cmd/restart.cpp
@@ -114,7 +114,7 @@ mp::ParseCode cmd::Restart::parse_args(mp::ArgParser* parser)
     QCommandLineOption all_option(all_option_name, "Restart all instances");
     parser->addOption(all_option);
 
-    mp::cmd::add_timeout(parser);
+    mp::cmd::add_instance_timeout(parser);
 
     auto status = parser->commandParse(this);
 

--- a/src/client/cli/cmd/shell.cpp
+++ b/src/client/cli/cmd/shell.cpp
@@ -151,7 +151,7 @@ mp::ParseCode cmd::Shell::parse_args(mp::ArgParser* parser)
 
     parser->addPositionalArgument("name", description, syntax);
 
-    mp::cmd::add_timeout(parser);
+    mp::cmd::add_instance_timeout(parser);
 
     auto status = parser->commandParse(this);
 

--- a/src/client/cli/cmd/start.cpp
+++ b/src/client/cli/cmd/start.cpp
@@ -173,7 +173,7 @@ mp::ParseCode cmd::Start::parse_args(mp::ArgParser* parser)
     QCommandLineOption all_option(all_option_name, "Start all instances");
     parser->addOption(all_option);
 
-    mp::cmd::add_timeout(parser);
+    mp::cmd::add_instance_timeout(parser);
 
     auto status = parser->commandParse(this);
 

--- a/src/client/cli/cmd/wait_ready.cpp
+++ b/src/client/cli/cmd/wait_ready.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "wait_ready.h"
+#include "common_cli.h"
+
+#include "animated_spinner.h"
+#include <multipass/exceptions/cmd_exceptions.h>
+#include <multipass/cli/argparser.h>
+#include <multipass/cli/formatter.h>
+#include <multipass/timer.h>
+
+namespace mp = multipass;
+namespace cmd = multipass::cmd;
+namespace mpl = multipass::logging;
+
+mp::ReturnCode cmd::WaitReady::run(mp::ArgParser* parser)
+{
+    auto ret = parse_args(parser);
+    if (ret != ParseCode::Ok)
+    {
+        return parser->returnCodeFrom(ret);
+    }
+
+    if (!spinner){
+        spinner = std::make_unique<multipass::AnimatedSpinner>(cout);
+        spinner->start("Waiting for Multipass daemon to be ready...");
+    }
+
+    // If the user has specified a timeout, we will create a timer
+    if (parser->isSet("timeout")){
+        timer = cmd::make_timer(parser->value("timeout").toInt(),
+                                spinner.get(),
+                                cerr,
+                                "Timed out waiting for Multipass daemon to be ready.");
+        timer->start();
+    }
+    
+    auto on_success = [this](WaitReadyReply& reply) {
+        if (timer)
+            timer->stop();
+        spinner->stop();
+        return ReturnCode::Ok;
+    };
+
+    auto on_failure = [this](grpc::Status& status) {
+
+        if (status.error_code() == grpc::StatusCode::NOT_FOUND && 
+            status.error_message() == "cannot connect to the multipass socket")
+        {
+            // This is the expected state for when the daemon is not yet ready
+            // Sleep for a short duration and signal to retry
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            return ReturnCode::Retry;
+        }
+        // For any other error, we will handle it as a standard failure
+        cerr << "Error Code: " << status.error_code() << "\n"
+             << "Error Message: " << status.error_message() << "\n";
+        return standard_failure_handler_for(name(), cerr, status);
+    };
+
+    request.set_verbosity_level(parser->verbosityLevel());
+    
+    ReturnCode return_code;
+
+    while ((return_code = dispatch(&RpcMethod::wait_ready, request, on_success, on_failure)) == 
+            ReturnCode::Retry)
+        ;
+
+    return return_code;
+}
+
+std::string cmd::WaitReady::name() const
+{
+    return "wait-ready";
+}
+
+QString cmd::WaitReady::short_help() const
+{
+    return QStringLiteral("Wait for the Multipass daemon to be ready");
+}
+
+QString cmd::WaitReady::description() const
+{
+    return QStringLiteral(
+        "Wait for the Multipass daemon to be ready.\n"
+        "This command will block until the daemon is ready to accept requests.\n"
+        "It can be used to ensure that the daemon is running before executing "
+        "other commands.\n"
+        "If a timeout is specified, it will wait for that duration before "
+        "exiting with an error if the daemon is not ready.");
+}
+
+mp::ParseCode cmd::WaitReady::parse_args(mp::ArgParser* parser)
+{
+    mp::cmd::add_timeout(parser);
+
+    auto status = parser->commandParse(this);
+
+    // Check if the command was parsed successfully
+    if (status != ParseCode::Ok)
+    {
+        return status;
+    }
+
+    try
+    {
+        mp::cmd::parse_timeout(parser);
+    }
+    catch (const mp::ValidationException& e)
+    {
+        cerr << "error: " << e.what() << "\n";
+        return ParseCode::CommandLineError;
+    }
+
+    return status;
+}

--- a/src/client/cli/cmd/wait_ready.cpp
+++ b/src/client/cli/cmd/wait_ready.cpp
@@ -67,9 +67,12 @@ mp::ReturnCode cmd::WaitReady::run(mp::ArgParser* parser)
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
             return ReturnCode::Retry;
         }
+
+        if (timer)
+            timer->stop();
+        spinner->stop();
+        
         // For any other error, we will handle it as a standard failure
-        cerr << "Error Code: " << status.error_code() << "\n"
-             << "Error Message: " << status.error_message() << "\n";
         return standard_failure_handler_for(name(), cerr, status);
     };
 

--- a/src/client/cli/cmd/wait_ready.cpp
+++ b/src/client/cli/cmd/wait_ready.cpp
@@ -19,9 +19,9 @@
 #include "animated_spinner.h"
 #include "common_cli.h"
 
-#include <multipass/timer.h>
 #include <multipass/cli/argparser.h>
 #include <multipass/exceptions/cmd_exceptions.h>
+#include <multipass/timer.h>
 
 #include <chrono>
 #include <thread>
@@ -60,9 +60,7 @@ mp::ReturnCode cmd::WaitReady::run(mp::ArgParser* parser)
     };
 
     auto on_failure = [this, &spinner, &timer](grpc::Status& status) {
-        if (status.error_code() == grpc::StatusCode::NOT_FOUND &&
-            (status.error_message() == "cannot connect to the multipass socket" ||
-             status.error_message() == "cannot connect to the image servers"))
+        if (status.error_code() == grpc::StatusCode::NOT_FOUND)
         {
             // This is the expected state for when the daemon is not yet ready
             // Sleep for a short duration and signal to retry

--- a/src/client/cli/cmd/wait_ready.h
+++ b/src/client/cli/cmd/wait_ready.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MULTIPASS_WAIT_READY_H
+#define MULTIPASS_WAIT_READY_H
+
+#include <multipass/cli/command.h>
+#include "animated_spinner.h"
+#include <multipass/timer.h>
+
+
+#include <chrono>
+#include <thread>
+
+namespace multipass
+{
+class Formatter;
+
+namespace cmd
+{
+class WaitReady final : public Command
+{
+public:
+    using Command::Command;
+    ReturnCode run(ArgParser* parser) override;
+
+    std::string name() const override;
+    QString short_help() const override;
+    QString description() const override;
+
+private:
+    WaitReadyRequest request;
+
+    ParseCode parse_args(ArgParser* parser);
+    std::unique_ptr<multipass::AnimatedSpinner> spinner;
+    std::unique_ptr<multipass::utils::Timer> timer;
+};
+} // namespace cmd
+} // namespace multipass
+#endif // MULTIPASS_WAIT_READY_H

--- a/src/client/cli/cmd/wait_ready.h
+++ b/src/client/cli/cmd/wait_ready.h
@@ -19,12 +19,6 @@
 #define MULTIPASS_WAIT_READY_H
 
 #include <multipass/cli/command.h>
-#include "animated_spinner.h"
-#include <multipass/timer.h>
-
-
-#include <chrono>
-#include <thread>
 
 namespace multipass
 {
@@ -46,8 +40,6 @@ private:
     WaitReadyRequest request;
 
     ParseCode parse_args(ArgParser* parser);
-    std::unique_ptr<multipass::AnimatedSpinner> spinner;
-    std::unique_ptr<multipass::utils::Timer> timer;
 };
 } // namespace cmd
 } // namespace multipass

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -619,6 +619,7 @@ auto connect_rpc(mp::DaemonRpc& rpc, mp::Daemon& daemon)
     QObject::connect(&rpc, &mp::DaemonRpc::on_snapshot, &daemon, &mp::Daemon::snapshot);
     QObject::connect(&rpc, &mp::DaemonRpc::on_restore, &daemon, &mp::Daemon::restore);
     QObject::connect(&rpc, &mp::DaemonRpc::on_daemon_info, &daemon, &mp::Daemon::daemon_info);
+    QObject::connect(&rpc, &mp::DaemonRpc::on_wait_ready, &daemon, &mp::Daemon::wait_ready);
 }
 
 enum class InstanceGroup
@@ -3124,6 +3125,41 @@ try
 
     server->Write(response);
     status_promise->set_value(grpc::Status{});
+}
+catch (const std::exception& e)
+{
+    status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
+}
+
+void mp::Daemon::wait_ready(const WaitReadyRequest* request,
+                       grpc::ServerReaderWriterInterface<WaitReadyReply, WaitReadyRequest>* server,
+                       std::promise<grpc::Status>* status_promise)
+try
+{
+    WaitReadyReply response;
+
+
+    mpl::ClientLogger<WaitReadyReply, WaitReadyRequest> logger{
+        mpl::level_from(request->verbosity_level()),
+        *config->logger,
+        server};
+
+    logger.log(mpl::Level::debug, "daemon", "Checking connection to image servers...");
+    
+    // We use wait_update_manifests_all_and_optionally_applied_force to check connectivity to image servers.
+    // If the force_manifest_network_download is true, it will download the manifests even if already cached.
+    try 
+    {
+        wait_update_manifests_all_and_optionally_applied_force(/*force_manifest_network_download=*/true);
+        logger.log(mpl::Level::debug, "daemon", "Successfully connected to image servers.");
+        server->Write(response);
+        status_promise->set_value(grpc::Status::OK);
+    }
+    catch(const std::exception& e)
+    {
+        logger.log(mpl::Level::error, "daemon", fmt::format("Failed to connect to image servers: {}", e.what()));
+        status_promise->set_value(grpc::Status(grpc::StatusCode::UNAVAILABLE, e.what(), ""));
+    }
 }
 catch (const std::exception& e)
 {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -3150,7 +3150,7 @@ try
     // If the force_manifest_network_download is true, it will download the manifests even if already cached.
     try 
     {
-        wait_update_manifests_all_and_optionally_applied_force(/*force_manifest_network_download=*/true);
+        wait_update_manifests_all_and_optionally_applied_force(/*force_manifest_network_download=*/false);
         logger.log(mpl::Level::debug, "daemon", "Successfully connected to image servers.");
         server->Write(response);
         status_promise->set_value(grpc::Status::OK);
@@ -3158,8 +3158,8 @@ try
     catch(const std::exception& e)
     {
         logger.log(mpl::Level::error, "daemon", fmt::format("Failed to connect to image servers: {}", e.what()));
-        status_promise->set_value(grpc::Status(grpc::StatusCode::UNAVAILABLE, e.what(), ""));
-    }
+        status_promise->set_value(grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, e.what(), ""));
+    } 
 }
 catch (const std::exception& e)
 {

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -167,6 +167,10 @@ public slots:
         grpc::ServerReaderWriterInterface<DaemonInfoReply, DaemonInfoRequest>* server,
         std::promise<grpc::Status>* status_promise);
 
+    virtual void wait_ready(const WaitReadyRequest* request,
+                            grpc::ServerReaderWriterInterface<WaitReadyReply, WaitReadyRequest>* server,
+                            std::promise<grpc::Status>* status_promise);
+
 private:
     void release_resources(const std::string& instance);
     void create_vm(const CreateRequest* request,

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -167,9 +167,10 @@ public slots:
         grpc::ServerReaderWriterInterface<DaemonInfoReply, DaemonInfoRequest>* server,
         std::promise<grpc::Status>* status_promise);
 
-    virtual void wait_ready(const WaitReadyRequest* request,
-                            grpc::ServerReaderWriterInterface<WaitReadyReply, WaitReadyRequest>* server,
-                            std::promise<grpc::Status>* status_promise);
+    virtual void wait_ready(
+        const WaitReadyRequest* request,
+        grpc::ServerReaderWriterInterface<WaitReadyReply, WaitReadyRequest>* server,
+        std::promise<grpc::Status>* status_promise);
 
 private:
     void release_resources(const std::string& instance);

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -98,20 +98,20 @@ int main_impl(int argc, char* argv[], mp::Signal& app_ready_signal)
                                                        // relevant settings handlers
 
     mp::Daemon daemon(std::move(config));
-    QObject::connect(&app,
-                     &QCoreApplication::aboutToQuit,
-                     &daemon,
-                     &mp::Daemon::shutdown_grpc_server,
-                     Qt::DirectConnection);
 
+    QObject::connect(&app,
+        &QCoreApplication::aboutToQuit,
+        &daemon,
+        &mp::Daemon::shutdown_grpc_server,
+        Qt::DirectConnection);
+        
     mpl::log(mpl::Level::info, "daemon", fmt::format("Starting Multipass {}", mp::version_string));
-    mpl::log(mpl::Level::info,
-             "daemon",
-             fmt::format("Daemon arguments: {}", app.arguments().join(" ")));
+    mpl::log(mpl::Level::info, "daemon", fmt::format("Daemon arguments: {}", app.arguments().join(" ")));
 
     // Signal the signal handler that app has completed its basic initialization, and
     // ready to process signals.
     app_ready_signal.signal();
+    
     auto exit_code = QCoreApplication::exec();
     // QConcurrent::run() invocations are dispatched through the global
     // thread pool. Wait until all threads in the pool are properly cleaned up.

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -100,18 +100,20 @@ int main_impl(int argc, char* argv[], mp::Signal& app_ready_signal)
     mp::Daemon daemon(std::move(config));
 
     QObject::connect(&app,
-        &QCoreApplication::aboutToQuit,
-        &daemon,
-        &mp::Daemon::shutdown_grpc_server,
-        Qt::DirectConnection);
-        
+                     &QCoreApplication::aboutToQuit,
+                     &daemon,
+                     &mp::Daemon::shutdown_grpc_server,
+                     Qt::DirectConnection);
+
     mpl::log(mpl::Level::info, "daemon", fmt::format("Starting Multipass {}", mp::version_string));
-    mpl::log(mpl::Level::info, "daemon", fmt::format("Daemon arguments: {}", app.arguments().join(" ")));
+    mpl::log(mpl::Level::info,
+             "daemon",
+             fmt::format("Daemon arguments: {}", app.arguments().join(" ")));
 
     // Signal the signal handler that app has completed its basic initialization, and
     // ready to process signals.
     app_ready_signal.signal();
-    
+
     auto exit_code = QCoreApplication::exec();
     // QConcurrent::run() invocations are dispatched through the global
     // thread pool. Wait until all threads in the pool are properly cleaned up.

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -461,6 +461,17 @@ grpc::Status mp::DaemonRpc::daemon_info(
         client_cert_from(context));
 }
 
+grpc::Status mp::DaemonRpc::wait_ready(grpc::ServerContext* context,
+                                 grpc::ServerReaderWriter<WaitReadyReply, WaitReadyRequest>* server)
+{
+    WaitReadyRequest request;
+    server->Read(&request);
+
+    return verify_client_and_dispatch_operation(
+        std::bind(&DaemonRpc::on_wait_ready, this, &request, server, std::placeholders::_1),
+        client_cert_from(context));
+}
+
 template <typename OperationSignal>
 grpc::Status mp::DaemonRpc::verify_client_and_dispatch_operation(OperationSignal signal,
                                                                  const std::string& client_cert)

--- a/src/daemon/daemon_rpc.cpp
+++ b/src/daemon/daemon_rpc.cpp
@@ -461,8 +461,9 @@ grpc::Status mp::DaemonRpc::daemon_info(
         client_cert_from(context));
 }
 
-grpc::Status mp::DaemonRpc::wait_ready(grpc::ServerContext* context,
-                                 grpc::ServerReaderWriter<WaitReadyReply, WaitReadyRequest>* server)
+grpc::Status mp::DaemonRpc::wait_ready(
+    grpc::ServerContext* context,
+    grpc::ServerReaderWriter<WaitReadyReply, WaitReadyRequest>* server)
 {
     WaitReadyRequest request;
     server->Read(&request);

--- a/src/daemon/daemon_rpc.h
+++ b/src/daemon/daemon_rpc.h
@@ -133,6 +133,9 @@ signals:
     void on_daemon_info(const DaemonInfoRequest* request,
                         grpc::ServerReaderWriter<DaemonInfoReply, DaemonInfoRequest>* server,
                         std::promise<grpc::Status>* status_promise);
+    void on_wait_ready(const WaitReadyRequest* request,
+                       grpc::ServerReaderWriter<WaitReadyReply, WaitReadyRequest>* server,
+                       std::promise<grpc::Status>* status_promise);
 
 private:
     template <typename OperationSignal>
@@ -202,5 +205,8 @@ protected:
     grpc::Status daemon_info(
         grpc::ServerContext* context,
         grpc::ServerReaderWriter<DaemonInfoReply, DaemonInfoRequest>* server) override;
+    grpc::Status wait_ready(
+        grpc::ServerContext* context,
+        grpc::ServerReaderWriter<WaitReadyReply, WaitReadyRequest>* server) override;
 };
 } // namespace multipass

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -45,6 +45,7 @@ service Rpc {
     rpc restore (stream RestoreRequest) returns (stream RestoreReply);
     rpc clone (stream CloneRequest) returns (stream CloneReply);
     rpc daemon_info (stream DaemonInfoRequest) returns (stream DaemonInfoReply);
+    rpc wait_ready (stream WaitReadyRequest) returns (stream WaitReadyReply);
 }
 
 message LaunchRequest {
@@ -549,4 +550,12 @@ message DaemonInfoReply {
     uint64 available_space = 2;
     uint32 cpus = 3;
     uint64 memory = 4;
+}
+
+message WaitReadyRequest {
+    int32 verbosity_level = 1;
+}
+
+message WaitReadyReply {
+    string log_line = 1;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(multipass_tests
   test_daemon_start.cpp
   test_daemon_suspend.cpp
   test_daemon_umount.cpp
+  test_daemon_wait_ready.cpp
   test_delayed_shutdown.cpp
   test_disabled_copy_move.cpp
   test_format_utils.cpp

--- a/tests/mock_client_rpc.h
+++ b/tests/mock_client_rpc.h
@@ -438,5 +438,17 @@ public:
                 PrepareAsyncdaemon_infoRaw,
                 (grpc::ClientContext * context, grpc::CompletionQueue* cq),
                 (override));
+    MOCK_METHOD((grpc::ClientReaderWriterInterface<multipass::WaitReadyRequest, multipass::WaitReadyReply>*),
+                wait_readyRaw,
+                (grpc::ClientContext * context),
+                (override));
+    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::WaitReadyRequest, multipass::WaitReadyReply>*),
+                Asyncwait_readyRaw,
+                (grpc::ClientContext * context, grpc::CompletionQueue* cq, void* tag),
+                (override));
+    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::WaitReadyRequest, multipass::WaitReadyReply>*),  
+                PrepareAsyncwait_readyRaw,
+                (grpc::ClientContext * context, grpc::CompletionQueue* cq),
+                (override));
 };
 } // namespace multipass::test

--- a/tests/mock_client_rpc.h
+++ b/tests/mock_client_rpc.h
@@ -438,15 +438,18 @@ public:
                 PrepareAsyncdaemon_infoRaw,
                 (grpc::ClientContext * context, grpc::CompletionQueue* cq),
                 (override));
-    MOCK_METHOD((grpc::ClientReaderWriterInterface<multipass::WaitReadyRequest, multipass::WaitReadyReply>*),
+    MOCK_METHOD((grpc::ClientReaderWriterInterface<multipass::WaitReadyRequest,
+                                                   multipass::WaitReadyReply>*),
                 wait_readyRaw,
                 (grpc::ClientContext * context),
                 (override));
-    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::WaitReadyRequest, multipass::WaitReadyReply>*),
+    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::WaitReadyRequest,
+                                                        multipass::WaitReadyReply>*),
                 Asyncwait_readyRaw,
                 (grpc::ClientContext * context, grpc::CompletionQueue* cq, void* tag),
                 (override));
-    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::WaitReadyRequest, multipass::WaitReadyReply>*),  
+    MOCK_METHOD((grpc::ClientAsyncReaderWriterInterface<multipass::WaitReadyRequest,
+                                                        multipass::WaitReadyReply>*),
                 PrepareAsyncwait_readyRaw,
                 (grpc::ClientContext * context, grpc::CompletionQueue* cq),
                 (override));

--- a/tests/mock_daemon.h
+++ b/tests/mock_daemon.h
@@ -183,6 +183,13 @@ struct MockDaemon : public Daemon
                  std::promise<grpc::Status>*),
                 (override));
 
+    MOCK_METHOD(void,
+                wait_ready,
+                (const WaitReadyRequest*,
+                 (grpc::ServerReaderWriterInterface<WaitReadyReply, WaitReadyRequest>*),
+                 std::promise<grpc::Status>*),
+                (override));
+
     template <typename Request, typename Reply>
     void set_promise_value(const Request*,
                            grpc::ServerReaderWriterInterface<Reply, Request>*,

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -3344,6 +3344,15 @@ TEST_F(Client, waitReadyCmdFailsWhenDaemonFails)
     EXPECT_THAT(send_command({"wait-ready"}), Eq(mp::ReturnCode::CommandFail));
 }
 
+TEST_F(Client, waitReadyCmdWithTimeoutFailsWhenDaemonFails)
+{
+    grpc::Status daemon_failure(grpc::StatusCode::FAILED_PRECONDITION, "");
+
+    EXPECT_CALL(mock_daemon, wait_ready(_, _)).WillOnce(Return(daemon_failure));
+
+    EXPECT_THAT(send_command({"wait-ready", "--timeout", "10"}), Eq(mp::ReturnCode::CommandFail));
+}
+
 // get/set cli tests
 struct TestGetSetHelp : Client, WithParamInterface<std::string>
 {

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -251,6 +251,9 @@ TEST_F(Daemon, receivesCommandsAndCallsCorrespondingSlot)
     EXPECT_CALL(daemon, clone)
         .WillOnce(
             Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::CloneRequest, mp::CloneReply>));
+    EXPECT_CALL(daemon, wait_ready(_, _, _))
+        .WillOnce(
+            Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::WaitReadyRequest, mp::WaitReadyReply>));
     EXPECT_CALL(mock_settings, get(Eq("foo"))).WillRepeatedly(Return("bar"));
 
     send_commands({{"test_keys"},
@@ -275,7 +278,8 @@ TEST_F(Daemon, receivesCommandsAndCallsCorrespondingSlot)
                    {"mount", ".", "target"},
                    {"umount", "instance"},
                    {"networks"},
-                   {"clone", "foo"}});
+                   {"clone", "foo"},
+                   {"wait-ready"}});
 }
 
 TEST_F(Daemon, providesVersion)

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -253,7 +253,8 @@ TEST_F(Daemon, receivesCommandsAndCallsCorrespondingSlot)
             Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::CloneRequest, mp::CloneReply>));
     EXPECT_CALL(daemon, wait_ready(_, _, _))
         .WillOnce(
-            Invoke(&daemon, &mpt::MockDaemon::set_promise_value<mp::WaitReadyRequest, mp::WaitReadyReply>));
+            Invoke(&daemon,
+                   &mpt::MockDaemon::set_promise_value<mp::WaitReadyRequest, mp::WaitReadyReply>));
     EXPECT_CALL(mock_settings, get(Eq("foo"))).WillRepeatedly(Return("bar"));
 
     send_commands({{"test_keys"},

--- a/tests/test_daemon_wait_ready.cpp
+++ b/tests/test_daemon_wait_ready.cpp
@@ -54,7 +54,7 @@ struct DaemonWaitReady : public mpt::DaemonTestFixture
     mpt::MockUtils::GuardedMock mock_utils_injection{mpt::MockUtils::inject<NiceMock>()};
     mpt::MockUtils& mock_utils = *mock_utils_injection.first;
 
-    const std::string wait_msg = fmt::format("Waiting for Multipass daemon to be ready...");
+    const std::string wait_msg = fmt::format("Waiting for Multipass daemon to be ready");
 };
 
 TEST_F(DaemonWaitReady, checkUpdateManifestCall)

--- a/tests/test_daemon_wait_ready.cpp
+++ b/tests/test_daemon_wait_ready.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common.h"
+#include "daemon_test_fixture.h"
+#include "mock_image_host.h"
+#include "mock_settings.h"
+#include "mock_permission_utils.h"
+#include "mock_utils.h"
+#include "mock_cert_provider.h"
+
+#include <src/daemon/daemon.h>
+
+#include <multipass/exceptions/download_exception.h>
+#include <multipass/format.h>
+
+#include <future>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+using namespace testing;
+
+struct DaemonWaitReady : public mpt::DaemonTestFixture
+{
+    void SetUp() override
+    {
+        EXPECT_CALL(mock_settings, register_handler).WillRepeatedly(Return(nullptr));
+        EXPECT_CALL(mock_settings, unregister_handler).Times(AnyNumber());
+        ON_CALL(mock_utils, contents_of(_)).WillByDefault(Return(mpt::root_cert));
+    }
+    
+    mpt::MockSettings::GuardedMock mock_settings_injection =
+        mpt::MockSettings::inject<StrictMock>();
+    mpt::MockSettings& mock_settings = *mock_settings_injection.first;
+
+    const mpt::MockPermissionUtils::GuardedMock mock_permission_utils_injection =
+        mpt::MockPermissionUtils::inject<NiceMock>();
+    mpt::MockPermissionUtils& mock_permission_utils = *mock_permission_utils_injection.first;
+
+    mpt::MockUtils::GuardedMock mock_utils_injection{mpt::MockUtils::inject<NiceMock>()};
+    mpt::MockUtils& mock_utils = *mock_utils_injection.first;
+
+    const std::string wait_msg = fmt::format("Waiting for Multipass daemon to be ready...");
+};
+
+TEST_F(DaemonWaitReady, checkUpdateManifestCall)
+{
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+
+    EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1).WillOnce(Return());
+
+    config_builder.image_hosts[0] = std::move(mock_image_host);
+
+    mp::Daemon daemon{config_builder.build()};
+
+    std::stringstream out_stream, cerr_stream;
+    send_command({"wait-ready"}, out_stream, cerr_stream);
+
+    EXPECT_THAT(out_stream.str(), HasSubstr(wait_msg));
+    EXPECT_TRUE(cerr_stream.str().empty());
+}
+
+TEST_F(DaemonWaitReady, updateManifestsThrowTriggersTheFailedCaseEventHandlerOfAsyncPeriodicDownloadTask)
+{
+    auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
+
+    EXPECT_CALL(*mock_image_host, update_manifests(false)).Times(1).WillOnce([]() {
+        throw mp::DownloadException{"dummy_url", "dummy_cause"};
+    });
+
+    config_builder.image_hosts[0] = std::move(mock_image_host);
+    mp::Daemon daemon{config_builder.build()};
+    
+    send_command({"wait-ready"});
+}

--- a/tests/test_daemon_wait_ready.cpp
+++ b/tests/test_daemon_wait_ready.cpp
@@ -81,7 +81,9 @@ TEST_F(DaemonWaitReady, updateManifestsThrowTriggersClientRetryPollingTillSucces
     auto mock_image_host = std::make_unique<NiceMock<mpt::MockImageHost>>();
 
     EXPECT_CALL(*mock_image_host, update_manifests(false))
-        .WillOnce([]() { throw mp::DownloadException{"dummy_url", "dummy_cause"}; })
+        .WillOnce([]() {
+            throw mp::DownloadException{"dummy_url", "dummy_cause"};
+        })
         .WillRepeatedly(Return());
 
     config_builder.image_hosts[0] = std::move(mock_image_host);


### PR DESCRIPTION
**Feature: Add `multipass wait-ready` command**

**Description:**
This PR introduces a new CLI command, `multipass wait-ready`. This command allows users and scripts to pause execution until the Multipass daemon is fully initialized and ready to accept requests. This is particularly beneficial for automation workflows that need to ensure the daemon is operational before proceeding with other Multipass operations.

The `wait-ready` command works by:
1.  Initially polling the daemon's gRPC socket until it becomes available.
2.  Once the socket is available, it sends a `WaitReady` request to the daemon.
3.  The daemon, upon receiving this request, verifies its readiness by attempting to update image manifests (which implicitly checks connectivity to image servers).
4.  The command supports a `--timeout` option (in seconds). If the daemon isn't ready within the specified timeout, the command exits with an error. If no timeout is given, it waits indefinitely.
5.  An animated spinner and context-relevant message provide user feedback during the waiting period.

**Motivation:**
- Improves the reliability of automated scripts and CI/CD pipelines that interact with Multipass by providing a deterministic way to wait for daemon initialization.
- Addresses scenarios where subsequent Multipass commands might fail if the daemon is still starting up.

**Related Issues:**
Fixes #452
Fixes #3723

**Key Implementation Changes:**
- **Client-side (`wait_ready.cpp`):** New command logic, including retry for socket connection, timeout handling (reusing `mp::cmd::parse_timeout`), and spinner integration.
- **Protocol (`multipass.proto`):** Added `WaitReadyRequest` / `WaitReadyReply` messages and `WaitReady` RPC method.
- **Daemon-side (`daemon_rpc.cpp`, `daemon.cpp`):**
    - New gRPC service handler in `daemon_rpc.cpp`.
    - Core readiness check in `daemon.cpp` leverages the existing `wait_update_manifests_all_and_optionally_applied_force()` function.

**How to Test:**
1.  Build this branch and `$ cd build`.
2.  Ensure the Multipass daemon is stopped.
3.  To verify `--timeout`, simply run the `wait-ready` command with the `--timeout` option:
```Bash
$ ./bin/multipass wait-ready --timeout 5
```
> Be sure not to start up the daemon first or the command might exit before the timeout.
- Expected: Info message "Waiting for Multipass daemon to be ready...", spinner is shown, command times out after ~5 seconds with an appropriate error message "Timed out waiting for Multipass daemon to be ready."
4. (Optional) To replicate the issue that happens when the client tries to use the daemon before its ready (without `wait-ready`), start up the daemon and immediately use `multipass launch`:
```Bash
$ sudo -v
$ (sudo ./bin/multipassd &) && ./bin/multipass launch
```
- Expected: Error message "launch failed: cannot connect to the multipass socket", "launch failed: Remote "" is unknown or unreachable.", or something like issue #3723
5.  Stop the Multipass daemon
```Bash
$ sudo pkill multipassd
```
6. To verify `wait-ready` command solves the issue, fit the `wait-ready` command between daemon startup and `multipass launch`:
```Bash
$ sudo -v
$ (sudo ./bin/multipassd &) && ./bin/multipass wait-ready && ./bin/multipass launch
```
> Optionally, add `--timeout` if desired.
- Expected: Info message "Waiting for Multipass daemon to be ready...", spinner is shown, command exits successfully (ReturnCode::Ok) once the daemon is ready (i.e., can connect to image servers) and the client begins retrieving the default _release_ image for the `multipass launch` process. _You may Ctrl+C here to terminate the launch process._

**Points for Reviewers:**
- Confirmation that using `wait_update_manifests_all_and_optionally_applied_force(true)` is an appropriate and robust proxy for overall daemon readiness.
- Feedback on the client-side error messages and user experience (spinner, timeout message) is appreciated. The current spinner implementation addresses @ricab's suggestion in #452.
- **Unit Tests:** Per @ricab 's comments in issue #452, unit tests have not yet been implemented for this initial PR to facilitate earlier review. I am prepared to add them based on feedback.