### PR TITLE
[3rd-party images] include qcow2 files when cloning

### DIFF
--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -139,10 +139,12 @@ void mp::BaseVirtualMachineFactory::copy_instance_dir_with_essential_files(
     fs::create_directory(dest_instance_dir_path);
     for (const auto& entry : fs::directory_iterator(source_instance_dir_path))
     {
-        // snapshot files are intentionally skipped; .iso file is included for all, .img file here
-        // is not relevant for non-qemu backends.
+        // snapshot files are intentionally skipped;
+        // .iso cloud init file is included for all,
+        // .img or .qcow2 file here is not relevant for non-qemu backends.
         if (entry.path().extension().string() == ".iso" ||
-            entry.path().extension().string() == ".img")
+            entry.path().extension().string() == ".img" ||
+            entry.path().extension().string() == ".qcow2")
         {
             const fs::path dest_file_path = dest_instance_dir_path / entry.path().filename();
             fs::copy(entry.path(), dest_file_path, fs::copy_options::update_existing);


### PR DESCRIPTION
Debian and Fedora ship their cloud images with the `.qcow2` file extension which does not get picked up by `multipass clone`.

Fixes #4271 

---

MULTI-2150