### PR TITLE
[ci] Enable coredump upload for macOS

### DIFF
--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -277,6 +277,7 @@ jobs:
 
     - name: Enable coredump
       if: ${{ runner.os == 'macOS' }}
+      working-directory: ${{ env.BUILD_DIR }}
       shell: bash
       run : |
         # Allow core dumps and set size to unlimited for this shell

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -307,7 +307,7 @@ jobs:
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
       if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE != '0' && runner.os == 'macOS' }}
-      timeout-minutes: 15
+      timeout-minutes: 30
       with:
         limit-access-to-actor: true
 

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -308,7 +308,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE != '0' && runner.os == 'macOS' }}
       with:
-        name: buildandtest-test-crash-${{ runner.os }}-${{ matrix.build-type }}
+        name: buildandtest-test-crash-${{ matrix.runs-on }}-${{ matrix.build-type }}
         path: |
           /cores/**
           bin/multipass_tests

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -275,10 +275,33 @@ jobs:
       if: ${{ runner.os == 'macOS' }}
       run: ccache --show-stats --zero-stats
 
+    - name: Enable coredump
+      if: ${{ runner.os == 'macOS' }}
+      run : |
+        # Allow core dumps and set size to unlimited for this shell
+        sudo sysctl -w kern.coredump=1
+        ulimit -c unlimited
+
+        # Ensure destination exists and is writable
+        sudo mkdir -p /cores
+        sudo chmod 1777 /cores
+
+        # Set filename pattern (macOS supports %N = process name, %P = pid)
+        sudo sysctl -w kern.corefile=/cores/%N.%P
+
     - name: Test
       working-directory: ${{ env.BUILD_DIR }}
+      shell: bash
       run: |
+        trap 'echo "MULTIPASS_TESTS_EXIT_CODE=$?" >> $GITHUB_ENV' EXIT
         ${{ env.ARCH_WRAPPER }} bin/multipass_tests
+
+    - name: Upload test coredump
+      uses: actions/upload-artifact@v4
+      if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE != '0' && runner.os == 'macOS' }}
+      with:
+        name: buildandtest-test-crash-${{ runner.os }}-${{ matrix.build-type }}
+        path: /cores/**
 
     - name: Package
       id: cmake-package

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -304,6 +304,13 @@ jobs:
         ulimit -c unlimited
         ${{ env.ARCH_WRAPPER }} bin/multipass_tests
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE != '0' && runner.os == 'macOS' }}
+      timeout-minutes: 15
+      with:
+        limit-access-to-actor: true
+
     - name: Upload test coredump
       uses: actions/upload-artifact@v4
       if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE != '0' && runner.os == 'macOS' }}

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -277,20 +277,14 @@ jobs:
 
     - name: Enable coredump
       if: ${{ runner.os == 'macOS' }}
+      shell: bash
       run : |
         # Allow core dumps and set size to unlimited for this shell
         sudo sysctl -w kern.coredump=1
-        sudo launchctl limit core unlimited || true
-        ulimit -c unlimited || true
-
-        echo 'ulimit -Sc unlimited' >> "$BASH_ENV"
-
         # This entitlement is needed for a proc to produce a coredump
         /usr/libexec/PlistBuddy -c "Add :com.apple.security.get-task-allow bool true" segv.entitlements
-
         # Code-sign the test executable to grant core dump entitlement
         codesign -s - -f --entitlements segv.entitlements bin/multipass_tests
-
         # Ensure destination exists and is writable
         sudo mkdir -p /cores || true
         sudo chmod 1777 /cores
@@ -306,6 +300,7 @@ jobs:
       shell: bash
       run: |
         trap 'echo "MULTIPASS_TESTS_EXIT_CODE=$?" >> $GITHUB_ENV' EXIT
+        ulimit -c unlimited
         ${{ env.ARCH_WRAPPER }} bin/multipass_tests
 
     - name: Upload test coredump

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -280,14 +280,18 @@ jobs:
       run : |
         # Allow core dumps and set size to unlimited for this shell
         sudo sysctl -w kern.coredump=1
+        launchctl limit core unlimited
         ulimit -c unlimited
 
         # Ensure destination exists and is writable
-        sudo mkdir -p /cores
-        sudo chmod 1777 /cores
+        mkdir -p "$GITHUB_WORKSPACE/cores"
+        sudo sysctl kern.corefile="$GITHUB_WORKSPACE/cores/core.%N.%P"
 
-        # Set filename pattern (macOS supports %N = process name, %P = pid)
-        sudo sysctl -w kern.corefile=/cores/%N.%P
+    - name: Print syctl coredump parameters
+      if: ${{ runner.os == 'macOS' }}
+      run : |
+        sysctl kern.coredump kern.corefile
+        ulimit -a
 
     - name: Test
       working-directory: ${{ env.BUILD_DIR }}
@@ -301,7 +305,9 @@ jobs:
       if: ${{ failure() && env.MULTIPASS_TESTS_EXIT_CODE != '0' && runner.os == 'macOS' }}
       with:
         name: buildandtest-test-crash-${{ runner.os }}-${{ matrix.build-type }}
-        path: /cores/**
+        path: |
+          cores/**
+          bin/multipass_tests
 
     - name: Package
       id: cmake-package

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -280,12 +280,20 @@ jobs:
       run : |
         # Allow core dumps and set size to unlimited for this shell
         sudo sysctl -w kern.coredump=1
-        launchctl limit core unlimited
-        ulimit -c unlimited
+        sudo launchctl limit core unlimited || true
+        ulimit -c unlimited || true
+
+        echo 'ulimit -Sc unlimited' >> "$BASH_ENV"
+
+        # This entitlement is needed for a proc to produce a coredump
+        /usr/libexec/PlistBuddy -c "Add :com.apple.security.get-task-allow bool true" segv.entitlements
+
+        # Code-sign the test executable to grant core dump entitlement
+        codesign -s - -f --entitlements segv.entitlements bin/multipass_tests
 
         # Ensure destination exists and is writable
-        mkdir -p "$GITHUB_WORKSPACE/cores"
-        sudo sysctl kern.corefile="$GITHUB_WORKSPACE/cores/core.%N.%P"
+        sudo mkdir -p /cores || true
+        sudo chmod 1777 /cores
 
     - name: Print syctl coredump parameters
       if: ${{ runner.os == 'macOS' }}
@@ -306,7 +314,7 @@ jobs:
       with:
         name: buildandtest-test-crash-${{ runner.os }}-${{ matrix.build-type }}
         path: |
-          cores/**
+          /cores/**
           bin/multipass_tests
 
     - name: Package

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -280,7 +280,7 @@ jobs:
       working-directory: ${{ env.BUILD_DIR }}
       shell: bash
       run : |
-        # Allow core dumps and set size to unlimited for this shell
+        # Allow core dumps
         sudo sysctl -w kern.coredump=1
         # This entitlement is needed for a proc to produce a coredump
         /usr/libexec/PlistBuddy -c "Add :com.apple.security.get-task-allow bool true" segv.entitlements
@@ -301,7 +301,7 @@ jobs:
       shell: bash
       run: |
         trap 'echo "MULTIPASS_TESTS_EXIT_CODE=$?" >> $GITHUB_ENV' EXIT
-        ulimit -c unlimited
+        ulimit -c 524288
         ${{ env.ARCH_WRAPPER }} bin/multipass_tests
 
     - name: Setup tmate session

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -19,6 +19,7 @@
 #include "mock_standard_paths.h"
 
 #include <QCoreApplication>
+#include <google/protobuf/stubs/common.h>
 
 namespace mp = multipass;
 
@@ -26,6 +27,8 @@ namespace mp = multipass;
 // also define main... DAMN THEM!
 int main(int argc, char* argv[])
 {
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
     QCoreApplication app(argc, argv);
     QCoreApplication::setApplicationName("multipass_tests");
 


### PR DESCRIPTION
Mostly CI improvements as a result of 2-day troubleshooting macos-15 crash session:

- ~~Enable coredump generation for multipass_tests by codesigning it with a proper entitlement~~
- ~~Enable coredump generation at kernel level by setting `kern.coredump` and `kern.corefile`~~
- ~~Upload core dump + test executable to GitHub Artifacts on segv~~
- Enable tmate session when test execution fails with segv
- ~~Add protobuf version validation macro to the tests/main.cpp~~
- ~~Get rid of the generate_grpc_cpp, use protobuf_generate function~~
- ~~Pin macos-15 xcode version to 16.0~~

Signed-off-by: Mustafa Kemal Gilor <mustafa.gilor@canonical.com>