### PR TITLE
[docs] Fix 404 and sitemap url

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 ogp_site_url = "https://documentation.ubuntu.com/multipass/en/latest/"
 
 html_baseurl = "https://documentation.ubuntu.com/multipass/"  # for sitemap.xml, the trailing slash is important
-sitemap_url_scheme = "en/latest/{link}"
+sitemap_url_scheme = "latest/{link}"
 
 # Preview name of the documentation website
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,6 +209,7 @@ linkcheck_ignore = [
     "https://sourceforge.net/projects/xming/",
     "http://www.straightrunning.com/XmingNotes/",
     "https://unix.stackexchange.com",  # it seems stackexchange is now blocking bots
+    "https://developer.hashicorp.com/packer"
 ]
 
 linkcheck_retries = 3

--- a/docs/how-to-guides/customise-multipass/build-multipass-images-with-packer.md
+++ b/docs/how-to-guides/customise-multipass/build-multipass-images-with-packer.md
@@ -5,7 +5,7 @@
 Custom images are only supported on Linux.
 ```
 
-[Packer](https://packer.io/) is a utility that lets you (re)build images to run in a variety of environments. Multipass can run those images too, provided some requirements are met (namely, the image has to boot on the hypervisor in use, and [cloud-init](https://cloudinit.readthedocs.io/en/latest/) needs to be available).
+[Packer](https://developer.hashicorp.com/packer) is a utility that lets you (re)build images to run in a variety of environments. Multipass can run those images too, provided some requirements are met (namely, the image has to boot on the hypervisor in use, and [cloud-init](https://cloudinit.readthedocs.io/en/latest/) needs to be available).
 
 ## Setting up the build directory
 

--- a/docs/how-to-guides/customise-multipass/set-up-the-driver.md
+++ b/docs/how-to-guides/customise-multipass/set-up-the-driver.md
@@ -110,7 +110,7 @@ From then on, all instances started with `multipass launch` will use VirtualBox 
 
 You can view instances with libvirt in two ways, using the `virsh` CLI or the [`virt-manager` GUI](https://virt-manager.org/).
 
-To use the `virsh` CLI, launch an instance and then run the command `virsh list` (see [`man virsh`](https://manpages.ubuntu.com/manpages/xenial/man1/virsh.1.html) for a command reference):
+To use the `virsh` CLI, launch an instance and then run the command `virsh list` (see [`man virsh`](https://manpages.ubuntu.com/manpages/questing/en/man1/virsh.1.html) for a command reference):
 
 ```{code-block} text
 virsh list

--- a/docs/how-to-guides/troubleshoot/troubleshoot-launch-start-issues.md
+++ b/docs/how-to-guides/troubleshoot/troubleshoot-launch-start-issues.md
@@ -87,7 +87,7 @@ Boot failures are often caused by VM image corruption, which can happen when the
 Here are some options to attempt recovery:
 
 - If you took a [snapshot](/explanation/snapshot) before incurring this issue, you could try to restore it. However, snapshots are typically stored layers against an original image file, so they may not be enough.
-- **Run [`fsck`](https://manpages.ubuntu.com/manpages/oracular/en/man8/fsck.8.html) in the Serial Console:**
+- **Run [`fsck`](https://manpages.ubuntu.com/manpages/questing/en/man8/fsck.8.html) in the Serial Console:**
 
   The `fsck` tool (short for "file system consistency check") is used to scan the file system for errors and attempt repairs.
 
@@ -269,7 +269,7 @@ Alternatively, try deleting the `network-cache` folder and restart the Multipass
 
 The images that Multipass uses with the QEMU driver follow a standard format — QCOW2 — which other tools can read.
 
-One example is [`qemu-nbd`](https://manpages.ubuntu.com/manpages/oracular/en/man8/qemu-nbd.8.html), which allows mounting the image. This tool is not shipped with Multipass, so you would need to install it manually.
+One example is [`qemu-nbd`](https://manpages.ubuntu.com/manpages/questing/en/man8/qemu-nbd.8.html), which allows mounting the image. This tool is not shipped with Multipass, so you would need to install it manually.
 
 Once you have it, you can search the web for recipes to mount a QCOW2 image. For example, here is a [a recipe](https://askubuntu.com/a/4404).
 


### PR DESCRIPTION
This PR fixes the failing CI caused by rate-limited Hashicorp links for Packer.

It also corrects the hardcoded path for `sitemap.xml` to remove the `/en/` string from url.