### PR TITLE
[docs] Add wait-ready reference documentation

### DIFF
--- a/docs/reference/command-line-interface/wait-ready.md
+++ b/docs/reference/command-line-interface/wait-ready.md
@@ -3,7 +3,7 @@
 
 > See also: [`start`](reference-command-line-interface-start), [`launch`](reference-command-line-interface-launch)
 
-The `multipass wait-ready` command blocks execution until the Multipass daemon is fully initialized and ready to accept requests. This is particularly useful in automated environments such as CI/CD pipelines, where subsequent Multipass commands may fail if the daemon has not yet finished starting up.
+The `multipass wait-ready` command blocks execution until the Multipass daemon is fully initialized and ready to accept requests. This is particularly useful in batch operations and automated environments such as CI/CD pipelines, where subsequent Multipass commands may fail if the daemon has not yet finished starting up.
 
 By waiting for the daemon to reach a ready state, scripts and services can safely perform operations such as launching or listing instances without encountering transient "daemon not ready" errors.
 


### PR DESCRIPTION


This PR addresses this issue: https://github.com/canonical/multipass/issues/4387 as well as the already closed PR: https://github.com/canonical/multipass/pull/4145

It adds a `wait-ready` reference page to the list of Multipass CLI references.