### PR TITLE
[docs] Alternative RDP procedure working with Wayland

### DIFF
--- a/data/cloud-init-yaml/cloud-init-gnome-rdp.yaml
+++ b/data/cloud-init-yaml/cloud-init-gnome-rdp.yaml
@@ -7,7 +7,6 @@ packages:
   - gnome-remote-desktop
   - winpr3-utils
 runcmd:
-  - whoami > /etc/whoami
   - sudo -u gnome-remote-desktop winpr-makecert3 -silent -rdp -path ~gnome-remote-desktop rdp-tls
   - grdctl --system rdp set-tls-key ~gnome-remote-desktop/rdp-tls.key
   - grdctl --system rdp set-tls-cert ~gnome-remote-desktop/rdp-tls.crt

--- a/docs/how-to-guides/customise-multipass/set-up-a-graphical-interface.md
+++ b/docs/how-to-guides/customise-multipass/set-up-a-graphical-interface.md
@@ -97,7 +97,6 @@ This RDP server only works with the default GNOME desktop. You can use it with U
     - gnome-remote-desktop
     - winpr3-utils
     runcmd:
-    - whoami > /etc/whoami
     - sudo -u gnome-remote-desktop winpr-makecert3 -silent -rdp -path ~gnome-remote-desktop rdp-tls
     - grdctl --system rdp set-tls-key ~gnome-remote-desktop/rdp-tls.key
     - grdctl --system rdp set-tls-cert ~gnome-remote-desktop/rdp-tls.crt


### PR DESCRIPTION
The [Set up a graphical interface](https://documentation.ubuntu.com/multipass/latest/how-to-guides/customise-multipass/set-up-a-graphical-interface/) guide no longer works with Ubuntu 25.10 instances because Ubuntu 25.10 removes X11 support from the GNOME desktop.

This alternative procedure still uses RDP to connect but the server setup ensures that it's compatible with Wayland. As a result, you can establish a graphical connection to Ubuntu 25.10 and later, presumably.