### PR TITLE
[tests-constants] Mark stoi result as unused

### DIFF
--- a/tests/test_constants.cpp
+++ b/tests/test_constants.cpp
@@ -25,8 +25,8 @@ using namespace testing;
 
 TEST(Constants, constantsConstraints)
 {
-    EXPECT_NO_THROW(std::stoi(mp::min_cpu_cores));
-    EXPECT_NO_THROW(std::stoi(mp::default_cpu_cores));
+    EXPECT_NO_THROW([[maybe_unused]] auto _ = std::stoi(mp::min_cpu_cores));
+    EXPECT_NO_THROW([[maybe_unused]] auto _ = std::stoi(mp::default_cpu_cores));
     EXPECT_NO_THROW(mp::MemorySize{mp::min_memory_size});
     EXPECT_NO_THROW(mp::MemorySize{mp::default_memory_size});
     EXPECT_NO_THROW(mp::MemorySize{mp::min_disk_size});


### PR DESCRIPTION
...to get rid of this:

<img width="751" height="557" alt="image" src="https://github.com/user-attachments/assets/f1fc543d-15ff-4267-8154-d746de8a39bd" />

MULTI-2399
