### PR TITLE
fix: run multipass delete as logged-in user to avoid authentication failure

### DIFF
--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -28,7 +28,8 @@ done
 
 if [ $DELETE_VMS -eq 1 ]; then
     echo "Removing VMs:"
-    multipass delete -vv --purge --all || echo "Failed to delete multipass VMs from underlying driver" >&2
+    sudo -u "$(logname)" multipass delete -vv --purge --all || echo "Failed to delete multipass VMs from underlying driver" >&2
+
 fi
 
 LAUNCH_AGENT_DEST="/Library/LaunchDaemons/com.canonical.multipassd.plist"


### PR DESCRIPTION
Hey team,

This small update fixes an issue in the macOS uninstall script where the multipass delete command fails due to authentication problems when running as root.

The fix makes the command run as the currently logged-in user instead, using:

--->>>  sudo -u $(logname) multipass delete -vv --purge --all

I tested the script after the change — uninstall now works correctly and all Multipass VMs and data are properly removed when confirmed.

Thanks for reviewing this!
