### PR TITLE
Fix GUI default onAppClose behavior on first run

### DIFF
--- a/src/client/gui/lib/providers.dart
+++ b/src/client/gui/lib/providers.dart
@@ -360,7 +360,13 @@ class GuiSettingNotifier extends Notifier<String?> {
   @override
   String? build() {
     final sharedPreferences = ref.read(sharedPreferencesProvider);
-    return sharedPreferences.getString(arg);
+// Define defaults for specific keys
+    final defaultValues = {
+      onAppCloseKey: 'ask',
+    };
+
+    // Return the stored value, or the default value, or null
+    return sharedPreferences.getString(arg) ?? defaultValues[arg];
   }
 
   void set(String value) {


### PR DESCRIPTION
### **Description:**
This change ensures that the GUI provides non-null default values for (onAppClose) on first run.

Previously, the GuiSettingNotifier could return null for these settings on the first run, causing the GUI to close running instances automatically, even though the UI displayed "Ask" as the default.

With this fix:

- GuiSettingNotifier now returns explicit defaults for first-run scenarios.
- The runtime behavior now matches the defaults displayed in the GUI, improving consistency and preventing unexpected 
closures.

Impact:

- Resolves a bug where the GUI would close running instances immediately on first launch.
- Ensures first-run experience is aligned with UI expectations.

Resolves: #4506 