### PR TITLE
[gui] Enhance FFI library loading

### DIFF
--- a/src/client/gui/lib/daemon_unavailable.dart
+++ b/src/client/gui/lib/daemon_unavailable.dart
@@ -87,10 +87,23 @@ class DaemonUnavailable extends ConsumerWidget {
                   ),
                 ),
                 const SizedBox(height: 12),
-                Text(
-                  errorMessage,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(fontSize: 14),
+                Theme(
+                  data: Theme.of(context).copyWith(
+                    textButtonTheme: TextButtonThemeData(
+                      style: TextButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        foregroundColor: Colors.black,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                    ),
+                  ),
+                  child: SelectableText(
+                    errorMessage,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontSize: 14),
+                  ),
                 ),
                 const SizedBox(height: 16),
                 Row(

--- a/src/client/gui/lib/daemon_unavailable.dart
+++ b/src/client/gui/lib/daemon_unavailable.dart
@@ -1,10 +1,43 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Tooltip;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'ffi.dart';
 import 'providers.dart';
+import 'tooltip.dart';
+import 'package:flutter/services.dart';
+
+class _CopyErrorIcon extends StatefulWidget {
+  final String errorMessage;
+  const _CopyErrorIcon({required this.errorMessage});
+
+  @override
+  State<_CopyErrorIcon> createState() => _CopyErrorIconState();
+}
+
+class _CopyErrorIconState extends State<_CopyErrorIcon> {
+  bool _copied = false;
+
+  void _copy() async {
+    await Clipboard.setData(ClipboardData(text: widget.errorMessage));
+    setState(() => _copied = true);
+    Future.delayed(const Duration(seconds: 2), () {
+      if (mounted) setState(() => _copied = false);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: _copied ? 'Copied!' : 'Copy error message',
+      child: IconButton(
+        icon: const Icon(Icons.copy, size: 20),
+        onPressed: _copy,
+      ),
+    );
+  }
+}
 
 class DaemonUnavailable extends ConsumerWidget {
   const DaemonUnavailable({super.key});
@@ -24,50 +57,60 @@ class DaemonUnavailable extends ConsumerWidget {
       // FFI library failed to load - show fatal error
       final errorMessage =
           ffiLoadError?.toString() ?? 'Failed to load libdart_ffi library';
-      content = Container(
-        padding: const EdgeInsets.all(20),
-        constraints: const BoxConstraints(maxWidth: 500),
-        decoration: const BoxDecoration(
-          color: Colors.white,
-          boxShadow: [
-            BoxShadow(color: Colors.black54, blurRadius: 10, spreadRadius: 5)
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(
-              Icons.error,
-              color: Colors.red,
-              size: 48,
+      content = Stack(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(20),
+            constraints: const BoxConstraints(maxWidth: 500),
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              boxShadow: [
+                BoxShadow(
+                    color: Colors.black54, blurRadius: 10, spreadRadius: 5)
+              ],
             ),
-            const SizedBox(height: 16),
-            const Text(
-              'Fatal Error',
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-                color: Colors.red,
-              ),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              errorMessage,
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 14),
-            ),
-            const SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                TextButton(
-                  onPressed: () => exit(1),
-                  child: const Text('Exit Application'),
+                const Icon(
+                  Icons.error,
+                  color: Colors.red,
+                  size: 48,
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  'Fatal Error',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.red,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  errorMessage,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontSize: 14),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    TextButton(
+                      onPressed: () => exit(1),
+                      child: const Text('Exit Application'),
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+          Positioned(
+            top: 8,
+            right: 8,
+            child: _CopyErrorIcon(errorMessage: errorMessage),
+          ),
+        ],
       );
     } else {
       // Regular daemon unavailable message
@@ -88,8 +131,7 @@ class DaemonUnavailable extends ConsumerWidget {
     }
 
     return IgnorePointer(
-      ignoring:
-          ffiAvailable, // Only allow interactions when FFI failed (to click Exit button)
+      ignoring: available, // Only allow interactions when daemon is available
       child: AnimatedOpacity(
         opacity: available ? 0 : 1,
         duration: const Duration(milliseconds: 500),

--- a/src/client/gui/lib/daemon_unavailable.dart
+++ b/src/client/gui/lib/daemon_unavailable.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'ffi.dart';
 import 'providers.dart';
 
 class DaemonUnavailable extends ConsumerWidget {
@@ -9,24 +12,84 @@ class DaemonUnavailable extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final available = ref.watch(daemonAvailableProvider);
+    final ffiAvailable = ref.watch(ffiAvailableProvider);
 
-    final content = Container(
-      padding: const EdgeInsets.all(20),
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        boxShadow: [
-          BoxShadow(color: Colors.black54, blurRadius: 10, spreadRadius: 5)
-        ],
-      ),
-      child: const Row(mainAxisSize: MainAxisSize.min, children: [
-        CircularProgressIndicator(color: Colors.orange),
-        SizedBox(width: 20),
-        Text('Waiting for daemon...'),
-      ]),
-    );
+    if (available) {
+      return const SizedBox.shrink();
+    }
+
+    Widget content;
+
+    if (!ffiAvailable) {
+      // FFI library failed to load - show fatal error
+      final errorMessage =
+          ffiLoadError?.toString() ?? 'Failed to load libdart_ffi library';
+      content = Container(
+        padding: const EdgeInsets.all(20),
+        constraints: const BoxConstraints(maxWidth: 500),
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(color: Colors.black54, blurRadius: 10, spreadRadius: 5)
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error,
+              color: Colors.red,
+              size: 48,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Fatal Error',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: Colors.red,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              errorMessage,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 14),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextButton(
+                  onPressed: () => exit(1),
+                  child: const Text('Exit Application'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+    } else {
+      // Regular daemon unavailable message
+      content = Container(
+        padding: const EdgeInsets.all(20),
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(color: Colors.black54, blurRadius: 10, spreadRadius: 5)
+          ],
+        ),
+        child: const Row(mainAxisSize: MainAxisSize.min, children: [
+          CircularProgressIndicator(color: Colors.orange),
+          SizedBox(width: 20),
+          Text('Waiting for daemon...'),
+        ]),
+      );
+    }
 
     return IgnorePointer(
-      ignoring: available,
+      ignoring:
+          ffiAvailable, // Only allow interactions when FFI failed (to click Exit button)
       child: AnimatedOpacity(
         opacity: available ? 0 : 1,
         duration: const Duration(milliseconds: 500),

--- a/src/client/gui/lib/ffi.dart
+++ b/src/client/gui/lib/ffi.dart
@@ -17,7 +17,40 @@ extension on ffi.Pointer<Utf8> {
   }
 }
 
-final _lib = ffi.DynamicLibrary.open(mpPlatform.ffiLibraryName);
+class FFILibrary {
+  final ffi.DynamicLibrary? _lib;
+  final Exception? _loadError;
+
+  FFILibrary._({ffi.DynamicLibrary? lib, Exception? loadError})
+      : _lib = lib,
+        _loadError = loadError;
+
+  factory FFILibrary._load() {
+    try {
+      final lib = ffi.DynamicLibrary.open(mpPlatform.ffiLibraryName);
+      return FFILibrary._(lib: lib);
+    } catch (e) {
+      return FFILibrary._(
+          loadError: Exception('Failed to load libdart_ffi library: $e'));
+    }
+  }
+
+  ffi.DynamicLibrary get lib {
+    if (_lib == null) {
+      throw _loadError!;
+    }
+    return _lib!;
+  }
+
+  bool get isAvailable => _lib != null;
+  Exception? get loadError => _loadError;
+}
+
+final _ffiLib = FFILibrary._load();
+final _lib = _ffiLib.lib;
+
+bool get isFFIAvailable => _ffiLib.isAvailable;
+Exception? get ffiLoadError => _ffiLib.loadError;
 
 final _multipassVersion = _lib.lookupFunction<ffi.Pointer<Utf8> Function(),
     ffi.Pointer<Utf8> Function()>('multipass_version');


### PR DESCRIPTION
resolves #4175 

<img width="470" alt="image" src="https://github.com/user-attachments/assets/abaca93c-4020-48a4-8c11-d96284a852e0" />

This pull request introduces changes to improve error handling and user experience when the FFI library fails to load. The updates include a new mechanism to detect FFI availability, enhancements to the `DaemonUnavailable` widget, and modifications to providers for better integration.

### Error Handling for FFI Library:

* [`src/client/gui/lib/ffi.dart`](diffhunk://#diff-0a91f284d9074caf859890b9d92d83e3eaeb2963f74491605435b5124bf5107bL20-R53): Introduced the `FFILibrary` class to encapsulate FFI library loading logic, handle errors gracefully, and provide utility methods (`isFFIAvailable` and `ffiLoadError`) for checking availability and accessing load errors.

### User Interface Enhancements:

* [`src/client/gui/lib/daemon_unavailable.dart`](diffhunk://#diff-45e88b27cc58ea15345a9f1736ad4d77b8f8ccf5eaa3fa0c85572876cad76a81R15-R74): Updated the `DaemonUnavailable` widget to display a fatal error message and an "Exit Application" button when the FFI library fails to load. Added a conditional check for `ffiAvailableProvider` to differentiate between fatal errors and regular daemon unavailability. [[1]](diffhunk://#diff-45e88b27cc58ea15345a9f1736ad4d77b8f8ccf5eaa3fa0c85572876cad76a81R15-R74) [[2]](diffhunk://#diff-45e88b27cc58ea15345a9f1736ad4d77b8f8ccf5eaa3fa0c85572876cad76a81R88-R92)

### Provider Updates:

* [`src/client/gui/lib/providers.dart`](diffhunk://#diff-62ce57ce08e2a6bf574b13c2d0798b8e626d66bcbdbc89e7f19c49a530d42fd2L20-R29): Added a new provider, `ffiAvailableProvider`, to propagate the FFI availability status throughout the application. Updated `grpcClientProvider` and `daemonAvailableProvider` to incorporate FFI availability checks, ensuring dependent functionality behaves appropriately when the FFI library is unavailable. [[1]](diffhunk://#diff-62ce57ce08e2a6bf574b13c2d0798b8e626d66bcbdbc89e7f19c49a530d42fd2L20-R29) [[2]](diffhunk://#diff-62ce57ce08e2a6bf574b13c2d0798b8e626d66bcbdbc89e7f19c49a530d42fd2R73-R77)