### PR TITLE
[sshfs-mount] make chown return 0 on Windows

### DIFF
--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -690,7 +690,7 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
 
 int mp::platform::Platform::chown(const char* path, unsigned int uid, unsigned int gid) const
 {
-    return -1;
+    return 0;
 }
 
 // new_ACL returns a new ACL unique ptr that retains all existing Hyper-V ACEs or NULL if no entries

--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -73,6 +73,7 @@ namespace mpu = multipass::utils;
 namespace
 {
 static const auto none = QStringLiteral("none");
+static constexpr auto kLogCategory = "platform-win";
 
 time_t time_t_from(const FILETIME* ft)
 {
@@ -690,6 +691,11 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
 
 int mp::platform::Platform::chown(const char* path, unsigned int uid, unsigned int gid) const
 {
+    logging::trace(kLogCategory,
+                   "chown() called for `{}` (uid: {}, gid: {}) but it's no-op.",
+                   path,
+                   uid,
+                   gid);
     return 0;
 }
 

--- a/src/sshfs_mount/sftp_server.cpp
+++ b/src/sshfs_mount/sftp_server.cpp
@@ -253,20 +253,6 @@ int reverse_id_for(const mp::id_mappings& id_maps, const int id, const int defau
                ? (default_found == id_maps.cend() ? default_id : default_found->first)
                : found->first;
 }
-
-int chown_shim(const char* path, unsigned int uid, unsigned int gid)
-{
-    // Do not bother calling the chown if IDs are set to no_id_available
-    // (e.g. in Windows)
-    if (uid == static_cast<decltype(gid)>(mp::no_id_info_available) ||
-        gid == static_cast<decltype(gid)>(mp::no_id_info_available))
-    {
-        return 0;
-    }
-
-    return MP_PLATFORM.chown(path, uid, gid);
-}
-
 } // namespace
 
 mp::SftpServer::SftpServer(SSHSession&& session,
@@ -599,7 +585,7 @@ int mp::SftpServer::handle_mkdir(sftp_client_message msg)
     int rev_uid = reverse_uid_for(parent_dir.ownerId(), parent_dir.ownerId());
     int rev_gid = reverse_gid_for(parent_dir.groupId(), parent_dir.groupId());
 
-    if (chown_shim(filename, rev_uid, rev_gid) < 0)
+    if (MP_PLATFORM.chown(filename, rev_uid, rev_gid) < 0)
     {
         mpl::log(mpl::Level::trace,
                  category,
@@ -734,7 +720,7 @@ int mp::SftpServer::handle_open(sftp_client_message msg)
         auto new_uid = reverse_uid_for(current_dir.ownerId(), current_dir.ownerId());
         auto new_gid = reverse_gid_for(current_dir.groupId(), current_dir.groupId());
 
-        if (chown_shim(filename, new_uid, new_gid) < 0)
+        if (MP_PLATFORM.chown(filename, new_uid, new_gid) < 0)
         {
             mpl::log(mpl::Level::trace,
                      category,
@@ -1193,9 +1179,9 @@ int mp::SftpServer::handle_setstat(sftp_client_message msg)
             return reply_perm_denied(msg);
         }
 
-        if (chown_shim(filename.u8string().c_str(),
-                       reverse_uid_for(msg->attr->uid, msg->attr->uid),
-                       reverse_gid_for(msg->attr->gid, msg->attr->gid)) < 0)
+        if (MP_PLATFORM.chown(filename.u8string().c_str(),
+                              reverse_uid_for(msg->attr->uid, msg->attr->uid),
+                              reverse_gid_for(msg->attr->gid, msg->attr->gid)) < 0)
         {
             mpl::log(mpl::Level::trace,
                      category,


### PR DESCRIPTION
chown is a platform-specific function which depends uid and gid. these values are not available in Windows, and the chown impl is by default returns -1. This causes filesystem operation failures in Windows hosts when sshfs mounts are used in guests. One example is as follows:

ubuntu@foo:~/Downloads$ echo "test" > foo.txt
-bash: foo.txt: Operation not permitted

This operation fails because it first lands in handle_open, which eventually calls chown to change the file's owner, which is a failure by default in Windows.

The patch fixes that by introducing a shim function, chown_shim which returns success when either uid or gid is set to no_id_info_available.

MULTI-2155