### PR TITLE
[tests/cloud_init_iso] fix `read` mock stack overrun

### DIFF
--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -218,10 +218,16 @@ TEST_F(CloudInitIso, readsIsoFileJolietVolumeDescriptorMalformed)
 
     auto read_returns_five_bytes_string =
         [](std::ifstream& file, char* buffer, std::streamsize size) -> std::ifstream& {
-        [&] {
-            ASSERT_EQ(5, size);
-            ASSERT_NE(nullptr, buffer);
-        }();
+        if (size != 5)
+        {
+            throw std::invalid_argument{"Size must be 5."};
+        }
+
+        if (nullptr == buffer)
+        {
+            throw std::invalid_argument{"Buffer must not be null!"};
+        }
+
         constexpr char buf[] = {'N', 'o', 'n', 'J', 'o'};
         std::memcpy(buffer, buf, size);
         return file;

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -218,8 +218,10 @@ TEST_F(CloudInitIso, readsIsoFileJolietVolumeDescriptorMalformed)
 
     auto read_returns_five_bytes_string =
         [](std::ifstream& file, char* buffer, std::streamsize size) -> std::ifstream& {
-        EXPECT_EQ(5, size);
-        EXPECT_NE(nullptr, buffer);
+        [&] {
+            ASSERT_EQ(5, size);
+            ASSERT_NE(nullptr, buffer);
+        }();
         constexpr char buf[] = {'N', 'o', 'n', 'J', 'o'};
         std::memcpy(buffer, buf, size);
         return file;

--- a/tests/test_cloud_init_iso.cpp
+++ b/tests/test_cloud_init_iso.cpp
@@ -217,8 +217,11 @@ TEST_F(CloudInitIso, readsIsoFileJolietVolumeDescriptorMalformed)
         .WillOnce(original_implementation_of_read);
 
     auto read_returns_five_bytes_string =
-        [](std::ifstream& file, char* buffer, std::streamsize) -> std::ifstream& {
-        std::strcpy(buffer, "NonJo");
+        [](std::ifstream& file, char* buffer, std::streamsize size) -> std::ifstream& {
+        EXPECT_EQ(5, size);
+        EXPECT_NE(nullptr, buffer);
+        constexpr char buf[] = {'N', 'o', 'n', 'J', 'o'};
+        std::memcpy(buffer, buf, size);
         return file;
     };
     EXPECT_CALL(*mock_file_ops, read(An<std::ifstream&>(), A<char*>(), A<std::streamsize>()))


### PR DESCRIPTION
read_returns_five_bytes_string mock was using std::strcpy to copy five characters from the string "NonJo". In reality, strcpy always terminates the destination with a '\0', which leads to an overflow since the destination is a 5-byte stack-allocated buffer.

This patch fixes that by replacing std::strcpy with std::memcpy.

MULTI-2156