### PR TITLE
[cloud-init] Expand /dev for core images

### DIFF
--- a/src/daemon/base_cloud_init_config.h
+++ b/src/daemon/base_cloud_init_config.h
@@ -20,7 +20,7 @@ namespace multipass
 {
 constexpr auto base_cloud_init_config = "growpart:\n"
                                         "    mode: auto\n"
-                                        "    devices: [\"/\"]\n"
+                                        "    devices: [\"/\", \"/dev\"]\n"
                                         "    ignore_growroot_disabled: false\n"
                                         "users:\n"
                                         "    - default\n"

--- a/tests/test_daemon.cpp
+++ b/tests/test_daemon.cpp
@@ -832,9 +832,9 @@ TEST_P(DaemonCreateLaunchTestSuite, defaultCloudInitGrowsRootFs)
                 auto const& growpart_stanza = desc.vendor_data_config["growpart"];
 
                 EXPECT_THAT(growpart_stanza, YAMLNodeContainsString("mode", "auto"));
-                EXPECT_THAT(
-                    growpart_stanza,
-                    YAMLNodeContainsStringArray("devices", std::vector<std::string>({"/"})));
+                EXPECT_THAT(growpart_stanza,
+                            YAMLNodeContainsStringArray("devices",
+                                                        std::vector<std::string>({"/", "/dev"})));
                 EXPECT_THAT(growpart_stanza,
                             YAMLNodeContainsString("ignore_growroot_disabled", "false"));
             }


### PR DESCRIPTION
- Prioritize the `/` mount point, but expand the `/dev` partition for Ubuntu Core images

Fixes #3229 

---

MULTI-2227