### PR TITLE
[hyper-v] Move disabling automatic checkpoints to vm creation

### DIFF
--- a/tests/hyperv/test_hyperv_backend.cpp
+++ b/tests/hyperv/test_hyperv_backend.cpp
@@ -114,8 +114,9 @@ struct HyperVBackend : public Test
                                                                  {"-EnableSecureBoot Off"},
                                                                  {"Set-VMProcessor"},
                                                                  {"Add-VMDvdDrive"},
-                                                                 {"Set-VMMemory"}};
-    inline static const std::vector<RunSpec> postfix_ctor_runs = {{"Set-VM"}, {"Get-VMCheckpoint"}};
+                                                                 {"Set-VMMemory"},
+                                                                 {"Set-VM"}};
+    inline static const std::vector<RunSpec> postfix_ctor_runs = {};
     inline static const RunSpec default_network_run = {"Set-VMNetworkAdapter"};
     inline static const RunSpec min_dtor_run = {"-ExpandProperty State", "Off"};
 


### PR DESCRIPTION
Currently, disabling automatic checkpoints causes issues when the VM is not in an appropriate state at the time the constructor is executed. This causes the daemon to crash since the command throws an exception.

Fixes: #4204 

MULTI-2061