### PR TITLE
[applevz] Basic VM functions

### DIFF
--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -30,6 +30,8 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+
 namespace multipass
 {
 struct IPAddress;
@@ -75,7 +77,7 @@ public:
     virtual std::string ssh_hostname()
     {
         return ssh_hostname(std::chrono::minutes(2));
-    };
+    }
     virtual std::string ssh_hostname(std::chrono::milliseconds timeout) = 0;
     virtual std::string ssh_username() = 0;
     virtual std::optional<IPAddress> management_ipv4() = 0;
@@ -131,3 +133,53 @@ protected:
     }
 };
 } // namespace multipass
+
+/**
+ * Formatter type specialization for CreateComputeSystemParameters
+ */
+template <typename Char>
+struct fmt::formatter<multipass::VirtualMachine::State, Char>
+{
+    constexpr auto parse(basic_format_parse_context<Char>& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(multipass::VirtualMachine::State state, FormatContext& ctx) const
+    {
+        std::string_view v = "(undefined)";
+        switch (state)
+        {
+        case multipass::VirtualMachine::State::off:
+            v = "off";
+            break;
+        case multipass::VirtualMachine::State::stopped:
+            v = "stopped";
+            break;
+        case multipass::VirtualMachine::State::starting:
+            v = "starting";
+            break;
+        case multipass::VirtualMachine::State::restarting:
+            v = "restarting";
+            break;
+        case multipass::VirtualMachine::State::running:
+            v = "running";
+            break;
+        case multipass::VirtualMachine::State::delayed_shutdown:
+            v = "delayed_shutdown";
+            break;
+        case multipass::VirtualMachine::State::suspending:
+            v = "suspending";
+            break;
+        case multipass::VirtualMachine::State::suspended:
+            v = "suspended";
+            break;
+        case multipass::VirtualMachine::State::unknown:
+            v = "unknown";
+            break;
+        }
+
+        return format_to(ctx.out(), "{}", v);
+    }
+};

--- a/src/platform/backends/apple/CMakeLists.txt
+++ b/src/platform/backends/apple/CMakeLists.txt
@@ -17,6 +17,7 @@ enable_language(OBJCXX)
 
 add_library(apple_backend STATIC
   apple_virtual_machine.cpp
+  apple_virtual_machine_factory.cpp
   apple_vz_bridge.mm
   apple_vz_wrapper.cpp
 )

--- a/src/platform/backends/apple/CMakeLists.txt
+++ b/src/platform/backends/apple/CMakeLists.txt
@@ -31,6 +31,8 @@ find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
 find_library(VIRTUALIZATION_FRAMEWORK Virtualization REQUIRED)
 
 target_link_libraries(apple_backend
+  PUBLIC
+    fmt::fmt-header-only
   PRIVATE
     daemon
     ${FOUNDATION_FRAMEWORK}

--- a/src/platform/backends/apple/CMakeLists.txt
+++ b/src/platform/backends/apple/CMakeLists.txt
@@ -27,16 +27,8 @@ set_source_files_properties(apple_vz_bridge.mm PROPERTIES
   COMPILE_FLAGS "-fobjc-arc"
 )
 
-find_library(FOUNDATION_FRAMEWORK Foundation)
-find_library(VIRTUALIZATION_FRAMEWORK Virtualization)
-
-if(NOT FOUNDATION_FRAMEWORK)
-  message(FATAL_ERROR "Could not find Foundation framework")
-endif()
-
-if(NOT VIRTUALIZATION_FRAMEWORK)
-  message(FATAL_ERROR "Could not find Virtualization framework. Ensure you're building on a macOS SDK that provides it.")
-endif()
+find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
+find_library(VIRTUALIZATION_FRAMEWORK Virtualization REQUIRED)
 
 target_link_libraries(apple_backend
   PRIVATE

--- a/src/platform/backends/apple/CMakeLists.txt
+++ b/src/platform/backends/apple/CMakeLists.txt
@@ -18,6 +18,7 @@ enable_language(OBJCXX)
 add_library(apple_backend STATIC
   apple_virtual_machine.cpp
   apple_vz_bridge.mm
+  apple_vz_wrapper.cpp
 )
 
 set_source_files_properties(apple_vz_bridge.mm PROPERTIES

--- a/src/platform/backends/apple/CMakeLists.txt
+++ b/src/platform/backends/apple/CMakeLists.txt
@@ -32,7 +32,9 @@ find_library(VIRTUALIZATION_FRAMEWORK Virtualization REQUIRED)
 
 target_link_libraries(apple_backend
   PUBLIC
+    Qt6::Core
     fmt::fmt-header-only
+    logger
   PRIVATE
     daemon
     ${FOUNDATION_FRAMEWORK}

--- a/src/platform/backends/apple/CMakeLists.txt
+++ b/src/platform/backends/apple/CMakeLists.txt
@@ -16,6 +16,7 @@
 enable_language(OBJCXX)
 
 add_library(apple_backend STATIC
+  apple_virtual_machine.cpp
   apple_vz_bridge.mm
 )
 
@@ -37,5 +38,7 @@ endif()
 
 target_link_libraries(apple_backend
   PRIVATE
+    daemon
     ${FOUNDATION_FRAMEWORK}
-    ${VIRTUALIZATION_FRAMEWORK})
+    ${VIRTUALIZATION_FRAMEWORK}
+    Qt6::Core)

--- a/src/platform/backends/apple/CMakeLists.txt
+++ b/src/platform/backends/apple/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+enable_language(OBJCXX)
+
+add_library(apple_backend STATIC
+  apple_vz_bridge.mm
+)
+
+set_source_files_properties(apple_vz_bridge.mm PROPERTIES
+  LANGUAGE OBJCXX
+  COMPILE_FLAGS "-fobjc-arc"
+)
+
+find_library(FOUNDATION_FRAMEWORK Foundation)
+find_library(VIRTUALIZATION_FRAMEWORK Virtualization)
+
+if(NOT FOUNDATION_FRAMEWORK)
+  message(FATAL_ERROR "Could not find Foundation framework")
+endif()
+
+if(NOT VIRTUALIZATION_FRAMEWORK)
+  message(FATAL_ERROR "Could not find Virtualization framework. Ensure you're building on a macOS SDK that provides it.")
+endif()
+
+target_link_libraries(apple_backend
+  PRIVATE
+    ${FOUNDATION_FRAMEWORK}
+    ${VIRTUALIZATION_FRAMEWORK})

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -87,4 +87,45 @@ void AppleVirtualMachine::resize_memory(const MemorySize& new_size)
 void AppleVirtualMachine::resize_disk(const MemorySize& new_size)
 {
 }
+
+void AppleVirtualMachine::set_state(apple::AppleVMState vm_state)
+{
+    mpl::debug(log_category, "set_state() -> VM `{}` VZ state `{}`", vm_name, vm_state);
+
+    const auto prev_state = state;
+    switch (vm_state)
+    {
+    case apple::AppleVMState::stopped:
+        state = State::stopped;
+        break;
+    case apple::AppleVMState::running:
+    case apple::AppleVMState::stopping:
+        state = State::running;
+        break;
+    case apple::AppleVMState::paused:
+        state = State::suspended;
+        break;
+    case apple::AppleVMState::error:
+        state = State::unknown;
+        break;
+    case apple::AppleVMState::starting:
+    case apple::AppleVMState::resuming:
+    case apple::AppleVMState::restoring:
+        state = State::starting;
+        break;
+    case apple::AppleVMState::pausing:
+    case apple::AppleVMState::saving:
+        state = State::suspending;
+        break;
+    }
+
+    if (state == prev_state)
+        return;
+
+    mpl::info(log_category,
+              "set_state() > VM {} state changed from {} to {}",
+              vm_name,
+              prev_state,
+              state);
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -136,12 +136,12 @@ void AppleVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 
     CFError error;
 
-    if (shutdown_policy == ShutdownPolicy::Poweroff)
+    if (shutdown_policy == ShutdownPolicy::Poweroff && MP_APPLE_VZ.can_stop(vm_handle))
     {
         mpl::debug(log_category, "shutdown() -> Forcing shutdown of VM `{}`", vm_name);
         error = MP_APPLE_VZ.stop_vm(vm_handle, true);
     }
-    else if (MP_APPLE_VZ.can_stop(vm_handle))
+    else if (MP_APPLE_VZ.can_request_stop(vm_handle))
     {
         mpl::debug(log_category, "shutdown() -> Requesting shutdown of VM `{}`", vm_name);
         error = MP_APPLE_VZ.stop_vm(vm_handle);

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -52,6 +52,24 @@ AppleVirtualMachine::AppleVirtualMachine(const VirtualMachineDescription& desc,
     handle_state_update();
 }
 
+AppleVirtualMachine::~AppleVirtualMachine()
+{
+    mpl::debug(log_category,
+               "AppleVirtualMachine::~AppleVirtualMachine() -> Destructing VM `{}`",
+               vm_name);
+
+    multipass::top_catch_all(vm_name, [this]() {
+        if (state == State::running)
+        {
+            suspend();
+        }
+        else
+        {
+            shutdown();
+        }
+    });
+}
+
 void AppleVirtualMachine::start()
 {
     mpl::debug(log_category, "start() -> Starting VM `{}`, current state {}", vm_name, state);

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -92,6 +92,7 @@ std::optional<IPAddress> AppleVirtualMachine::management_ipv4()
 
 void AppleVirtualMachine::handle_state_update()
 {
+    monitor->persist_state_for(vm_name, state);
 }
 
 void AppleVirtualMachine::update_cpus(int num_cores)

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -31,8 +31,7 @@ AppleVirtualMachine::AppleVirtualMachine(const VirtualMachineDescription& desc,
 {
 }
 
-AppleVirtualMachine::~AppleVirtualMachine()
-{
+    mpl::debug(log_category, "Created handle for VM '{}'", vm_name);
 }
 
 void AppleVirtualMachine::start()

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -269,6 +269,7 @@ void AppleVirtualMachine::set_state(apple::AppleVMState vm_state)
         break;
     case apple::AppleVMState::running:
     case apple::AppleVMState::stopping:
+        // No `stopping` state in Multipass yet
         state = State::running;
         break;
     case apple::AppleVMState::paused:

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -185,7 +185,34 @@ void AppleVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 
 void AppleVirtualMachine::suspend()
 {
-    monitor->on_suspend();
+    mpl::debug(log_category, "suspend() -> Suspending VM `{}`, current state {}", vm_name, state);
+
+    if (MP_APPLE_VZ.can_pause(vm_handle))
+    {
+        state = State::suspending;
+        handle_state_update();
+
+        const auto error = MP_APPLE_VZ.pause_vm(vm_handle);
+        if (error)
+        {
+            mpl::error(log_category, "suspend() -> VM '{}' failed to suspend: {}", vm_name, error);
+            throw std::runtime_error(
+                fmt::format("VM '{}' failed to suspend, check logs for more details", vm_name));
+        }
+
+        drop_ssh_session();
+
+        // Reflect vm's state
+        set_state(MP_APPLE_VZ.get_state(vm_handle));
+        handle_state_update();
+    }
+    else
+    {
+        mpl::warn(log_category,
+                  "suspend() -> VM `{}` cannot be suspended from state `{}`",
+                  vm_name,
+                  state);
+    }
 }
 
 VirtualMachine::State AppleVirtualMachine::current_state()

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -278,14 +278,18 @@ void AppleVirtualMachine::handle_state_update()
 
 void AppleVirtualMachine::update_cpus(int num_cores)
 {
+    assert(num_cores > 0);
+    desc.num_cores = num_cores;
 }
 
 void AppleVirtualMachine::resize_memory(const MemorySize& new_size)
 {
+    desc.mem_size = new_size;
 }
 
 void AppleVirtualMachine::resize_disk(const MemorySize& new_size)
 {
+    // Must be able to handle RAW and ASIF disk images
 }
 
 void AppleVirtualMachine::set_state(apple::AppleVMState vm_state)

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -46,7 +46,7 @@ AppleVirtualMachine::AppleVirtualMachine(const VirtualMachineDescription& desc,
                "AppleVirtualMachine::AppleVirtualMachine() -> Created handle for VM '{}'",
                vm_name);
 
-    // Reflect compute system's state
+    // Reflect vm's state
     const auto curr_state = MP_APPLE_VZ.get_state(vm_handle);
     set_state(curr_state);
     handle_state_update();
@@ -78,16 +78,13 @@ void AppleVirtualMachine::start()
     }
     else
     {
-        mpl::debug(log_category,
-                   "start() -> VM `{}` cannot be started from state `{}`",
-                   vm_name,
-                   curr_state);
-
-        throw VMStateIdempotentException(
-            fmt::format("VM `{}` cannot be started from state `{}`", vm_name, curr_state));
+        mpl::warn(log_category,
+                  "start() -> VM `{}` cannot be started from state `{}`",
+                  vm_name,
+                  curr_state);
     }
 
-    // Reflect compute system's state
+    // Reflect vm's state
     curr_state = MP_APPLE_VZ.get_state(vm_handle);
     set_state(curr_state);
     handle_state_update();
@@ -99,7 +96,7 @@ void AppleVirtualMachine::start()
             fmt::format("VM '{}' failed to start, check logs for more details", vm_name));
     }
 
-    mpl::debug(log_category, "start() -> Started/resumed VM `{}`", vm_name);
+    mpl::debug(log_category, "start() -> VM `{}` running", vm_name);
 }
 
 void AppleVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
@@ -113,7 +110,7 @@ void AppleVirtualMachine::suspend()
 
 VirtualMachine::State AppleVirtualMachine::current_state()
 {
-    return VirtualMachine::State::unknown;
+    return state;
 }
 
 int AppleVirtualMachine::ssh_port()

--- a/src/platform/backends/apple/apple_virtual_machine.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <apple/apple_virtual_machine.h>
+
+#include <multipass/exceptions/virtual_machine_state_exceptions.h>
+#include <multipass/top_catch_all.h>
+#include <multipass/vm_status_monitor.h>
+
+namespace multipass::apple
+{
+AppleVirtualMachine::AppleVirtualMachine(const VirtualMachineDescription& desc,
+                                         VMStatusMonitor& monitor,
+                                         const SSHKeyProvider& key_provider,
+                                         const Path& instance_dir)
+    : BaseVirtualMachine{desc.vm_name, key_provider, instance_dir}, desc{desc}, monitor{&monitor}
+{
+}
+
+AppleVirtualMachine::~AppleVirtualMachine()
+{
+}
+
+void AppleVirtualMachine::start()
+{
+}
+
+void AppleVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
+{
+}
+
+void AppleVirtualMachine::suspend()
+{
+    monitor->on_suspend();
+}
+
+VirtualMachine::State AppleVirtualMachine::current_state()
+{
+    return VirtualMachine::State::unknown;
+}
+
+int AppleVirtualMachine::ssh_port()
+{
+    return 22;
+}
+
+std::string AppleVirtualMachine::ssh_hostname(std::chrono::milliseconds timeout)
+{
+    return "";
+}
+
+std::string AppleVirtualMachine::ssh_username()
+{
+    return desc.ssh_username;
+}
+
+std::optional<IPAddress> AppleVirtualMachine::management_ipv4()
+{
+    return std::nullopt;
+}
+
+void AppleVirtualMachine::handle_state_update()
+{
+}
+
+void AppleVirtualMachine::update_cpus(int num_cores)
+{
+}
+
+void AppleVirtualMachine::resize_memory(const MemorySize& new_size)
+{
+}
+
+void AppleVirtualMachine::resize_disk(const MemorySize& new_size)
+{
+}
+} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_virtual_machine.h
+++ b/src/platform/backends/apple/apple_virtual_machine.h
@@ -60,5 +60,6 @@ private:
 private:
     VirtualMachineDescription desc;
     VMStatusMonitor* monitor;
+    VMHandle vm_handle{nullptr};
 };
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_virtual_machine.h
+++ b/src/platform/backends/apple/apple_virtual_machine.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <shared/base_virtual_machine.h>
+
+#include <multipass/virtual_machine_description.h>
+
+namespace multipass
+{
+class VMStatusMonitor;
+}
+
+namespace multipass::apple
+{
+class AppleVirtualMachine : public BaseVirtualMachine
+{
+public:
+    AppleVirtualMachine(const VirtualMachineDescription& desc,
+                        VMStatusMonitor& monitor,
+                        const SSHKeyProvider& key_provider,
+                        const Path& instance_dir);
+    ~AppleVirtualMachine();
+
+    void start() override;
+    void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;
+    void suspend() override;
+    State current_state() override;
+    int ssh_port() override;
+    std::string ssh_hostname(std::chrono::milliseconds timeout) override;
+    std::string ssh_username() override;
+    std::optional<IPAddress> management_ipv4() override;
+    void handle_state_update() override;
+    void update_cpus(int num_cores) override;
+    void resize_memory(const MemorySize& new_size) override;
+    void resize_disk(const MemorySize& new_size) override;
+
+private:
+    VirtualMachineDescription desc;
+    VMStatusMonitor* monitor;
+};
+} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_virtual_machine.h
+++ b/src/platform/backends/apple/apple_virtual_machine.h
@@ -17,9 +17,10 @@
 
 #pragma once
 
-#include <shared/base_virtual_machine.h>
+#include <apple/apple_vz_wrapper.h>
 
 #include <multipass/virtual_machine_description.h>
+#include <shared/base_virtual_machine.h>
 
 namespace multipass
 {
@@ -39,15 +40,22 @@ public:
     void start() override;
     void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;
     void suspend() override;
+
     State current_state() override;
+
     int ssh_port() override;
     std::string ssh_hostname(std::chrono::milliseconds timeout) override;
     std::string ssh_username() override;
     std::optional<IPAddress> management_ipv4() override;
+
     void handle_state_update() override;
+
     void update_cpus(int num_cores) override;
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
+
+private:
+    void set_state(apple::AppleVMState vm_state);
 
 private:
     VirtualMachineDescription desc;

--- a/src/platform/backends/apple/apple_virtual_machine.h
+++ b/src/platform/backends/apple/apple_virtual_machine.h
@@ -36,6 +36,7 @@ public:
                         VMStatusMonitor& monitor,
                         const SSHKeyProvider& key_provider,
                         const Path& instance_dir);
+    ~AppleVirtualMachine();
 
     void start() override;
     void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;

--- a/src/platform/backends/apple/apple_virtual_machine.h
+++ b/src/platform/backends/apple/apple_virtual_machine.h
@@ -35,7 +35,6 @@ public:
                         VMStatusMonitor& monitor,
                         const SSHKeyProvider& key_provider,
                         const Path& instance_dir);
-    ~AppleVirtualMachine();
 
     void start() override;
     void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;

--- a/src/platform/backends/apple/apple_virtual_machine_factory.cpp
+++ b/src/platform/backends/apple/apple_virtual_machine_factory.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <apple/apple_virtual_machine_factory.h>
+
+namespace multipass::apple
+{
+AppleVirtualMachineFactory::AppleVirtualMachineFactory(const Path& data_dir)
+    : BaseVirtualMachineFactory(
+          MP_UTILS.derive_instances_dir(data_dir, get_backend_directory_name(), instances_subdir))
+{
+}
+
+VirtualMachine::UPtr AppleVirtualMachineFactory::create_virtual_machine(
+    const VirtualMachineDescription& desc,
+    const SSHKeyProvider& key_provider,
+    VMStatusMonitor& monitor)
+{
+    return nullptr;
+}
+
+VMImage AppleVirtualMachineFactory::prepare_source_image(const VMImage& source_image)
+{
+    return VMImage{};
+}
+
+void AppleVirtualMachineFactory::prepare_instance_image(const VMImage& instance_image,
+                                                        const VirtualMachineDescription& desc)
+{
+}
+
+void AppleVirtualMachineFactory::hypervisor_health_check()
+{
+}
+
+void AppleVirtualMachineFactory::remove_resources_for_impl(const std::string& name)
+{
+}
+
+VirtualMachine::UPtr AppleVirtualMachineFactory::clone_vm_impl(
+    const std::string& source_vm_name,
+    const multipass::VMSpecs& src_vm_specs,
+    const VirtualMachineDescription& desc,
+    VMStatusMonitor& monitor,
+    const SSHKeyProvider& key_provider)
+{
+    return nullptr;
+}
+} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_virtual_machine_factory.h
+++ b/src/platform/backends/apple/apple_virtual_machine_factory.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <shared/base_virtual_machine_factory.h>
+
+#include <multipass/path.h>
+
+namespace multipass::apple
+{
+class AppleVirtualMachineFactory final : public BaseVirtualMachineFactory
+{
+public:
+    explicit AppleVirtualMachineFactory(const Path& data_dir);
+
+    [[nodiscard]] VirtualMachine::UPtr create_virtual_machine(const VirtualMachineDescription& desc,
+                                                              const SSHKeyProvider& key_provider,
+                                                              VMStatusMonitor& monitor) override;
+
+    [[nodiscard]] VMImage prepare_source_image(const VMImage& source_image) override;
+    void prepare_instance_image(const VMImage& instance_image,
+                                const VirtualMachineDescription& desc) override;
+    void hypervisor_health_check() override;
+
+    [[nodiscard]] QString get_backend_version_string() const override
+    {
+        return "apple";
+    };
+
+    QString get_backend_directory_name() const override
+    {
+        return "apple";
+    };
+
+protected:
+    void remove_resources_for_impl(const std::string& name) override;
+
+private:
+    VirtualMachine::UPtr clone_vm_impl(const std::string& source_vm_name,
+                                       const multipass::VMSpecs& src_vm_specs,
+                                       const VirtualMachineDescription& desc,
+                                       VMStatusMonitor& monitor,
+                                       const SSHKeyProvider& key_provider) override;
+};
+} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+namespace multipass::apple
+{
+} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -36,5 +36,12 @@ CFErrorRef stop_with_completion_handler(VMHandle& vm_handle);
 CFErrorRef request_stop_with_error(VMHandle& vm_handle);
 CFErrorRef pause_with_completion_handler(VMHandle& vm_handle);
 CFErrorRef resume_with_completion_handler(VMHandle& vm_handle);
+
+// Getting the state of VM
+bool can_start(VMHandle& vm_handle);
+bool can_pause(VMHandle& vm_handle);
+bool can_resume(VMHandle& vm_handle);
+bool can_stop(VMHandle& vm_handle);
+bool can_request_stop(VMHandle& vm_handle);
 }
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -21,6 +21,8 @@
 
 #include <multipass/virtual_machine_description.h>
 
+#include <fmt/format.h>
+
 namespace multipass::apple
 {
 using VMHandle = std::shared_ptr<void>;
@@ -60,3 +62,55 @@ bool can_stop(VMHandle& vm_handle);
 bool can_request_stop(VMHandle& vm_handle);
 
 } // namespace multipass::apple
+
+template <>
+struct fmt::formatter<multipass::apple::AppleVMState>
+{
+    constexpr auto parse(format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(const multipass::apple::AppleVMState& state, FormatContext& ctx) const
+    {
+        std::string_view v = "(undefined)";
+        switch (state)
+        {
+        case multipass::apple::AppleVMState::stopped:
+            v = "stopped";
+            break;
+        case multipass::apple::AppleVMState::running:
+            v = "running";
+            break;
+        case multipass::apple::AppleVMState::paused:
+            v = "paused";
+            break;
+        case multipass::apple::AppleVMState::error:
+            v = "error";
+            break;
+        case multipass::apple::AppleVMState::starting:
+            v = "starting";
+            break;
+        case multipass::apple::AppleVMState::pausing:
+            v = "pausing";
+            break;
+        case multipass::apple::AppleVMState::resuming:
+            v = "resuming";
+            break;
+        case multipass::apple::AppleVMState::stopping:
+            v = "stopping";
+            break;
+        case multipass::apple::AppleVMState::saving:
+            v = "saving";
+            break;
+        case multipass::apple::AppleVMState::restoring:
+            v = "restoring";
+            break;
+        default:
+            v = "unknown";
+            break;
+        }
+        return format_to(ctx.out(), "{}", v);
+    }
+};

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -17,6 +17,17 @@
 
 #pragma once
 
+#include <multipass/virtual_machine_description.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+
 namespace multipass::apple
 {
+using VMHandle = std::shared_ptr<void>;
+
+extern "C"
+{
+CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                   VMHandle& out_handle);
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -49,7 +49,10 @@ CFError request_stop_with_error(VMHandle& vm_handle);
 CFError pause_with_completion_handler(VMHandle& vm_handle);
 CFError resume_with_completion_handler(VMHandle& vm_handle);
 
-// Getting the state of VM
+// Getting VM state
+AppleVMState get_state(VMHandle& vm_handle);
+
+// Validate the state of VM
 bool can_start(VMHandle& vm_handle);
 bool can_pause(VMHandle& vm_handle);
 bool can_resume(VMHandle& vm_handle);

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -25,6 +25,20 @@ namespace multipass::apple
 {
 using VMHandle = std::shared_ptr<void>;
 
+enum class AppleVMState
+{
+    stopped,
+    running,
+    paused,
+    error,
+    starting,
+    pausing,
+    resuming,
+    stopping,
+    saving,
+    restoring
+};
+
 CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
                                 VMHandle& out_handle);
 

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -55,6 +55,8 @@ CFError resume_with_completion_handler(VMHandle& vm_handle);
 
 // Saving and restoring VM
 CFError save_machine_state_to_url(const VMHandle& vm_handle, const std::filesystem::path& path);
+CFError restore_machine_state_from_url(const VMHandle& vm_handle,
+                                       const std::filesystem::path& path);
 
 // Getting VM state
 AppleVMState get_state(VMHandle& vm_handle);

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -54,9 +54,10 @@ CFError pause_with_completion_handler(const VMHandle& vm_handle);
 CFError resume_with_completion_handler(const VMHandle& vm_handle);
 
 // Saving and restoring VM
-CFError save_machine_state_to_url(const VMHandle& vm_handle, const std::filesystem::path& path);
-CFError restore_machine_state_from_url(const VMHandle& vm_handle,
-                                       const std::filesystem::path& path);
+CFError save_machine_state_to_url(const VMHandle& vm_handle, const std::filesystem::path& path)
+    API_AVAILABLE(macos(14.0));
+CFError restore_machine_state_from_url(const VMHandle& vm_handle, const std::filesystem::path& path)
+    API_AVAILABLE(macos(14.0));
 
 // Getting VM state
 AppleVMState get_state(const VMHandle& vm_handle);

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -29,5 +29,12 @@ extern "C"
 {
 CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
                                    VMHandle& out_handle);
+
+// Starting and stopping VM
+CFErrorRef start_with_completion_handler(VMHandle& vm_handle);
+CFErrorRef stop_with_completion_handler(VMHandle& vm_handle);
+CFErrorRef request_stop_with_error(VMHandle& vm_handle);
+CFErrorRef pause_with_completion_handler(VMHandle& vm_handle);
+CFErrorRef resume_with_completion_handler(VMHandle& vm_handle);
 }
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -47,11 +47,11 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
                                 VMHandle& out_handle);
 
 // Starting and stopping VM
-CFError start_with_completion_handler(VMHandle& vm_handle);
-CFError stop_with_completion_handler(VMHandle& vm_handle);
-CFError request_stop_with_error(VMHandle& vm_handle);
-CFError pause_with_completion_handler(VMHandle& vm_handle);
-CFError resume_with_completion_handler(VMHandle& vm_handle);
+CFError start_with_completion_handler(const VMHandle& vm_handle);
+CFError stop_with_completion_handler(const VMHandle& vm_handle);
+CFError request_stop_with_error(const VMHandle& vm_handle);
+CFError pause_with_completion_handler(const VMHandle& vm_handle);
+CFError resume_with_completion_handler(const VMHandle& vm_handle);
 
 // Saving and restoring VM
 CFError save_machine_state_to_url(const VMHandle& vm_handle, const std::filesystem::path& path);
@@ -59,15 +59,14 @@ CFError restore_machine_state_from_url(const VMHandle& vm_handle,
                                        const std::filesystem::path& path);
 
 // Getting VM state
-AppleVMState get_state(VMHandle& vm_handle);
+AppleVMState get_state(const VMHandle& vm_handle);
 
 // Validate the state of VM
-bool can_start(VMHandle& vm_handle);
-bool can_pause(VMHandle& vm_handle);
-bool can_resume(VMHandle& vm_handle);
-bool can_stop(VMHandle& vm_handle);
-bool can_request_stop(VMHandle& vm_handle);
-
+bool can_start(const VMHandle& vm_handle);
+bool can_pause(const VMHandle& vm_handle);
+bool can_resume(const VMHandle& vm_handle);
+bool can_stop(const VMHandle& vm_handle);
+bool can_request_stop(const VMHandle& vm_handle);
 } // namespace multipass::apple
 
 template <>

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -17,25 +17,23 @@
 
 #pragma once
 
