### PR TITLE
[daemon] Improve file URL error message (#4198)

### DIFF
--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -281,6 +281,12 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
         QUrl image_url(QString::fromStdString(query.release));
         VMImage source_image, vm_image;
 
+        if (image_url.host().size() != 0)
+            throw std::runtime_error(fmt::format("Unexpected hostname in file URL; did you mean "
+                                                 "`file:///{}/{}`? (Note the third slash.)",
+                                                 image_url.host(),
+                                                 image_url.path()));
+
         if (!QFile::exists(image_url.path()))
             throw std::runtime_error(
                 fmt::format("Custom image `{}` does not exist.", image_url.path()));


### PR DESCRIPTION
Local file URLs should have three slashes after "file:".

This just adds an error message alerting the user to the fact that non-local file URLs aren't supported (at least, not yet), and suggesting a fix. The wording feels a little clumsy to me, but I'm not sure of a better way to phrase it without becoming confusing.