### PR TITLE
docs: Standardize landing page format

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,11 +22,34 @@ Developers can use Multipass to prototype cloud deployments and to create fresh,
 
 ## In this documentation
 
-|                                                                                                      |                                                                                             |
-|------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| [Tutorial](/tutorial/index)</br>  Get started - a hands-on introduction to Multipass for new users </br> | [How-to guides](/how-to-guides/index) </br> Step-by-step guides covering key operations and common tasks |
-| [Explanation](/explanation/index) </br> Concepts - discussion and clarification of key topics                   | [Reference](/reference/index) </br> Technical information - specifications, APIs, architecture       |
+````{grid} 1 1 2 2
 
+```{grid-item-card} [Tutorial](tutorial/index)
+
+**Get started:** a hands-on introduction to Multipass for new users
+```
+
+```{grid-item-card} [How-to guides](how-to-guides/index)
+
+**Step-by-step guides** covering key operations and common tasks
+```
+
+````
+
+````{grid} 1 1 2 2
+:reverse:
+
+```{grid-item-card} [Reference](reference/index)
+
+**Technical information** - specifications, APIs, architecture 
+```
+
+```{grid-item-card} [Explanation](explanation/index)
+
+**Concepts** - discussion and clarification of key topics
+```
+
+````
 ---
 
 ## Project and community
@@ -34,7 +57,7 @@ Developers can use Multipass to prototype cloud deployments and to create fresh,
 We value your input and contributions! Here are some ways you can join our community or get help with your Multipass questions:
 
 * Read our [Code of Conduct](https://ubuntu.com/community/code-of-conduct)
-* Read our quick guide: [Contribute to Multipass docs](./contribute-to-multipass-docs)
+* Read our quick guide: {ref}`contribute-to-multipass-docs`
 * Join the [Discourse forum](https://discourse.ubuntu.com/c/project/multipass/21/)
 * Report an issue or contribute to the code on [GitHub](https://github.com/canonical/multipass/issues)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Developers can use Multipass to prototype cloud deployments and to create fresh,
 
 ```{grid-item-card} [Reference](reference/index)
 
-**Technical information** - specifications, APIs, architecture 
+**Technical information** - specifications, APIs, architecture
 ```
 
 ```{grid-item-card} [Explanation](explanation/index)


### PR DESCRIPTION
This PR updates the landing page (specifically the "In this documentation" section) to align with the standardized format used across other canonical products , improving consistency and user experience.

## Changes Made

- Replaced markdown table with a responsive grid layout (and cards) for and aligning to design patterns of other canonical products.

## Reference implementation

The new format follows the same structure as other canonical product documentation:
• [Chisel docs](https://documentation.ubuntu.com/chisel/en/latest/)
• [Ubuntu server docs](https://documentation.ubuntu.com/server/)

## Testing

- [x] Verified layout renders correctly across different screen sizes
- [x] Confirmed all links and navigation elements function properly

## Screenshots
### Before
<img width="810" alt="Screenshot 2025-06-18 at 09 27 37" src="https://github.com/user-attachments/assets/fb0436a1-a634-4575-823b-7e0224e6d6ad" />

### After


<img width="776" alt="Screenshot 2025-06-18 at 09 55 12" src="https://github.com/user-attachments/assets/74574d58-e1b8-4084-bfa9-3d73b9c37a06" />


MULTI-2031
