### PR TITLE
[format] Stick with 100 characters in Python too

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,7 +34,7 @@ insert_final_newline = true
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-max_line_length = 79
+max_line_length = 100
 trim_trailing_whitespace = true
 
 [*.{yaml,yml}]


### PR DESCRIPTION
Use 100 characters for the maximum line length in python files (same as in C++). Conforms to existing code.