-#include <multipass/virtual_machine_description.h>
+#include <apple/cf_error.h>
 
-#include <CoreFoundation/CoreFoundation.h>
+#include <multipass/virtual_machine_description.h>
 
 namespace multipass::apple
 {
 using VMHandle = std::shared_ptr<void>;
 
-extern "C"
-{
-CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
-                                   VMHandle& out_handle);
+CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                VMHandle& out_handle);
 
 // Starting and stopping VM
-CFErrorRef start_with_completion_handler(VMHandle& vm_handle);
-CFErrorRef stop_with_completion_handler(VMHandle& vm_handle);
-CFErrorRef request_stop_with_error(VMHandle& vm_handle);
-CFErrorRef pause_with_completion_handler(VMHandle& vm_handle);
-CFErrorRef resume_with_completion_handler(VMHandle& vm_handle);
+CFError start_with_completion_handler(VMHandle& vm_handle);
+CFError stop_with_completion_handler(VMHandle& vm_handle);
+CFError request_stop_with_error(VMHandle& vm_handle);
+CFError pause_with_completion_handler(VMHandle& vm_handle);
+CFError resume_with_completion_handler(VMHandle& vm_handle);
 
 // Getting the state of VM
 bool can_start(VMHandle& vm_handle);
@@ -43,5 +41,5 @@ bool can_pause(VMHandle& vm_handle);
 bool can_resume(VMHandle& vm_handle);
 bool can_stop(VMHandle& vm_handle);
 bool can_request_stop(VMHandle& vm_handle);
