### PR TITLE
[ci] add vcpkg binary caching

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,7 +74,10 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
       SNAPCRAFT_BUILD_INFO: 1
+      USERNAME: ${{ github.repository_owner }}
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
 
     timeout-minutes: 120
     steps:
@@ -162,7 +165,22 @@ jobs:
         fi
 
         if [ -n "${VCPKG_BINARY_SOURCES}" ]; then
-          sed -i "/build-environment:/a \    - VCPKG_BINARY_SOURCES: ${VCPKG_BINARY_SOURCES}" snap/snapcraft.yaml
+          sed -i '/build-environment:/ {
+          a\
+            - VCPKG_BINARY_SOURCES: '"${VCPKG_BINARY_SOURCES}"'\
+            - FEED_URL: '"${FEED_URL}"'\
+            - USERNAME: '"${USERNAME}"'\
+            - GITHUB_TOKEN: '"${{ secrets.GITHUB_TOKEN }}"'
+          }' snap/snapcraft.yaml
+          sed -i "/build-packages:/a \    - mono-complete" snap/snapcraft.yaml
+          sed -i '0,/override-build: |/ {
+            /override-build: |/ a\
+              curl -L -o /usr/local/bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe\
+              ln -sf /usr/local/bin/nuget.exe /usr/local/bin/nuget\
+              export PATH=$PATH:/usr/local/bin\
+              mono /usr/local/bin/nuget.exe sources add -name GitHubPackages -source "${FEED_URL}" -username "${USERNAME}" -password "${GITHUB_TOKEN}" -storePasswordInClearText\
+              mono /usr/local/bin/nuget.exe setapikey "${GITHUB_TOKEN}" -source "${FEED_URL}"
+          }' snap/snapcraft.yaml
         fi
 
         if [ -n "${GITHUB_ACTIONS}" ]; then

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -179,7 +179,7 @@ jobs:
         fi
 
     - name: Install nuget
-      if: ${{ runner.os == 'macOS' && matrix.arch == 'arm64' && env.VCPKG_BINARY_SOURCES }}
+      if: ${{ contains(matrix.runs-on, 'macos-15') }}
       run: |
         brew install nuget mono
 

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -170,6 +170,7 @@ jobs:
         vcpkgDirectory: '${{ github.workspace }}/3rd-party/vcpkg'
 
     - name: Configure NuGet Source
+      continue-on-error: true
       if: ${{ runner.os == 'Windows' }}
       shell: 'bash'
       run: |

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -20,7 +20,10 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
   S3_BUCKET: multipass-ci
+  USERNAME: ${{ github.repository_owner }}
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
 
 jobs:
   CheckLint:
@@ -165,6 +168,21 @@ jobs:
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgDirectory: '${{ github.workspace }}/3rd-party/vcpkg'
+
+    - name: Configure NuGet Source
+      if: ${{ runner.os == 'Windows' }}
+      shell: 'bash'
+      run: |
+        "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
+          sources add \
+          -source "${{ env.FEED_URL }}" \
+          -storepasswordincleartext \
+          -name "GitHubPackages" \
+          -username "${{ env.USERNAME }}" \
+          -password "${{ secrets.GITHUB_TOKEN }}"
+        "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
+          setapikey "${{ secrets.GITHUB_TOKEN }}" \
+          -source "${{ env.FEED_URL }}"
 
     - name: Set up CCache
       if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -55,12 +55,12 @@ jobs:
         set -euo pipefail
 
         MATRIX='{"include": ['
-        MATRIX+='{"runs-on": "windows-latest"},'
+        MATRIX+='{"runs-on": "windows-latest", "mono": ""},'
         MATRIX+='{"runs-on": "multipass-macos-12-x64", "arch": "x86_64", "target": "12"},'
         MATRIX+='{"runs-on": "multipass-macos-12-arm", "arch": "arm64", "target": "12"},'
-        MATRIX+='{"runs-on": "macos-13", "arch": "x86_64", "target": "13"},'
-        MATRIX+='{"runs-on": "macos-14", "arch": "arm64", "target": "14"},'
-        MATRIX+='{"runs-on": "macos-15", "arch": "arm64", "target": "15"}'
+        MATRIX+='{"runs-on": "macos-13", "arch": "x86_64", "target": "13", "mono": "mono"},'
+        MATRIX+='{"runs-on": "macos-14", "arch": "arm64", "target": "14", "mono": ""},'
+        MATRIX+='{"runs-on": "macos-15", "arch": "arm64", "target": "15", "mono": ""}'
         MATRIX+=']}'
 
         echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
@@ -171,17 +171,16 @@ jobs:
 
     - name: Configure NuGet Source
       continue-on-error: true
-      if: ${{ runner.os == 'Windows' }}
       shell: 'bash'
       run: |
-        "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
+        ${{ matrix.mono }} "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
           sources add \
           -source "${{ env.FEED_URL }}" \
           -storepasswordincleartext \
           -name "GitHubPackages" \
           -username "${{ env.USERNAME }}" \
           -password "${{ secrets.GITHUB_TOKEN }}"
-        "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
+        ${{ matrix.mono }} "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
           setapikey "${{ secrets.GITHUB_TOKEN }}" \
           -source "${{ env.FEED_URL }}"
 

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -189,6 +189,7 @@ jobs:
       continue-on-error: true
       shell: 'bash'
       run: |
