### PR TITLE
[gui] Fix flutter rendering problems

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,6 +89,7 @@ apps:
     environment: &_client-environment
       XDG_DATA_HOME: $SNAP_USER_DATA
       XDG_DATA_DIRS: $SNAP/usr/share
+      FLUTTER_LINUX_RENDERER: software
     command: bin/bundle/multipass_gui
     command-chain: [bin/set-xdg-vars]
     plugs:


### PR DESCRIPTION
This PR adds an environment variable to do proper software rendering within the flutter GUI. This avoids flickering problems when flutter attempts to send GPU instructions to the CPU in Mesa drivers (or possibly when drivers are not available) according to [flutter/flutter#169508](https://github.com/flutter/flutter/issues/169508). Fixes #4369 (tested) when this PR is merged into main.

This solution should only be temporary until we (or flutter) solve the root cause of bad rendering, since it could impose some additional load in less modern CPUs.

## Additional info
- It seems like it is only caused by snap confinement, since the built version has no problems.
- Previous versions of flutter do not enable this fix, probably due to bad flutter software rendering, but the flickering is the same. So, it requires #4441 
- This problem appears after the latest 1.16.1, unclear what caused it in our end. It could be a flutter update, since it seems to have been their problem. I examined the diff between main and the 1.16.1 tag and there was nothing obvious that could have caused it (no driver change, no snapcraft.yaml change or linux.patch change). 

MULTI-2357