### PR TITLE
[tics] Notify Multipass team on workflow failure

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -88,7 +88,7 @@ jobs:
         installTics: true
 
     - name: Report workflow failure
-      if: ${{ failure() || cancelled() }}
+      if: ${{ !success() }}
       uses: mattermost/action-mattermost-notify@master
       with:
         MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION
This PR adds a step to the TICS workflow that sends a notification to the [Multipass](https://chat.canonical.com/canonical/channels/multipass) Mattermost channel when the workflow fails. Below is an example message that would be sent to Mattermost:

```
🔴 @mp
Scheduled [TICS](https://github.com/canonical/multipass/actions/runs/17801613177) workflow failed.
```

MULTI-2240