### PR TITLE
[windows-macos] Macos-15: use xcode 16.0 

### DIFF
--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -114,11 +114,14 @@ jobs:
         fetch-depth: 0 # Need full history to derive version
         submodules: 'recursive'
 
-    # Use specific xcode version in macos-15
+    # Use specific xcode version in macos-15. The reason is that protobuf 29 is not
+    # happy with the AppleClang-17, which is shipped with Xcode >= 16.3.
+    #
+    # https://github.com/protocolbuffers/protobuf/issues/21447
     - uses: maxim-lobanov/setup-xcode@v1
       if: ${{ contains(matrix.runs-on, 'macos-15') }}
       with:
-        xcode-version: '16.0'
+        xcode-version: '16.2'
 
     - name: Enable symlinks
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
The protobuf 29 is not happy with the AppleClang17; this patch fixes that by pinning the Xcode version to 16 for now.

https://github.com/protocolbuffers/protobuf/issues/21447