### PR TITLE
[network] Bridges with long names use hash suffix

### DIFF
--- a/src/platform/backends/shared/linux/backend_utils.cpp
+++ b/src/platform/backends/shared/linux/backend_utils.cpp
@@ -29,6 +29,7 @@
 #include <scope_guard.hpp>
 
 #include <QCoreApplication>
+#include <QCryptographicHash>
 #include <QDBusMetaType>
 #include <QString>
 #include <QtDBus/QtDBus>
@@ -192,6 +193,36 @@ auto make_bridge_rollback_guard(std::string_view log_category,
     });
 }
 
+QString generate_bridge_name(const std::string& interface)
+{
+    static constexpr auto base_name = "br-";
+    static constexpr auto base_name_len = 3; // length of "br-"
+
+    auto full_name = QString("%1%2").arg(base_name).arg(QString::fromStdString(interface));
+
+    // If it fits within the limit, use it as-is (most readable)
+    if (full_name.length() <= max_bridge_name_len)
+        return full_name;
+
+    // Otherwise, truncate and add hash suffix for uniqueness
+    // Use 3-character hash suffix: 15 - 3 ("br-") - 1 ("-") - 3 (hash) = 8 chars for interface
+    static constexpr auto hash_suffix_len = 3;
+    static constexpr auto separator_len = 1;
+    constexpr auto max_iface_portion =
+        max_bridge_name_len - base_name_len - separator_len - hash_suffix_len;
+
+    // Generate a short hash of the full interface name to ensure uniqueness
+    QCryptographicHash hash(QCryptographicHash::Md5);
+    hash.addData(interface.c_str(), interface.length());
+    auto hash_result = hash.result().toHex();
+    auto hash_suffix = hash_result.left(hash_suffix_len);
+
+    // Use as much of the interface name as possible for readability
+    auto iface_portion = QString::fromStdString(interface).left(max_iface_portion);
+
+    return QString("%1%2-%3").arg(base_name).arg(iface_portion).arg(hash_suffix);
+}
+
 std::string generate_random_subnet()
 {
     gen.seed(std::chrono::system_clock::now().time_since_epoch().count());
@@ -222,7 +253,6 @@ std::string mp::Backend::create_bridge_with(const std::string& interface)
     static constexpr auto log_category_create = "create bridge";
     static constexpr auto log_category_rollback = "rollback bridge";
     static const auto root_path = QDBusObjectPath{"/"};
-    static const auto base_name = QStringLiteral("br-");
 
     static std::once_flag once;
     std::call_once(once, [] { qDBusRegisterMetaType<VariantMapMap>(); });
@@ -232,7 +262,7 @@ std::string mp::Backend::create_bridge_with(const std::string& interface)
     auto nm_settings =
         get_checked_interface(system_bus, nm_bus_name, nm_settings_obj, nm_settings_ifc);
 
-    auto parent_name = (base_name + interface.c_str()).left(max_bridge_name_len);
+    auto parent_name = generate_bridge_name(interface);
     auto child_name = parent_name + "-child";
     mpl::debug(log_category_create, "Creating bridge: {}", parent_name);
 

--- a/tests/linux/test_backend_utils.cpp
+++ b/tests/linux/test_backend_utils.cpp
@@ -31,6 +31,7 @@
 #include <multipass/logging/log.h>
 #include <multipass/memory_size.h>
 
+#include <QCryptographicHash>
 #include <QMap>
 #include <QVariant>
 
@@ -186,7 +187,33 @@ struct CreateBridgeTest : public Test
 
     static QString get_bridge_name(const char* child)
     {
-        return (QString{"br-"} + child).left(15);
+        // This must match the logic in generate_bridge_name() in backend_utils.cpp
+        static constexpr auto base_name = "br-";
+        static constexpr auto base_name_len = 3;
+        static constexpr auto max_bridge_name_len = 15;
+
+        auto full_name = QString("%1%2").arg(base_name).arg(child);
+
+        // If it fits within the limit, use it as-is (most readable)
+        if (full_name.length() <= max_bridge_name_len)
+            return full_name;
+
+        // Otherwise, truncate and add hash suffix for uniqueness
+        static constexpr auto hash_suffix_len = 3;
+        static constexpr auto separator_len = 1;
+        constexpr auto max_iface_portion =
+            max_bridge_name_len - base_name_len - separator_len - hash_suffix_len;
+
+        // Generate a short hash of the full interface name to ensure uniqueness
+        QCryptographicHash hash(QCryptographicHash::Md5);
+        hash.addData(child, strlen(child));
+        auto hash_result = hash.result().toHex();
+        auto hash_suffix = hash_result.left(hash_suffix_len);
+
+        // Use as much of the interface name as possible for readability
+        auto iface_portion = QString(child).left(max_iface_portion);
+
+        return QString("%1%2-%3").arg(base_name).arg(iface_portion).arg(hash_suffix);
     }
 
     MockDBusProvider::GuardedMock mock_dbus_injection = MockDBusProvider::inject();


### PR DESCRIPTION
This pull request introduces a new strategy for generating bridge names in the Linux backend to ensure uniqueness when interface names are long by truncating long interface names and appending a short hash. This ensures that bridge names are both readable and unique.
* Updated the bridge creation logic in `create_bridge_with` to use the new `generate_bridge_name` function, replacing the previous simple truncation method. 
* Added `QCryptographicHash` includes to both `backend_utils.cpp` and `test_backend_utils.cpp` to support the new hashing logic for bridge name generation.

Originally:

- `eth123456789abc` → `br-eth123456789` (truncated to 15 chars)
- `eth123456789xyz` → `br-eth123456789` (same name - __collision__)

With the fix:
- `eth123456789abc` → `br-eth12345-8f9` (unique hash suffix)
- `eth123456789xyz` → `br-eth12345-a2c` (different hash - __no collision__)

Short names (unchanged, fully readable):

- `eth0` → `br-eth0`
- `wlan0` → `br-wlan0`
- `enp0s3` → `br-enp0s3`


resolves #2158 