### PR TITLE
[cmake] Build vcpkg release-only by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if(NOT VCPKG_BUILD_DEFAULT)
   set(VCPKG_HOST_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release")
   set(VCPKG_TARGET_TRIPLET "${VCPKG_HOST_ARCH}-${VCPKG_HOST_OS}-release")
 else()
-  message(NOTICE "Will build `vcpkg` deps in both `debug` and `release` configurations. Be aware that it will take nearly twice the time to build the `vcpkg` deps.")
+  message(NOTICE "Will build `vcpkg` deps in both `debug` and `release` configurations. Be aware that it will take around twice the time to build the `vcpkg` deps.")
 endif()
 
 message(STATUS "Bootstrapping vcpkg...")


### PR DESCRIPTION
The default `cmake configure` with CMAKE_BUILD_TYPE=DEBUG builds both the debug and the release variants of the `vcpkg` deps due to how vcpkg ecosystem is shaped (e.g. some deps need stuff that's only available in the `release` configuration). This causes us to spend twice the time waiting for the vcpkg to finish the building the deps, which is especially troublesome in cold-builds (i.e. no cache).

This patch fixes that by unsetting the VCPKG_BUILD_DEFAULT parameter in debug builds. VCPKG_BUILD_DEFAULT is now a option to the build.

To enable building debug variant of vcpkg deps, use the following:

> -DVCPKG_BUILD_DEFAULT:BOOL=ON

MULTI-2360