### PR TITLE
[docs] Update dependencies & configuration in MacOS build instructions

### DIFF
--- a/BUILD.macOS.md
+++ b/BUILD.macOS.md
@@ -53,6 +53,12 @@ If you encounter errors about missing `pkg-config` or `ninja`, install them with
 
 This is required for CMake to find all necessary build tools and dependencies.
 
+If you encounter Python errors about missing `tomli` during the QEMU build step, install it with:
+
+    pip3 install tomli
+
+This is required for Python-based build scripts.
+
 ### Install Submodules
 
     cd <multipass>

--- a/BUILD.macOS.md
+++ b/BUILD.macOS.md
@@ -45,7 +45,7 @@ means to obtain these dependencies is with Homebrew <https://brew.sh/>.
 Building
 ---------------------------------------
 
-### Additional dependencies for Apple Silicon
+### Additional configuration
 
 If you encounter errors about missing `pkg-config` or `ninja`, install them with:
 
@@ -58,6 +58,17 @@ If you encounter Python errors about missing `tomli` during the QEMU build step,
     pip3 install tomli
 
 This is required for Python-based build scripts.
+
+#### Xcode setup
+
+After installing Xcode, you may need to configure the command line tools and complete the initial setup:
+
+    sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+    sudo xcodebuild -runFirstLaunch
+
+The first command sets the active developer directory to your Xcode installation. This is necessary when xcodebuild is not found in the PATH or when there are multiple Xcode installations.
+
+The second command runs Xcode's first launch setup, which installs additional components and tools required for building iOS and macOS applications. This may be needed if you encounter errors about missing Xcode tools or frameworks during the build process.
 
 ### Install Submodules
 

--- a/BUILD.macOS.md
+++ b/BUILD.macOS.md
@@ -45,8 +45,20 @@ means to obtain these dependencies is with Homebrew <https://brew.sh/>.
 Building
 ---------------------------------------
 
+### Additional dependencies for Apple Silicon
+
+If you encounter errors about missing `pkg-config` or `ninja`, install them with:
+
+    brew install pkg-config ninja
+
+This is required for CMake to find all necessary build tools and dependencies.
+
+### Install Submodules
+
     cd <multipass>
     git submodule update --init --recursive
+
+### Build Multipass
 
 To build with official Qt sources do:
 


### PR DESCRIPTION
On a newly set-up Macbook M2, I needed to install pkg-config and ninja with brew as well as the tomli python package in order to build Multipass successfully. This was not indicated in the BUILD.macOS.md file. 

Additionally, I found that even after a full Xcode installation I was running into issues with `xcodebuild` not being found even though the command succeeded in the command line when trying to build the GUI. After running the two xcode related commands in sudo I was able to successfully build the GUI