### PR TITLE
[ci] Automatically clean up old issues

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -22,7 +22,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
-          only-issue-labels: "question"
+          only-issue-labels: "needs-info"
           start-date: 2025-10-20
           exempt-all-milestones: true
           exempt-all-assignees: true


### PR DESCRIPTION
GitHub issues with the `question` label will be marked as stale after 30 days and then closed as "Not planned" after an additional 14 days.

This will only affect GitHub issues create from this day on.

Issues that have an assignee or are part of a milestone are exempt.

See [GitHub docs](https://docs.github.com/en/actions/tutorials/manage-your-work/close-inactive-issues) for the inspiration and [actions/stale](https://github.com/marketplace/actions/close-stale-issues) for reference documentation.

MULTI-2349