### PR TITLE
[macos] Remove duplicate GUI app bundle

### DIFF
--- a/src/client/gui/CMakeLists.txt.macos
+++ b/src/client/gui/CMakeLists.txt.macos
@@ -18,9 +18,13 @@ set(MULTIPASS_GUI_BUNDLE_RELATIVE "Multipass.app")
 set(MULTIPASS_GUI_EXEC_PATH_RELATIVE_TO_BUNDLE Contents/MacOS)
 set(MULTIPASS_GUI_EXECUTABLE multipass_gui)
 
-set(MULTIPASS_GUI_BUILD_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-cmake_path(RELATIVE_PATH MULTIPASS_GUI_BUILD_DIR)
+# Calculate relative path from Flutter working directory to build output directory
+# Flutter requires a relative path for --build-dir
+file(RELATIVE_PATH MULTIPASS_GUI_BUILD_DIR_RELATIVE
+     ${CMAKE_SOURCE_DIR}/src/client/gui
+     ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
+set(MULTIPASS_GUI_BUILD_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 set(MULTIPASS_GUI_PATH ${MULTIPASS_GUI_BUILD_DIR}/${MULTIPASS_GUI_PREFIX})
 set(MULTIPASS_GUI_BUNDLE ${MULTIPASS_GUI_PATH}/${MULTIPASS_GUI_BUNDLE_RELATIVE})
 set(MULTIPASS_GUI_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/client/gui)
@@ -36,7 +40,7 @@ add_custom_command(OUTPUT ${MULTIPASS_GUI_EXECUTABLE_FULL_PATH}
   WORKING_DIRECTORY ${MULTIPASS_GUI_SOURCE_DIR}
   COMMAND ${CMAKE_COMMAND} -E make_directory lib/generated
   COMMAND $<TARGET_FILE:protobuf::protoc> --plugin=protoc-gen-dart=${DART_PROTOC_PLUGIN} --dart_out=grpc:lib/generated -I ../../rpc ../../rpc/multipass.proto google/protobuf/timestamp.proto
-  COMMAND ${FLUTTER_EXECUTABLE} config --build-dir=${MULTIPASS_GUI_BUILD_DIR}
+  COMMAND ${FLUTTER_EXECUTABLE} config --build-dir=${MULTIPASS_GUI_BUILD_DIR_RELATIVE}
   COMMAND ${FLUTTER_EXECUTABLE} build ${MULTIPASS_GUI_TARGET} ${FLUTTER_BUILD_ARGS}
   COMMAND ${FLUTTER_EXECUTABLE} config --build-dir=
 )


### PR DESCRIPTION
When building Multipass on macOS, the build process was creating two identical Multipass.app bundles:
- One in the expected location: `build/bin/macos/Build/Products/Release/Multipass.app`
- A duplicate in a nested structure: `build/build/bin/macos/Build/Products/Release/Multipass.app`

The issue stemmed from how the Flutter build directory was being configured in `src/client/gui/CMakeLists.txt.macos`. The original code was:

1. Setting `MULTIPASS_GUI_BUILD_DIR` to `CMAKE_RUNTIME_OUTPUT_DIRECTORY` (which is `build/bin`)
2. Converting it to a relative path using `cmake_path(RELATIVE_PATH MULTIPASS_GUI_BUILD_DIR)`
3. Passing this relative path to Flutter's `--build-dir` option

The problem was that Flutter interprets relative paths relative to its working directory (`src/client/gui/`), not the project root. So when given the relative path `build/bin`, Flutter would create its build output at `src/client/gui/build/bin/...`, which CMake would then see as `build/build/bin/...` due to nested directory structures.

The fix calculates the proper relative path from Flutter's working directory to the desired build output directory:

```cmake
# Calculate relative path from Flutter working directory to build output directory
# Flutter requires a relative path for --build-dir
file(RELATIVE_PATH MULTIPASS_GUI_BUILD_DIR_RELATIVE 
     ${CMAKE_SOURCE_DIR}/src/client/gui 
     ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
```

This ensures Flutter receives the correct relative path (`../../../build/bin`) that, when interpreted from its working directory, points to the intended build location.

Flutter's build system requires the `--build-dir` parameter to be a relative path, not an absolute one. Attempting to use an absolute path results in the error: "build-dir should be a relative path". This is a constraint of the Flutter toolchain that is responsible for the relatively verbose nature of the new CMake code.

- **Before**: Two identical 93.4MB app bundles were created
- **After**: Only one app bundle is created in the correct location