+        # https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages
         ${{ matrix.mono }} "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
           sources add \
           -source "${{ env.FEED_URL }}" \

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -169,12 +169,22 @@ jobs:
       with:
         vcpkgDirectory: '${{ github.workspace }}/3rd-party/vcpkg'
 
+      # TODO: remove this when self-hosted runners are dropped
+    - name: Disable vcpkg binary cache on self-hosted runners
+      id: disable-cache
+      shell: bash
+      run: |
+        if [[ "${{ matrix['runs-on'] }}" == *multipass* ]]; then
+          echo "VCPKG_BINARY_SOURCES=" >> $GITHUB_ENV
+        fi
+
     - name: Install nuget
-      if: ${{ runner.os == 'macOS' && matrix.arch == 'arm64' }}
+      if: ${{ runner.os == 'macOS' && matrix.arch == 'arm64' && env.VCPKG_BINARY_SOURCES }}
       run: |
         brew install nuget mono
 
     - name: Configure NuGet Source
+      if: ${{ env.VCPKG_BINARY_SOURCES }} # TODO: remove this when self-hosted runners are dropped
       id: setup_nuget
       continue-on-error: true
       shell: 'bash'

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -169,7 +169,13 @@ jobs:
       with:
         vcpkgDirectory: '${{ github.workspace }}/3rd-party/vcpkg'
 
+    - name: Install nuget
+      if: ${{ runner.os == 'macOS' && matrix.arch == 'arm64' }}
+      run: |
+        brew install nuget mono
+
     - name: Configure NuGet Source
+      id: setup_nuget
       continue-on-error: true
       shell: 'bash'
       run: |
@@ -183,6 +189,17 @@ jobs:
         ${{ matrix.mono }} "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
           setapikey "${{ secrets.GITHUB_TOKEN }}" \
           -source "${{ env.FEED_URL }}"
+
+    - name: Overwrite Homebrew nuget shim with nuget DLL
+      continue-on-error: true
+      if: ${{ steps.setup_nuget.outcome == 'success' && runner.os == 'macOS' && matrix.arch == 'arm64' }}
+      run: |
+        # Locate the real NuGet.exe in Homebrew’s Cellar
+        NUGET_EXE="$(brew --prefix nuget)/libexec/NuGet.exe"
+        # Remove the old shim and replace it with a symlink
+        sudo rm -f /opt/homebrew/bin/nuget
+        sudo ln -s "$NUGET_EXE" /opt/homebrew/bin/nuget
+        sudo chmod +x /opt/homebrew/bin/nuget
 
     - name: Set up CCache
       if: ${{ runner.os == 'macOS' }}


### PR DESCRIPTION
This PR introduces [binary caching](https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages?pivots=linux-runner) for vcpkg. Since going open source, we can take advantage of [GitHub Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages) to host binary caches.

Binary caching is enabled by setting the `VCPKG_BINARY_SOURCES` environment variable. A tutorial for how to do this can be found [here](https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages) and was generally followed for changes in this PR.

For MacOS and ARM, there is seemingly no official support or guide, and with the differences in bundled packages in GitHub hosted runners, a little bit of tailoring is required. On non-Windows machines, once a binary source has been registered, vcpkg seems to be hard coded to call `mono nuget` in order to restore or upload binaries. `mono` expects a .Net assembly compiled for Intel architecture, so when an ARM compatible package is bundled in the image from GitHub this fails. To get around this, NuGet is manually downloaded and symlinked so that vcpkg will call it.

On Linux, binary caching must be configured within the snapcraft image. Again the appropriate NuGet binary needs to be downloaded and configured so that it is callable from the command line with `mono nuget`.

Build times are considerably shorter once all dependencies are cached with the "Configure" step taking less than a few minutes. On average, this saves around 30 minutes which is approximately a 33-50% improvement in build times.

Because of the expectancy that self-hosted runners will be dropped soon, binary caching is disabled for them.

### Future improvements

#### GitHub Packages

GitHub Packages does not offer any sort of retention policy meaning that as vcpkg binaries change versions, Packages will increasingly become more and more cluttered with old versions of binaries. A solution to this problem is to setup a scheduled GitHub Action with [actions/delete-package-versions](https://github.com/marketplace/actions/delete-package-versions) and `min-versions-to-keep: 1` to only keep the most recent version of a binary.

#### Visibility

There are two storage plans for GitHub Packages which depends on visibility. Publicly visible packages show up on the [front page](https://github.com/orgs/canonical/packages?repo_name=multipass) of the Multipass repo, but have unlimited storage and bandwidth quota. Having these packages there is a bit unsightly and to the uneducated visitors they are seemingly irrelevant to Multipass and might confuse someone trying to download the Multipass application. Setting the visibility to private would be preferential, but is subject to [billing](https://docs.github.com/en/billing/managing-billing-for-your-products/about-billing-for-github-packages).

An alternative solution for storage is to use our [AWS S3 bucket](https://learn.microsoft.com/en-us/vcpkg/reference/binarycaching#aws). At this point, it is unclear whether this removes binaries from GitHub Packages or is simply a different backend storage provider for GitHub Packages. Also, since I do not have access to Multipass' AWS account, available storage quotas and unknown and so whether this is a viable solution is also unknown.

---

P.S. You can even setup binary caching [locally](https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-local?pivots=shell-bash) to speed up builds!

MULTI-2030