### PR TITLE
[utils] Remove old Qt JSON utils

### DIFF
--- a/include/multipass/cli/alias_dict.h
+++ b/include/multipass/cli/alias_dict.h
@@ -28,8 +28,6 @@
 
 #include <boost/json.hpp>
 
-class QJsonObject;
-
 namespace multipass
 {
 static constexpr auto default_context_name = "default";

--- a/include/multipass/json_utils.h
+++ b/include/multipass/json_utils.h
@@ -20,36 +20,17 @@
 #include "singleton.h"
 #include "utils/sorted_map_view.h"
 
-#include <multipass/network_interface.h>
-
-#include <QJsonArray>
-#include <QJsonObject>
 #include <QString>
 #include <QStringList>
 
 #include <boost/json.hpp>
 
-#include <filesystem>
-#include <optional>
 #include <ostream>
 #include <string>
-#include <vector>
-
-#define MP_JSONUTILS multipass::JsonUtils::instance()
 
 namespace multipass
 {
 struct VMSpecs;
-class JsonUtils : public Singleton<JsonUtils>
-{
-public:
-    explicit JsonUtils(const Singleton<JsonUtils>::PrivatePass&) noexcept;
-
-    virtual std::string json_to_string(const QJsonObject& root) const;
-    virtual QJsonValue update_cloud_init_instance_id(const QJsonValue& id,
-                                                     const std::string& src_vm_name,
-                                                     const std::string& dest_vm_name) const;
-};
 
 boost::json::object update_unique_identifiers_of_metadata(const boost::json::object& metadata,
                                                           const multipass::VMSpecs& src_specs,
@@ -150,10 +131,6 @@ void pretty_print(std::ostream& os,
                   const boost::json::value& value,
                   const PrettyPrintOptions& opts = {});
 std::string pretty_print(const boost::json::value& value, const PrettyPrintOptions& opts = {});
-
-// Temporary conversion functions to migrate between Qt and Boost JSON values.
-boost::json::value qjson_to_boost_json(const QJsonValue& value);
-QJsonValue boost_json_to_qjson(const boost::json::value& value);
 } // namespace multipass
 
 // These are in the global namespace so that Boost.JSON can look them up via ADL for `QString` and

--- a/src/client/cli/formatter/json_formatter.cpp
+++ b/src/client/cli/formatter/json_formatter.cpp
@@ -316,14 +316,10 @@ std::string mp::JsonFormatter::format(const mp::AliasDict& aliases) const
 
 std::string mp::JsonFormatter::format(const ZonesReply& reply) const
 {
-    QJsonObject root_object;
+    boost::json::object root_object;
 
     for (const auto& zone : reply.zones())
-    {
-        QJsonObject zone_object;
-        zone_object["available"] = zone.available();
-        root_object[QString::fromStdString(zone.name())] = zone_object;
-    }
+        root_object[zone.name()] = {{"available", zone.available()}};
 
-    return MP_JSONUTILS.json_to_string(root_object);
+    return pretty_print(root_object);
 }

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -38,6 +38,7 @@
 
 #include <QFile>
 #include <QProcess>
+#include <QRegularExpression>
 #include <QString>
 #include <QTemporaryFile>
 

--- a/src/platform/backends/shared/base_availability_zone.cpp
+++ b/src/platform/backends/shared/base_availability_zone.cpp
@@ -25,8 +25,6 @@
 
 #include <scope_guard.hpp>
 
-#include <QJsonDocument>
-
 namespace mpl = multipass::logging;
 
 namespace

--- a/src/platform/backends/shared/base_availability_zone_manager.cpp
+++ b/src/platform/backends/shared/base_availability_zone_manager.cpp
@@ -24,8 +24,6 @@
 
 #include <fmt/format.h>
 
-#include <QJsonDocument>
-
 namespace mpl = multipass::logging;
 
 namespace

--- a/src/platform/backends/shared/base_snapshot.h
+++ b/src/platform/backends/shared/base_snapshot.h
@@ -93,7 +93,6 @@ private:
 
     auto erase_helper();
     QString derive_snapshot_filename() const;
-    QJsonObject serialize() const;
     void persist() const;
 
 private:

--- a/src/utils/json_utils.cpp
+++ b/src/utils/json_utils.cpp
@@ -24,9 +24,6 @@
 #include <multipass/utils.h>
 #include <multipass/vm_specs.h>
 
-#include <QJsonArray>
-#include <QJsonDocument>
-
 #include <boost/algorithm/string/replace.hpp>
 
 #include <sstream>
@@ -82,28 +79,6 @@ void pretty_print_scalar(std::ostream& os, const boost::json::value& value)
         os << serialize(value);
 }
 } // namespace
