### PR TITLE
Implemented YAML Abstraction 

### DIFF
--- a/src/blueprint_provider/default_vm_blueprint_provider.cpp
+++ b/src/blueprint_provider/default_vm_blueprint_provider.cpp
@@ -176,14 +176,6 @@ auto blueprints_map_for(const std::string& archive_file_path,
     return blueprints_map;
 }
 
-std::string get_blueprint_version(const YAML::Node& blueprint_instance)
-{
-    if (blueprint_instance["images"])
-        return "v2";
-
-    return "v1";
-}
-
 void merge_yaml_entries(YAML::Node& ours,
                         const YAML::Node& theirs,
                         const std::string& key,
@@ -222,6 +214,185 @@ void merge_yaml_entries(YAML::Node& ours,
                                                     mp::utils::emit_yaml(theirs))};
 }
 
+// Abstract all of the following YAML schema boilerplate
+
+// Begin YAML schema handling abstraction
+struct BlueprintSchemaHandler
+{
+    const YAML::Node& blueprint_config;
+    const std::string& blueprint_name;
+    const QString& arch;
+    mp::URLDownloader* url_downloader;
+    bool& needs_update;
+    mp::VirtualMachineDescription& vm_desc;
+    mp::ClientLaunchData& client_launch_data;
+
+    mp::Query handle()
+    {
+        mp::Query query{"", "default", false, "", mp::Query::Type::Alias};
+
+        auto blueprint_instance = blueprint_config[instances_key][blueprint_name];
+
+        if (blueprint_config["blueprint-version"].as<std::string>() == version_v2)
+        {
+            auto arch_node = blueprint_instance["images"][arch.toStdString()];
+
+            if (arch_node["url"])
+                query.release = arch_node["url"].as<std::string>();
+            else
+                throw mp::InvalidBlueprintException(
+                    fmt::format("No image URL for architecture {} in Blueprint", arch));
+
+            query.query_type = mp::Query::Type::HttpDownload;
+
+            if (arch_node["sha256"])
+            {
+                auto sha256_string = arch_node["sha256"].as<std::string>();
+                if (QString::fromStdString(sha256_string).startsWith("http"))
+                {
+                    mpl::log(mpl::Level::debug,
+                             category,
+                             fmt::format("Downloading SHA256 from {}", sha256_string));
+                    auto downloaded_sha256 =
+                        url_downloader->download(QUrl(QString::fromStdString(sha256_string)));
+                    if (downloaded_sha256.size() > 64)
+                        downloaded_sha256.truncate(64);
+                    sha256_string = QString(downloaded_sha256).toStdString();
+                }
+                mpl::log(mpl::Level::debug,
+                         category,
+                         fmt::format("Add SHA256 \"{}\" to image record", sha256_string));
+                vm_desc.image.id = sha256_string;
+            }
+            else
+            {
+                mpl::log(mpl::Level::debug, category, "No SHA256 to check");
+            }
+        }
+        else if (blueprint_instance["image"])
+        {
+            auto image_str{blueprint_config[instances_key][blueprint_name]["image"].as<std::string>()};
+            auto tokens = mp::utils::split(image_str, ":");
+
+            if (tokens.size() == 2)
+            {
+                query.remote_name = tokens[0];
+                query.release = tokens[1];
+            }
+            else if (tokens.size() == 1)
+            {
+                query.release = tokens[0];
+            }
+            else
+            {
+                needs_update = true;
+                throw mp::InvalidBlueprintException("Unsupported image scheme in Blueprint");
+            }
+        }
+
+        if (blueprint_instance["limits"]["min-cpu"])
+        {
+            try
+            {
+                auto min_cpus = blueprint_instance["limits"]["min-cpu"].as<int>();
+
+                if (vm_desc.num_cores == 0)
+                {
+                    vm_desc.num_cores = min_cpus;
+                }
+                else if (vm_desc.num_cores < min_cpus)
+                {
+                    throw mp::BlueprintMinimumException("Number of CPUs", std::to_string(min_cpus));
+                }
+            }
+            catch (const YAML::BadConversion&)
+            {
+                needs_update = true;
+                throw mp::InvalidBlueprintException(
+                    fmt::format("Minimum CPU value in Blueprint is invalid"));
+            }
+        }
+
+        if (blueprint_instance["limits"]["min-mem"])
+        {
+            auto min_mem_size_str{blueprint_instance["limits"]["min-mem"].as<std::string>()};
+
+            try
+            {
+                mp::MemorySize min_mem_size{min_mem_size_str};
+
+                if (vm_desc.mem_size.in_bytes() == 0)
+                {
+                    vm_desc.mem_size = min_mem_size;
+                }
+                else if (vm_desc.mem_size < min_mem_size)
+                {
+                    throw mp::BlueprintMinimumException("Memory size", min_mem_size_str);
+                }
+            }
+            catch (const mp::InvalidMemorySizeException&)
+            {
+                needs_update = true;
+                throw mp::InvalidBlueprintException(
+                    fmt::format("Minimum memory size value in Blueprint is invalid"));
+            }
+        }
+
+        if (blueprint_instance["limits"]["min-disk"])
+        {
+            auto min_disk_space_str{blueprint_instance["limits"]["min-disk"].as<std::string>()};
+
+            try
+            {
+                mp::MemorySize min_disk_space{min_disk_space_str};
+
+                if (vm_desc.disk_space.in_bytes() == 0)
+                {
+                    vm_desc.disk_space = min_disk_space;
+                }
+                else if (vm_desc.disk_space < min_disk_space)
+                {
+                    throw mp::BlueprintMinimumException("Disk space", min_disk_space_str);
+                }
+            }
+            catch (const mp::InvalidMemorySizeException&)
+            {
+                needs_update = true;
+                throw mp::InvalidBlueprintException(
+                    fmt::format("Minimum disk space value in Blueprint is invalid"));
+            }
+        }
+
+        if (blueprint_instance["cloud-init"]["vendor-data"])
+        {
+            try
+            {
+                auto cloud_init_config =
+                    YAML::Load(blueprint_instance["cloud-init"]["vendor-data"].as<std::string>());
+                merge_yaml_entries(vm_desc.vendor_data_config, cloud_init_config, "vendor-data", true);
+            }
+            catch (const YAML::BadConversion&)
+            {
+                needs_update = true;
+                throw mp::InvalidBlueprintException(
+                    fmt::format("Cannot convert cloud-init data for the {} Blueprint", blueprint_name));
+            }
+        }
+
+        auto blueprint_workspaces = blueprint_instance["workspace"];
+        if (blueprint_workspaces && blueprint_workspaces.as<bool>())
+        {
+            mpl::log(mpl::Level::trace,
+                     category,
+                     fmt::format("Add workspace {} to RPC answer", blueprint_name));
+            client_launch_data.workspaces_to_be_created.push_back(blueprint_name);
+        }
+
+        return query;
+    }
+};
+
+// Blueprint YAML node parsing abstraction
 mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config,
                                    const std::string& blueprint_name,
                                    mp::VirtualMachineDescription& vm_desc,
