### PR TITLE
[ci-clang-tidy] Disable clang-tidy run for CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -146,7 +146,7 @@ jobs:
         /snap/bin/snapcraft pull --use-lxd multipass
 
     - name: Run clang-tidy through the diff
-      if: ${{ matrix.build-type == 'Debug' }}
+      if: ${{ false && matrix.build-type == 'Debug' }}
       run: |
         /snap/bin/snapcraft pull --use-lxd run-clang-tidy
 


### PR DESCRIPTION
There are some rough edges to be fixed.