-
-mp::JsonUtils::JsonUtils(const Singleton<JsonUtils>::PrivatePass& pass) noexcept
-    : Singleton<JsonUtils>{pass}
-{
-}
-
-std::string mp::JsonUtils::json_to_string(const QJsonObject& root) const
-{
-    // The function name toJson() is shockingly wrong, for it converts an actual JsonDocument to a
-    // QByteArray.
-    return QJsonDocument(root).toJson().toStdString();
-}
-
-QJsonValue mp::JsonUtils::update_cloud_init_instance_id(const QJsonValue& id,
-                                                        const std::string& src_vm_name,
-                                                        const std::string& dest_vm_name) const
-{
-    std::string id_str = id.toString().toStdString();
-    assert(id_str.size() >= src_vm_name.size());
-
-    return QJsonValue{QString::fromStdString(id_str.replace(0, src_vm_name.size(), dest_vm_name))};
-}
 
 boost::json::object mp::update_unique_identifiers_of_metadata(const boost::json::object& metadata,
                                                               const multipass::VMSpecs& src_specs,
@@ -259,37 +234,6 @@ std::string mp::pretty_print(const boost::json::value& value, const PrettyPrintO
     std::ostringstream os;
     pretty_print(os, value, opts);
     return os.str();
-}
-
-boost::json::value mp::qjson_to_boost_json(const QJsonValue& value)
-{
-    QJsonDocument doc;
-    switch (value.type())
-    {
-    case QJsonValue::Array:
-        doc = QJsonDocument{value.toArray()};
-        break;
-    case QJsonValue::Object:
-        doc = QJsonDocument{value.toObject()};
-        break;
-    default:
-        assert(false && "unsupported type");
-    }
-    return boost::json::parse(std::string_view(doc.toJson()));
-}
-
-QJsonValue mp::boost_json_to_qjson(const boost::json::value& value)
-{
-    auto json_data = serialize(value);
-    auto doc = QJsonDocument::fromJson(
-        QByteArray{json_data.data(), static_cast<qsizetype>(json_data.size())});
-    if (doc.isArray())
-        return doc.array();
-    else if (doc.isObject())
-        return doc.object();
-
-    assert(false && "unsupported type");
-    std::abort();
 }
 
 void tag_invoke(const boost::json::value_from_tag&,

--- a/tests/unit/test_json_utils.cpp
+++ b/tests/unit/test_json_utils.cpp
@@ -22,8 +22,6 @@
 #include <multipass/vm_specs.h>
 
 #include <QFileDevice>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QString>
 
 #include <cctype>
@@ -89,12 +87,6 @@ TEST(TestJsonUtils, updatesUniqueIdentifiersOfMetadata)
                                                     "src_vm",
                                                     "dst_vm"),
               dst_metadata);
-}
-
-TEST(TestJsonUtils, updateCloudInitInstanceIdSucceed)
-{
-    EXPECT_EQ(MP_JSONUTILS.update_cloud_init_instance_id(QJsonValue{"vm1_e_e_e"}, "vm1", "vm2"),
-              QJsonValue{"vm2_e_e_e"});
 }
 
 TEST(TestJsonUtils, lookupInArray)


### PR DESCRIPTION
It's finally happening! There's no longer any Qt JSON code in the tree, so we can remove the old utility functions from `json_utils.h`.