### PR TITLE
[ci] use dedicated self-hosted tiobe runner

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, reactive, amd64, 2xlarge, noble]
+    runs-on: self-hosted-linux-amd64-noble-2xlarge-tiobe
 
     env:
       VCPKG_FORCE_SYSTEM_BINARIES: 1

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted-linux-amd64-noble-2xlarge-tiobe
+    strategy:
+      matrix:
+        os: [self-hosted-linux-amd64-noble-2xlarge-tiobe,
+          self-hosted-linux-amd64-noble-large-tiobe]
+    runs-on: ${{ matrix.os }}
 
     env:
       VCPKG_FORCE_SYSTEM_BINARIES: 1


### PR DESCRIPTION
Using single label to prevent confusion with multiple labels.

https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/available_runners/

MULTI-2105