### PR TITLE
Update ssh_client.cpp

### DIFF
--- a/src/ssh/ssh_client.cpp
+++ b/src/ssh/ssh_client.cpp
@@ -171,10 +171,10 @@ int mp::SSHClient::exec_string(const std::string& cmd_line)
             ssh_string_free_char(exit_signal_status);
         }
         return static_cast<int>(exit_status);
-    } else {
-        if (exit_signal_status != nullptr) {
-            ssh_string_free_char(exit_signal_status);
-        }
-        return -1;
     }
+    
+    if (exit_signal_status != nullptr) {
+        ssh_string_free_char(exit_signal_status);
+    }
+    return -1;
 }


### PR DESCRIPTION
Fixes #4227 

The modified file contains one of the deprecated function `ssh_channel_get_exit_status`. Replaced it with `ssh_channel_get_exit_state`.

@sharder996 