### PR TITLE
[test-platform-linux] Override libvirt.so properly

### DIFF
--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.cpp
@@ -125,7 +125,7 @@ mp::LibVirtVirtualMachineFactory::LibVirtVirtualMachineFactory(
 }
 
 mp::LibVirtVirtualMachineFactory::LibVirtVirtualMachineFactory(const mp::Path& data_dir)
-    : LibVirtVirtualMachineFactory(data_dir, "libvirt.so.0")
+    : LibVirtVirtualMachineFactory(data_dir, default_libvirt_object_path)
 {
 }
 

--- a/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine_factory.h
@@ -47,6 +47,8 @@ public:
     // Making this public makes this modifiable which is necessary for testing
     LibvirtWrapper::UPtr libvirt_wrapper;
 
+    inline static std::string default_libvirt_object_path{"libvirt.so.0"};
+
 protected:
     void remove_resources_for_impl(const std::string& name) override;
 

--- a/tests/linux/test_platform_linux.cpp
+++ b/tests/linux/test_platform_linux.cpp
@@ -83,7 +83,24 @@ struct PlatformLinux : public mpt::TestWithMockedBinPath
 
     void with_minimally_mocked_libvirt(std::function<void()> test_contents)
     {
-        mp::LibvirtWrapper libvirt_wrapper{""};
+        // Override the libvirt path with "" so the wrapper would load the mock
+        // implementation during the test. It's hacky, but good enough for now
+        // since we're going to remove the libvirt backend anyway.
+        struct OverrideLibvirtPath
+        {
+            OverrideLibvirtPath()
+                : prev(multipass::LibVirtVirtualMachineFactory::default_libvirt_object_path)
+            {
+                multipass::LibVirtVirtualMachineFactory::default_libvirt_object_path = "";
+            }
+            ~OverrideLibvirtPath()
+            {
+                multipass::LibVirtVirtualMachineFactory::default_libvirt_object_path = prev;
+            }
+
+        private:
+            std::string prev;
+        } const b;
         test_contents();
     }
 


### PR DESCRIPTION
The with_minimally_mocked_libvirt function was constructing a new
libvirt wrapper before the test body, but it's essentially a no-op
since the libvirt factory uses its own instance of the wrapper.

The patch fixes that by properly overriding the default libvirt.so
path so the mock implementation would be loaded.

Signed-off-by: Mustafa Kemal Gilor <mustafa.gilor@canonical.com>