### PR TITLE
[network] Handle empty cache dir path in url_downloader constructor

### DIFF
--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -241,7 +241,8 @@ mp::URLDownloader::URLDownloader(std::chrono::milliseconds timeout) : URLDownloa
 }
 
 mp::URLDownloader::URLDownloader(const mp::Path& cache_dir, std::chrono::milliseconds timeout)
-    : cache_dir_path{QDir(cache_dir).filePath("network-cache")}, timeout{timeout}
+    : cache_dir_path{cache_dir.isEmpty() ? Path() : QDir(cache_dir).filePath("network-cache")},
+      timeout{timeout}
 {
 }
 


### PR DESCRIPTION
Resolves #1098 

This PR modifies the URLDownloader constructor to check if the `cache_dir` parameter is empty before appending "network-cache". Previously, URLDownloader constructor was unconditionally appending "network-cache" to the cache directory path, even when initialized with an empty path. This caused QDir("") to resolve to the current directory, resulting in ./network-cache being created wherever tests were executed.

Now when tests instantiate URLDownloader with just a timeout parameter (which calls the no-argument constructor that passes an empty Path()), the cache_dir_path will now remain empty instead of being set to "./network-cache". This prevents Qt's QNetworkDiskCache from creating the network-cache directory in the current working directory when running the `multipass_tests` executable.

MULTI-2301