### PR TITLE
[yaml] Use DoubleQuoted for octals instead of LocalTag

### DIFF
--- a/src/utils/yaml_node_utils.cpp
+++ b/src/utils/yaml_node_utils.cpp
@@ -131,7 +131,7 @@ std::string mp::utils::emit_yaml(const YAML::Node& node)
                 if (value.length() >= 2 && value[0] == '0' &&
                     std::all_of(value.begin() + 1, value.end(), ::isdigit))
                 {
-                    emitter << YAML::LocalTag("str") << value;
+                    emitter << YAML::DoubleQuoted << value;
                     break;
                 }
             }

--- a/tests/test_yaml_node_utils.cpp
+++ b/tests/test_yaml_node_utils.cpp
@@ -178,12 +178,10 @@ TEST(UtilsTests, emitYamlWithOctalString)
 
     const std::string result = mpu::emit_yaml(node);
 
-    // The octal strings should be tagged as strings to preserve their format
-    EXPECT_TRUE(result.find("permissions: !str \"0755\"") != std::string::npos ||
-                result.find("permissions: !str 0755") != std::string::npos);
-    EXPECT_TRUE(result.find("another_permission: !str \"0644\"") != std::string::npos ||
-                result.find("another_permission: !str 0644") != std::string::npos);
-    // Non-octal strings should not be tagged
+    // The octal strings should be double-quoted to preserve their format as strings
+    EXPECT_TRUE(result.find("permissions: \"0755\"") != std::string::npos);
+    EXPECT_TRUE(result.find("another_permission: \"0644\"") != std::string::npos);
+    // Non-octal strings should not be quoted (or may be quoted, both are acceptable)
     EXPECT_TRUE(result.find("not_octal: 0abc") != std::string::npos ||
                 result.find("not_octal: \"0abc\"") != std::string::npos);
     EXPECT_TRUE(result.find("regular_string: hello") != std::string::npos ||


### PR DESCRIPTION
This pull request updates the YAML emission logic to use double quotes for strings that look like octal numbers, rather than attempting to them explicitly as strings. Corresponding unit tests have also been updated to reflect this new behavior.

YAML::DoubleQuoted was originally avoided in favor of explicit tags due to perceived issues with timeouts using DoubleQuoted, but it appears that this is not a result of the use of DoubleQuoted (loading some cloud-init YAMLs simply takes a long time!)

fixes #4418
