### PR TITLE
snap: add content interface to expose multipass binaries

### DIFF
--- a/docs/how-to-guides/customise-multipass/index.md
+++ b/docs/how-to-guides/customise-multipass/index.md
@@ -10,6 +10,7 @@ The following guides provide step-by-step instructions on how to customise Multi
 - [Set up a graphical interface](how-to-guides-customise-multipass-set-up-a-graphical-interface)
 - [Use a different terminal from the system icon](how-to-guides-customise-multipass-use-a-different-terminal-from-the-system-icon)
 - [Integrate with Windows Terminal](how-to-guides-customise-multipass-integrate-with-windows-terminal)
+- [Use Multipass content interface](how-to-guides-customise-multipass-use-multipass-content-interface)
 - [Configure where Multipass stores external data](how-to-guides-customise-multipass-configure-where-multipass-stores-external-data)
 - [Configure Multipass’s default logging level](how-to-guides-customise-multipass-configure-multipass-default-logging-level)
 
@@ -30,6 +31,7 @@ build-multipass-images-with-packer
 set-up-a-graphical-interface
 use-a-different-terminal-from-the-system-icon
 integrate-with-windows-terminal
+use-multipass-content-interface
 configure-where-multipass-stores-external-data
 configure-multipass-default-logging-level
 ```

--- a/docs/how-to-guides/customise-multipass/use-multipass-content-interface.md
+++ b/docs/how-to-guides/customise-multipass/use-multipass-content-interface.md
@@ -1,0 +1,118 @@
+(how-to-guides-customise-multipass-use-multipass-content-interface)=
+# Use Multipass content interface
+
+The Multipass snap provides a content interface that allows other snaps to access its executables. This is useful for tools that need to interact with Multipass from within a strictly confined snap environment.
+
+## What's Exposed
+
+The `multipass-bin` slot exposes:
+- `/snap/multipass/current/bin/multipass` - The Multipass CLI client
+- `/snap/multipass/current/bin/multipassd` - The Multipass daemon binary
+
+## How to Use It
+
+### 1. In Your snapcraft.yaml
+
+Add a plug to consume the multipass-bin content:
+
+```yaml
+plugs:
+  multipass-bin:
+    interface: content
+    content: multipass-executables
+    target: $SNAP/multipass-bin
+    default-provider: multipass
+```
+
+### 2. Connect the Interface
+
+After installing both snaps:
+
+```bash
+sudo snap connect your-snap:multipass-bin multipass:multipass-bin
+```
+
+### 3. Access the Multipass Binary
+
+The multipass binary will be available at `$SNAP/multipass-bin/multipass`:
+
+```bash
+#!/bin/bash
+# Example: Call multipass info from your snap
+$SNAP/multipass-bin/multipass info
+```
+
+## Example: multipass-exporter Snap
+
+Here's a complete example for a Prometheus exporter that needs to run `multipass info`:
+
+```yaml
+name: multipass-exporter
+base: core22
+confinement: strict
+
+apps:
+  exporter:
+    command: bin/multipass-exporter
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+      - multipass-bin
+
+plugs:
+  multipass-bin:
+    interface: content
+    content: multipass-executables
+    target: $SNAP/multipass-bin
+    default-provider: multipass
+
+parts:
+  exporter:
+    plugin: go
+    source: .
+    build-packages:
+      - golang-go
+```
+
+Then in your exporter code:
+
+```go
+package main
+
+import (
+    "os"
+    "os/exec"
+    "path/filepath"
+)
+
+func getMultipassInfo() ([]byte, error) {
+    snapPath := os.Getenv("SNAP")
+    multipassBin := filepath.Join(snapPath, "multipass-bin", "multipass")
+    
+    cmd := exec.Command(multipassBin, "info", "--format", "json")
+    return cmd.Output()
+}
+```
+
+## Notes
+
+- The multipass daemon must be running for the commands to work
+- Make sure to handle the case where the content interface might not be connected
+- The consuming snap only gets read access to the binaries
+- Environment variables may need to be set properly for multipass to connect to the daemon
+
+## Troubleshooting
+
+**Interface not connected?**
+```bash
+snap connections your-snap
+```
+
+**Permission denied?**
+```bash
+sudo snap connect your-snap:multipass-bin multipass:multipass-bin
+```
+
+**Binary not found?**
+Check that the `$SNAP/multipass-bin` path exists after connecting the interface.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,14 @@ plugs:
     interface: home
     read: all
 
+slots:
+  multipass-bin:
+    interface: content
+    content: multipass-executables
+    read:
+      - $SNAP/bin/multipass
+      - $SNAP/bin/multipassd
+
 apps:
   multipassd:
     command: bin/launch-multipassd


### PR DESCRIPTION
### Problem

Tools running in strictly confined snaps can't execute multipass commands because they don't have access to the multipass binary. This came up with multipass-exporter, which needs to run `multipass info` to collect metrics for Prometheus.

### Solution

I've added a content interface that exposes the multipass binaries so other snaps can access them. This is the standard way to share binaries between snaps in a safe, controlled manner.

The implementation adds a `multipass-bin` slot to the snapcraft.yaml that exposes:
- The multipass CLI client (`/bin/multipass`)
- The multipassd daemon binary (`/bin/multipassd`)

### How It Works

Other snaps can now consume this content interface by adding a plug in their snapcraft.yaml:

```yaml
plugs:
  multipass-bin:
    interface: content
    content: multipass-executables
    target: $SNAP/multipass-bin
    default-provider: multipass
```

After connecting the interface (`snap connect their-snap:multipass-bin multipass:multipass-bin`), they'll be able to execute multipass commands from `$SNAP/multipass-bin/multipass`.

### Documentation

I've added a complete how-to guide that explains:
- What the interface exposes
- How to set it up in consuming snaps
- A full working example for multipass-exporter
- Troubleshooting tips

### Testing

The changes are pretty straightforward - just adding a slot declaration. The actual binary paths already exist in the snap, so there's no risk of breaking existing functionality. Once the snap is built with this change, other snaps will be able to connect to it.

Fixes #4401