-}
+
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.h
+++ b/src/platform/backends/apple/apple_vz_bridge.h
@@ -23,6 +23,8 @@
 
 #include <fmt/format.h>
 
+#include <filesystem>
+
 namespace multipass::apple
 {
 using VMHandle = std::shared_ptr<void>;
@@ -50,6 +52,9 @@ CFError stop_with_completion_handler(VMHandle& vm_handle);
 CFError request_stop_with_error(VMHandle& vm_handle);
 CFError pause_with_completion_handler(VMHandle& vm_handle);
 CFError resume_with_completion_handler(VMHandle& vm_handle);
+
+// Saving and restoring VM
+CFError save_machine_state_to_url(const VMHandle& vm_handle, const std::filesystem::path& path);
 
 // Getting VM state
 AppleVMState get_state(VMHandle& vm_handle);

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -234,6 +234,13 @@ CFError resume_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
+AppleVMState get_state(VMHandle& vm_handle)
+{
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return AppleVMState([vm state]);
+}
+
 bool can_start(VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -185,7 +185,12 @@ CFError request_stop_with_error(VMHandle& vm_handle)
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     NSError* err = nil;
-    [vm requestStopWithError:&err];
+    if (![vm requestStopWithError:&err] && !err)
+    {
+        err = [NSError errorWithDomain:@"multipass.apple.vzbridge"
+                                  code:-1
+                              userInfo:@{NSLocalizedDescriptionKey : @"Unknown error"}];
+    }
 
     return err ? CFError((__bridge_retained CFErrorRef)err) : CFError();
 }

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -232,4 +232,34 @@ CFErrorRef resume_with_completion_handler(VMHandle& vm_handle) {
 
     return err;
 }
+
+bool can_start(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canStart];
+}
+
+bool can_pause(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canPause];
+}
+
+bool can_resume(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canResume];
+}
+
+bool can_stop(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canStop];
+}
+
+bool can_request_stop(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canRequestStop];
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -135,4 +135,101 @@ CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& d
         return nullptr;
     }
 }
