### PR TITLE
[cmake] Add cmake preset for clang sanitizer build

### DIFF
--- a/3rd-party/vcpkg-triplets/x64-linux-sanitizers.cmake
+++ b/3rd-party/vcpkg-triplets/x64-linux-sanitizers.cmake
@@ -1,0 +1,17 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Force debug build
+# Force compilers
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+set(VCPKG_C_FLAGS           "${VCPKG_C_FLAGS} -fno-omit-frame-pointer")
+set(VCPKG_CXX_FLAGS         "${VCPKG_CXX_FLAGS} -fno-omit-frame-pointer")
+
+set(VCPKG_C_FLAGS_DEBUG     "${VCPKG_C_FLAGS_DEBUG} -O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error")
+set(VCPKG_CXX_FLAGS_DEBUG   "${VCPKG_CXX_FLAGS_DEBUG} -O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error")
+set(VCPKG_LINKER_FLAGS_DEBUG "${VCPKG_LINKER_FLAGS_DEBUG} -fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error")

--- a/3rd-party/vcpkg-triplets/x64-linux-sanitizers.cmake
+++ b/3rd-party/vcpkg-triplets/x64-linux-sanitizers.cmake
@@ -9,9 +9,13 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)
 
-set(VCPKG_C_FLAGS           "${VCPKG_C_FLAGS} -fno-omit-frame-pointer")
-set(VCPKG_CXX_FLAGS         "${VCPKG_CXX_FLAGS} -fno-omit-frame-pointer")
+set(VCPKG_C_FLAGS   "${VCPKG_C_FLAGS} -fsanitize=address,undefined,leak -fno-omit-frame-pointer")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -fsanitize=address,undefined,leak -fno-omit-frame-pointer")
 
-set(VCPKG_C_FLAGS_DEBUG     "${VCPKG_C_FLAGS_DEBUG} -O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error")
-set(VCPKG_CXX_FLAGS_DEBUG   "${VCPKG_CXX_FLAGS_DEBUG} -O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error")
-set(VCPKG_LINKER_FLAGS_DEBUG "${VCPKG_LINKER_FLAGS_DEBUG} -fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error")
+# Qt builds host tools (moc, rcc, uic) that execute during the build.
+# Instrumenting them with sanitizers causes them to crash.
+if(NOT PORT MATCHES "^qt")
+    set(VCPKG_C_FLAGS_DEBUG   "${VCPKG_C_FLAGS_DEBUG} -O0 -g3 -fsanitize=address,undefined,leak")
+    set(VCPKG_CXX_FLAGS_DEBUG "${VCPKG_CXX_FLAGS_DEBUG} -O0 -g3 -fsanitize=address,undefined,leak")
+    set(VCPKG_LINKER_FLAGS_DEBUG "${VCPKG_LINKER_FLAGS_DEBUG} -fsanitize=address,undefined,leak")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,27 +70,29 @@ elseif(CCACHE_PROGRAM)
   set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()
 
-if(NOT MULTIPASS_VCPKG_BUILD_DEFAULT)
-  message(STATUS "Will build `vcpkg` dependencies in `release-only` mode.")
+if(NOT VCPKG_TARGET_TRIPLET)
+  if(NOT MULTIPASS_VCPKG_BUILD_DEFAULT)
+    message(STATUS "Will build `vcpkg` dependencies in `release-only` mode.")
 
