### PR TITLE
[gui] Set minimum RAM and disk size based on image type in launch form

### DIFF
--- a/src/client/gui/lib/catalogue/launch_form.dart
+++ b/src/client/gui/lib/catalogue/launch_form.dart
@@ -95,13 +95,20 @@ class _LaunchFormState extends ConsumerState<LaunchForm> {
       onSaved: (value) => launchRequest.numCores = value!,
     );
 
+    // Determine minimums based on image type
+    final isCore = imageInfo.aliasesInfo.any((a) => a.alias.contains('core'));
+    final minRam = isCore ? 512.mebi : 1024.mebi;
+    final minDisk = isCore ? 1.gibi : 5.gibi;
+
     final memorySlider = RamSlider(
       initialValue: defaultRam,
+      min: minRam,
       onSaved: (value) => launchRequest.memSize = '${value!}B',
     );
 
     final diskSlider = DiskSlider(
       initialValue: defaultDisk,
+      min: minDisk,
       onSaved: (value) => launchRequest.diskSpace = '${value!}B',
     );
 


### PR DESCRIPTION
implements #4228 

This pull request introduces a feature to dynamically determine minimum RAM and disk space requirements based on the image type in the `LaunchForm` widget. These changes enhance the configurability of sliders for memory and disk space.

Key changes:

### Dynamic minimums for sliders:
* [`src/client/gui/lib/catalogue/launch_form.dart`](diffhunk://#diff-1859f216fc901caa87909945aef29585a3d98e3b5e265a7e804870ae8a3a652fR98-R111): Added logic to calculate `minRam` and `minDisk` based on whether the image type is identified as "core" or not. Core images have lower minimum requirements (512 MiB RAM, 1 GiB disk), while non-core images have higher minimums (1024 MiB RAM, 5 GiB disk). These values are set as the minimums for the `RamSlider` and `DiskSlider`.