### PR TITLE
[macos] Delete VMs as logged-in user

### DIFF
--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -28,7 +28,8 @@ done
 
 if [ $DELETE_VMS -eq 1 ]; then
     echo "Removing VMs:"
-    multipass delete -vv --purge --all || echo "Failed to delete multipass VMs from underlying driver" >&2
+    sudo -u "$(logname)" multipass delete -vv --purge --all || echo "Failed to delete multipass VMs from underlying driver" >&2
+
 fi
 
 LAUNCH_AGENT_DEST="/Library/LaunchDaemons/com.canonical.multipassd.plist"


### PR DESCRIPTION
This ensures the uninstall script executes the multipass delete command under the currently logged-in user's context, preventing authentication issues on macOS.

Closes #4483 