### PR TITLE
Add troubleshooting link for network launch errors.

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -588,8 +588,11 @@ mp::ReturnCode cmd::Launch::request_launch(const ArgParser* parser)
 
                 // TODO: show the option which triggered the error only. This will need a refactor
                 // in the LaunchError proto.
-                error_details = "Invalid network options supplied";
-            }
+               error_details =
+                    "Invalid network options. "
+                    "To troubleshoot, see "
+                    "https://documentation.ubuntu.com/multipass/stable/how-to-guides/troubleshoot/";
+
         }
 
         return standard_failure_handler_for(name(), cerr, status, error_details);


### PR DESCRIPTION
This pull request adds a helpful message when a Multipass instance launch fails due to network-related issues.

When the launch fails (e.g., firewall blocking the network), users will see a link to the official troubleshooting documentation:

https://multipass.run/docs/troubleshoot-networking

This improves the user experience by guiding users directly to the firewall troubleshooting instructions without requiring them to search the documentation.

Related issue: #533
