### PR TITLE
[snap/snapcraft.yaml] add `gettext` to the build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -286,6 +286,7 @@ parts:
     - libseccomp-dev
     - meson
     - python3-venv
+    - gettext
     stage-packages:
     - libpixman-1-0
     stage:


### PR DESCRIPTION
Qemu build fails with the following output in an arm64 environment:

[4/12] Generating po/bg/LC_MESSAGES/qemu-bg.mo with a custom command FAILED: po/bg/LC_MESSAGES/qemu.mo
/snap/gnome-42-2204-sdk/current/usr/bin/msgfmt -o po/bg/LC_MESSAGES/qemu.mo ../po/bg.po /snap/gnome-42-2204-sdk/current/usr/bin/msgfmt: error while loading shared libraries: libgettextsrc-0.21.so: cannot open shared object file: No such file or directory ninja: build stopped: subcommand failed.

The gettext package provides libgettextsrc-0.21.so.

MULTI-2036