### PR TITLE
Fix Windows installer logs path

### DIFF
--- a/docs/how-to-guides/troubleshoot/access-logs.md
+++ b/docs/how-to-guides/troubleshoot/access-logs.md
@@ -37,7 +37,7 @@ The Multipass GUI produces its own logs, that can be found under `~/Library/Appl
 
 On Windows, the Event system is used and Event Viewer lets you access them. Our logs are currently under "Windows Logs/Application", where you can filter by "Multipass" Event source. You can then export the selected events to a file.
 
-Logs from the installation and uninstall process can be found under `%APPDATA%\Local\Temp`. Sort the contents of the directory by "Date Modified" to bring the newest files to the top. The name of the file containing the logs follows the pattern `MSI[0-9a-z].LOG`.
+Logs from the installation and uninstall process can be found under `%TEMP%`. Sort the contents of the directory by "Date Modified" to bring the newest files to the top. The name of the file containing the logs follows the pattern `MSI[0-9a-z].LOG`.
 
 The Multipass GUI produces its own logs, that can be found under `%APPDATA%\com.canonical\Multipass GUI\multipass_gui.log`
 


### PR DESCRIPTION
Previously the documentation had the path of the install logs as `%APPDATA%\Local\Temp`, this by default resolves to `C:\Users\<user>\AppData\Roaming\Local\Temp` which is not the correct path. This PR uses `%TEMP%` which by default resolves to `C:\Users\<user>\AppData\Local\Temp` which is where the logs are stored*.

Thanks to @holta for pointing out this issue in #4209

*as pointed out by @xmkg, logs may not always be in the `%TEMP%` folder