### PR TITLE
[macos] remove unused gRPC socket definition

### DIFF
--- a/packaging/macos/com.canonical.multipassd.plist.in
+++ b/packaging/macos/com.canonical.multipassd.plist.in
@@ -21,17 +21,6 @@
     <key>KeepAlive</key>
     <true/>
 
-    <key>Sockets</key>
-    <dict>
-       <key>Listeners</key>
-       <dict>
-            <key>SockServiceName</key>
-            <string>50051</string>
-            <key>SockType</key>
-            <string>stream</string>
-        </dict>
-    </dict>
-
     <key>StandardOutPath</key>
     <string>/Library/Logs/Multipass/multipassd.log</string>
     <key>StandardErrorPath</key>


### PR DESCRIPTION
resolves #4287 

Old versions of Multipass on MacOS had launchd listen to a hardcoded tcp socket opened at port 50051. This was updated in https://github.com/canonical/multipass/commit/0f77459b9aa3ebba13100bd63898b8b25aede952 but the definition in the plist file was never updated.  This PR removes the unused TCP socket from being created on port 50051