### PR TITLE
docs: fix OGP string

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://documentation.ubuntu.com/multipass"
+ogp_site_url = "https://documentation.ubuntu.com/multipass/en/latest/"
 
 
 # Preview name of the documentation website


### PR DESCRIPTION
The OGP var defined in `conf.py` affects the meta tags in the rendered HTML of the documentation. 

The string needs to end with a forward slash and include the default `<lang>` and `<version>` for the documentation.

It is currently defined as `"https://documentation.ubuntu.com/multipass"`, which yields
incorrect meta tags, for example:

```html
<meta property="og:url" content="https://documentation.ubuntu.com/how-to-guides/install-multipass/" />
```

Changing to `"https://documentation.ubuntu.com/multipass/en/latest/"`, yields the correct URL in the content property:

```html
<meta property="og:url" content="https://documentation.ubuntu.com/multipass/en/latest/how-to-guides/install-multipass/" />
```

When saving a page to Zotero, for example, we then get the correct documentation URL:

![ogp-after](https://github.com/user-attachments/assets/9900bab4-f5f7-4cb7-965a-fc08e3a5c626)

Whereas before, the URL was wrong:

![ogp-before](https://github.com/user-attachments/assets/ee5393a5-ce50-4ed4-b601-a35adba13b7e)

This should hopefully fix #4139 .
