### PR TITLE
[dnsmasq_server] wait for a reasonable amount of time for exit

### DIFF
--- a/src/platform/backends/qemu/linux/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/linux/dnsmasq_server.cpp
@@ -26,6 +26,7 @@
 
 #include <QDir>
 
+#include <chrono>
 #include <fstream>
 
 namespace mp = multipass;
@@ -69,6 +70,9 @@ mp::DNSMasqServer::DNSMasqServer(const Path& data_dir,
 
 mp::DNSMasqServer::~DNSMasqServer()
 {
+    constexpr static auto terminate_timeout = std::chrono::milliseconds(10000).count();
+    constexpr static auto kill_timeout = std::chrono::milliseconds(5000).count();
+
     if (dnsmasq_cmd && dnsmasq_cmd->running())
     {
         QObject::disconnect(finish_connection);
@@ -76,13 +80,15 @@ mp::DNSMasqServer::~DNSMasqServer()
         mpl::log(mpl::Level::debug, "dnsmasq", "terminating");
         dnsmasq_cmd->terminate();
 
-        if (!dnsmasq_cmd->wait_for_finished(1000))
+        if (!dnsmasq_cmd->wait_for_finished(terminate_timeout))
         {
             mpl::log(mpl::Level::info, "dnsmasq", "failed to terminate nicely, killing");
-
             dnsmasq_cmd->kill();
-            if (!dnsmasq_cmd->wait_for_finished(100))
-                mpl::log(mpl::Level::warning, "dnsmasq", "failed to kill");
+
+            if (!dnsmasq_cmd->wait_for_finished(kill_timeout))
+            {
+                mpl::log(mpl::Level::warning, "dnsmasq", "failed to kill (timed out)");
+            }
         }
     }
 }


### PR DESCRIPTION
The existing timeout values (term: 1000ms, kill:100ms) are not good enough to allow dnsmasq to terminate itself. it causes daemon to get stuck on shutdown:

> [info] [dnsmasq] failed to terminate nicely, killing
> [warning] [dnsmasq] failed to kill
> [warning] [Qt] QProcess: Destroyed while process ("dnsmasq") is still running.

Bump terminate timeout to 10s, and kill timeout to 5s.