### PR TITLE
Docs/fix windows build instructions

### DIFF
--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -6,23 +6,30 @@
 
 Install chocolatey, a package manager, to download the rest of the dependencies: <https://chocolatey.org/>.
 
-Press Windows Key+X and Run Windows PowerShell(Admin) then follow the chocolatey instructions to "Install with
-Powershell.exe".
+Press Windows Key+X and Run Windows PowerShell(Admin) then follow the chocolatey instructions to
+"Install with Powershell.exe".
 
 ### Dependencies
-After chocolatey is installed you can now install the rest of the dependencies from the Powershell(Admin). To get the best results, in the following order:
-```
+
+After chocolatey is installed you can now install the rest of the dependencies from the
+Powershell(Admin). To get the best results, in the following order:
+
+```[pwsh]
 choco install cmake ninja qemu openssl git wget unzip -yfd
 ```
-```
+
+```[pwsh]
 choco install visualstudio2019buildtools visualstudio2019-workload-vctools -yfd
 ```
 
-You may have to disable Windows Defender Real-time protection if you want the packages to install quicker. Search for
-Windows Defender Security Center, go to Virus & threat protection, then Virus and thread protection settings, disable Real-time protection.
+You may have to disable Windows Defender Real-time protection if you want the packages to install
+quicker. Search for Windows Defender Security Center, go to Virus & threat protection, then Virus
+and thread protection settings, disable Real-time protection.
 
-NOTE: visualcpp-build-tools is only the installer package. For this reason, choco cannot detect any new compiler tool
-updates so choco upgrade will report no new updates available. To update the compiler and related tooling or fix a broken `visualstudio2019buildtools` installation do the following:
+NOTE: visualcpp-build-tools is only the installer package. For this reason, choco cannot detect any
+new compiler tool updates so choco upgrade will report no new updates available. To update the
+compiler and related tooling or fix a broken `visualstudio2019buildtools` installation do the following:
+
 1. Go to "Add or remove programs"
 2. Search for the Microsoft Visual Studio Installer
 3. Click Modify
@@ -30,24 +37,27 @@ updates so choco upgrade will report no new updates available. To update the com
 5. For Windows 11, add "C++/CLI support for v142 build tools" in the "Desktop development with C++" kit
 6. Complete the installation
 
