### PR TITLE
[format] Add formatting rules to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,44 @@
+root = true
+
+[CMakeLists.txt]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cpp,h}]
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+trim_trailing_whitespace = true
+
+[*.dart]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.{json,json5}]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 79
+trim_trailing_whitespace = true
+
+[*.{yaml,yml}]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This is just a first pass at copying some of our style rules into a [`.editorconfig`](https://editorconfig.org/) file so that (hopefully) everyone's favorite editors will see these rules and set the various options appropriately. There are probably more rules we could set, but this should cover the basics.

If you're an Emacser like me, then you can add this to your `.dir-locals.el` to enable editorconfig support in the Multipass repo, if it's not already enabled globally in your config: `((nil . ((mode . editorconfig))))`