### PR TITLE
[ci] CI tweaks

### DIFF
--- a/.github/workflows/dynamic-ci.yml
+++ b/.github/workflows/dynamic-ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - release/[0-9]+.[0-9]+
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:


### PR DESCRIPTION
A couple tweaks to the new CI setup

1. `lint.yml` does more than just lint C++ code, so we need it to run all the time
2. Stop running CI when pushing tags (as per team discussion)