### PR TITLE
[docs] Fix linux build instructions

### DIFF
--- a/BUILD.linux.md
+++ b/BUILD.linux.md
@@ -93,6 +93,12 @@ Optionally, enable auto-complete in Bash:
 source <multipass>/completions/bash/multipass
 ```
 
+To be able to use the binaries without specifying their path:
+
+```
+export PATH=<build-dir>/bin
+```
+
 Now you can use the `multipass` command from your terminal (for example
 `<multipass>/build/bin/multipass launch --name foo`) or launch the GUI client with the command
 `<multipass>/build/bin/multipass.gui`.

--- a/BUILD.linux.md
+++ b/BUILD.linux.md
@@ -84,7 +84,7 @@ Copy the desktop file that Multipass clients expect to find in your home:
 
 ```
 mkdir -p ~/.local/share/multipass/
-cp <multipass>/data/multipass.gui.autostart.desktop ~/.local/share/multipass/
+cp <multipass>/src/client/gui/assets/multipass.gui.autostart.desktop ~/.local/share/multipass/
 ```
 
 Optionally, enable auto-complete in Bash:


### PR DESCRIPTION
Fixes autostart file path in the linux build instructions. 
Also adds an additional recommendation to said instructions.