### PR TITLE
[cxx20] Use defaulted comparison operators

### DIFF
--- a/include/multipass/cloud_init_iso.h
+++ b/include/multipass/cloud_init_iso.h
@@ -42,18 +42,12 @@ public:
     void write_to(const std::filesystem::path& path);
     void read_from(const std::filesystem::path& path);
 
-    friend bool operator==(const CloudInitIso& lhs, const CloudInitIso& rhs)
-    {
-        return lhs.files == rhs.files;
-    }
+    friend bool operator==(const CloudInitIso& lhs, const CloudInitIso& rhs) = default;
 
 private:
     struct FileEntry
     {
-        friend bool operator==(const FileEntry& lhs, const FileEntry& rhs)
-        {
-            return std::tie(lhs.name, lhs.data) == std::tie(rhs.name, rhs.data);
-        }
+        friend bool operator==(const FileEntry& lhs, const FileEntry& rhs) = default;
 
         std::string name;
         std::string data;

--- a/include/multipass/memory_size.h
+++ b/include/multipass/memory_size.h
@@ -24,12 +24,8 @@ namespace multipass
 class MemorySize
 {
 public:
-    friend bool operator==(const MemorySize& a, const MemorySize& b) noexcept;
-    friend bool operator!=(const MemorySize& a, const MemorySize& b) noexcept;
-    friend bool operator<(const MemorySize& a, const MemorySize& b) noexcept;
-    friend bool operator>(const MemorySize& a, const MemorySize& b) noexcept;
-    friend bool operator<=(const MemorySize& a, const MemorySize& b) noexcept;
-    friend bool operator>=(const MemorySize& a, const MemorySize& b) noexcept;
+    friend inline bool operator==(const MemorySize& a, const MemorySize& b) noexcept = default;
+    friend inline auto operator<=>(const MemorySize& a, const MemorySize& b) noexcept = default;
 
     MemorySize() noexcept;
     explicit MemorySize(const std::string& val);
@@ -48,12 +44,5 @@ private:
 };
 
 long long in_bytes(const std::string& mem_value);
-
-bool operator==(const MemorySize& a, const MemorySize& b) noexcept;
-bool operator!=(const MemorySize& a, const MemorySize& b) noexcept;
-bool operator<(const MemorySize& a, const MemorySize& b) noexcept;
-bool operator>(const MemorySize& a, const MemorySize& b) noexcept;
-bool operator<=(const MemorySize& a, const MemorySize& b) noexcept;
-bool operator>=(const MemorySize& a, const MemorySize& b) noexcept;
 
 } // namespace multipass

--- a/include/multipass/network_interface.h
+++ b/include/multipass/network_interface.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <string>
-#include <tuple>
 
 namespace multipass
 {
@@ -27,10 +26,8 @@ struct NetworkInterface
     std::string id;
     std::string mac_address;
     bool auto_mode;
+
+    friend inline bool operator==(const NetworkInterface& a, const NetworkInterface& b) = default;
 };
 
-inline bool operator==(const NetworkInterface& a, const NetworkInterface& b)
-{
-    return std::tie(a.id, a.auto_mode, a.mac_address) == std::tie(b.id, b.auto_mode, b.mac_address);
-}
 } // namespace multipass

--- a/include/multipass/network_interface_info.h
+++ b/include/multipass/network_interface_info.h
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 #include <string>
-#include <tuple>
 #include <vector>
 
 namespace multipass
@@ -39,12 +38,9 @@ struct NetworkInterfaceInfo
     std::string description;
     std::vector<std::string> links = {}; // default initializer allows aggregate init of the other 3
     bool needs_authorization = false;    // idem
-};
 
-inline bool operator==(const NetworkInterfaceInfo& a, const NetworkInterfaceInfo& b)
-{
-    return std::tie(a.id, a.type, a.description, a.links, a.needs_authorization) ==
-           std::tie(b.id, b.type, b.description, b.links, b.needs_authorization);
-}
+    friend inline bool operator==(const NetworkInterfaceInfo& a,
+                                  const NetworkInterfaceInfo& b) = default;
+};
 
 } // namespace multipass

--- a/include/multipass/vm_image_info.h
+++ b/include/multipass/vm_image_info.h
@@ -37,32 +37,7 @@ public:
     QString version;
     int64_t size;
     bool verify;
-};
 
-inline bool operator==(const VMImageInfo& a, const VMImageInfo& b)
-{
-    return std::tie(a.aliases,
-                    a.os,
-                    a.release,
-                    a.release_title,
-                    a.release_codename,
-                    a.supported,
-                    a.image_location,
-                    a.id,
-                    a.stream_location,
-                    a.version,
-                    a.size,
-                    a.verify) == std::tie(b.aliases,
-                                          b.os,
-                                          b.release,
-                                          b.release_title,
-                                          b.release_codename,
-                                          b.supported,
-                                          b.image_location,
-                                          b.id,
-                                          b.stream_location,
-                                          b.version,
-                                          b.size,
-                                          b.verify);
-}
+    friend inline bool operator==(const VMImageInfo& a, const VMImageInfo& b) = default;
+};
 } // namespace multipass

--- a/src/utils/memory_size.cpp
+++ b/src/utils/memory_size.cpp
@@ -118,36 +118,6 @@ long long mp::MemorySize::in_gigabytes() const noexcept
     return bytes / gibi; // integer division to floor
 }
 
-bool mp::operator==(const MemorySize& a, const MemorySize& b) noexcept
-{
-    return a.bytes == b.bytes;
-}
-
-bool mp::operator!=(const MemorySize& a, const MemorySize& b) noexcept
-{
-    return a.bytes != b.bytes;
-}
-
-bool mp::operator<(const MemorySize& a, const MemorySize& b) noexcept
-{
-    return a.bytes < b.bytes;
-}
-
-bool mp::operator>(const MemorySize& a, const MemorySize& b) noexcept
-{
-    return a.bytes > b.bytes;
-}
-
-bool mp::operator<=(const MemorySize& a, const MemorySize& b) noexcept
-{
-    return a.bytes <= b.bytes;
-}
-
-bool mp::operator>=(const MemorySize& a, const MemorySize& b) noexcept
-{
-    return a.bytes >= b.bytes;
-}
-
 std::string mp::MemorySize::human_readable(unsigned int precision, bool trim_zeros) const
 {
     const auto giga = std::pair{gibi, "GiB"};


### PR DESCRIPTION
This replaces a few manually-implemented comparison operators with the defaults. I guess these got missed in the big C++20 PR.