### PR TITLE
[docs] Clarify home directory in ext. storage docs

### DIFF
--- a/docs/how-to-guides/customise-multipass/configure-where-multipass-stores-external-data.md
+++ b/docs/how-to-guides/customise-multipass/configure-where-multipass-stores-external-data.md
@@ -22,7 +22,7 @@ First, stop the Multipass daemon:
 sudo snap stop multipass
 ```
 
-Since Multipass is installed using a strictly confined snap, it is limited on what it can do or access on your host. Depending on where the new storage directory is located, you will need to connect the respective interface to the Multipass snap. Because of [snap confinement](https://snapcraft.io/docs/snap-confinement), this directory needs to be located in either `/home` (connected by default) or one of the removable mounts points (`/mnt` or `/media`). To connect the removable mount points, use the command:
+Since Multipass is installed using a strictly confined snap, it is limited on what it can do or access on your host. Depending on where the new storage directory is located, you will need to connect the respective interface to the Multipass snap. Because of [snap confinement](https://snapcraft.io/docs/snap-confinement), this directory needs to be located in either your home directory (`~`, e.g. `/home/username/`, which is connected by default) or one of the removable mounts points (`/mnt` or `/media`). To connect the removable mount points, use the command:
 
   ```{code-block} text
   sudo snap connect multipass:removable-media


### PR DESCRIPTION
This pull request makes a minor documentation update to clarify the requirements for configuring where Multipass stores external data. The change improves the explanation of directory locations supported by snap confinement.

* Documentation clarification: Updated the description of allowed storage directory locations for Multipass, specifying that the home directory ( `~`,(e.g. `/home/username/`) is connected by default.

resolves #4421