@@ -230,216 +401,25 @@ mp::Query blueprint_from_yaml_node(YAML::Node& blueprint_config,
                                    mp::URLDownloader* url_downloader,
                                    bool& needs_update)
 {
-    mp::Query query{"", "default", false, "", mp::Query::Type::Alias};
-
-    if (!blueprint_config[instances_key][blueprint_name])
-    {
-        throw mp::InvalidBlueprintException(
-            fmt::format("There are no instance definitions matching Blueprint name \"{}\"",
-                        blueprint_name));
-    }
-
-    auto blueprint_instance = blueprint_config[instances_key][blueprint_name];
-
-    if (!blueprint_config["blueprint-version"])
-    {
-        blueprint_config["blueprint-version"] = get_blueprint_version(blueprint_instance);
-    }
-
-    mpl::log(mpl::Level::debug,
-             category,
-             fmt::format("Loading Blueprint \"{}\", version {}",
-                         blueprint_name,
-                         blueprint_config["blueprint-version"].as<std::string>()));
-
-    auto blueprint_aliases = blueprint_config["aliases"];
-    if (blueprint_aliases)
-    {
-        for (const auto& alias_to_be_defined : blueprint_aliases)
-        {
-            auto alias_name = alias_to_be_defined.first.as<std::string>();
-            auto instance_and_command =
-                mp::utils::split(alias_to_be_defined.second.as<std::string>(), ":");
-            if (instance_and_command.size() != 2)
-                throw mp::InvalidBlueprintException(
-                    fmt::format("Alias definition must be in the form instance:command"));
-
-            mpl::log(mpl::Level::trace,
-                     category,
-                     fmt::format("Add alias [{}, {}, {}] to RPC answer",
-                                 alias_name,
-                                 instance_and_command[0],
-                                 instance_and_command[1]));
-            mp::AliasDefinition alias_definition{instance_and_command[0],
-                                                 instance_and_command[1],
-                                                 "map"};
-            client_launch_data.aliases_to_be_created.emplace(alias_name, alias_definition);
-        }
-    }
-
-    // TODO: Abstract all of the following YAML schema boilerplate
-
-    if (blueprint_config["blueprint-version"].as<std::string>() == version_v2)
-    {
-        auto arch_node = blueprint_instance["images"][arch.toStdString()];
-
-        if (arch_node["url"])
-            query.release = arch_node["url"].as<std::string>();
-        else
-            throw mp::InvalidBlueprintException(
-                fmt::format("No image URL for architecture {} in Blueprint", arch));
-
-        query.query_type = mp::Query::Type::HttpDownload;
-
-        if (arch_node["sha256"])
-        {
-            auto sha256_string = arch_node["sha256"].as<std::string>();
-            if (QString::fromStdString(sha256_string).startsWith("http"))
-            {
-                mpl::log(mpl::Level::debug,
-                         category,
-                         fmt::format("Downloading SHA256 from {}", sha256_string));
-                auto downloaded_sha256 =
-                    url_downloader->download(QUrl(QString::fromStdString(sha256_string)));
-                if (downloaded_sha256.size() > 64)
-                    downloaded_sha256.truncate(64); // To account for newlines or other content.
-                sha256_string = QString(downloaded_sha256).toStdString();
-            }
-            mpl::log(mpl::Level::debug,
-                     category,
-                     fmt::format("Add SHA256 \"{}\" to image record", sha256_string));
-            vm_desc.image.id = sha256_string;
-        }
-        else
-        {
-            mpl::log(mpl::Level::debug, category, "No SHA256 to check");
-        }
-    }
-    else if (blueprint_instance["image"])
-    {
-        // This only supports the "alias" and "remote:alias" scheme at this time
-        auto image_str{blueprint_config[instances_key][blueprint_name]["image"].as<std::string>()};
-        auto tokens = mp::utils::split(image_str, ":");
-
-        if (tokens.size() == 2)
-        {
-            query.remote_name = tokens[0];
-            query.release = tokens[1];
-        }
-        else if (tokens.size() == 1)
-        {
-            query.release = tokens[0];
-        }
-        else
-        {
-            needs_update = true;
-            throw mp::InvalidBlueprintException("Unsupported image scheme in Blueprint");
-        }
-    }
-
-    if (blueprint_instance["limits"]["min-cpu"])
-    {
-        try
-        {
-            auto min_cpus = blueprint_instance["limits"]["min-cpu"].as<int>();
-
-            if (vm_desc.num_cores == 0)
-            {
-                vm_desc.num_cores = min_cpus;
-            }
-            else if (vm_desc.num_cores < min_cpus)
-            {
-                throw mp::BlueprintMinimumException("Number of CPUs", std::to_string(min_cpus));
-            }
-        }
-        catch (const YAML::BadConversion&)
-        {
-            needs_update = true;
-            throw mp::InvalidBlueprintException(
-                fmt::format("Minimum CPU value in Blueprint is invalid"));
-        }
-    }
-
-    if (blueprint_instance["limits"]["min-mem"])
-    {
-        auto min_mem_size_str{blueprint_instance["limits"]["min-mem"].as<std::string>()};
-
-        try
-        {
-            mp::MemorySize min_mem_size{min_mem_size_str};
-
-            if (vm_desc.mem_size.in_bytes() == 0)
-            {
-                vm_desc.mem_size = min_mem_size;
-            }
-            else if (vm_desc.mem_size < min_mem_size)
-            {
-                throw mp::BlueprintMinimumException("Memory size", min_mem_size_str);
-            }
-        }
-        catch (const mp::InvalidMemorySizeException&)
-        {
-            needs_update = true;
-            throw mp::InvalidBlueprintException(
-                fmt::format("Minimum memory size value in Blueprint is invalid"));
-        }
-    }
-
-    if (blueprint_instance["limits"]["min-disk"])
-    {
-        auto min_disk_space_str{blueprint_instance["limits"]["min-disk"].as<std::string>()};
-
-        try
-        {
-            mp::MemorySize min_disk_space{min_disk_space_str};
-
-            if (vm_desc.disk_space.in_bytes() == 0)
-            {
-                vm_desc.disk_space = min_disk_space;
-            }
-            else if (vm_desc.disk_space < min_disk_space)
-            {
-                throw mp::BlueprintMinimumException("Disk space", min_disk_space_str);
-            }
-        }
-        catch (const mp::InvalidMemorySizeException&)
-        {
-            needs_update = true;
-            throw mp::InvalidBlueprintException(
-                fmt::format("Minimum disk space value in Blueprint is invalid"));
-        }
-    }
-
-    if (blueprint_instance["cloud-init"]["vendor-data"])
-    {
-        try
-        {
-            auto cloud_init_config =
-                YAML::Load(blueprint_instance["cloud-init"]["vendor-data"].as<std::string>());
-            merge_yaml_entries(vm_desc.vendor_data_config, cloud_init_config, "vendor-data", true);
-        }
-        catch (const YAML::BadConversion&)
-        {
-            needs_update = true;
-            throw mp::InvalidBlueprintException(
-                fmt::format("Cannot convert cloud-init data for the {} Blueprint", blueprint_name));
-        }
-    }
-
-    auto blueprint_workspaces = blueprint_instance["workspace"];
-    if (blueprint_workspaces && blueprint_workspaces.as<bool>())
-    {
-        mpl::log(mpl::Level::trace,
-                 category,
-                 fmt::format("Add workspace {} to RPC answer", blueprint_name));
-        client_launch_data.workspaces_to_be_created.push_back(blueprint_name);
-    }
-
-    return query;
+    BlueprintSchemaHandler handler{
+        blueprint_config,
+        blueprint_name,
+        arch,
+        url_downloader,
+        needs_update,
+        vm_desc,
+        client_launch_data
+    };
+    return handler.handle();
 }
