### PR TITLE
[sftp-tests] Fix UBs in the test code

### DIFF
--- a/tests/test_sftp_client.cpp
+++ b/tests/test_sftp_client.cpp
@@ -926,7 +926,7 @@ TEST_F(SFTPClient, pullDirSuccessSymlink)
         .WillOnce(Return(
             make_unique_dummy_sftp_attr(SSH_FILEXFER_TYPE_SYMLINK, source_path / "symlink")));
 
-    REPLACE(sftp_readlink, [](auto...) { return (char*)malloc(10); });
+    REPLACE(sftp_readlink, [](auto...) { return strdup("dummy/link"); });
     EXPECT_CALL(*mock_file_ops, is_directory).WillOnce(Return(false));
     EXPECT_CALL(*mock_file_ops, remove(_, _)).WillOnce(Return(true));
     EXPECT_CALL(*mock_file_ops, create_symlink(_, target_path / "symlink", _));
@@ -983,7 +983,7 @@ TEST_F(SFTPClient, pullDirCannotCreateSymlink)
         .WillOnce(Return(
             make_unique_dummy_sftp_attr(SSH_FILEXFER_TYPE_SYMLINK, source_path / "symlink")));
 
-    REPLACE(sftp_readlink, [](auto...) { return (char*)malloc(10); });
+    REPLACE(sftp_readlink, [](auto...) { return strdup("dummy/link"); });
     EXPECT_CALL(*mock_file_ops, is_directory).WillOnce(Return(false));
     EXPECT_CALL(*mock_file_ops, remove(_, _)).WillOnce(Return(true));
     auto err = std::make_error_code(std::errc::permission_denied);
@@ -1015,7 +1015,7 @@ TEST_F(SFTPClient, pullDirSymlinkOverDir)
         .WillOnce(Return(
             make_unique_dummy_sftp_attr(SSH_FILEXFER_TYPE_SYMLINK, source_path / "symlink")));
 
-    REPLACE(sftp_readlink, [](auto...) { return (char*)malloc(10); });
+    REPLACE(sftp_readlink, [](auto...) { return strdup("dummy/link"); });
     EXPECT_CALL(*mock_file_ops, is_directory).WillOnce(Return(true));
     EXPECT_CALL(mock_platform, set_permissions(_, _, _)).WillRepeatedly(Return(true));
 


### PR DESCRIPTION
The sftp_attributes struct allocated by calloc was wrapped by a unique
pointer in some instances without specifying a custom deleter, which in
turn causes the allocated memory to be freed by ::delete, causing a
mismatch.

The patch fixes that by replacing all such instances with a correct
unique_ptr with custom deleter.

Signed-off-by: Mustafa Kemal Gilor <mustafa.gilor@canonical.com>