### PR TITLE
[macos] Increase the timeout for launchd

### DIFF
--- a/packaging/macos/com.canonical.multipassd.plist.in
+++ b/packaging/macos/com.canonical.multipassd.plist.in
@@ -25,6 +25,9 @@
     <string>/Library/Logs/Multipass/multipassd.log</string>
     <key>StandardErrorPath</key>
     <string>/Library/Logs/Multipass/multipassd.log</string>
+
+    <key>ExitTimeOut</key>
+    <integer>45</integer>
 </dict>
 
 </plist>


### PR DESCRIPTION
Increase the timeout after which launchd tires to wait for the daemon to
quit on SIGTERM and sends it a SIGKILL. The daemon can take a while to
quit before suspending VMs finish writing to disk. Fixes #4319.