-} // namespace
+// End YAML schema handling abstraction
 
-mp::DefaultVMBlueprintProvider::DefaultVMBlueprintProvider(
+} // end anonymous namespace
+
+namespace multipass
+{
+
+DefaultVMBlueprintProvider::DefaultVMBlueprintProvider(
     const QUrl& blueprints_url,
     URLDownloader* downloader,
     const QDir& archive_dir,
@@ -454,7 +434,7 @@ mp::DefaultVMBlueprintProvider::DefaultVMBlueprintProvider(
     update_blueprints();
 }
 
-mp::DefaultVMBlueprintProvider::DefaultVMBlueprintProvider(
+DefaultVMBlueprintProvider::DefaultVMBlueprintProvider(
     URLDownloader* downloader,
     const QDir& archive_dir,
     const std::chrono::milliseconds& blueprints_ttl,
@@ -467,9 +447,9 @@ mp::DefaultVMBlueprintProvider::DefaultVMBlueprintProvider(
 {
 }
 
-mp::Query mp::DefaultVMBlueprintProvider::fetch_blueprint_for(const std::string& blueprint_name,
-                                                              VirtualMachineDescription& vm_desc,
-                                                              ClientLaunchData& client_launch_data)
+mp::Query DefaultVMBlueprintProvider::fetch_blueprint_for(const std::string& blueprint_name,
+                                                         VirtualMachineDescription& vm_desc,
+                                                         ClientLaunchData& client_launch_data)
 {
     update_blueprints();
 
@@ -484,10 +464,10 @@ mp::Query mp::DefaultVMBlueprintProvider::fetch_blueprint_for(const std::string&
                                     needs_update);
 }
 
-mp::Query mp::DefaultVMBlueprintProvider::blueprint_from_file(const std::string& path,
-                                                              const std::string& blueprint_name,
-                                                              VirtualMachineDescription& vm_desc,
-                                                              ClientLaunchData& client_launch_data)
+mp::Query DefaultVMBlueprintProvider::blueprint_from_file(const std::string& path,
+                                                         const std::string& blueprint_name,
+                                                         VirtualMachineDescription& vm_desc,
+                                                         ClientLaunchData& client_launch_data)
 {
     mpl::log(mpl::Level::debug,
              category,
@@ -525,8 +505,7 @@ mp::Query mp::DefaultVMBlueprintProvider::blueprint_from_file(const std::string&
                                     needs_update);
 }
 
-std::optional<mp::VMImageInfo> mp::DefaultVMBlueprintProvider::info_for(
-    const std::string& blueprint_name)
+std::optional<mp::VMImageInfo> DefaultVMBlueprintProvider::info_for(const std::string& blueprint_name)
 {
     update_blueprints();
 
@@ -584,7 +563,7 @@ std::optional<mp::VMImageInfo> mp::DefaultVMBlueprintProvider::info_for(
     return image_info;
 }
 
-std::vector<mp::VMImageInfo> mp::DefaultVMBlueprintProvider::all_blueprints()
+std::vector<mp::VMImageInfo> DefaultVMBlueprintProvider::all_blueprints()
 {
     update_blueprints();
 
@@ -601,7 +580,7 @@ std::vector<mp::VMImageInfo> mp::DefaultVMBlueprintProvider::all_blueprints()
         }
         catch (const InvalidBlueprintException& e)
         {
-            // Don't force updates in info_for() since we are looping and only force the update once
+            // Do not force updates in info_for() since we are looping and only force the update once
             // we finish iterating.
             needs_update = false;
             will_need_update = true;
@@ -621,7 +600,7 @@ std::vector<mp::VMImageInfo> mp::DefaultVMBlueprintProvider::all_blueprints()
     return blueprint_info;
 }
 
-std::string mp::DefaultVMBlueprintProvider::name_from_blueprint(const std::string& blueprint_name)
+std::string DefaultVMBlueprintProvider::name_from_blueprint(const std::string& blueprint_name)
 {
     if (blueprint_map.count(blueprint_name) == 1)
         return blueprint_name;
@@ -639,7 +618,7 @@ std::string mp::DefaultVMBlueprintProvider::name_from_blueprint(const std::strin
     return {};
 }
 
-int mp::DefaultVMBlueprintProvider::blueprint_timeout(const std::string& blueprint_name)
+int DefaultVMBlueprintProvider::blueprint_timeout(const std::string& blueprint_name)
 {
     auto timeout_seconds{0};
 
@@ -672,7 +651,7 @@ int mp::DefaultVMBlueprintProvider::blueprint_timeout(const std::string& bluepri
     return timeout_seconds;
 }
 
-void mp::DefaultVMBlueprintProvider::fetch_blueprints()
+void DefaultVMBlueprintProvider::fetch_blueprints()
 {
     url_downloader->download_to(blueprints_url, archive_file_path, -1, -1, [](auto...) {
         return true;
@@ -682,7 +661,7 @@ void mp::DefaultVMBlueprintProvider::fetch_blueprints()
         blueprints_map_for(archive_file_path.toStdString(), needs_update, arch.toStdString());
 }
 
-void mp::DefaultVMBlueprintProvider::update_blueprints()
+void DefaultVMBlueprintProvider::update_blueprints()
 {
     const auto now = std::chrono::steady_clock::now();
     if ((now - last_update) > blueprints_ttl || needs_update)
@@ -707,3 +686,5 @@ void mp::DefaultVMBlueprintProvider::update_blueprints()
         }
     }
 }
+
+} // namespace multipass


### PR DESCRIPTION
I opened this PR because I implemented (I think it's OK) the TODO in the modified file:
- The code that handled the “YAML boilerplate schema” for blueprints has been abstracted into the BlueprintSchemaHandler struct and the blueprint_from_yaml_node method.
- The YAML parsing and validation logic for blueprints is centralized and reusable.

This is useful because:
- It reduces code duplication: By centralizing the YAML parsing and validation logic, you avoid repeating the same code in multiple places.
- It handles error centralization: All exceptions and checks are handled uniformly.