### PR TITLE
Solve error from suspended instances on GUI close

### DIFF
--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -184,9 +184,15 @@ class _AppState extends ConsumerState<App> with WindowListener {
     }
 
     stopAllInstances() {
+      final runningVMs = ref
+          .read(vmStatusesProvider)
+          .entries
+          .where((entry) => entry.value == Status.RUNNING)
+          .map((entry) => entry.key)
+          .toList();
       final notificationsNotifier = ref.read(notificationsProvider.notifier);
       notificationsNotifier.addOperation(
-        ref.read(grpcClientProvider).stop([]),
+        ref.read(grpcClientProvider).stop(runningVMs),
         loading: 'Stopping all instances',
         onError: (error) => 'Failed to stop all instances: $error',
         onSuccess: (_) {


### PR DESCRIPTION
Raised in #4200, the GUI had a bug relating to stopping instances. Similar to `multipass stop --all`, if the GUI is configured to close all running instances or the user selects that option in the closing prompt, the GUI will attempt to close all instances before closing the GUI itself. This will cause an error and prevent the GUI from closing if there is at least one running instance and at least one suspended instances. If at least one suspended instance is lexicographically sorted behind the running instance the GUI cannot be closed with the option of "closing all running instances".

To solve that, the GUI now only requests to close the instances that are actually running.

Then `multipass_tests` was run and all tests passed.

Fixes #4200 

MULTI-2234