-  # Propagate macOS deployment target to vcpkg triplet
-  if(APPLE AND DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
-    set(VCPKG_TRIPLETS_DIR "${CMAKE_CURRENT_BINARY_DIR}/vcpkg-triplets")
-    configure_file(
-      "${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/vcpkg-triplets/osx-release.cmake.in"
-      "${VCPKG_TRIPLETS_DIR}/${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release.cmake"
-      @ONLY
-    )
-    set(VCPKG_OVERLAY_TRIPLETS "${VCPKG_TRIPLETS_DIR}" CACHE STRING "Custom vcpkg triplets directory")
-    message(STATUS "Generated vcpkg triplet: ${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release.cmake with deployment target ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    # Propagate macOS deployment target to vcpkg triplet
+    if(APPLE AND DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+      set(VCPKG_TRIPLETS_DIR "${CMAKE_CURRENT_BINARY_DIR}/vcpkg-triplets")
+      configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/3rd-party/vcpkg-triplets/osx-release.cmake.in"
+        "${VCPKG_TRIPLETS_DIR}/${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release.cmake"
+        @ONLY
+      )
+      set(VCPKG_OVERLAY_TRIPLETS "${VCPKG_TRIPLETS_DIR}" CACHE STRING "Custom vcpkg triplets directory")
+      message(STATUS "Generated vcpkg triplet: ${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release.cmake with deployment target ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    endif()
+
+    set(VCPKG_HOST_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release")
+    set(VCPKG_TARGET_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release")
+  else()
+    set(VCPKG_HOST_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}")
+    set(VCPKG_TARGET_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}")
+    message(NOTICE "Will build `vcpkg` deps in both `debug` and `release` configurations. Be aware that it will take around twice the time to build the `vcpkg` deps.")
   endif()
-
-  set(VCPKG_HOST_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release")
-  set(VCPKG_TARGET_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release")
-else()
-  set(VCPKG_HOST_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}")
-  set(VCPKG_TARGET_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}")
-  message(NOTICE "Will build `vcpkg` deps in both `debug` and `release` configurations. Be aware that it will take around twice the time to build the `vcpkg` deps.")
 endif()
 
 message(STATUS "Bootstrapping vcpkg...")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -175,10 +175,11 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak,float-divide-by-zero,float-cast-overflow -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern -fno-sanitize-recover=all -D_GLIBCXX_ASSERTIONS -DDEBUG -fsanitize-undefined-trap-on-error",
-                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak,float-divide-by-zero,float-cast-overflow -fsanitize=pointer-compare,pointer-subtract -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern -fno-sanitize-recover=all -D_GLIBCXX_ASSERTIONS -DDEBUG -fsanitize-undefined-trap-on-error",
+                "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak,float-divide-by-zero,float-cast-overflow -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern -fno-sanitize-recover=all -D_GLIBCXX_ASSERTIONS -DDEBUG",
+                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak,float-divide-by-zero,float-cast-overflow -fsanitize=pointer-compare,pointer-subtract -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern -fno-sanitize-recover=all -D_GLIBCXX_ASSERTIONS -DDEBUG",
                 "CMAKE_EXE_LINKER_FLAGS_DEBUG": "-fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error",
                 "CMAKE_SHARED_LINKER_FLAGS_DEBUG": "-fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error",
+                "VCPKG_HOST_TRIPLET": "x64-linux-sanitizers",
                 "VCPKG_TARGET_TRIPLET": "x64-linux-sanitizers"
             },
             "environment": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -163,13 +163,34 @@
                     "value": "ON"
                 }
             }
+        },
+        {
+            "name": "clang-sanitizers-debug",
+            "displayName": "Debug with ASan/UBSan/Leak Sanitizers",
+            "inherits": [
+                "common",
+                "debug"
+            ],
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_C_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak,float-divide-by-zero,float-cast-overflow -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern -fno-sanitize-recover=all -D_GLIBCXX_ASSERTIONS -DDEBUG -fsanitize-undefined-trap-on-error",
+                "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g3 -fno-omit-frame-pointer -fsanitize=address,undefined,leak,float-divide-by-zero,float-cast-overflow -fsanitize=pointer-compare,pointer-subtract -fsanitize-address-use-after-scope -ftrivial-auto-var-init=pattern -fno-sanitize-recover=all -D_GLIBCXX_ASSERTIONS -DDEBUG -fsanitize-undefined-trap-on-error",
+                "CMAKE_EXE_LINKER_FLAGS_DEBUG": "-fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error",
+                "CMAKE_SHARED_LINKER_FLAGS_DEBUG": "-fsanitize=address,undefined,leak -fsanitize-undefined-trap-on-error",
+                "VCPKG_TARGET_TRIPLET": "x64-linux-sanitizers"
+            },
+            "environment": {
+                "CC": "clang",
+                "CXX": "clang++"
+            }
         }
     ],
     "buildPresets": [
         {
             "name": "configured-at-present",
-            "description":
-                "Build whatever configure preset is configured at the moment. Requires the preset to be configured to `${sourceDir}/build` folder.",
+            "description": "Build whatever configure preset is configured at the moment. Requires the preset to be configured to `${sourceDir}/build` folder.",
             "configurePreset": "common"
         }
     ]


### PR DESCRIPTION
CMake presets are a much better and convenient way to manage cmake settings. This patch introduces a preset that enables a Clang debug build with address, undefined behavior, and leak sanitizers enabled.

Also, add a vcpkg triplet for building the dependencies with compatible flags.

```sh
# Configure
cmake --preset clang-sanitizers-debug
# Build
cmake --build --preset clang-sanitizers-debug
```