### PR TITLE
[fix] Cross-references for `customise-multipass/`

### DIFF
--- a/docs/how-to-guides/customise-multipass/authenticate-clients-with-the-multipass-service.md
+++ b/docs/how-to-guides/customise-multipass/authenticate-clients-with-the-multipass-service.md
@@ -1,7 +1,7 @@
 (how-to-guides-customise-multipass-authenticate-clients-with-the-multipass-service)=
 # Authenticate clients with the Multipass service
 
-> See also: [`authenticate`](/reference/command-line-interface/authenticate), [local.passphrase](/reference/settings/local-passphrase), [Service](/explanation/service)
+> See also: [`authenticate`](reference-command-line-interface-authenticate), [local.passphrase](reference-settings-local-passphrase), [Service](explanation-service)
 
 Multipass requires clients to be authenticated with the service before allowing commands to
 complete. The installing user is automatically authenticated.

--- a/docs/how-to-guides/customise-multipass/configure-multipass-default-logging-level.md
+++ b/docs/how-to-guides/customise-multipass/configure-multipass-default-logging-level.md
@@ -1,7 +1,7 @@
 (how-to-guides-customise-multipass-configure-multipass-default-logging-level)=
 # Configure Multipass’s default logging level
 
-> See also: [Logging levels](/reference/logging-levels)
+> See also: [Logging levels](reference-logging-levels)
 
 This document demonstrates how to configure the default logging level of the Multipass service. Changing the logging level can be useful, for example, if you want to decrease the size of logging files or get more detailed information about what the daemon is doing. Logging levels can be set to one of the following: `error`, `warning`, `info`, `debug`, or `trace`, with case sensitivity.
 

--- a/docs/how-to-guides/customise-multipass/index.md
+++ b/docs/how-to-guides/customise-multipass/index.md
@@ -3,15 +3,15 @@
 
 The following guides provide step-by-step instructions on how to customise Multipass to address specific needs, from managing Multipass drivers to configuring a graphical user interface.
 
-- [Set up the driver](set-up-the-driver)
-- [Migrate from Hyperkit to QEMU on macOS](migrate-from-hyperkit-to-qemu-on-macos)
-- [Authenticate clients with the Multipass service](authenticate-clients-with-the-multipass-service)
-- [Build Multipass images with Packer](build-multipass-images-with-packer)
-- [Set up a graphical interface](set-up-a-graphical-interface)
-- [Use a different terminal from the system icon](use-a-different-terminal-from-the-system-icon)
-- [Integrate with Windows Terminal](integrate-with-windows-terminal)
-- [Configure where Multipass stores external data](configure-where-multipass-stores-external-data)
-- [Configure Multipass’s default logging level](configure-multipass-default-logging-level)
+- [Set up the driver](how-to-guides-customise-multipass-set-up-the-driver)
+- [Migrate from Hyperkit to QEMU on macOS](how-to-guides-customise-multipass-migrate-from-hyperkit-to-qemu-on-macos)
+- [Authenticate clients with the Multipass service](how-to-guides-customise-multipass-authenticate-clients-with-the-multipass-service)
+- [Build Multipass images with Packer](how-to-guides-customise-multipass-build-multipass-images-with-packer)
+- [Set up a graphical interface](how-to-guides-customise-multipass-set-up-a-graphical-interface)
+- [Use a different terminal from the system icon](how-to-guides-customise-multipass-use-a-different-terminal-from-the-system-icon)
+- [Integrate with Windows Terminal](how-to-guides-customise-multipass-integrate-with-windows-terminal)
+- [Configure where Multipass stores external data](how-to-guides-customise-multipass-configure-where-multipass-stores-external-data)
+- [Configure Multipass’s default logging level](how-to-guides-customise-multipass-configure-multipass-default-logging-level)
 
 <!-- REMOVED FROM DOCS AND MOVED TO COMMUNITY KNOWLEDGE
 - [Use Multipass remotely](/)

