### PR TITLE
Improve CLI help text for consistency and clarity.

### DIFF
--- a/src/client/cli/argparser.cpp
+++ b/src/client/cli/argparser.cpp
@@ -122,7 +122,7 @@ mp::ParseCode mp::ArgParser::prepare_alias_execution(const QString& alias)
 
 mp::ParseCode mp::ArgParser::parse(const std::optional<mp::AliasDict>& aliases)
 {
-    QCommandLineOption help_option(help_option_names, "Displays help on commandline options");
+    QCommandLineOption help_option(help_option_names, "Display this help message and exit.");
     QCommandLineOption verbose_option(
         {"v", "verbose"},
         "Increase logging verbosity. Repeat the 'v' in the short option for more detail. "

--- a/src/client/cli/cmd/clone.cpp
+++ b/src/client/cli/cmd/clone.cpp
@@ -74,10 +74,7 @@ mp::ParseCode cmd::Clone::parse_args(ArgParser* parser)
 
     const QCommandLineOption destination_name_option{
         {"n", "name"},
-        "An optional custom name for the cloned instance. The name must follow the usual validity "
-        "rules "
-        "(see \"help launch\"). Default: \"<source_name>-cloneN\", where N is the Nth cloned "
-        "instance.",
+        "Specify a custom name for the cloned instance. The name must follow the same validity rules as instance names (see \"help launch\"). Default: \"<source_name>-cloneN\", where N is the Nth cloned instance.",
         "destination-name"};
 
     parser->addOption(destination_name_option);

--- a/src/client/cli/cmd/help.cpp
+++ b/src/client/cli/cmd/help.cpp
@@ -56,7 +56,7 @@ QString cmd::Help::short_help() const
 
 QString cmd::Help::description() const
 {
-    return QStringLiteral("Displays help for the given command.");
+    return QStringLiteral("Display this help message and exit.");
 }
 
 mp::ParseCode cmd::Help::parse_args(mp::ArgParser* parser)


### PR DESCRIPTION
This PR updates the CLI help text for the --help option and the clone command's --name option for clarity and consistency, as suggested by the community. Also updates the help command's description.
