### PR TITLE
[macos] Copy libdart_ffi dylib to Frameworks dir

### DIFF
--- a/src/client/gui/CMakeLists.txt.macos
+++ b/src/client/gui/CMakeLists.txt.macos
@@ -42,7 +42,18 @@ add_custom_command(OUTPUT ${MULTIPASS_GUI_EXECUTABLE_FULL_PATH}
 )
 
 add_custom_target(${MULTIPASS_GUI_EXECUTABLE} ALL
-  DEPENDS ${MULTIPASS_GUI_EXECUTABLE_FULL_PATH}
+  DEPENDS ${MULTIPASS_GUI_EXECUTABLE_FULL_PATH} dart_ffi
+)
+
+# Copy libdart_ffi.dylib to the app bundle's Frameworks directory after Flutter build
+add_custom_command(TARGET ${MULTIPASS_GUI_EXECUTABLE} POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    $<TARGET_FILE:dart_ffi>
+    ${MULTIPASS_GUI_BUNDLE}/Contents/Frameworks/libdart_ffi.dylib
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    $<TARGET_FILE:dart_ffi>
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${MULTIPASS_GUI_PREFIX}/${MULTIPASS_GUI_BUNDLE_RELATIVE}/Contents/Frameworks/libdart_ffi.dylib
+  COMMENT "Copying libdart_ffi.dylib to app bundles"
 )
 
 install(DIRECTORY ${MULTIPASS_GUI_BUNDLE}/Contents


### PR DESCRIPTION
This is the MacOS equivalent of #4212 that copies the libdart_ffi.dylib file to the app bundle's Frameworks directory after the Flutter build is complete in order to avoid GUI errors on startup because the GUI cannot find the libdart_ffi library.

With this change, the shortcut to the Multipass.app Application in the build/bin folder is now usable right after a successful GUI build.

The reason for the two copy operations is because the MacOS build creates two separate Multipass.app bundles in different directories during the build process. One at `build/bin/macos/Build/Products/Release/Multipass.app` and one at `build/build/bin/macos/Build/Products/Release/Multipass.app`