### PR TITLE
[client/gui] symlink libdart_ffi to bundle/lib post build

### DIFF
--- a/src/client/gui/CMakeLists.txt
+++ b/src/client/gui/CMakeLists.txt
@@ -42,4 +42,11 @@ if(MULTIPASS_ENABLE_FLUTTER_GUI)
   else() # Windows
     include("CMakeLists.txt.windows")
   endif()
+
+  add_custom_command(TARGET dart_ffi POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E create_symlink
+      $<TARGET_FILE:dart_ffi>
+      "${CMAKE_BINARY_DIR}/bin/bundle/lib/$<TARGET_FILE_NAME:dart_ffi>"
+      COMMENT "Creating symlink `$<TARGET_FILE:dart_ffi>` --> `bundle/lib/$<TARGET_FILE_NAME:dart_ffi>`"
+  )
 endif()


### PR DESCRIPTION
The GUI binary, multipass.gui's RUNPATH is $ORIGIN/lib, which resolves to `$REPO_ROOT/build/bin/bundle/lib/`, whereas the libdart_ffi.so is in `$REPO_ROOT/build/lib` folder. Hence, the multipass.gui fails to launch on local builds if libdart_ffi.so is not somehow placed to the library search path manually (i.e. by copying, or by LD_LIBRARY_PATH).

This patch adds a libdart_ffi.so symlink to the bundle/lib so the GUI can find the dart_ffi library on local build without relying on a manual intervention.