### PR TITLE
[gui-cmake] Make plugins wait for flutter_assemble

### DIFF
--- a/src/client/gui/linux/CMakeLists.txt
+++ b/src/client/gui/linux/CMakeLists.txt
@@ -90,6 +90,9 @@ set_target_properties(${BINARY_NAME}
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_dependencies(${plugin}_plugin flutter_assemble)
+endforeach(plugin)
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build


### PR DESCRIPTION
Our GUI build fails intermittently on CI (linux build), usually with a link error:

> :: [        ] generated_plugin_registrant.cc:(.text+0x26): undefined reference to `file_selector_plugin_register_with_registrar'

My intuition is that this is due to the fact that the flutter and the plugin builds are running in parallel in a racy way. What makes me believe this is the case is:

> :: [ +902 ms] [22/24] Linking CXX shared library plugins/tray_menu/libtray_menu_plugin.so
> :: [ +360 ms] [7/24] Linking CXX shared library plugins/file_selector_linux/libfile_selector_linux_plugin.so
> :: [+1183 ms] [23/24] Linking CXX executable intermediates_do_not_run/multipass_gui

Note the numbering, 22/24, 7/24 and 23/24, which suggests some out of order build action is going on.

The patch makes the plugin build wait for the flutter_assemble, aiming to eliminate the race.

MULTI-2400