### PR TITLE
docs: Fix "Contribute to this page" button in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,6 +152,7 @@ html_context = {
 
 # The following instructions are to display a clickable pencil "Edit" button on every page, in the top-right.
 html_theme_options = {
+    "source_edit_link": "https://github.com/canonical/multipass",
     "source_repository": "https://github.com/canonical/multipass",
     "source_branch": "main",
     "source_directory": "docs/",


### PR DESCRIPTION

This PR adds a link to the **"Contribute to this page"** button in the Multipass documentation. While this button is currently visible, it is non-functional due to a missing setting.

Following [Furo theme documentation](https://pradyunsg.me/furo/customisation/top-of-page-buttons/#with-arbitrary-urls), we’ve added the `source_edit_link ` to  html_options in `conf.py` to properly link the button to our docs. NOTE: we use this as the base theme in the starter pack.

Reference implementation:

* [Charmcraft Docs – conf.py line 55](https://github.com/canonical/charmcraft/blob/fc17daa7ee1dde979d9685006195e71a2de6337f/docs/conf.py#L55)

This should now allow contributors to easily open our GH repo from any page in the documentation.
