### PR TITLE
[cmake] remove obsolete gtest workaround

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,11 +176,6 @@ target_link_libraries(multipass_tests
   yaml
 )
 
-# need https://github.com/google/googletest/commit/a09ea700d32bab83325aff9ff34d0582e50e3997 before this can be removed
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  target_compile_options(multipass_tests PRIVATE -Wno-inconsistent-missing-override)
-endif()
-
 add_test(NAME multipass_tests
   COMMAND multipass_tests
 )


### PR DESCRIPTION
Referenced gtest code has been merged in for quite some time.

https://github.com/google/googletest/blob/7e2c425db2c2e024b2807bfe6d386f4ff068d0d6/googlemock/include/gmock/internal/gmock-pp.h#L31