### PR TITLE
[tests] Fix mock delegation on base classes

### DIFF
--- a/tests/common.h
+++ b/tests/common.h
@@ -76,9 +76,10 @@
 //     `MP_DELEGATE_MOCK_CALLS_ON_BASE_WITH_MATCHERS(mock_widget, Widget, render, (A<Canvas>()))`
 // This will redirect the version of `MockWidget::render` that takes one argument of type `Canvas`.
 #define MP_DELEGATE_MOCK_CALLS_ON_BASE_WITH_MATCHERS(mock, method, BaseT, ...)                     \
-    ON_CALL(mock, method __VA_ARGS__).WillByDefault([m = &mock](auto&&... args) {                  \
-        return m->BaseT::method(std::forward<decltype(args)>(args)...);                            \
-    })
+    ON_CALL(mock, method __VA_ARGS__)                                                              \
+        .WillByDefault([m = &mock](auto&&... args) -> decltype(auto) {                             \
+            return m->BaseT::method(std::forward<decltype(args)>(args)...);                        \
+        })
 
 // Teach GTest to print Qt stuff
 QT_BEGIN_NAMESPACE


### PR DESCRIPTION
Fix delegation of mock calls on base classes when the method returns a
reference. To that end, make sure the underlying lambda keeps the right
return type. This avoids returning dangling references to temporaries.
