### PR TITLE
[ci] Install nuget on macOS 14 with brew too

### DIFF
--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -170,7 +170,7 @@ jobs:
         fi
 
     - name: Install nuget
-      if: ${{ contains(matrix.runs-on, 'macos-15') }}
+      if: ${{ contains(matrix.runs-on, 'macos-15') || contains(matrix.runs-on, 'macos-14') }}
       run: |
         brew install nuget mono
 


### PR DESCRIPTION
Fixes vcpkg caching on macOS 14.

Without this, the incantation to overwrite nuget fails: https://github.com/canonical/multipass/actions/runs/16224912911/job/45814502234#step:16:28

We could instead tweak the recipe to find nuget parts from the baked install, but this is a quicker fix that costs 12s per CI run and keeps our CI setup a little simpler (no need to branch based on macOS version).