--- a/docs/how-to-guides/customise-multipass/integrate-with-windows-terminal.md
+++ b/docs/how-to-guides/customise-multipass/integrate-with-windows-terminal.md
@@ -28,7 +28,7 @@ Open a terminal (Windows Terminal or any other) and enable the integration with 
 multipass set client.apps.windows-terminal.profiles=primary
 ```
 
-For more information on this setting, see [`client.apps.windows-terminal.profiles`](/reference/settings/client-apps-windows-terminal-profiles). Until you modify it, Multipass will try to add the profile if it finds it missing. To remove the profile see {ref}`integrate-with-windows-terminal-revert` below.
+For more information on this setting, see [`client.apps.windows-terminal.profiles`](reference-settings-client-apps-windows-terminal-profiles). Until you modify it, Multipass will try to add the profile if it finds it missing. To remove the profile see {ref}`integrate-with-windows-terminal-revert` below.
 
 ## Open a Multipass tab
 

--- a/docs/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos.md
+++ b/docs/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos.md
@@ -1,7 +1,7 @@
 (how-to-guides-customise-multipass-migrate-from-hyperkit-to-qemu-on-macos)=
 # Migrate from Hyperkit to QEMU on macOS
 
-> See also: [`set`](/explanation/driver), [local.driver](/explanation/driver), [Driver](/explanation/driver), [How to set up the driver](/how-to-guides/customise-multipass/set-up-the-driver)
+> See also: [`set`](explanation-driver), [local.driver](reference-settings-local-driver), [Driver](explanation-driver), [How to set up the driver](how-to-guides-customise-multipass-set-up-the-driver)
 
 As of Multipass 1.12, the Hyperkit driver is being deprecated. New installs will start with the QEMU driver set by default, but existing installs will retain the previous driver setting. Multipass will warn Hyperkit users of the deprecation and ask them to move to QEMU. To facilitate that, Multipass 1.12 will migrate Hyperkit instances to QEMU.
 

--- a/docs/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos.md
+++ b/docs/how-to-guides/customise-multipass/migrate-from-hyperkit-to-qemu-on-macos.md
@@ -1,7 +1,7 @@
 (how-to-guides-customise-multipass-migrate-from-hyperkit-to-qemu-on-macos)=
 # Migrate from Hyperkit to QEMU on macOS
 
-> See also: [`set`](explanation-driver), [local.driver](reference-settings-local-driver), [Driver](explanation-driver), [How to set up the driver](how-to-guides-customise-multipass-set-up-the-driver)
+> See also: [`set`](reference-command-line-interface-set), [local.driver](reference-settings-local-driver), [Driver](explanation-driver), [How to set up the driver](how-to-guides-customise-multipass-set-up-the-driver)
 
 As of Multipass 1.12, the Hyperkit driver is being deprecated. New installs will start with the QEMU driver set by default, but existing installs will retain the previous driver setting. Multipass will warn Hyperkit users of the deprecation and ask them to move to QEMU. To facilitate that, Multipass 1.12 will migrate Hyperkit instances to QEMU.
 

--- a/docs/how-to-guides/customise-multipass/use-a-different-terminal-from-the-system-icon.md
+++ b/docs/how-to-guides/customise-multipass/use-a-different-terminal-from-the-system-icon.md
@@ -1,7 +1,7 @@
 (how-to-guides-customise-multipass-use-a-different-terminal-from-the-system-icon)=
 # Use a different terminal from the system icon
 
-> See also: [How to install Multipass](/how-to-guides/install-multipass), [`shell`](/reference/command-line-interface/shell).
+> See also: [How to install Multipass](how-to-guides-install-multipass), [`shell`](reference-command-line-interface-shell).
 
 If you want, you can change the terminal application used by the Multipass system menu icon.
 


### PR DESCRIPTION
This PR solves the issue of standardizing the internal linking to use the recommended Myst cross-linking [standard ](https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html)instead of relative linking to internal documents. 

This provides the docs with capability of always linking to the correct document even in situations where a file has been moved or renamed.




MULTI-2157