### PR TITLE
gui: enforce default close behavior when unset (Fixes #4506)

### DIFF
--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -168,7 +168,16 @@ class _AppState extends ConsumerState<App> with WindowListener {
     final daemonAvailable = ref.read(daemonAvailableProvider);
     final vmsRunning =
         ref.read(vmStatusesProvider).values.contains(Status.RUNNING);
-    final closeJob = ref.read(guiSettingProvider(onAppCloseKey));
+    var closeJob = ref.read(guiSettingProvider(onAppCloseKey));
+
+// Fix for Issue #4506: enforce default when setting is empty or not set
+if (closeJob == null || closeJob.toString().trim().isEmpty) {
+  const defaultCloseAction = 'ask';
+  // Update provider so future reads are correct
+  ref.read(guiSettingProvider(onAppCloseKey).notifier).state = defaultCloseAction;
+  // Use default for this run
+  closeJob = defaultCloseAction;
+}
 
     // nothing to do
     if (!daemonAvailable || !vmsRunning || closeJob == 'nothing') {


### PR DESCRIPTION
This PR fixes Issue #4506, where the default close behavior was not reflected
in the GUI when the setting `onAppCloseKey` was not set.

### Root cause
`closeJob` was read from settings but not given a default when missing.

### Fix
- When `closeJob` is null or empty, enforce the default action `"ask"`.
- Immediately update the provider state so UI and behavior match.

### Result
Multipass GUI now behaves correctly when first installed or when the user has
no stored preference.

Fixes #4506

— @vardhan30016
