### PR TITLE
Fix client key permissions

### DIFF
--- a/src/cert/ssl_cert_provider.cpp
+++ b/src/cert/ssl_cert_provider.cpp
@@ -388,6 +388,11 @@ mp::SSLCertProvider::KeyCertificatePair make_cert_key_pair(const QDir& cert_dir,
         client_cert_key.write(priv_key_path);
         client_cert.write(cert_path);
 
+        MP_PLATFORM.set_permissions(priv_key_path.toStdU16String(),
+                                    std::filesystem::perms::owner_all |
+                                        std::filesystem::perms::group_read |
+                                        std::filesystem::perms::others_read);
+
         return {client_cert.as_pem(), client_cert_key.as_pem()};
     }
 }

--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -460,7 +460,7 @@ DWORD set_specific_perms(LPSTR path, WELL_KNOWN_SID_TYPE sid_type, DWORD access_
 
 DWORD convert_permissions(int unix_perms)
 {
-    if (unix_perms & 07)
+    if (unix_perms == 07)
         return GENERIC_ALL;
 
     DWORD access_mask = 0;


### PR DESCRIPTION
There was a change in logic in when permissions are set for ssl certificates which caused newly created client certificates to have overly restrictive permissions. This fixes that.

Also there was a bug where unix permissions weren't converted to Windows permissions correctly. This fixes that.

Setting the permissions of the file to read by everyone does not change security since the parent folder maintains the user only access. However, in the future it would be nice to give read permissions directly to the user instead of everyone.

closes #4193 