### PR TITLE
[windows-macos] Macos: remove the arch wrapper

### DIFF
--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -131,9 +131,13 @@ jobs:
           pixman \
           pkg-config \
           python \
-          wget \
-          mono \
-          nuget
+          wget
+
+        # Force brew nuget & mono
+        brew install nuget || true
+        brew install mono || true
+        brew link --overwrite mono
+        brew link --overwrite nuget
 
     - name: Install dependencies from pip
       if: ${{ runner.os == 'macOS' }}


### PR DESCRIPTION
The arch wrapper is needed when cross-compiling, i.e. intel->arm and vice versa. The reason why the arch wrapper was needed in the beginning was there were no ARM based runners as described in this commit:

> https://github.com/canonical/multipass/commit/bbe964b893df660ca52f2a7acf68914405068c2f

Since then, the arch wrapper has basically became redundant. We now use the respective arch for producing intel and arm packages, hence making the wrapper redundant.

Made several changes on the steps that depend on the "arch" variable:

- Replaced the arch check in nuget shim replace step with a file type check.
- Install nuget step now checks if nuget or mono is present or not. If not, then proceeds with installing them.

MULTI-2355