### PR TITLE
[cmake] Hide vcpkg OpenSSL symbols

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -62,6 +62,12 @@ if(MSVC)
   qt6_disable_unicode_defines(multipassd)
 else()
   add_executable(multipassd daemon_main.cpp)
+  # Hide OpenSSL symbols to prevent conflicts with Qt's dynamically loaded SSL plugin
+  if(UNIX AND NOT APPLE)
+    target_link_options(multipassd PRIVATE
+      "-Wl,--exclude-libs,libssl.a"
+      "-Wl,--exclude-libs,libcrypto.a")
+  endif()
 endif()
 
 target_link_libraries(multipassd


### PR DESCRIPTION
When compiling Multipass locally on Linux there is an OpenSSL version conflict between the OpenSSL that is statically linked from vcpkg and the OpenSSL that Qt dynamically links when using the `QNetworkManager` class. This PR adds a linker argument to hide the OpenSSL symbols from vcpkg so that `multipassd` uses vcpkg's OpenSSL for certificate generation and Qt uses its TLS plugin for networking.