### PR TITLE
[linux/process_factory] unblock all signals after a child fork()

### DIFF
--- a/src/platform/backends/shared/linux/process_factory.cpp
+++ b/src/platform/backends/shared/linux/process_factory.cpp
@@ -25,6 +25,8 @@
 #include <multipass/process/simple_process_spec.h>
 #include <multipass/snap_utils.h>
 
+#include <signal.h>
+
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 
@@ -52,6 +54,15 @@ public:
     void setup_child_process() final
     {
         mp::BasicProcess::setup_child_process();
+
+        // This function runs after fork, but before exec, which is a perfect
+        // place to reset the signal masks.
+        // Unblock all signals for the child process
+        {
+            sigset_t set;
+            sigemptyset(&set);
+            sigprocmask(SIG_SETMASK, &set, nullptr);
+        }
 
         apparmor.next_exec_under_policy(process_spec->apparmor_profile_name().toLatin1());
     }


### PR DESCRIPTION
multipassd blocks SIGINT, SIGTERM and SIGUSR1 as a part of the watchdog logic. As spawning a child process involves fork()ing multipassd, the blocked signal set would be inherited by the child too. We rely on sending signals to child process for various purposes, graceful exit is being the most prominent one.

This patch clears the blocked signals after a fork so the child would get an unblocked signal set by default.