### PR TITLE
[apple] Induce a build failure

### DIFF
--- a/tests/apple/test_apple_virtual_machine.cpp
+++ b/tests/apple/test_apple_virtual_machine.cpp
@@ -23,5 +23,6 @@ namespace multipass::test
 {
 struct AppleVirtualMachine_UnitTests : public testing::Test
 {
+    CauseABuildFailure
 };
 }; // namespace multipass::test


### PR DESCRIPTION
Demoing turning on feature flags which induces a build failure. Builds with feature flags should be considered experimental and so, should not fail the entire workflow.