### PR TITLE
[macos] IP address validation

### DIFF
--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -76,7 +76,7 @@ bool subnet_used_locally(const std::string& subnet)
 
 bool can_reach_gateway(const std::string& ip)
 {
-    return MP_UTILS.run_cmd_for_status("ping", {"-n", "-q", ip.c_str(), "-c", "-1", "-W", "1"});
+    return MP_UTILS.run_cmd_for_status("ping", {"-n", "-q", ip.c_str(), "-c", "1", "-W", "1"});
 }
 
 auto virtual_switch_subnet(const QString& bridge_name)
@@ -194,9 +194,7 @@ auto make_bridge_rollback_guard(std::string_view log_category,
     });
 }
 
-} // namespace
-
-std::string mp::backend::generate_random_subnet()
+std::string generate_random_subnet()
 {
     gen.seed(std::chrono::system_clock::now().time_since_epoch().count());
     for (auto i = 0; i < 100; ++i)
@@ -216,6 +214,8 @@ std::string mp::backend::generate_random_subnet()
 
     throw std::runtime_error("Could not determine a subnet for networking.");
 }
+
+} // namespace
 
 // @precondition no bridge exists for this interface
 // @precondition interface identifies an ethernet device
@@ -286,7 +286,7 @@ std::string mp::Backend::get_subnet(const mp::Path& network_dir, const QString& 
     if (MP_FILEOPS.size(subnet_file) > 0)
         return MP_FILEOPS.read_all(subnet_file).trimmed().toStdString();
 
-    auto new_subnet = mp::backend::generate_random_subnet();
+    auto new_subnet = generate_random_subnet();
     MP_FILEOPS.write(subnet_file, new_subnet.data(), new_subnet.length());
     return new_subnet;
 }

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -25,7 +25,6 @@
 #include <multipass/process/basic_process.h>
 #include <multipass/top_catch_all.h>
 #include <multipass/utils.h>
-#include <shared/shared_backend_utils.h>
 
 #include <scope_guard.hpp>
 

--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -25,6 +25,7 @@
 #include <multipass/process/basic_process.h>
 #include <multipass/top_catch_all.h>
 #include <multipass/utils.h>
+#include <shared/shared_backend_utils.h>
 
 #include <scope_guard.hpp>
 

--- a/src/platform/backends/shared/linux/backend_utils.h
+++ b/src/platform/backends/shared/linux/backend_utils.h
@@ -36,8 +36,6 @@ class ProcessFactory;
 
 namespace backend
 {
-std::string generate_random_subnet();
-
 class CreateBridgeException : public std::runtime_error
 {
 public:

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -17,6 +17,7 @@
 
 #include "backend_utils.h"
 
+#include <multipass/logging/log.h>
 #include <multipass/platform.h>
 #include <multipass/process/simple_process_spec.h>
 
@@ -24,6 +25,8 @@ namespace mp = multipass;
 
 namespace
 {
+constexpr auto category = "backend-utils";
+
 QString simplify_mac_address(const QString& input_mac_address)
 {
     // Trim the (first) leading 0 of each segment of the a MAC address.
@@ -99,6 +102,11 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
         if (match.captured(2) == arp_format_mac_address)
         {
             mp::IPAddress current_ip{match.captured(1).toStdString()};
+
+            mpl::trace(category,
+                       "Found ip match \'{}\': for mac address: \'{}\'",
+                       current_ip.as_string(),
+                       mac_address);
 
             if ((!best_match.has_value() || current_ip > best_match.value()) && ping_ip(current_ip))
             {

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -74,6 +74,7 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
     // ? (192.168.64.2) at 52:54:0:2a:12:b6 on bridge100 ifscope [bridge]
     // ? (192.168.64.3) at 52:54:0:85:72:55 on bridge100 ifscope [bridge]
     // ? (192.168.64.4) at 52:54:0:e1:cd:ab on bridge100 ifscope [bridge]
+    // ? (192.168.64.5) at 52:54:0:e1:cd:ab on bridge100 ifscope [bridge]
     // ? (192.168.64.255) at ff:ff:ff:ff:ff:ff on bridge100 ifscope [bridge]
     // ? (224.0.0.251) at 1:0:5e:0:0:fb on en0 ifscope permanent [ethernet]
 

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -84,8 +84,6 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
     const QString arp_format_mac_address =
         simplify_mac_address(QString::fromStdString(mac_address));
 
-    std::optional<mp::IPAddress> best_match;
-
     while (iter.hasNext())
     {
         QRegularExpressionMatch match = iter.next();
@@ -99,13 +97,12 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
                        current_ip.as_string(),
                        mac_address);
 
-            if ((!best_match.has_value() || current_ip > best_match.value()) &&
-                mp::backend::can_reach_gateway(current_ip.as_string()))
+            if (mp::backend::can_reach_gateway(current_ip.as_string()))
             {
-                best_match = current_ip;
+                return {mp::IPAddress{match.captured(1).toStdString()}};
             }
         }
     }
 
-    return best_match;
+    return std::nullopt;
 }

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -20,7 +20,7 @@
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
 #include <multipass/process/simple_process_spec.h>
-#include <shared/shared_backend_utils.h>
+#include <multipass/utils.h>
 
 namespace mp = multipass;
 
@@ -64,6 +64,11 @@ QString get_arp_output()
     return QString{arp_process->read_all_standard_output()};
 }
 
+bool can_reach_gateway(const std::string& ip)
+{
+    return MP_UTILS.run_cmd_for_status("ping", {"-n", "-q", ip.c_str(), "-c", "1", "-t", "1"});
+}
+
 } // namespace
 
 std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& mac_address)
