### PR TITLE
[rpc/CMakeLists.txt] add `/bigobj` flag

### DIFF
--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -18,6 +18,8 @@ file(MAKE_DIRECTORY ${GRPC_GENERATED_SOURCE_DIR})
 
 if(NOT MSVC)
   add_compile_options(-Wno-error=pedantic)
+else()
+  add_compile_options(/bigobj)
 endif()
 
 generate_grpc_cpp(GRPC_GENERATED_SOURCES ${GRPC_GENERATED_SOURCE_DIR} ${MULTIPASS_PROTOCOL_SPEC})


### PR DESCRIPTION
RPC Compilation fails due to the produced object size in Windows; this PR fixes that by passing the "/bigobj" flag.