+
+CFErrorRef start_with_completion_handler(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    // __block does not retain; we return ownership to caller.
+    __block CFErrorRef err = nullptr;
+
+    [vm startWithCompletionHandler:^(NSError* _Nullable error) {
+      if (err) {
+          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
+          err = (CFErrorRef)CFBridgingRetain(error);
+      }
+
+      dispatch_semaphore_signal(sema);
+    }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return err;
+}
+
+CFErrorRef stop_with_completion_handler(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    // __block does not retain; we return ownership to caller.
+    __block CFErrorRef err = nullptr;
+
+    [vm stopWithCompletionHandler:^(NSError* _Nullable error) {
+      if (err) {
+          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
+          err = (CFErrorRef)CFBridgingRetain(error);
+      }
+
+      dispatch_semaphore_signal(sema);
+    }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return err;
+}
+
+CFErrorRef request_stop_with_error(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    NSError* err = nil;
+    [vm requestStopWithError:&err];
+
+    return err ? (CFErrorRef)CFBridgingRetain(err) : nullptr;
+}
+
+CFErrorRef pause_with_completion_handler(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    // __block does not retain; we return ownership to caller.
+    __block CFErrorRef err = nullptr;
+
+    [vm pauseWithCompletionHandler:^(NSError* _Nullable error) {
+      if (err) {
+          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
+          err = (CFErrorRef)CFBridgingRetain(error);
+      }
+
+      dispatch_semaphore_signal(sema);
+    }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return err;
+}
+
+CFErrorRef resume_with_completion_handler(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    // __block does not retain; we return ownership to caller.
+    __block CFErrorRef err = nullptr;
+
+    [vm resumeWithCompletionHandler:^(NSError* _Nullable error) {
+      if (err) {
+          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
+          err = (CFErrorRef)CFBridgingRetain(error);
+      }
+
+      dispatch_semaphore_signal(sema);
+    }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return err;
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -269,6 +269,29 @@ CFError save_machine_state_to_url(const VMHandle& vm_handle, const std::filesyst
     return CFError(err_ref);
 }
 
+CFError restore_machine_state_from_url(const VMHandle& vm_handle, const std::filesystem::path& path)
+{
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    __block CFErrorRef err_ref = nullptr;
+
+    [vm restoreMachineStateFromURL:nsURLFromStdFilesystemPath(path)
+                 completionHandler:^(NSError* _Nullable error) {
+                   if (error)
+                   {
+                       err_ref = (__bridge_retained CFErrorRef)error;
+                   }
+
+                   dispatch_semaphore_signal(sema);
+                 }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return CFError(err_ref);
+}
+
 AppleVMState get_state(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -35,8 +35,8 @@ NSString* nsStringFromQString(const QString& s)
 
 namespace multipass::apple
 {
-CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
-                                   VMHandle& out_handle)
+CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                VMHandle& out_handle)
 {
     @autoreleasepool
     {
@@ -56,7 +56,7 @@ CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& d
         VZDiskImageStorageDeviceAttachment* diskAttachment =
             [[VZDiskImageStorageDeviceAttachment alloc] initWithURL:diskURL readOnly:NO error:&err];
         if (err)
-            return (CFErrorRef)CFBridgingRetain(err);
+            return CFError((__bridge_retained CFErrorRef)err);
 
         VZVirtioBlockDeviceConfiguration* disk =
             [[VZVirtioBlockDeviceConfiguration alloc] initWithAttachment:diskAttachment];
@@ -70,7 +70,7 @@ CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& d
                                                            readOnly:YES
                                                               error:&err];
         if (err)
-            return (CFErrorRef)CFBridgingRetain(err);
+            return CFError((__bridge_retained CFErrorRef)err);
 
         VZVirtioBlockDeviceConfiguration* cloudIso =
             [[VZVirtioBlockDeviceConfiguration alloc] initWithAttachment:cloudAttachment];
@@ -91,7 +91,7 @@ CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& d
                                    options:VZEFIVariableStoreInitializationOptionAllowOverwrite
                                      error:&err];
         if (err)
-            return (CFErrorRef)CFBridgingRetain(err);
+            return CFError((__bridge_retained CFErrorRef)err);
 
         config.bootLoader = efi;
 
@@ -123,7 +123,7 @@ CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& d
         if (![config validateWithError:&err])
         {
             if (err)
-                return (CFErrorRef)CFBridgingRetain(err);
+                return CFError((__bridge_retained CFErrorRef)err);
         }
 
         // Create VM handle
@@ -132,22 +132,22 @@ CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& d
         void* cfRef = (void*)CFBridgingRetain(virtualMachine);
         out_handle = VMHandle(cfRef, [](void* p) { CFRelease(p); });
 
-        return nullptr;
+        return CFError();
     }
 }
 
-CFErrorRef start_with_completion_handler(VMHandle& vm_handle) {
+CFError start_with_completion_handler(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
-    // __block does not retain; we return ownership to caller.
-    __block CFErrorRef err = nullptr;
+    __block CFErrorRef err_ref = nullptr;
 
     [vm startWithCompletionHandler:^(NSError* _Nullable error) {
-      if (err) {
-          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
-          err = (CFErrorRef)CFBridgingRetain(error);
+      if (error)
+      {
+          err_ref = (__bridge_retained CFErrorRef)error;
       }
 
       dispatch_semaphore_signal(sema);
@@ -155,21 +155,21 @@ CFErrorRef start_with_completion_handler(VMHandle& vm_handle) {
 
     dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
 
-    return err;
+    return CFError(err_ref);
 }
 
-CFErrorRef stop_with_completion_handler(VMHandle& vm_handle) {
+CFError stop_with_completion_handler(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
-    // __block does not retain; we return ownership to caller.
-    __block CFErrorRef err = nullptr;
+    __block CFErrorRef err_ref = nullptr;
 
     [vm stopWithCompletionHandler:^(NSError* _Nullable error) {
-      if (err) {
-          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
-          err = (CFErrorRef)CFBridgingRetain(error);
+      if (error)
+      {
+          err_ref = (__bridge_retained CFErrorRef)error;
       }
 
       dispatch_semaphore_signal(sema);
@@ -177,30 +177,31 @@ CFErrorRef stop_with_completion_handler(VMHandle& vm_handle) {
 
     dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
 
-    return err;
+    return CFError(err_ref);
 }
 
-CFErrorRef request_stop_with_error(VMHandle& vm_handle) {
+CFError request_stop_with_error(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     NSError* err = nil;
     [vm requestStopWithError:&err];
 
-    return err ? (CFErrorRef)CFBridgingRetain(err) : nullptr;
+    return err ? CFError((__bridge_retained CFErrorRef)err) : CFError();
 }
 
-CFErrorRef pause_with_completion_handler(VMHandle& vm_handle) {
+CFError pause_with_completion_handler(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
-    // __block does not retain; we return ownership to caller.
-    __block CFErrorRef err = nullptr;
+    __block CFErrorRef err_ref = nullptr;
 
     [vm pauseWithCompletionHandler:^(NSError* _Nullable error) {
-      if (err) {
-          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
-          err = (CFErrorRef)CFBridgingRetain(error);
+      if (error)
+      {
+          err_ref = (__bridge_retained CFErrorRef)error;
       }
 
       dispatch_semaphore_signal(sema);
@@ -208,21 +209,21 @@ CFErrorRef pause_with_completion_handler(VMHandle& vm_handle) {
 
     dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
 
-    return err;
+    return CFError(err_ref);
 }
 
-CFErrorRef resume_with_completion_handler(VMHandle& vm_handle) {
+CFError resume_with_completion_handler(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
-    // __block does not retain; we return ownership to caller.
-    __block CFErrorRef err = nullptr;
+    __block CFErrorRef err_ref = nullptr;
 
     [vm resumeWithCompletionHandler:^(NSError* _Nullable error) {
-      if (err) {
-          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
-          err = (CFErrorRef)CFBridgingRetain(error);
+      if (error)
+      {
+          err_ref = (__bridge_retained CFErrorRef)error;
       }
 
       dispatch_semaphore_signal(sema);
@@ -230,7 +231,7 @@ CFErrorRef resume_with_completion_handler(VMHandle& vm_handle) {
 
     dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
 
-    return err;
+    return CFError(err_ref);
 }
 
 bool can_start(VMHandle& vm_handle) {

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -17,6 +17,122 @@
 
 #include <apple/apple_vz_bridge.h>
 
+#include <CoreFoundation/CoreFoundation.h>
+#include <Foundation/Foundation.h>
+#include <Virtualization/Virtualization.h>
+
+#include <QString>
+#include <QUrl>
+
+namespace
+{
+NSString* nsStringFromQString(const QString& s)
+{
+    QByteArray utf8 = s.toUtf8();
+    return [NSString stringWithUTF8String:utf8.constData()];
+}
+} // namespace
+
 namespace multipass::apple
 {
+CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                   VMHandle& out_handle)
+{
+    @autoreleasepool
+    {
+        NSError* err = nil;
+
+        VZVirtualMachineConfiguration* config = [[VZVirtualMachineConfiguration alloc] init];
+
+        // CPU & memory
+        config.CPUCount = desc.num_cores;
+        config.memorySize = desc.mem_size.in_bytes();
+
+        // Storage devices
+        NSMutableArray<VZStorageDeviceConfiguration*>* storageDevices = [NSMutableArray array];
+
+        NSString* diskPath = nsStringFromQString(desc.image.image_path);
+        NSURL* diskURL = [NSURL fileURLWithPath:diskPath];
+        VZDiskImageStorageDeviceAttachment* diskAttachment =
+            [[VZDiskImageStorageDeviceAttachment alloc] initWithURL:diskURL readOnly:NO error:&err];
+        if (err)
+            return (CFErrorRef)CFBridgingRetain(err);
+
+        VZVirtioBlockDeviceConfiguration* disk =
+            [[VZVirtioBlockDeviceConfiguration alloc] initWithAttachment:diskAttachment];
+        [storageDevices addObject:disk];
+
+        // Cloud-init ISO
+        NSString* cloudIsoPath = nsStringFromQString(desc.cloud_init_iso);
+        NSURL* cloudIsoURL = [NSURL fileURLWithPath:cloudIsoPath];
+        VZDiskImageStorageDeviceAttachment* cloudAttachment =
+            [[VZDiskImageStorageDeviceAttachment alloc] initWithURL:cloudIsoURL
+                                                           readOnly:YES
+                                                              error:&err];
+        if (err)
+            return (CFErrorRef)CFBridgingRetain(err);
+
+        VZVirtioBlockDeviceConfiguration* cloudIso =
+            [[VZVirtioBlockDeviceConfiguration alloc] initWithAttachment:cloudAttachment];
+        [storageDevices addObject:cloudIso];
+
+        config.storageDevices = storageDevices;
+
+        // EFI Variable store
+        NSString* efivarsFilename = [NSString stringWithFormat:@"vm-efivars"];
+        NSString* efivarsPath =
+            [NSTemporaryDirectory() stringByAppendingPathComponent:efivarsFilename];
+
+        // EFI bootloader
+        NSURL* efivarsURL = [NSURL fileURLWithPath:efivarsPath];
+        VZEFIBootLoader* efi = [[VZEFIBootLoader alloc] init];
+        efi.variableStore = [[VZEFIVariableStore alloc]
+            initCreatingVariableStoreAtURL:efivarsURL
+                                   options:VZEFIVariableStoreInitializationOptionAllowOverwrite
+                                     error:&err];
+        if (err)
+            return (CFErrorRef)CFBridgingRetain(err);
+
+        config.bootLoader = efi;
+
+        // Entropy device
+        VZVirtioEntropyDeviceConfiguration* entropy =
+            [[VZVirtioEntropyDeviceConfiguration alloc] init];
+        config.entropyDevices = @[ entropy ];
+
+        // Network device
+        VZVirtioNetworkDeviceConfiguration* netDevice =
+            [[VZVirtioNetworkDeviceConfiguration alloc] init];
+
+        VZNATNetworkDeviceAttachment* natAttachment = [[VZNATNetworkDeviceAttachment alloc] init];
+        netDevice.attachment = natAttachment;
+
+        VZMACAddress* mac = [[VZMACAddress alloc]
+            initWithString:[NSString stringWithCString:desc.default_mac_address.c_str()
+                                              encoding:NSUTF8StringEncoding]];
+        [netDevice setMACAddress:mac];
+
+        config.networkDevices = @[ netDevice ];
+
+        // Memory balloon device
+        VZVirtioTraditionalMemoryBalloonDeviceConfiguration* balloon =
+            [[VZVirtioTraditionalMemoryBalloonDeviceConfiguration alloc] init];
+        config.memoryBalloonDevices = @[ balloon ];
+
+        // Validate configuration
+        if (![config validateWithError:&err])
+        {
+            if (err)
+                return (CFErrorRef)CFBridgingRetain(err);
+        }
+
+        // Create VM handle
+        VZVirtualMachine* virtualMachine = [[VZVirtualMachine alloc] initWithConfiguration:config];
+
+        void* cfRef = (void*)CFBridgingRetain(virtualMachine);
+        out_handle = VMHandle(cfRef, [](void* p) { CFRelease(p); });
+
+        return nullptr;
+    }
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -143,7 +143,7 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
     }
 }
 
-CFError start_with_completion_handler(VMHandle& vm_handle)
+CFError start_with_completion_handler(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -165,7 +165,7 @@ CFError start_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-CFError stop_with_completion_handler(VMHandle& vm_handle)
+CFError stop_with_completion_handler(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -187,7 +187,7 @@ CFError stop_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-CFError request_stop_with_error(VMHandle& vm_handle)
+CFError request_stop_with_error(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -202,7 +202,7 @@ CFError request_stop_with_error(VMHandle& vm_handle)
     return err ? CFError((__bridge_retained CFErrorRef)err) : CFError();
 }
 
-CFError pause_with_completion_handler(VMHandle& vm_handle)
+CFError pause_with_completion_handler(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -224,7 +224,7 @@ CFError pause_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-CFError resume_with_completion_handler(VMHandle& vm_handle)
+CFError resume_with_completion_handler(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -299,35 +299,35 @@ AppleVMState get_state(const VMHandle& vm_handle)
     return AppleVMState([vm state]);
 }
 
-bool can_start(VMHandle& vm_handle)
+bool can_start(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canStart];
 }
 
-bool can_pause(VMHandle& vm_handle)
+bool can_pause(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canPause];
 }
 
-bool can_resume(VMHandle& vm_handle)
+bool can_resume(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canResume];
 }
 
-bool can_stop(VMHandle& vm_handle)
+bool can_stop(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canStop];
 }
 
-bool can_request_stop(VMHandle& vm_handle)
+bool can_request_stop(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <apple/apple_vz_bridge.h>
+
+namespace multipass::apple {} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -31,6 +31,13 @@ NSString* nsStringFromQString(const QString& s)
     QByteArray utf8 = s.toUtf8();
     return [NSString stringWithUTF8String:utf8.constData()];
 }
+
+NSURL* nsURLFromStdFilesystemPath(const std::filesystem::path& p)
+{
+    std::string utf8 = p.string();
+    NSString* nsString = [NSString stringWithUTF8String:utf8.c_str()];
+    return [NSURL fileURLWithPath:nsString];
+}
 } // namespace
 
 namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -17,4 +17,6 @@
 
 #include <apple/apple_vz_bridge.h>
 
-namespace multipass::apple {} // namespace multipass::apple
+namespace multipass::apple
+{
+} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_bridge.mm
+++ b/src/platform/backends/apple/apple_vz_bridge.mm
@@ -234,31 +234,36 @@ CFError resume_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-bool can_start(VMHandle& vm_handle) {
+bool can_start(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canStart];
 }
 
-bool can_pause(VMHandle& vm_handle) {
+bool can_pause(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canPause];
 }
 
-bool can_resume(VMHandle& vm_handle) {
+bool can_resume(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canResume];
 }
 
-bool can_stop(VMHandle& vm_handle) {
+bool can_stop(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canStop];
 }
 
-bool can_request_stop(VMHandle& vm_handle) {
+bool can_request_stop(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canRequestStop];

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -93,6 +93,13 @@ CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
     return err;
 }
 
+AppleVMState AppleVZ::get_state(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::get_state(...)");
+
+    return multipass::apple::get_state(vm_handle);
+}
+
 bool AppleVZ::can_start(VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_start(...)");

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -15,8 +15,29 @@
  *
  */
 
+#include <apple/apple_vz_bridge.h>
 #include <apple/apple_vz_wrapper.h>
+
+#include <multipass/logging/log.h>
+
+namespace mpl = multipass::logging;
+
+namespace
+{
+constexpr static auto kLogCategory = "vz-wrapper";
+} // namespace
 
 namespace multipass::apple
 {
+CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::create_vm(...)");
+
+    auto err = init_with_configuration(desc, out_handle);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::create_vm(...) succeeded");
+
+    return CFError(err);
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -111,4 +111,39 @@ CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
 
     return err;
 }
+
+bool AppleVZ::can_start(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_start(...)");
+
+    return multipass::apple::can_start(vm_handle);
+}
+
+bool AppleVZ::can_pause(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_pause(...)");
+
+    return multipass::apple::can_pause(vm_handle);
+}
+
+bool AppleVZ::can_resume(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_resume(...)");
+
+    return multipass::apple::can_resume(vm_handle);
+}
+
+bool AppleVZ::can_stop(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_stop(...)");
+
+    return multipass::apple::can_stop(vm_handle);
+}
+
+bool AppleVZ::can_request_stop(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_request_stop(...)");
+
+    return multipass::apple::can_request_stop(vm_handle);
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -81,4 +81,34 @@ CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
 
     return err;
 }
+
+CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::pause_vm(...)");
+
+    if (!can_pause(vm_handle))
+        mpl::debug(kLogCategory, "VM not in a state that allows pausing");
+
+    auto err = pause_with_completion_handler(vm_handle);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::pause_vm(...) succeeded");
+
+    return err;
+}
+
+CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::resume_vm(...)");
+
+    if (!can_resume(vm_handle))
+        mpl::debug(kLogCategory, "VM not in a state that allows resuming");
+
+    auto err = resume_with_completion_handler(vm_handle);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::resume_vm(...) succeeded");
+
+    return err;
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -40,4 +40,45 @@ CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_
 
     return CFError(err);
 }
+
+CFError AppleVZ::start_vm(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
+
+    if (!can_start(vm_handle))
+        mpl::debug(kLogCategory, "VM not in a state that allows starting");
+
+    auto err = start_with_completion_handler(vm_handle);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::start_vm(...) succeeded");
+
+    return CFError(err);
+}
+
+CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
+
+    CFError err;
+    if (force)
+    {
+        if (!can_stop(vm_handle))
+            mpl::debug(kLogCategory, "VM not in a state that allows stopping");
+
+        err = CFError(stop_with_completion_handler(vm_handle));
+    }
+    else
+    {
+        if (!can_request_stop(vm_handle))
+            mpl::debug(kLogCategory, "VM not in a state that allows stopping");
+
+        err = CFError(request_stop_with_error(vm_handle));
+    }
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::stop_vm(...) succeeded");
+
+    return err;
+}
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -93,6 +93,31 @@ CFError AppleVZ::resume_vm(const VMHandle& vm_handle) const
     return err;
 }
 
+CFError AppleVZ::save_vm_to_file(const VMHandle& vm_handle, const std::filesystem::path& path) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::save_vm_to_file(...)");
+
+    auto err = save_machine_state_to_url(vm_handle, path);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::save_vm_to_file(...) succeeded");
+
+    return err;
+}
+
+CFError AppleVZ::restore_vm_from_file(const VMHandle& vm_handle,
+                                      const std::filesystem::path& path) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::restore_vm_from_file(...)");
+
+    auto err = restore_machine_state_from_url(vm_handle, path);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::restore_vm_from_file(...) succeeded");
+
+    return err;
+}
+
 AppleVMState AppleVZ::get_state(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::get_state(...)");

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <apple/apple_vz_wrapper.h>
+
+namespace multipass::apple
+{
+} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -53,7 +53,7 @@ CFError AppleVZ::start_vm(VMHandle& vm_handle) const
     return err;
 }
 
-CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
+CFError AppleVZ::stop_vm(VMHandle& vm_handle, bool force) const
 {
     mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
 

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -45,9 +45,6 @@ CFError AppleVZ::start_vm(VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
 
-    if (!can_start(vm_handle))
-        mpl::debug(kLogCategory, "VM not in a state that allows starting");
-
     auto err = start_with_completion_handler(vm_handle);
 
     if (!err)
@@ -62,19 +59,9 @@ CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
 
     CFError err;
     if (force)
-    {
-        if (!can_stop(vm_handle))
-            mpl::debug(kLogCategory, "VM not in a state that allows stopping");
-
         err = stop_with_completion_handler(vm_handle);
-    }
     else
-    {
-        if (!can_request_stop(vm_handle))
-            mpl::debug(kLogCategory, "VM not in a state that allows stopping");
-
         err = request_stop_with_error(vm_handle);
-    }
 
     if (!err)
         mpl::debug(kLogCategory, "AppleVZ::stop_vm(...) succeeded");
@@ -85,9 +72,6 @@ CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
 CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::pause_vm(...)");
-
-    if (!can_pause(vm_handle))
-        mpl::debug(kLogCategory, "VM not in a state that allows pausing");
 
     auto err = pause_with_completion_handler(vm_handle);
 
@@ -100,9 +84,6 @@ CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
 CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::resume_vm(...)");
-
-    if (!can_resume(vm_handle))
-        mpl::debug(kLogCategory, "VM not in a state that allows resuming");
 
     auto err = resume_with_completion_handler(vm_handle);
 

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -41,7 +41,7 @@ CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_
     return err;
 }
 
-CFError AppleVZ::start_vm(VMHandle& vm_handle) const
+CFError AppleVZ::start_vm(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
 
@@ -53,9 +53,9 @@ CFError AppleVZ::start_vm(VMHandle& vm_handle) const
     return err;
 }
 
-CFError AppleVZ::stop_vm(VMHandle& vm_handle, bool force) const
+CFError AppleVZ::stop_vm(const VMHandle& vm_handle, bool force) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
+    mpl::debug(kLogCategory, "AppleVZ::stop_vm(...)");
 
     CFError err;
     if (force)
@@ -69,7 +69,7 @@ CFError AppleVZ::stop_vm(VMHandle& vm_handle, bool force) const
     return err;
 }
 
-CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
+CFError AppleVZ::pause_vm(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::pause_vm(...)");
 
@@ -81,7 +81,7 @@ CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
     return err;
 }
 
-CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
+CFError AppleVZ::resume_vm(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::resume_vm(...)");
 
@@ -93,42 +93,42 @@ CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
     return err;
 }
 
-AppleVMState AppleVZ::get_state(VMHandle& vm_handle) const
+AppleVMState AppleVZ::get_state(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::get_state(...)");
 
     return multipass::apple::get_state(vm_handle);
 }
 
-bool AppleVZ::can_start(VMHandle& vm_handle) const
+bool AppleVZ::can_start(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_start(...)");
 
     return multipass::apple::can_start(vm_handle);
 }
 
-bool AppleVZ::can_pause(VMHandle& vm_handle) const
+bool AppleVZ::can_pause(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_pause(...)");
 
     return multipass::apple::can_pause(vm_handle);
 }
 
-bool AppleVZ::can_resume(VMHandle& vm_handle) const
+bool AppleVZ::can_resume(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_resume(...)");
 
     return multipass::apple::can_resume(vm_handle);
 }
 
-bool AppleVZ::can_stop(VMHandle& vm_handle) const
+bool AppleVZ::can_stop(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_stop(...)");
 
     return multipass::apple::can_stop(vm_handle);
 }
 
-bool AppleVZ::can_request_stop(VMHandle& vm_handle) const
+bool AppleVZ::can_request_stop(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_request_stop(...)");
 

--- a/src/platform/backends/apple/apple_vz_wrapper.cpp
+++ b/src/platform/backends/apple/apple_vz_wrapper.cpp
@@ -38,7 +38,7 @@ CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_
     if (!err)
         mpl::debug(kLogCategory, "AppleVZ::create_vm(...) succeeded");
 
-    return CFError(err);
+    return err;
 }
 
 CFError AppleVZ::start_vm(VMHandle& vm_handle) const
@@ -53,7 +53,7 @@ CFError AppleVZ::start_vm(VMHandle& vm_handle) const
     if (!err)
         mpl::debug(kLogCategory, "AppleVZ::start_vm(...) succeeded");
 
-    return CFError(err);
+    return err;
 }
 
 CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
@@ -66,14 +66,14 @@ CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
         if (!can_stop(vm_handle))
             mpl::debug(kLogCategory, "VM not in a state that allows stopping");
 
-        err = CFError(stop_with_completion_handler(vm_handle));
+        err = stop_with_completion_handler(vm_handle);
     }
     else
     {
         if (!can_request_stop(vm_handle))
             mpl::debug(kLogCategory, "VM not in a state that allows stopping");
 
-        err = CFError(request_stop_with_error(vm_handle));
+        err = request_stop_with_error(vm_handle);
     }
 
     if (!err)

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -33,17 +33,21 @@ public:
     using Singleton<AppleVZ>::Singleton;
 
     virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
-    virtual CFError start_vm(VMHandle& vm_handle) const;
-    virtual CFError stop_vm(VMHandle& vm_handle, bool force = false) const;
-    virtual CFError pause_vm(VMHandle& vm_handle) const;
-    virtual CFError resume_vm(VMHandle& vm_handle) const;
 
-    virtual AppleVMState get_state(VMHandle& vm_handle) const;
+    // Starting and stopping VM
+    virtual CFError start_vm(const VMHandle& vm_handle) const;
+    virtual CFError stop_vm(const VMHandle& vm_handle, bool force = false) const;
+    virtual CFError pause_vm(const VMHandle& vm_handle) const;
+    virtual CFError resume_vm(const VMHandle& vm_handle) const;
 
-    virtual bool can_start(VMHandle& vm_handle) const;
-    virtual bool can_pause(VMHandle& vm_handle) const;
-    virtual bool can_resume(VMHandle& vm_handle) const;
-    virtual bool can_stop(VMHandle& vm_handle) const;
-    virtual bool can_request_stop(VMHandle& vm_handle) const;
+    // Getting VM state
+    virtual AppleVMState get_state(const VMHandle& vm_handle) const;
+
+    // Validate the state of VM
+    virtual bool can_start(const VMHandle& vm_handle) const;
+    virtual bool can_pause(const VMHandle& vm_handle) const;
+    virtual bool can_resume(const VMHandle& vm_handle) const;
+    virtual bool can_stop(const VMHandle& vm_handle) const;
+    virtual bool can_request_stop(const VMHandle& vm_handle) const;
 };
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -33,5 +33,7 @@ public:
     using Singleton<AppleVZ>::Singleton;
 
     virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
+    virtual CFError start_vm(VMHandle& vm_handle) const;
+    virtual CFError stop_vm(bool force, VMHandle& vm_handle) const;
 };
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -40,6 +40,12 @@ public:
     virtual CFError pause_vm(const VMHandle& vm_handle) const;
     virtual CFError resume_vm(const VMHandle& vm_handle) const;
 
+    // Saving and restoring VM
+    virtual CFError save_vm_to_file(const VMHandle& vm_handle,
+                                    const std::filesystem::path& path) const;
+    virtual CFError restore_vm_from_file(const VMHandle& vm_handle,
+                                         const std::filesystem::path& path) const;
+
     // Getting VM state
     virtual AppleVMState get_state(const VMHandle& vm_handle) const;
 

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <multipass/singleton.h>
+
+#define MP_APPLE_VZ multipass::apple::AppleVZ::instance()
+
+namespace multipass::apple
+{
+class AppleVZ : public Singleton<AppleVZ>
+{
+public:
+    using Singleton<AppleVZ>::Singleton;
+};
+} // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -34,7 +34,7 @@ public:
 
     virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
     virtual CFError start_vm(VMHandle& vm_handle) const;
-    virtual CFError stop_vm(bool force, VMHandle& vm_handle) const;
+    virtual CFError stop_vm(VMHandle& vm_handle, bool force = false) const;
     virtual CFError pause_vm(VMHandle& vm_handle) const;
     virtual CFError resume_vm(VMHandle& vm_handle) const;
 

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -17,7 +17,11 @@
 
 #pragma once
 
+#include <apple/apple_vz_bridge.h>
+#include <apple/cf_error.h>
+
 #include <multipass/singleton.h>
+#include <multipass/virtual_machine_description.h>
 
 #define MP_APPLE_VZ multipass::apple::AppleVZ::instance()
 
@@ -27,5 +31,7 @@ class AppleVZ : public Singleton<AppleVZ>
 {
 public:
     using Singleton<AppleVZ>::Singleton;
+
+    virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
 };
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -37,5 +37,11 @@ public:
     virtual CFError stop_vm(bool force, VMHandle& vm_handle) const;
     virtual CFError pause_vm(VMHandle& vm_handle) const;
     virtual CFError resume_vm(VMHandle& vm_handle) const;
+
+    virtual bool can_start(VMHandle& vm_handle) const;
+    virtual bool can_pause(VMHandle& vm_handle) const;
+    virtual bool can_resume(VMHandle& vm_handle) const;
+    virtual bool can_stop(VMHandle& vm_handle) const;
+    virtual bool can_request_stop(VMHandle& vm_handle) const;
 };
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -35,5 +35,7 @@ public:
     virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
     virtual CFError start_vm(VMHandle& vm_handle) const;
     virtual CFError stop_vm(bool force, VMHandle& vm_handle) const;
+    virtual CFError pause_vm(VMHandle& vm_handle) const;
+    virtual CFError resume_vm(VMHandle& vm_handle) const;
 };
 } // namespace multipass::apple

--- a/src/platform/backends/apple/apple_vz_wrapper.h
+++ b/src/platform/backends/apple/apple_vz_wrapper.h
@@ -38,6 +38,8 @@ public:
     virtual CFError pause_vm(VMHandle& vm_handle) const;
     virtual CFError resume_vm(VMHandle& vm_handle) const;
 
+    virtual AppleVMState get_state(VMHandle& vm_handle) const;
+
     virtual bool can_start(VMHandle& vm_handle) const;
     virtual bool can_pause(VMHandle& vm_handle) const;
     virtual bool can_resume(VMHandle& vm_handle) const;

--- a/src/platform/backends/apple/cf_error.h
+++ b/src/platform/backends/apple/cf_error.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <CoreFoundation/CoreFoundation.h>
+
+namespace multipass::apple
+{
+struct CFError
+{
+    CFErrorRef ref = nullptr;
+
+    explicit CFError(CFErrorRef r = nullptr) : ref(r)
+    {
+    }
+
+    CFError(const CFError&) = delete;
+
+    CFError(CFError&& other) noexcept : ref(other.ref)
+    {
+        other.ref = nullptr;
+    }
+
+    CFError& operator=(const CFError&) = delete;
+
+    CFError& operator=(CFError&& other) noexcept
+    {
+        if (this != &other)
+        {
+            CFRelease(ref);
+
+            ref = other.ref;
+            other.ref = nullptr;
+        }
+        return *this;
+    }
+
+    ~CFError() noexcept
+    {
+        CFRelease(ref);
+    }
+
+    // Allow implicit conversion to CFErrorRef for easy passing
+    operator CFErrorRef() const
+    {
+        return ref;
+    }
+};
+} // namespace multipass::apple

--- a/src/platform/backends/apple/cf_error.h
+++ b/src/platform/backends/apple/cf_error.h
@@ -73,7 +73,8 @@ struct CFError
     {
         if (this != &other)
         {
-            CFRelease(ref);
+            if (ref)
+                CFRelease(ref);
 
             ref = other.ref;
             other.ref = nullptr;
@@ -83,13 +84,14 @@ struct CFError
 
     ~CFError() noexcept
     {
-        CFRelease(ref);
+        if (ref)
+            CFRelease(ref);
     }
 
-    // Allow implicit conversion to CFErrorRef for easy passing
-    operator CFErrorRef() const
+    // Check if error is present
+    explicit operator bool() const noexcept
     {
-        return ref;
+        return ref != nullptr;
     }
 };
 
@@ -98,7 +100,7 @@ struct CFError
 namespace fmt
 {
 template <>
-struct formatter<CFErrorRef>
+struct formatter<multipass::apple::CFError>
 {
     template <typename ParseContext>
     constexpr auto parse(ParseContext& ctx)
@@ -107,24 +109,28 @@ struct formatter<CFErrorRef>
     }
 
     template <typename FormatContext>
-    auto format(CFErrorRef e, FormatContext& ctx)
+    auto format(const multipass::apple::CFError& e, FormatContext& ctx) const
     {
-        if (!e)
-            return format_to(ctx.out(), "<null CFErrorRef>");
+        if (!e.ref)
+            return format_to(ctx.out(), "<null CFError>");
 
-        CFIndex code = CFErrorGetCode(e);
-        CFStringRef domain = CFErrorGetDomain(e);
-        CFStringRef desc = CFErrorCopyDescription(e);
-        std::string sdomain = multipass::apple::CFStringToStdString(domain);
-        std::string sdesc = multipass::apple::CFStringToStdString(desc);
+        CFIndex code = CFErrorGetCode(e.ref);
+        CFStringRef domain = CFErrorGetDomain(e.ref);
+        CFStringRef desc = CFErrorCopyDescription(e.ref);
 
-        CFRelease(desc);
+        std::string domain_str = multipass::apple::CFStringToStdString(domain);
+        std::string desc_str = multipass::apple::CFStringToStdString(desc);
 
-        return format_to(ctx.out(),
-                         "{} ({}): {}",
-                         sdomain.empty() ? "CFError" : sdomain,
-                         code,
-                         sdesc);
+        auto result = format_to(ctx.out(),
+                                "{} ({}): {}",
+                                domain_str.empty() ? "CFError" : domain_str,
+                                code,
+                                desc_str.empty() ? "<unknown error>" : desc_str);
+
+        if (desc)
+            CFRelease(desc);
+
+        return result;
     }
 };
 

--- a/tests/apple/CMakeLists.txt
+++ b/tests/apple/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (C) Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+target_sources(multipass_tests PRIVATE
+)

--- a/tests/apple/CMakeLists.txt
+++ b/tests/apple/CMakeLists.txt
@@ -13,5 +13,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-target_sources(multipass_tests PRIVATE
+target_sources(multipass_tests
+  PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/test_apple_virtual_machine.cpp
 )

--- a/tests/apple/mock_apple_vz_wrapper.h
+++ b/tests/apple/mock_apple_vz_wrapper.h
@@ -49,6 +49,14 @@ public:
                 resume_vm,
                 (const multipass::apple::VMHandle& vm_handle),
                 (const, override));
+    MOCK_METHOD(apple::CFError,
+                save_vm_to_file,
+                (const multipass::apple::VMHandle& vm_handle, const std::filesystem::path& path),
+                (const, override));
+    MOCK_METHOD(apple::CFError,
+                restore_vm_from_file,
+                (const multipass::apple::VMHandle& vm_handle, const std::filesystem::path& path),
+                (const, override));
     MOCK_METHOD(apple::AppleVMState,
                 get_state,
                 (const multipass::apple::VMHandle& vm_handle),

--- a/tests/apple/mock_apple_vz_wrapper.h
+++ b/tests/apple/mock_apple_vz_wrapper.h
@@ -49,6 +49,10 @@ public:
                 resume_vm,
                 (multipass::apple::VMHandle & vm_handle),
                 (const, override));
+    MOCK_METHOD(apple::AppleVMState,
+                get_state,
+                (multipass::apple::VMHandle & vm_handle),
+                (const, override));
     MOCK_METHOD(bool, can_start, (multipass::apple::VMHandle & vm_handle), (const, override));
     MOCK_METHOD(bool, can_pause, (multipass::apple::VMHandle & vm_handle), (const, override));
     MOCK_METHOD(bool, can_resume, (multipass::apple::VMHandle & vm_handle), (const, override));

--- a/tests/apple/mock_apple_vz_wrapper.h
+++ b/tests/apple/mock_apple_vz_wrapper.h
@@ -39,7 +39,7 @@ public:
                 (const, override));
     MOCK_METHOD(apple::CFError,
                 stop_vm,
-                (bool force, multipass::apple::VMHandle& vm_handle),
+                (multipass::apple::VMHandle & vm_handle, bool force),
                 (const, override));
     MOCK_METHOD(apple::CFError,
                 pause_vm,

--- a/tests/apple/mock_apple_vz_wrapper.h
+++ b/tests/apple/mock_apple_vz_wrapper.h
@@ -41,5 +41,23 @@ public:
                 stop_vm,
                 (bool force, multipass::apple::VMHandle& vm_handle),
                 (const, override));
+    MOCK_METHOD(apple::CFError,
+                pause_vm,
+                (multipass::apple::VMHandle & vm_handle),
+                (const, override));
+    MOCK_METHOD(apple::CFError,
+                resume_vm,
+                (multipass::apple::VMHandle & vm_handle),
+                (const, override));
+    MOCK_METHOD(bool, can_start, (multipass::apple::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool, can_pause, (multipass::apple::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool, can_resume, (multipass::apple::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool, can_stop, (multipass::apple::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool,
+                can_request_stop,
+                (multipass::apple::VMHandle & vm_handle),
+                (const, override));
+
+    MP_MOCK_SINGLETON_BOILERPLATE(MockAppleVZ, AppleVZ);
 };
 } // namespace multipass::test

--- a/tests/apple/mock_apple_vz_wrapper.h
+++ b/tests/apple/mock_apple_vz_wrapper.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "tests/common.h"
+#include "tests/mock_singleton_helpers.h"
+
+#include <apple/apple_vz_wrapper.h>
+
+namespace multipass::test
+{
+class MockAppleVZ : public multipass::apple::AppleVZ
+{
+public:
+    using AppleVZ::AppleVZ;
+    MOCK_METHOD(apple::CFError,
+                create_vm,
+                (const multipass::VirtualMachineDescription& desc,
+                 multipass::apple::VMHandle& out_handle),
+                (const, override));
+    MOCK_METHOD(apple::CFError,
+                start_vm,
+                (multipass::apple::VMHandle & vm_handle),
+                (const, override));
+    MOCK_METHOD(apple::CFError,
+                stop_vm,
+                (bool force, multipass::apple::VMHandle& vm_handle),
+                (const, override));
+};
+} // namespace multipass::test

--- a/tests/apple/mock_apple_vz_wrapper.h
+++ b/tests/apple/mock_apple_vz_wrapper.h
@@ -35,31 +35,31 @@ public:
                 (const, override));
     MOCK_METHOD(apple::CFError,
                 start_vm,
-                (multipass::apple::VMHandle & vm_handle),
+                (const multipass::apple::VMHandle& vm_handle),
                 (const, override));
     MOCK_METHOD(apple::CFError,
                 stop_vm,
-                (multipass::apple::VMHandle & vm_handle, bool force),
+                (const multipass::apple::VMHandle& vm_handle, bool force),
                 (const, override));
     MOCK_METHOD(apple::CFError,
                 pause_vm,
-                (multipass::apple::VMHandle & vm_handle),
+                (const multipass::apple::VMHandle& vm_handle),
                 (const, override));
     MOCK_METHOD(apple::CFError,
                 resume_vm,
-                (multipass::apple::VMHandle & vm_handle),
+                (const multipass::apple::VMHandle& vm_handle),
                 (const, override));
     MOCK_METHOD(apple::AppleVMState,
                 get_state,
-                (multipass::apple::VMHandle & vm_handle),
+                (const multipass::apple::VMHandle& vm_handle),
                 (const, override));
-    MOCK_METHOD(bool, can_start, (multipass::apple::VMHandle & vm_handle), (const, override));
-    MOCK_METHOD(bool, can_pause, (multipass::apple::VMHandle & vm_handle), (const, override));
-    MOCK_METHOD(bool, can_resume, (multipass::apple::VMHandle & vm_handle), (const, override));
-    MOCK_METHOD(bool, can_stop, (multipass::apple::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool, can_start, (const multipass::apple::VMHandle& vm_handle), (const, override));
+    MOCK_METHOD(bool, can_pause, (const multipass::apple::VMHandle& vm_handle), (const, override));
+    MOCK_METHOD(bool, can_resume, (const multipass::apple::VMHandle& vm_handle), (const, override));
+    MOCK_METHOD(bool, can_stop, (const multipass::apple::VMHandle& vm_handle), (const, override));
     MOCK_METHOD(bool,
                 can_request_stop,
-                (multipass::apple::VMHandle & vm_handle),
+                (const multipass::apple::VMHandle& vm_handle),
                 (const, override));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockAppleVZ, AppleVZ);

--- a/tests/apple/test_apple_virtual_machine.cpp
+++ b/tests/apple/test_apple_virtual_machine.cpp
@@ -15,9 +15,10 @@
  *
  */
 
-#include <apple/apple_virtual_machine.h>
-
+#include "mock_apple_vz_wrapper.h"
 #include "tests/common.h"
+
+#include <apple/apple_virtual_machine.h>
 
 namespace multipass::test
 {

--- a/tests/apple/test_apple_virtual_machine.cpp
+++ b/tests/apple/test_apple_virtual_machine.cpp
@@ -112,12 +112,6 @@ TEST_F(AppleVirtualMachine_UnitTests, startFromRunningStateNoOp)
     EXPECT_CALL(mock_apple_vz, can_start(_)).WillOnce(Return(false));
     EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
 
-    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
-    logger_scope.mock_logger->expect_log(mpl::Level::warning,
-                                         fmt::format("VM `{}` cannot be started from state `{}`",
-                                                     desc.vm_name,
-                                                     mp::apple::AppleVMState::running));
-
     vm.start();
 
     EXPECT_EQ(vm.current_state(), VirtualMachine::State::running);

--- a/tests/apple/test_apple_virtual_machine.cpp
+++ b/tests/apple/test_apple_virtual_machine.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <apple/apple_virtual_machine.h>
+
+#include "tests/common.h"
+
+namespace multipass::test
+{
+struct AppleVirtualMachine_UnitTests : public testing::Test
+{
+};
+}; // namespace multipass::test

--- a/tests/apple/test_apple_virtual_machine.cpp
+++ b/tests/apple/test_apple_virtual_machine.cpp
@@ -17,12 +17,145 @@
 
 #include "mock_apple_vz_wrapper.h"
 #include "tests/common.h"
+#include "tests/mock_logger.h"
+#include "tests/mock_status_monitor.h"
+#include "tests/stub_ssh_key_provider.h"
+#include "tests/temp_dir.h"
+#include "tests/temp_file.h"
 
 #include <apple/apple_virtual_machine.h>
+#include <multipass/exceptions/virtual_machine_state_exceptions.h>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+namespace mpt = multipass::test;
+using namespace testing;
 
 namespace multipass::test
 {
 struct AppleVirtualMachine_UnitTests : public testing::Test
 {
+    mpt::TempFile dummy_image;
+    mpt::TempFile dummy_cloud_init_iso;
+    mpt::TempDir dummy_instances_dir;
+    const std::string dummy_vm_name{"lord-of-the-pings"};
+
+    mp::VirtualMachineDescription desc{2,
+                                       mp::MemorySize{"3M"},
+                                       mp::MemorySize{}, // not used
+                                       dummy_vm_name,
+                                       "aa:bb:cc:dd:ee:ff",
+                                       {},
+                                       "",
+                                       {dummy_image.name(), "", "", "", {}, {}},
+                                       dummy_cloud_init_iso.name(),
+                                       {},
+                                       {},
+                                       {},
+                                       {}};
+
+    mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject();
+
+    mpt::StubSSHKeyProvider stub_key_provider{};
+    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+
+    mpt::MockAppleVZ::GuardedMock mock_apple_vz_injection{mpt::MockAppleVZ::inject<NiceMock>()};
+    mpt::MockAppleVZ& mock_apple_vz = *mock_apple_vz_injection.first;
+
+    mpt::TempDir instance_dir;
 };
+
+TEST_F(AppleVirtualMachine_UnitTests, startFromStoppedStateCallsStartVm)
+{
+    mp::apple::AppleVirtualMachine vm{desc, mock_monitor, stub_key_provider, instance_dir.path()};
+
+    EXPECT_CALL(mock_apple_vz, get_state(_))
+        .WillOnce(Return(apple::AppleVMState::stopped))
+        .WillOnce(Return(apple::AppleVMState::running));
+    EXPECT_CALL(mock_apple_vz, can_start(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_apple_vz, start_vm(_)).WillOnce(Invoke([](auto&) {
+        return apple::CFError{};
+    }));
+    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::starting));
+    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::running));
+
+    vm.start();
+
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::running);
+}
+
+TEST_F(AppleVirtualMachine_UnitTests, startFromPausedStateCallsResumeVm)
+{
+    mp::apple::AppleVirtualMachine vm{desc, mock_monitor, stub_key_provider, instance_dir.path()};
+
+    EXPECT_CALL(mock_apple_vz, get_state(_))
+        .WillOnce(Return(apple::AppleVMState::paused))
+        .WillOnce(Return(apple::AppleVMState::running));
+    EXPECT_CALL(mock_apple_vz, can_resume(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_apple_vz, resume_vm(_)).WillOnce(Invoke([](auto&) {
+        return apple::CFError{};
+    }));
+    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, mp::VirtualMachine::State::starting));
+    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, mp::VirtualMachine::State::running));
+
+    vm.start();
+
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::running);
+}
+
+TEST_F(AppleVirtualMachine_UnitTests, startFromRunningStateNoOp)
+{
+    mp::apple::AppleVirtualMachine vm{desc, mock_monitor, stub_key_provider, instance_dir.path()};
+
+    EXPECT_CALL(mock_apple_vz, get_state(_)).WillRepeatedly(Return(apple::AppleVMState::running));
+    EXPECT_CALL(mock_apple_vz, can_resume(_)).Times(0);
+    EXPECT_CALL(mock_apple_vz, can_start(_)).WillOnce(Return(false));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
+    logger_scope.mock_logger->expect_log(mpl::Level::warning,
+                                         fmt::format("VM `{}` cannot be started from state `{}`",
+                                                     desc.vm_name,
+                                                     mp::apple::AppleVMState::running));
+
+    vm.start();
+
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::running);
+}
+
+TEST_F(AppleVirtualMachine_UnitTests, startVmErrorThrowsRuntimeError)
+{
+    mp::apple::AppleVirtualMachine vm{desc, mock_monitor, stub_key_provider, instance_dir.path()};
+
+    CFErrorRef error_ref = CFErrorCreate(kCFAllocatorDefault, CFSTR("TestDomain"), 42, nullptr);
+    apple::CFError error{error_ref};
+
+    EXPECT_CALL(mock_apple_vz, get_state(_))
+        .WillOnce(Return(apple::AppleVMState::stopped))
+        .WillOnce(Return(apple::AppleVMState::error));
+    EXPECT_CALL(mock_apple_vz, can_start(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_apple_vz, start_vm(_)).WillOnce(Return(ByMove(std::move(error))));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
+
+    EXPECT_THROW(vm.start(), std::runtime_error);
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::unknown);
+}
+
+TEST_F(AppleVirtualMachine_UnitTests, startResumeErrorThrowsRuntimeError)
+{
+    mp::apple::AppleVirtualMachine vm{desc, mock_monitor, stub_key_provider, instance_dir.path()};
+
+    CFErrorRef error_ref = CFErrorCreate(kCFAllocatorDefault, CFSTR("TestDomain"), 42, nullptr);
+    apple::CFError error{error_ref};
+
+    EXPECT_CALL(mock_apple_vz, get_state(_))
+        .WillOnce(Return(apple::AppleVMState::paused))
+        .WillOnce(Return(apple::AppleVMState::error));
+    EXPECT_CALL(mock_apple_vz, can_resume(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_apple_vz, resume_vm(_)).WillOnce(Return(ByMove(std::move(error))));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
+
+    EXPECT_THROW(vm.start(), std::runtime_error);
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::unknown);
+}
 }; // namespace multipass::test


### PR DESCRIPTION
This PR implements some of the basic functions for manipulating the state of a virtual machine using the Apple Virtualization Framework. This includes:

- `start()`
- `shutdown(ShutdownPolicy shutdown_policy)`
- `suspend()`

All Objective-C++ code, other helper functions needed to perform these actions, and unit tests for these functions are also included.

On top of being able to manually manage memory, Objective-C uses Automatic Reference Counting (ARC) where the system reference counting to automatically insert appropriate memory management method calls for you at compile-time. However, in order for objects to persist across the Objective-C/C++ boundary, we must use some types from the `CoreFoundation` library instead of the `Foundation` library, i.e., `CFErrorRef` over `NSError`, also known as Toll-Free Bridged Types. This allows us to control who owns the object and avoids having ARC and the Objective-C memory management system release memory before we are done with it. There are several macros that are used to tell the compiler about the ownership semantics of an object, but we mainly use:

- `__bridge`; for objects such as the `VMHandle` which were declared on the C++ side and where we don't want ownership to transfer when casting the `std::shared_ptr<void>` to virtualization framework virtual machine type; `VZVirtualMachine`.

- `__bridge_retained`: for objects that were created on the Objective-C side and for which we want to persist even after the block in which they were created finishes. We are responsible for manually freeing this type of object, so care must be taken in order when using this macro to prevent memory leaks. The use of this macro here is limited to returning errors from the Objective-C side to the C++ side through the use of the custom C++ type; `CFError`, which automatically calls `CFRelease` when destructed.

The other unique memory management mechanism that is used is the `autoreleasepool` block. This is used in special circumstances when a large number of temporary autoreleased object. The `autoreleasepool` sends an `autorelease` message to all objects in that block which are immediately released instead of at the end of the current event-loop iteration. This prevents temporary objects from unnecessarily accumulating and causing excessive overhead.

Additional reading:
- [Toll-Free Bridged Types](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFDesignConcepts/Articles/tollFreeBridgedTypes.html)
- [Core Foundation Memory Management](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/CFMemoryMgmt.html)
- [About Memory Management](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/MemoryMgmt.html)

---

MULTI-2258
MULTI-2261