### PR TITLE
[gui] add `Select All` option to terminal right click menu

### DIFF
--- a/src/client/gui/lib/vm_details/terminal.dart
+++ b/src/client/gui/lib/vm_details/terminal.dart
@@ -176,6 +176,10 @@ class ResetTerminalFontIntent extends Intent {
   const ResetTerminalFontIntent();
 }
 
+class SelectAllTerminalTextIntent extends Intent {
+  const SelectAllTerminalTextIntent();
+}
+
 class _VmTerminalState extends ConsumerState<VmTerminal> {
   static const defaultFontSize = 13.0;
   static const minFontSize = 2.5;
@@ -291,6 +295,16 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
           );
         },
       ),
+      ContextMenuButtonItem(
+        label: 'Select All',
+        onPressed: () {
+          ContextMenuController.removeAny();
+          Actions.maybeInvoke(
+            context,
+            const SelectAllTerminalTextIntent(),
+          );
+        },
+      ),
     ];
 
     final style = Theme.of(context).textButtonTheme.style?.copyWith(
@@ -402,6 +416,45 @@ class _VmTerminalState extends ConsumerState<VmTerminal> {
           if (selection == null) return null;
           final text = terminal.buffer.getText(selection);
           await Clipboard.setData(ClipboardData(text: text));
+          return null;
+        },
+      ),
+      SelectAllTerminalTextIntent: CallbackAction<SelectAllTerminalTextIntent>(
+        onInvoke: (_) async {
+          // Select all text in the terminal buffer
+          final buffer = terminal.buffer;
+
+          // Check if there's any content to select
+          if (buffer.height == 0) return null;
+
+          // Find the last line with actual content
+          int lastContentLine = buffer.height - 1;
+          for (int i = buffer.height - 1; i >= 0; i--) {
+            final line = buffer.lines[i];
+            // Check if the line has any non-empty content
+            bool hasContent = false;
+            for (int j = 0; j < line.length; j++) {
+              if (line.getCodePoint(j) != 0 && line.getCodePoint(j) != 32) {
+                // not null and not space
+                hasContent = true;
+                break;
+              }
+            }
+            if (hasContent) {
+              lastContentLine = i;
+              break;
+            }
+          }
+
+          // Create a selection from the first line to the last line with content
+          // Start from the first line, first column
+          final start = buffer.createAnchor(0, 0);
+          // End at the last content line, last column
+          final end =
+              buffer.createAnchor(buffer.viewWidth - 1, lastContentLine);
+
+          // Set the selection to cover all meaningful text
+          terminalController.setSelection(start, end);
           return null;
         },
       ),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b6e71b6f-d76d-4ccc-bcea-42ee0155fbad)
This pull request introduces a new option to the right click menu in the terminal tab in the GUI, enabling users to select all text within the terminal buffer. The changes include the addition of a new `Intent` class, modifications to the context menu, and implementation of the logic for selecting all terminal text.

### New Feature: Select All Terminal Text

* **Added `SelectAllTerminalTextIntent` class**: Introduced a new `Intent` class to handle the "Select All" functionality. 
* **Updated context menu**: Added a new "Select All" option in the terminal's context menu, which triggers the `SelectAllTerminalTextIntent`. 
* **Implemented selection logic**: Defined the logic for selecting all meaningful text in the terminal buffer, ensuring that only non-empty lines are included in the selection. This involves creating anchors for the start and end of the selection and applying it via the `terminalController`.