### PR TITLE
[ci] Fix obsolete path to requirements.txt

### DIFF
--- a/.github/workflows/monitor-usns.yml
+++ b/.github/workflows/monitor-usns.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Python dependencies
       uses: BSFishy/pip-action@v1
       with:
-        requirements: tools/requirements.txt
+        requirements: tools/process-snaps/requirements.txt
 
     - name: Install Snap dependencies
       run: |


### PR DESCRIPTION
Action "Monitor USNs" has been failing: https://github.com/canonical/multipass/actions/workflows/monitor-usns.yml

This fixes it: https://github.com/canonical/multipass/actions/runs/19538296586