-
 ### Git
 
 You need to enable symlinks in Windows Git, have a look at
 [the git-for-windows docs](https://github.com/git-for-windows/git/wiki/Symbolic-Links).
 
 For Windows 11:
+
 1. Go to "Developer Settings"
 2. Enable "Developer mode"
 
 ### Qt6
 
 To install Qt6, use `aqt`. First install it with chocolatey:
-```
+
+```[pwsh]
 choco install aqt -yfd
 ```
+
 Then specify the following options in the installation command:
-```
+
+```[pwsh]
 aqt install-qt windows desktop 6.2.4 win64_msvc2019_64 -O C:/Qt
 ```
 
@@ -67,7 +77,8 @@ Search for "Edit environment variables for your account" then edit your Path var
 Cmder is a sane terminal emulator for windows, which includes git and SSH support among other things.
 
 Install with chocolatey:
-```
+
+```[pwsh]
 choco install cmder -yfd
 ```
 
@@ -81,23 +92,30 @@ The following will setup a task that you can use to build things with the VS2019
     ``/icon "%CMDER_ROOT%\icons\cmder.ico"``
 6. In the commands box, add:
 
-    ``cmd /k ""%ConEmuDir%\..\init.bat" && "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64" -new_console:d:%USERPROFILE%``
+    ```[]
+    cmd /k ""%ConEmuDir%\..\init.bat" && "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64" -new_console:d:%USERPROFILE%
+    ```
+
 7. Give the task a name (first box), such as vs2019 and click Save Settings.
 8. Now run cmder, click on the green "+" and click on the vs2019 task
-This will open a new terminal tab and run the VS2019 setup. CMake can now find the VS compiler. Go to the [Building](./BUILD.windows.md#building) section.
+This will open a new terminal tab and run the VS2019 setup. CMake can now find the VS compiler.
+Go to the [Building](./BUILD.windows.md#building) section.
 
 #### x64 Native Tools Command Prompt
 
-x64 Native Tools Command Prompt is the native console from the MVSC installation. On startup it updates its environment variables to include all tools installed via MSVC for 64-bit. If you are using 32-bit, use the x86 Native Tools Command Prompt.
+x64 Native Tools Command Prompt is the native console from the MVSC installation. On startup it
+updates its environment variables to include all tools installed via MSVC for 64-bit. If you are
+using 32-bit, use the x86 Native Tools Command Prompt.
 
-If you want to use the environment variables in a different console, look at: https://learn.microsoft.com/nb-no/cpp/build/building-on-the-command-line?view=msvc-170.
+If you want to use the environment variables in a different console, look at:
+[Use the Microsoft C++ toolset from the command line](https://learn.microsoft.com/nb-no/cpp/build/building-on-the-command-line?view=msvc-170).
 
 #### Powershell only
 
 Using a Visual-Studio command-prompt-enabled PowerShell to build the project is also possible.
 Open a new PowerShell terminal, then invoke the following commands:
 
-```pwsh
+```[pwsh]
 # Try to determine the Visual Studio install path
 $VSPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -latest -property installationPath
 
@@ -110,16 +128,18 @@ Enter-VsDevShell -VsInstallPath "$VSPath" -DevCmdArguments '-arch=x64'
 
 ## Building
 
-```
+```[batch]
 cd <multipass>
 git submodule update --init --recursive
 mkdir build
 cd build
 ```
-```
+
+```[batch]
 cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=..\3rd-party\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_PREFIX_PATH=C:\Qt\6.2.4\msvc2019_64\ ../
 ```
-```
+
+```[batch]
 cmake --build .
 ```
 
@@ -131,27 +151,33 @@ To create an installer, run `ninja package`.
 ### Enable Hyper-V
 
 Before starting `multipassd`, you'll have to enable the Hyper-V functionality in Windows 10/11 Pro.
-See: https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v
+See: [Install Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v)
 
 Press Windows Key + X, Select Windows PowerShell (Admin)and run:
-```
+
+```[pwsh]
 Enable-WindowsOptionalFeature -Online -FeatureName:Microsoft-Hyper-V -All
 ```
+
 ### Start the daemon (`multipassd`)
 
 1. Press Windows Key + X, Select Windows PowerShell (Admin)
 2. Run `multipassd` (for example: `multipassd --logger=stderr`)
-3. Alternatively, you can install `multipassd` as a Windows Service (Run `multipassd /install` in a Powershell(Admin)). Installing `multipassd` as a Windows Service is a must for Windows 11
+3. Alternatively, you can install `multipassd` as a Windows Service (Run `multipassd /install` in a
+   Powershell(Admin)). Installing `multipassd` as a Windows Service is a must for Windows 11
 4. To stop and uninstall the Windows service, Run `multipassd /uninstall`
 
 ### Run `multipass`
 
 With the `multipassd` daemon now running on another shell (or as a windows service) you can now run `multipass`.
-Press Windows Key + X, Select Windows PowerShell, or alternatively run cmd.exe on the search bar. Then, try `multipass help`.
+
+1. Press Windows Key + X, Select Windows PowerShell, or alternatively run cmd.exe on the search bar.
+2. Then, try `multipass help`.
 
 ### Permissions/privileges for `multipassd`
 
-`multipassd` needs Administrator privileges in order to create symlinks when using mounts and to manage Hyper-V instances.
+`multipassd` needs Administrator privileges in order to create symlinks when using mounts and to
+manage Hyper-V instances.
 
 If you don't need symlink support you can run `multipassd` on a less privileged shell but your user account
 needs to be part of the Hyper-V Administrators group:

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -22,13 +22,20 @@ choco install cmake ninja qemu openssl git wget unzip -yfd
 choco install visualstudio2019buildtools visualstudio2019-workload-vctools -yfd
 ```
 
+Alternatively, install the more recent VS2022 toolchain:
+
+```[pwsh]
+choco install visualstudio2022buildtools visualstudio2022-workload-vctools -yfd
+```
+
 You may have to disable Windows Defender Real-time protection if you want the packages to install
 quicker. Search for Windows Defender Security Center, go to Virus & threat protection, then Virus
 and thread protection settings, disable Real-time protection.
 
 NOTE: visualcpp-build-tools is only the installer package. For this reason, choco cannot detect any
 new compiler tool updates so choco upgrade will report no new updates available. To update the
-compiler and related tooling or fix a broken `visualstudio2019buildtools` installation do the following:
+compiler and related tooling or fix a broken `visualstudio2019buildtools` or
+`visualstudio2022buildtools` installation do the following:
 
 1. Go to "Add or remove programs"
 2. Search for the Microsoft Visual Studio Installer
@@ -61,6 +68,12 @@ Then specify the following options in the installation command:
 aqt install-qt windows desktop 6.2.4 win64_msvc2019_64 -O C:/Qt
 ```
 
+If you installed the VS2022 toolchain, use the following options:
+
+```[pwsh]
+aqt install-qt windows desktop 6.2.4 win64_msvc2022_64 -O C:/Qt
+```
+
 ### Path setup
 
 You'll have to manually add CMake and Qt to your account's PATH variable.
@@ -69,6 +82,11 @@ Search for "Edit environment variables for your account" then edit your Path var
 
 - `C:\Program Files\CMake\bin`
 - `C:\Qt\6.2.4\msvc2019_64\bin`
+
+If you installed the VS2022 toolchain, the pahts are instead:
+
+- `C:\Program Files\CMake\bin`
+- `C:\Qt\6.2.4\msvc2022_64\bin`
 
 ### Console setup
 
@@ -100,6 +118,12 @@ The following will setup a task that you can use to build things with the VS2019
 8. Now run cmder, click on the green "+" and click on the vs2019 task
 This will open a new terminal tab and run the VS2019 setup. CMake can now find the VS compiler.
 Go to the [Building](./BUILD.windows.md#building) section.
+
+If you installed the VS2022 toolchain instead, the command in step 6 should be:
+
+```[]
+cmd /k ""%ConEmuDir%\..\init.bat" && "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64" -new_console:d:%USERPROFILE%
+```
 
 #### x64 Native Tools Command Prompt
 
@@ -137,6 +161,12 @@ cd build
 
 ```[batch]
 cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=..\3rd-party\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_PREFIX_PATH=C:\Qt\6.2.4\msvc2019_64\ ../
+```
+
+If you are using the VS2022 toolchain, change the previous command to:
+
+```[batch]
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=..\3rd-party\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_PREFIX_PATH=C:\Qt\6.2.4\msvc2022_64\ ../
 ```
 
 ```[batch]

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -27,7 +27,7 @@ updates so choco upgrade will report no new updates available. To update the com
 2. Search for the Microsoft Visual Studio Installer
 3. Click Modify
 4. Click Modify in the Installer interface
-5. (W11) Add "C++/CLI support for v142 build tools" in the "Desktop development with C++" kit
+5. For Windows 11, add "C++/CLI support for v142 build tools" in the "Desktop development with C++" kit
 6. Complete the installation
 
 
@@ -36,7 +36,7 @@ updates so choco upgrade will report no new updates available. To update the com
 You need to enable symlinks in Windows Git, have a look at
 [the git-for-windows docs](https://github.com/git-for-windows/git/wiki/Symbolic-Links).
 
-(Windows 11)
+For Windows 11:
 1. Go to "Developer Settings"
 2. Enable "Developer mode"
 

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -177,7 +177,7 @@ cmake --build .
 ```
 
 This builds `multipass` and `multipassd`.
-To create an installer, run `ninja package`.
+To create an installer, run `cmake --build . --target package`.
 
 ## Running `multipass`
 

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -22,10 +22,6 @@ choco install cmake ninja qemu openssl git wget unzip -yfd
 choco install visualstudio2019buildtools visualstudio2019-workload-vctools -yfd
 ```
 
-You may have to disable Windows Defender Real-time protection if you want the packages to install
-quicker. Search for Windows Defender Security Center, go to Virus & threat protection, then Virus
-and thread protection settings, disable Real-time protection.
-
 NOTE: visualcpp-build-tools is only the installer package. For this reason, choco cannot detect any
 new compiler tool updates so choco upgrade will report no new updates available. To update the
 compiler and related tooling or fix a broken `visualstudio2019buildtools` installation do the following:

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -92,6 +92,22 @@ x64 Native Tools Command Prompt is the native console from the MVSC installation
 
 If you want to use the environment variables in a different console, look at: https://learn.microsoft.com/nb-no/cpp/build/building-on-the-command-line?view=msvc-170.
 
+#### Powershell only
+
+Using a Visual-Studio command-prompt-enabled PowerShell to build the project is also possible.
+Open a new PowerShell terminal, then invoke the following commands:
+
+```pwsh
+# Try to determine the Visual Studio install path
+$VSPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -latest -property installationPath
+
+# Import the PowerShell module
+Import-Module "$VSPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+
+# Enable VS developer PowerShell
+Enter-VsDevShell -VsInstallPath "$VSPath" -DevCmdArguments '-arch=x64'
+```
+
 ## Building
 
 ```
@@ -109,24 +125,6 @@ cmake --build .
 
 This builds `multipass` and `multipassd`.
 To create an installer, run `ninja package`.
-
-## Building (alternative, PowerShell only)
-
-Using a Visual-Studio command-prompt-enabled PowerShell to build the project is also possible.
-Open a new PowerShell terminal, then invoke the following commands:
-
-```pwsh
-# Try to determine the Visual Studio install path
-$VSPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -products Microsoft.VisualStudio.Product.BuildTools -latest -property installationPath
-
-# Import the PowerShell module
-Import-Module "$VSPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
-
-# Enable VS developer PowerShell
-Enter-VsDevShell -VsInstallPath "$VSPath" -DevCmdArguments '-arch=x64'
-```
-
-Then, follow the steps in the previous "Building" step to build the project.
 
 ## Running `multipass`
 

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -4,10 +4,10 @@
 
 ### Chocolatey
 
-Install chocolatey, a package manager, to download the rest of the dependencies: <https://chocolatey.org/>
+Install chocolatey, a package manager, to download the rest of the dependencies: <https://chocolatey.org/>.
 
 Press Windows Key+X and Run Windows PowerShell(Admin) then follow the chocolatey instructions to "Install with
-Powershell.exe"
+Powershell.exe".
 
 ### Dependencies
 After chocolatey is installed you can now install the rest of the dependencies from the Powershell(Admin). To get the best results, in the following order:
@@ -19,8 +19,7 @@ choco install visualstudio2019buildtools visualstudio2019-workload-vctools -yfd
 ```
 
 You may have to disable Windows Defender Real-time protection if you want the packages to install quicker. Search for
-Windows Defender Security Center, go to Virus & threat protection, then Virus and thread protection settings, disable
-Real-time protection.
+Windows Defender Security Center, go to Virus & threat protection, then Virus and thread protection settings, disable Real-time protection.
 
 NOTE: visualcpp-build-tools is only the installer package. For this reason, choco cannot detect any new compiler tool
 updates so choco upgrade will report no new updates available. To update the compiler and related tooling or fix a broken `visualstudio2019buildtools` installation do the following:
@@ -67,32 +66,31 @@ Search for "Edit environment variables for your account" then edit your Path var
 
 Cmder is a sane terminal emulator for windows, which includes git and SSH support among other things.
 
-Install with `chocolatey`:
+Install with chocolatey:
 ```
 choco install cmder -yfd
 ```
 
 The following will setup a task that you can use to build things with the VS2019 compiler toolchain.
 
-Run cmder which should be installed by default on C:\tools\cmder\Cmder.exe
-Click on the green "+" sign on the right lower corner of cmder
-Select "Setup tasks..."
-Click the "+" button to add a new task
-In the task parameters box add (basically copying from cmd:Cmder task):
-``/icon "%CMDER_ROOT%\icons\cmder.ico"``
-In the commands box, add:
-``cmd /k ""%ConEmuDir%\..\init.bat" && "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64" -new_console:d:%USERPROFILE%``
+1. Run cmder which should be installed by default on C:\tools\cmder\Cmder.exe
+2. Click on the green "+" sign on the right lower corner of cmder
+3. Select "Setup tasks..."
+4. Click the "+" button to add a new task
+5. In the task parameters box add (basically copying from cmd:Cmder task):
+    ``/icon "%CMDER_ROOT%\icons\cmder.ico"``
+6. In the commands box, add:
 
-Give the task a name (first box), such as vs2019 and click Save Settings.
-
-Now run cmder, click on the green "+" and click on the vs2019 task
+    ``cmd /k ""%ConEmuDir%\..\init.bat" && "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64" -new_console:d:%USERPROFILE%``
+7. Give the task a name (first box), such as vs2019 and click Save Settings.
+8. Now run cmder, click on the green "+" and click on the vs2019 task
 This will open a new terminal tab and run the VS2019 setup. CMake can now find the VS compiler. Go to the [Building](./BUILD.windows.md#building) section.
 
 #### x64 Native Tools Command Prompt
 
 x64 Native Tools Command Prompt is the native console from the MVSC installation. On startup it updates its environment variables to include all tools installed via MSVC for 64-bit. If you are using 32-bit, use the x86 Native Tools Command Prompt.
 
-If you want to use the environment variables in a different console, look at: https://learn.microsoft.com/nb-no/cpp/build/building-on-the-command-line?view=msvc-170
+If you want to use the environment variables in a different console, look at: https://learn.microsoft.com/nb-no/cpp/build/building-on-the-command-line?view=msvc-170.
 
 ## Building
 
@@ -109,8 +107,8 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=..\3rd-pa
 cmake --build .
 ```
 
-This builds multipass and multipassd.
-To create an installer, run `ninja package`
+This builds `multipass` and `multipassd`.
+To create an installer, run `ninja package`.
 
 ## Building (alternative, PowerShell only)
 
@@ -130,37 +128,37 @@ Enter-VsDevShell -VsInstallPath "$VSPath" -DevCmdArguments '-arch=x64'
 
 Then, follow the steps in the previous "Building" step to build the project.
 
-## Running multipass
+## Running `multipass`
 
 ### Enable Hyper-V
 
-Before starting multipassd, you'll have to enable the Hyper-V functionality in Windows 10 Pro.
+Before starting `multipassd`, you'll have to enable the Hyper-V functionality in Windows 10/11 Pro.
 See: https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v
 
-    Press Windows Key + X, Select Windows PowerShell (Admin)
-    Run "Enable-WindowsOptionalFeature -Online -FeatureName:Microsoft-Hyper-V -All"
+Press Windows Key + X, Select Windows PowerShell (Admin)and run:
+```
+Enable-WindowsOptionalFeature -Online -FeatureName:Microsoft-Hyper-V -All
+```
+### Start the daemon (`multipassd`)
 
-### Start the daemon (multipassd)
+1. Press Windows Key + X, Select Windows PowerShell (Admin)
+2. Run `multipassd` (for example: `multipassd --logger=stderr`)
+3. Alternatively, you can install `multipassd` as a Windows Service (Run `multipassd /install` in a Powershell(Admin)). Installing `multipassd` as a Windows Service is a must for Windows 11
+4. To stop and uninstall the Windows service, Run `multipassd /uninstall`
 
-    Press Windows Key + X, Select Windows PowerShell (Admin)
-    Run multipassd (for example: multipassd --logger=stderr)
-    Alternatively, you can install multipassd as a Windows Service (Run multipassd /install in a Powershell(Admin)). Installing multipassd as a Windows Service is a must for Windows 11.
-    To stop and uninstall the Windows service, Run "multipassd /uninstall"
+### Run `multipass`
 
-### Run multipass
+With the `multipassd` daemon now running on another shell (or as a windows service) you can now run `multipass`.
+Press Windows Key + X, Select Windows PowerShell, or alternatively run cmd.exe on the search bar. Then, try `multipass help`.
 
-    With the multipassd daemon now running on another shell (or as a windows service) you can now run multipass.
-    Press Windows Key + X, Select Windows PowerShell, or alternatively run cmd.exe on the search bar
-    Try "multipass help"
+### Permissions/privileges for `multipassd`
 
-### Permissions/privileges for multipassd
+`multipassd` needs Administrator privileges in order to create symlinks when using mounts and to manage Hyper-V instances.
 
-multipassd needs Administrator privileges in order to create symlinks when using mounts and to manage Hyper-V instances.
-
-If you don't need symlink support you can run multipassd on a less privileged shell but your user account
+If you don't need symlink support you can run `multipassd` on a less privileged shell but your user account
 needs to be part of the Hyper-V Administrators group:
 
-    Press Windows key + X, Select "Computer Management"
-    Under System Tools->Local Users and Groups->Groups
-    Select on Hyper-V Administrators, add your account
-    Sign out or reboot for changes to take effect
+1. Press Windows key + X, Select "Computer Management"
+2. Under System Tools->Local Users and Groups->Groups
+3. Select on Hyper-V Administrators, add your account
+4. Sign out or reboot for changes to take effect

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -25,25 +25,34 @@ Windows Defender Security Center, go to Virus & threat protection, then Virus an
 Real-time protection.
 
 NOTE: visualcpp-build-tools is only the installer package. For this reason, choco cannot detect any new compiler tool
-updates so choco upgrade will report no new updates available. To update the compiler and related tooling, you will need
-to search for "Add or remove programs", find "Microsoft Visual Studio Installer" and click "Modify".
+updates so choco upgrade will report no new updates available. To update the compiler and related tooling or fix a broken `visualstudio2019buildtools` installation do the following:
+1. Go to "Add or remove programs"
+2. Search for the Microsoft Visual Studio Installer
+3. Click Modify
+4. Click Modify in the Installer interface
+5. (W11) Add "C++/CLI support for v142 build tools" in the "Desktop development with C++" kit
+6. Complete the installation
+
 
 ### Git
 
 You need to enable symlinks in Windows Git, have a look at
 [the git-for-windows docs](https://github.com/git-for-windows/git/wiki/Symbolic-Links).
 
+(Windows 11)
+1. Go to "Developer Settings"
+2. Enable "Developer mode"
+
 ### Qt6
 
-Install the latest stable version of Qt6 (6.2.4 at the moment): <https://www.qt.io/download-thank-you?os=windows/>.
-
-In the online installer, under Qt, select MSVC 2019 64-bit.
-
-If you already have Qt installed, run the MaintenanceTool included in the Qt directory to update to the latest version.
-
-Alternatively, download the
-[qtbase archive](https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_624/qt.qt6.624.win64_msvc2019_64/6.2.4-0-202203140926qtbase-Windows-Windows_10_21H2-MSVC2019-Windows-Windows_10_21H2-X86_64.7z)
-and extract it to `C:\Qt` (so it ends up in `C:\Qt\6.2.4`).
+To install Qt6, use `aqt`. First install it with chocolatey:
+```
+choco install aqt -yfd
+```
+Then specify the following options in the installation command:
+```
+aqt install-qt windows desktop 6.2.4 win64_msvc2019_64 -O C:/Qt
+```
 
 ### Path setup
 

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -106,7 +106,7 @@ choco install cmder -yfd
 The following will setup a task that you can use to build things with the VS2019 compiler toolchain.
 
 1. Run cmder which should be installed by default on C:\tools\cmder\Cmder.exe
-2. Click on the green "+" sign on the right lower corner of cmder
+2. Click the dropdown arrow next to the green "+" sign in the lower right corner of cmder
 3. Select "Setup tasks..."
 4. Click the "+" button to add a new task
 5. In the task parameters box add (basically copying from cmd:Cmder task):

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -86,7 +86,7 @@ Search for "Edit environment variables for your account" then edit your Path var
 - `C:\Program Files\CMake\bin`
 - `C:\Qt\6.2.4\msvc2019_64\bin`
 
-If you installed the VS2022 toolchain, the pahts are instead:
+If you installed the VS2022 toolchain, the paths are instead:
 
 - `C:\Program Files\CMake\bin`
 - `C:\Qt\6.2.4\msvc2022_64\bin`

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -149,7 +149,7 @@ See: https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-st
 
     Press Windows Key + X, Select Windows PowerShell (Admin)
     Run multipassd (for example: multipassd --logger=stderr)
-    Alternatively, you can install multipassd as a Windows Service (Run "multipassd /install")
+    Alternatively, you can install multipassd as a Windows Service (Run multipassd /install in a Powershell(Admin)). Installing multipassd as a Windows Service is a must for Windows 11.
     To stop and uninstall the Windows service, Run "multipassd /uninstall"
 
 ### Run multipass

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -14,7 +14,7 @@ Powershell.exe"
 ### Dependencies
 After chocolatey is installed you can now install the rest of the dependencies from the Powershell(Admin). To get the best results, in the following order:
 ```
-choco install cmake ninja qemu openssl git -yfd
+choco install cmake ninja qemu openssl git wget unzip -yfd
 ```
 ```
 choco install visualstudio2019buildtools visualstudio2019-workload-vctools -yfd

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -98,12 +98,19 @@ If you want to use the environment variables in a different console, look at: ht
 
 Building
 ---------------------------------------
-    cd <multipass>
-    git submodule update --init --recursive
-    mkdir build
-    cd build
-    cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ../
-    ninja
+
+```
+cd <multipass>
+git submodule update --init --recursive
+mkdir build
+cd build
+```
+```
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=..\3rd-party\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_PREFIX_PATH=C:\Qt\6.2.4\msvc2019_64\ ../
+```
+```
+cmake --build .
+```
 
 This builds multipass and multipassd.
 To create an installer, run `ninja package`

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -1,8 +1,6 @@
-Build instructions for Windows 10
-=================================
+# Build instructions for Windows 10/11 Pro
 
-Environment Setup
------------------
+## Environment Setup
 
 ### Chocolatey
 
@@ -96,8 +94,7 @@ x64 Native Tools Command Prompt is the native console from the MVSC installation
 
 If you want to use the environment variables in a different console, look at: https://learn.microsoft.com/nb-no/cpp/build/building-on-the-command-line?view=msvc-170
 
-Building
----------------------------------------
+## Building
 
 ```
 cd <multipass>
@@ -115,8 +112,7 @@ cmake --build .
 This builds multipass and multipassd.
 To create an installer, run `ninja package`
 
-Building (alternative, PowerShell only)
----------------------------------------
+## Building (alternative, PowerShell only)
 
 Using a Visual-Studio command-prompt-enabled PowerShell to build the project is also possible.
 Open a new PowerShell terminal, then invoke the following commands:
@@ -134,8 +130,7 @@ Enter-VsDevShell -VsInstallPath "$VSPath" -DevCmdArguments '-arch=x64'
 
 Then, follow the steps in the previous "Building" step to build the project.
 
-Running multipass
----------------------------------------
+## Running multipass
 
 ### Enable Hyper-V
 

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -11,9 +11,14 @@ Install chocolatey, a package manager, to download the rest of the dependencies:
 Press Windows Key+X and Run Windows PowerShell(Admin) then follow the chocolatey instructions to "Install with
 Powershell.exe"
 
-After chocolatey is installed you can now install the rest of the dependencies:
-
-    choco install visualstudio2019buildtools visualstudio2019-workload-vctools cmake ninja cmder qemu-img openssl -yfd
+### Dependencies
+After chocolatey is installed you can now install the rest of the dependencies from the Powershell(Admin). To get the best results, in the following order:
+```
+choco install cmake ninja qemu openssl git -yfd
+```
+```
+choco install visualstudio2019buildtools visualstudio2019-workload-vctools -yfd
+```
 
 You may have to disable Windows Defender Real-time protection if you want the packages to install quicker. Search for
 Windows Defender Security Center, go to Virus & threat protection, then Virus and thread protection settings, disable

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -6,8 +6,8 @@
 
 Install chocolatey, a package manager, to download the rest of the dependencies: <https://chocolatey.org/>.
 
-Press Windows Key+X and Run Windows PowerShell(Admin) then follow the chocolatey instructions to
-"Install with Powershell.exe".
+Press Windows Key+X and Run Windows PowerShell(Admin) or Terminal(Admin) then follow the chocolatey
+instructions to "Install with Powershell.exe".
 
 ### Dependencies
 
@@ -152,7 +152,7 @@ To create an installer, run `cmake --build . --target package`.
 Before starting `multipassd`, you'll have to enable the Hyper-V functionality in Windows 10/11 Pro.
 See: [Install Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v)
 
-Press Windows Key + X, Select Windows PowerShell (Admin)and run:
+Press Windows Key + X, Select Windows PowerShell (Admin) or Terminal(Admin) and run:
 
 ```[pwsh]
 Enable-WindowsOptionalFeature -Online -FeatureName:Microsoft-Hyper-V -All
@@ -160,7 +160,7 @@ Enable-WindowsOptionalFeature -Online -FeatureName:Microsoft-Hyper-V -All
 
 ### Start the daemon (`multipassd`)
 
-1. Press Windows Key + X, Select Windows PowerShell (Admin)
+1. Press Windows Key + X, Select Windows PowerShell (Admin) or Terminal(Admin)
 2. Run `multipassd` (for example: `multipassd --logger=stderr`)
 3. Alternatively, you can install `multipassd` as a Windows Service (Run `multipassd /install` in a
    Powershell(Admin)). Installing `multipassd` as a Windows Service is a must for Windows 11
@@ -170,7 +170,7 @@ Enable-WindowsOptionalFeature -Online -FeatureName:Microsoft-Hyper-V -All
 
 With the `multipassd` daemon now running on another shell (or as a windows service) you can now run `multipass`.
 
-1. Press Windows Key + X, Select Windows PowerShell, or alternatively run cmd.exe on the search bar.
+1. Press Windows Key + X, Select Windows PowerShell, or Terminal.
 2. Then, try `multipass help`.
 
 ### Permissions/privileges for `multipassd`

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -63,9 +63,16 @@ Search for "Edit environment variables for your account" then edit your Path var
 - `C:\Program Files\CMake\bin`
 - `C:\Qt\6.2.4\msvc2019_64\bin`
 
-### Cmder setup
+### Console setup
+
+#### Cmder
 
 Cmder is a sane terminal emulator for windows, which includes git and SSH support among other things.
+
+Install with `chocolatey`:
+```
+choco install cmder -yfd
+```
 
 The following will setup a task that you can use to build things with the VS2019 compiler toolchain.
 
@@ -80,12 +87,17 @@ In the commands box, add:
 
 Give the task a name (first box), such as vs2019 and click Save Settings.
 
+Now run cmder, click on the green "+" and click on the vs2019 task
+This will open a new terminal tab and run the VS2019 setup. CMake can now find the VS compiler. Go to the [Building](./BUILD.windows.md#building) section.
+
+#### x64 Native Tools Command Prompt
+
+x64 Native Tools Command Prompt is the native console from the MVSC installation. On startup it updates its environment variables to include all tools installed via MSVC for 64-bit. If you are using 32-bit, use the x86 Native Tools Command Prompt.
+
+If you want to use the environment variables in a different console, look at: https://learn.microsoft.com/nb-no/cpp/build/building-on-the-command-line?view=msvc-170
+
 Building
 ---------------------------------------
-
-Run cmder, click on the green "+" and click on the vs2019 task
-This will open a new terminal tab and run the VS2019 setup. CMake can now find the VS compiler.
-
     cd <multipass>
     git submodule update --init --recursive
     mkdir build

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -74,6 +74,9 @@ If you installed the VS2022 toolchain, use the following options:
 aqt install-qt windows desktop 6.2.4 win64_msvc2022_64 -O C:/Qt
 ```
 
+Alternatively, download the [qtbase archive](https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_624/qt.qt6.624.win64_msvc2019_64/6.2.4-0-202203140926qtbase-Windows-Windows_10_21H2-MSVC2019-Windows-Windows_10_21H2-X86_64.7z)
+and extract it to `C:\Qt` (so it ends up in `C:\Qt\6.2.4`).
+
 ### Path setup
 
 You'll have to manually add CMake and Qt to your account's PATH variable.

--- a/BUILD.windows.md
+++ b/BUILD.windows.md
@@ -22,20 +22,13 @@ choco install cmake ninja qemu openssl git wget unzip -yfd
 choco install visualstudio2019buildtools visualstudio2019-workload-vctools -yfd
 ```
 
-Alternatively, install the more recent VS2022 toolchain:
-
-```[pwsh]
-choco install visualstudio2022buildtools visualstudio2022-workload-vctools -yfd
-```
-
 You may have to disable Windows Defender Real-time protection if you want the packages to install
 quicker. Search for Windows Defender Security Center, go to Virus & threat protection, then Virus
 and thread protection settings, disable Real-time protection.
 
 NOTE: visualcpp-build-tools is only the installer package. For this reason, choco cannot detect any
 new compiler tool updates so choco upgrade will report no new updates available. To update the
-compiler and related tooling or fix a broken `visualstudio2019buildtools` or
-`visualstudio2022buildtools` installation do the following:
+compiler and related tooling or fix a broken `visualstudio2019buildtools` installation do the following:
 
 1. Go to "Add or remove programs"
 2. Search for the Microsoft Visual Studio Installer
@@ -68,12 +61,6 @@ Then specify the following options in the installation command:
 aqt install-qt windows desktop 6.2.4 win64_msvc2019_64 -O C:/Qt
 ```
 
-If you installed the VS2022 toolchain, use the following options:
-
-```[pwsh]
-aqt install-qt windows desktop 6.2.4 win64_msvc2022_64 -O C:/Qt
-```
-
 Alternatively, download the [qtbase archive](https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_624/qt.qt6.624.win64_msvc2019_64/6.2.4-0-202203140926qtbase-Windows-Windows_10_21H2-MSVC2019-Windows-Windows_10_21H2-X86_64.7z)
 and extract it to `C:\Qt` (so it ends up in `C:\Qt\6.2.4`).
 
@@ -85,11 +72,6 @@ Search for "Edit environment variables for your account" then edit your Path var
 
 - `C:\Program Files\CMake\bin`
 - `C:\Qt\6.2.4\msvc2019_64\bin`
-
-If you installed the VS2022 toolchain, the paths are instead:
-
-- `C:\Program Files\CMake\bin`
-- `C:\Qt\6.2.4\msvc2022_64\bin`
 
 ### Console setup
 
@@ -121,12 +103,6 @@ The following will setup a task that you can use to build things with the VS2019
 8. Now run cmder, click on the green "+" and click on the vs2019 task
 This will open a new terminal tab and run the VS2019 setup. CMake can now find the VS compiler.
 Go to the [Building](./BUILD.windows.md#building) section.
-
-If you installed the VS2022 toolchain instead, the command in step 6 should be:
-
-```[]
-cmd /k ""%ConEmuDir%\..\init.bat" && "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64" -new_console:d:%USERPROFILE%
-```
 
 #### x64 Native Tools Command Prompt
 
@@ -164,12 +140,6 @@ cd build
 
 ```[batch]
 cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=..\3rd-party\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_PREFIX_PATH=C:\Qt\6.2.4\msvc2019_64\ ../
-```
-
-If you are using the VS2022 toolchain, change the previous command to:
-
-```[batch]
-cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=..\3rd-party\vcpkg\scripts\buildsystems\vcpkg.cmake -DCMAKE_PREFIX_PATH=C:\Qt\6.2.4\msvc2022_64\ ../
 ```
 
 ```[batch]


### PR DESCRIPTION
Following from #4113, the build instructions for Windows were reviewed and tested on Windows 11 Pro. The instructions were adapted to cover the gap to the newer OS to allow building in its environment. The installation of `git` and `qt6` were also unified to be done through chocolatey and aqt respectively.

Additionally, general formatting and organization of the file was changed minimally to improve visual clarity and to unify formatting in the file.

The Windows 10 Pro specific instructions were left as-is when they would conflict with the Windows 11 Pro instructions. In those cases, a separate section for Windows 11 Pro was made.

Untested sections so far:
Permissions/privileges for multipassd in Windows 11
ninja package in Windows 11
cmder and powershell-only console setups in Windows 11
Installation while disabling the Anti-Virus in Windows 11