### PR TITLE
[bash] Avoid using sed in bash major version check

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -463,7 +463,8 @@ _multipass_complete()
 
 # Check the Bash version. Bash < 4 does not have `compopt`, which we use for completing `launch --network`. We
 # disable some completions on that command based on this test.
-if [[ $(echo ${BASH_VERSION} | sed s/\\..*//g) -gt 3 ]]; then
+bash_major_version=${BASH_VERSION%%.*}
+if [[ $bash_major_version -gt 3 ]]; then
     OLD_BASH=false
 else
     OLD_BASH=true


### PR DESCRIPTION
This pull request updates the Bash version check logic in the `_multipass_complete()` function to use a more robust method for extracting the major version number. This change replaces the previous `sed`-based extraction of the major version from `BASH_VERSION` with Bash parameter expansion, storing the result in `bash_major_version` for improved clarity and robustness. (`completions/bash/multipass`)

resolves #3267 