@@ -98,7 +103,7 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
                        current_ip.as_string(),
                        mac_address);
 
-            if (mp::backend::can_reach_gateway(current_ip.as_string()))
+            if (can_reach_gateway(current_ip.as_string()))
             {
                 return current_ip;
             }

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -79,8 +79,8 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
     // ? (224.0.0.251) at 1:0:5e:0:0:fb on en0 ifscope permanent [ethernet]
 
     const QString arp_output = get_arp_output();
-    const QRegularExpression ip_and_mac_address_pair_regex(R"(\(([^)\s]+)\) at ([^\s]+))");
-    QRegularExpressionMatchIterator iter = ip_and_mac_address_pair_regex.globalMatch(arp_output);
+    const QRegularExpression arp_reg(R"(\(([^)\s]+)\) at ([^\s]+))");
+    QRegularExpressionMatchIterator iter = arp_reg.globalMatch(arp_output);
 
     const QString arp_format_mac_address =
         simplify_mac_address(QString::fromStdString(mac_address));
@@ -100,7 +100,7 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
 
             if (mp::backend::can_reach_gateway(current_ip.as_string()))
             {
-                return {mp::IPAddress{match.captured(1).toStdString()}};
+                return current_ip;
             }
         }
     }

--- a/tests/macos/test_backend_utils.cpp
+++ b/tests/macos/test_backend_utils.cpp
@@ -71,11 +71,7 @@ TEST_P(GetNeighbourIPValidInputsTests, validInputCases)
 
     EXPECT_CALL(*mock_utils, run_cmd_for_status(QString("ping"), _, _))
         .WillRepeatedly([](const QString&, const QStringList& args, auto&&) {
-            if (args.contains("192.168.64.5"))
-            {
-                return false;
-            }
-            return true;
+            return !args.contains("192.168.64.5");
         });
 
     EXPECT_EQ(mp::backend::get_neighbour_ip(existed_mac).value().as_string(), expected_mapped_ip);

--- a/tests/macos/test_backend_utils.cpp
+++ b/tests/macos/test_backend_utils.cpp
@@ -15,8 +15,10 @@
  *
  */
 
-#include "src/platform/backends/shared/macos/backend_utils.h"
 #include "tests/mock_process_factory.h"
+#include "tests/mock_utils.h"
+
+#include <src/platform/backends/shared/macos/backend_utils.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;
@@ -29,6 +31,8 @@ const QByteArray mock_arp_output_stream = QByteArray{R"(
 ? (192.168.64.2) at 52:54:0:2a:12:b6 on bridge100 ifscope [bridge]
 ? (192.168.64.3) at 52:54:0:85:72:55 on bridge100 ifscope [bridge]
 ? (192.168.64.4) at 52:54:0:e1:cd:ab on bridge100 ifscope [bridge]
+? (192.168.64.5) at 50:eb:f6:7f:39:a7 on bridge100 ifscope [bridge]
+? (192.168.64.6) at 50:eb:f6:7f:39:a7 on bridge100 ifscope [bridge]
 ? (192.168.64.255) at ff:ff:ff:ff:ff:ff on bridge100 ifscope [bridge]
 ? (224.0.0.251) at 1:0:5e:0:0:fb on en0 ifscope permanent [ethernet])"};
 }
@@ -63,6 +67,17 @@ struct GetNeighbourIPValidInputsTests
 TEST_P(GetNeighbourIPValidInputsTests, validInputCases)
 {
     const auto& [existed_mac, expected_mapped_ip] = GetParam();
+    auto [mock_utils, utils_guard] = mpt::MockUtils::inject();
+
+    EXPECT_CALL(*mock_utils, run_cmd_for_status(QString("ping"), _, _))
+        .WillRepeatedly([](const QString&, const QStringList& args, auto&&) {
+            if (args.contains("192.168.64.5"))
+            {
+                return false;
+            }
+            return true;
+        });
+
     EXPECT_EQ(mp::backend::get_neighbour_ip(existed_mac).value().as_string(), expected_mapped_ip);
 }
 
@@ -71,6 +86,7 @@ INSTANTIATE_TEST_SUITE_P(GetNeighbourIPTestsInstantiation,
                          Values(std::make_pair("52:54:00:2a:12:b6", "192.168.64.2"),
                                 std::make_pair("52:54:00:85:72:55", "192.168.64.3"),
                                 std::make_pair("52:54:00:e1:cd:ab", "192.168.64.4"),
+                                std::make_pair("50:eb:f6:7f:39:a7", "192.168.64.6"),
                                 std::make_pair("01:00:5e:00:00:fb", "224.0.0.251")));
 
 struct GetNeighbourIPInValidInputsTests : public GetNeighbourIpFixture,


### PR DESCRIPTION
This PR adds some validation to the process that resolves IP addresses from MAC addresses on macOS. Due to past changes made by Apple, we now use ARP to resolve IP addresses. The ARP table is, however, a cache that can potentially contain old and stale IP addresses before they are purged.

For launching Ubuntu Core images, this creates several problems. The initialization of an Ubuntu Core image is completed in two phases which is separated by the guest rebooting itself. Networking is partially initialized during the first phase, and macOS assigns it an IP address. During the second phase after the guest reboots, guest networking finishes initializing causing macOS to assign it another IP address. Now, ARP contains two IP addresses for the same MAC address.

To solve this, I have added a couple countermeasures:
1. Before returning an IP address, ping the address looking for a response signalling the machine is ready for communication.
2. If there are multiple IP addresses for the same MAC address, iterate over all IP's pinging each one and return the address who delivers a ping response.

Addresses #3541 

---

MULTI-2242