### PR TITLE
[daemon] Improve file URL error message (#4198)

### DIFF
--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -281,6 +281,10 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
         QUrl image_url(QString::fromStdString(query.release));
         VMImage source_image, vm_image;
 
+        if (image_url.host().size() != 0)
+            throw std::runtime_error(
+                fmt::format("Invalid file URL `{}`; did you forget a slash?", query.release));
+
         if (!QFile::exists(image_url.path()))
             throw std::runtime_error(
                 fmt::format("Custom image `{}` does not exist.", image_url.path()));

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -285,11 +285,11 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
             throw std::runtime_error(
                 fmt::format("Invalid file URL `{}`; did you forget a slash?", query.release));
 
-        if (!QFile::exists(image_url.path()))
-            throw std::runtime_error(
-                fmt::format("Custom image `{}` does not exist.", image_url.path()));
+        source_image.image_path = image_url.toLocalFile();
 
-        source_image.image_path = image_url.path();
+        if (!QFile::exists(source_image.image_path))
+            throw std::runtime_error(
+                fmt::format("Custom image `{}` does not exist.", source_image.image_path));
 
         if (source_image.image_path.endsWith(".xz"))
         {

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -273,6 +273,10 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type,
         }
         else
         {
+            if (image_url.host().size() != 0)
+                throw std::runtime_error(
+                    fmt::format("Invalid file URL `{}`; did you forget a slash?", query.release));
+
             if (!QFile::exists(image_url.path()))
                 throw std::runtime_error(
                     fmt::format("Custom image `{}` does not exist.", image_url.path()));

--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -277,11 +277,12 @@ mp::VMImage mp::LXDVMImageVault::fetch_image(const FetchType& fetch_type,
                 throw std::runtime_error(
                     fmt::format("Invalid file URL `{}`; did you forget a slash?", query.release));
 
-            if (!QFile::exists(image_url.path()))
-                throw std::runtime_error(
-                    fmt::format("Custom image `{}` does not exist.", image_url.path()));
+            source_image.image_path = image_url.toLocalFile();
 
-            source_image.image_path = image_url.path();
+            if (!QFile::exists(source_image.image_path))
+                throw std::runtime_error(
+                    fmt::format("Custom image `{}` does not exist.", source_image.image_path));
+
             id = MP_IMAGE_VAULT_UTILS.compute_file_hash(source_image.image_path);
             last_modified = QDateTime::currentDateTime();
         }

--- a/tests/disabling_macros.h
+++ b/tests/disabling_macros.h
@@ -27,17 +27,20 @@
 #define DISABLE_ON_WINDOWS(testName) DISABLED_##testName
 #define DISABLE_ON_WINDOWS_AND_MACOS(testName) DISABLED_##testName
 #define DISABLE_ON_MACOS(testName) testName
+#define DISABLE_ON_UNIX(testName) testName
 
 #elif MULTIPASS_PLATFORM_APPLE
 
 #define DISABLE_ON_WINDOWS(testName) testName
 #define DISABLE_ON_WINDOWS_AND_MACOS(testName) DISABLED_##testName
 #define DISABLE_ON_MACOS(testName) DISABLED_##testName
+#define DISABLE_ON_UNIX(testName) DISABLED_##testName
 
 #else // Linux
 
 #define DISABLE_ON_WINDOWS(testName) testName
 #define DISABLE_ON_WINDOWS_AND_MACOS(testName) testName
 #define DISABLE_ON_MACOS(testName) testName
+#define DISABLE_ON_UNIX(testName) DISABLED_##testName
 
 #endif

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -296,6 +296,28 @@ TEST_F(ImageVault, nonexistentLocalFileImageThrows)
         mpt::match_what(StrEq(fmt::format("Custom image `{}` does not exist.", missing_file))));
 }
 
+TEST_F(ImageVault, DISABLE_ON_UNIX(imageFileNameWithDriveLetter))
+{
+    mpt::TempFile file;
+    // Verify that our temp file has a drive letter.
+    EXPECT_TRUE(file.name().at(1) == u':');
+
+    mp::DefaultVMImageVault vault{hosts,
+                                  &url_downloader,
+                                  cache_dir.path(),
+                                  data_dir.path(),
+                                  mp::days{0}};
+
+    const mp::Query query{"", file.url().toStdString(), false, "", mp::Query::Type::LocalFile};
+
+    EXPECT_NO_THROW(vault.fetch_image(mp::FetchType::ImageOnly,
+                                      query,
+                                      stub_prepare,
+                                      stub_monitor,
+                                      std::nullopt,
+                                      save_dir.path()));
+}
+
 TEST_F(ImageVault, imageCloneFailOnNonExistSrcImage)
 {
     mp::DefaultVMImageVault vault{hosts,


### PR DESCRIPTION
Local file URLs should have three slashes after "file:".

This just adds an error message alerting the user to the fact that non-local file URLs aren't supported (at least, not yet), and suggesting a fix. The wording feels a little clumsy to me, but I'm not sure of a better way to phrase it without becoming confusing.

(Recreated this from #4341 in the original repo so CI passes.)