### PR TITLE
[gui] Add certificate check to grpc client

### DIFF
--- a/include/multipass/dart_ffi.h
+++ b/include/multipass/dart_ffi.h
@@ -18,6 +18,8 @@ struct KeyCertificatePair
 
 struct KeyCertificatePair get_cert_pair();
 
+char* get_root_cert();
+
 enum SettingResult
 {
     Ok,

--- a/src/client/gui/ffi/dart_ffi.cpp
+++ b/src/client/gui/ffi/dart_ffi.cpp
@@ -95,6 +95,26 @@ struct KeyCertificatePair get_cert_pair()
     }
 }
 
+char* get_root_cert()
+{
+    static constexpr auto error = "failed retrieving root certificate";
+    try
+    {
+        const auto cert = MP_UTILS.contents_of(MP_PLATFORM.get_root_cert_path().u8string().c_str());
+        return strdup(cert.c_str());
+    }
+    catch (const std::exception& e)
+    {
+        mpl::warn(category, fmt::format("{}: {}", error, e.what()));
+        return nullptr;
+    }
+    catch (...)
+    {
+        mpl::warn(category, error);
+        return nullptr;
+    }
+}
+
 static std::once_flag initialize_settings_once_flag;
 
 char* settings_file()

--- a/src/client/gui/ffi/dart_ffi.cpp
+++ b/src/client/gui/ffi/dart_ffi.cpp
@@ -100,7 +100,8 @@ char* get_root_cert()
     static constexpr auto error = "failed retrieving root certificate";
     try
     {
-        const auto cert = MP_UTILS.contents_of(MP_PLATFORM.get_root_cert_path().u8string().c_str());
+        const auto cert_path = MP_PLATFORM.get_root_cert_path();
+        const auto cert = MP_UTILS.contents_of(QString::fromStdU16String(cert_path.u16string()));
         return strdup(cert.c_str());
     }
     catch (const std::exception& e)

--- a/src/client/gui/lib/ffi.dart
+++ b/src/client/gui/lib/ffi.dart
@@ -137,6 +137,11 @@ class KeyCertificatePair {
 final _getCertPair = _lib.lookupFunction<_NativeKeyCertificatePair Function(),
     _NativeKeyCertificatePair Function()>('get_cert_pair');
 
+final _getRootCert = _lib
+    .lookupFunction<ffi.Pointer<Utf8> Function(), ffi.Pointer<Utf8> Function()>(
+  'get_root_cert',
+);
+
 String get multipassVersion => _multipassVersion().toDartString();
 
 String generatePetname([Iterable<String> existing = const []]) {
@@ -167,6 +172,10 @@ KeyCertificatePair getCertPair() {
   final cert = utf8.encode(pair.pem_cert.string);
   final key = utf8.encode(pair.pem_cert_key.string);
   return KeyCertificatePair(cert, key);
+}
+
+List<int> getRootCert() {
+  return utf8.encode(_getRootCert().string);
 }
 
 String settingsFile() => _settingsFile().string;

--- a/src/client/gui/lib/grpc_client.dart
+++ b/src/client/gui/lib/grpc_client.dart
@@ -239,20 +239,22 @@ class GrpcClient {
 class CustomChannelCredentials extends ChannelCredentials {
   final List<int> certificateChain;
   final List<int> certificateKey;
+  final List<int> rootCertificate;
 
   CustomChannelCredentials({
     super.authority,
     required List<int> certificate,
     required this.certificateKey,
+    required this.rootCertificate,
   })  : certificateChain = certificate,
         super.secure(
           certificates: certificate,
-          onBadCertificate: allowBadCertificates,
         );
 
   @override
   SecurityContext get securityContext {
     final ctx = super.securityContext!;
+    ctx.setTrustedCertificatesBytes(rootCertificate);
     ctx.useCertificateChainBytes(certificateChain);
     ctx.usePrivateKeyBytes(certificateKey);
     return ctx;

--- a/src/client/gui/lib/providers.dart
+++ b/src/client/gui/lib/providers.dart
@@ -29,11 +29,13 @@ final grpcClientProvider = Provider((ref) {
 
   final address = getServerAddress();
   final certPair = getCertPair();
+  final rootCert = getRootCert();
 
   var channelCredentials = CustomChannelCredentials(
     authority: 'localhost',
     certificate: certPair.cert,
     certificateKey: certPair.key,
+    rootCertificate: rootCert,
   );
 
   return GrpcClient(


### PR DESCRIPTION
This pull request introduces support for loading and using a root certificate for secure gRPC connections in the client GUI. The changes add a new FFI binding and retrieval method for the root certificate, update the credentials handling to include the root certificate, and propagate this through the provider setup.

**Certificate Management Improvements:**

* Added a new FFI function `get_root_cert` in both C++ (`dart_ffi.cpp`) and Dart (`ffi.dart`) to retrieve the root certificate from the platform. [[1]](diffhunk://#diff-ed42989e5f6878e79523cbc2b507752aae44f3c4ca80ba052c743a48cd218d7fR21-R22) [[2]](diffhunk://#diff-cbb1d58f70f76ec2eaf0b1aca1a176bb82bcbf480341ccb19d4d033f4be1f11cR98-R118) [[3]](diffhunk://#diff-0a91f284d9074caf859890b9d92d83e3eaeb2963f74491605435b5124bf5107bR140-R144) [[4]](diffhunk://#diff-0a91f284d9074caf859890b9d92d83e3eaeb2963f74491605435b5124bf5107bR177-R180)
* Updated the `CustomChannelCredentials` class in `grpc_client.dart` to include a `rootCertificate` field and set trusted certificates using the root certificate bytes in the security context.

**Provider Integration:**

* Modified the gRPC client provider in `providers.dart` to retrieve and pass the root certificate to `CustomChannelCredentials` when creating the gRPC client.


MULTI-1798