### PR TITLE
[hyper-v] Invalidate cached mgmt IP address on update_state()

### DIFF
--- a/src/platform/backends/hyperv/hyperv_virtual_machine.cpp
+++ b/src/platform/backends/hyperv/hyperv_virtual_machine.cpp
@@ -440,6 +440,21 @@ void mp::HyperVVirtualMachine::ensure_vm_is_running()
 
 void mp::HyperVVirtualMachine::update_state()
 {
+    // Invalidate the management IP address on state update.
+    {
+        // The reason "why" is as follows:
+        // - The daemon starts and constructs the VM
+        // - The mgmt IP address gets cached on the first invocation of management_ipv4()
+        // - `multipass restart` initiates a guest reboot with "sudo reboot"
+        // -  It's an "out-of-band" reboot in perspective of Hyper-V backend since
+        //    it does not trigger the "on_restart" function afterwards.
+        // - The cached "vm->ip address is not reset
+        // - management_ipv4() continues to report the stale IP address from the previous boot
+        mpl::log(mpl::Level::debug,
+                 vm_name,
+                 "Invalidating cached mgmt IP address upon state update");
+        ip = std::nullopt;
+    }
     monitor->persist_state_for(vm_name, state);
 }
 

--- a/src/platform/backends/hyperv/hyperv_virtual_machine.cpp
+++ b/src/platform/backends/hyperv/hyperv_virtual_machine.cpp
@@ -442,14 +442,8 @@ void mp::HyperVVirtualMachine::update_state()
     // Invalidate the management IP address on state update.
     if (current_state() == VirtualMachine::State::running)
     {
-        // The reason "why" is as follows:
-        // - The daemon starts and constructs the VM
-        // - The mgmt IP address gets cached on the first invocation of management_ipv4()
-        // - `multipass restart` initiates a guest reboot with "sudo reboot"
-        // -  It's an "out-of-band" reboot in perspective of Hyper-V backend since
-        //    it does not trigger the "on_restart" function afterwards.
-        // - The cached "vm->ip address is not reset
-        // - management_ipv4() continues to report the stale IP address from the previous boot
+        // Cached IPs become stale when the guest is restarted from within. By resetting them here
+        // we at least cover multipass's restart initiatives, which include state updates.
         mpl::log(mpl::Level::debug,
                  vm_name,
                  "Invalidating cached mgmt IP address upon state update");

--- a/src/platform/backends/hyperv/hyperv_virtual_machine.cpp
+++ b/src/platform/backends/hyperv/hyperv_virtual_machine.cpp
@@ -387,7 +387,6 @@ void mp::HyperVVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
         state_wait.wait(lock, [this] { return shutdown_while_starting; });
     }
 
-    ip = std::nullopt;
     update_state();
 }
 
@@ -453,7 +452,7 @@ void mp::HyperVVirtualMachine::update_state()
         mpl::log(mpl::Level::debug,
                  vm_name,
                  "Invalidating cached mgmt IP address upon state update");
-        ip = std::nullopt;
+        management_ip = std::nullopt;
     }
     monitor->persist_state_for(vm_name, state);
 }
@@ -470,7 +469,7 @@ std::string mp::HyperVVirtualMachine::ssh_username()
 
 std::string mp::HyperVVirtualMachine::management_ipv4()
 {
-    if (!ip)
+    if (!management_ip)
     {
         // Not using cached SSH session for this because a) the underlying functions do not
         // guarantee constness; b) we endure the penalty of creating a new session only when we
@@ -478,9 +477,9 @@ std::string mp::HyperVVirtualMachine::management_ipv4()
         auto result =
             remote_ip(VirtualMachine::ssh_hostname(), ssh_port(), ssh_username(), key_provider);
         if (result)
-            ip.emplace(result.value());
+            management_ip.emplace(result.value());
     }
-    return ip ? ip.value().as_string() : "UNKNOWN";
+    return management_ip ? management_ip.value().as_string() : "UNKNOWN";
 }
 
 std::string mp::HyperVVirtualMachine::ipv6()

--- a/src/platform/backends/hyperv/hyperv_virtual_machine.cpp
+++ b/src/platform/backends/hyperv/hyperv_virtual_machine.cpp
@@ -440,6 +440,7 @@ void mp::HyperVVirtualMachine::ensure_vm_is_running()
 void mp::HyperVVirtualMachine::update_state()
 {
     // Invalidate the management IP address on state update.
+    if (current_state() == VirtualMachine::State::running)
     {
         // The reason "why" is as follows:
         // - The daemon starts and constructs the VM

--- a/src/platform/backends/hyperv/hyperv_virtual_machine.h
+++ b/src/platform/backends/hyperv/hyperv_virtual_machine.h
@@ -95,7 +95,6 @@ private:
 
     VirtualMachineDescription desc; // TODO we should probably keep this in the base class instead
     const QString name;
-    std::optional<multipass::IPAddress> ip;
     std::unique_ptr<PowerShell> power_shell;
     VMStatusMonitor* monitor;
     bool update_suspend_status{true};


### PR DESCRIPTION
The cached management IP address becomes stale on some operations when it happens out-of-band, like "multipass restart", where it's a SSH-induced guest reboot.

This patch fixes that by invalidating the cached IP address on every update_state() invocation.

Fixes: #3354

MULTI-2068