### PR TITLE
[cpack] Pass build target to preinstall script

### DIFF
--- a/packaging/cpack.cmake
+++ b/packaging/cpack.cmake
@@ -131,6 +131,8 @@ if(APPLE)
   set(MULTIPASSD_PLIST "com.canonical.multipassd.plist")
   configure_file("${CMAKE_SOURCE_DIR}/packaging/macos/${MULTIPASSD_PLIST}.in"
                  "${CMAKE_BINARY_DIR}/${MULTIPASSD_PLIST}" @ONLY)
+  configure_file("${CMAKE_SOURCE_DIR}/packaging/macos/preinstall-multipassd.sh.in"
+                 "${CMAKE_BINARY_DIR}/preinstall-multipassd.sh" @ONLY)
   configure_file("${CMAKE_SOURCE_DIR}/packaging/macos/postinstall-multipassd.sh.in"
                  "${CMAKE_BINARY_DIR}/postinstall-multipassd.sh" @ONLY)
   configure_file("${CMAKE_SOURCE_DIR}/packaging/macos/postinstall-multipass.sh.in"
@@ -144,7 +146,7 @@ if(APPLE)
 
   set(CPACK_COMPONENT_MULTIPASS_GUI_PLIST "${CMAKE_SOURCE_DIR}/packaging/macos/multipass-gui-component.plist")
 
-  set(CPACK_PREFLIGHT_MULTIPASSD_SCRIPT  "${CMAKE_SOURCE_DIR}/packaging/macos/preinstall-multipassd.sh")
+  set(CPACK_PREFLIGHT_MULTIPASSD_SCRIPT  "${CMAKE_BINARY_DIR}/preinstall-multipassd.sh")
   set(CPACK_POSTFLIGHT_MULTIPASSD_SCRIPT "${CMAKE_BINARY_DIR}/postinstall-multipassd.sh")
   set(CPACK_POSTFLIGHT_MULTIPASS_SCRIPT  "${CMAKE_BINARY_DIR}/postinstall-multipass.sh")
   set(CPACK_POSTFLIGHT_MULTIPASS_GUI_SCRIPT  "${CMAKE_BINARY_DIR}/postinstall-multipass-gui.sh")

--- a/packaging/macos/preinstall-multipassd.sh.in
+++ b/packaging/macos/preinstall-multipassd.sh.in
@@ -2,19 +2,18 @@
 set -e
 
 # Check CPU supports Hypervisor.framework's requirements
-# Ref: https://developer.apple.com/documentation/hypervisor
+# Ref: https://developer.apple.com/documentation/hypervisor
 CPU_OK=`sysctl -n kern.hv_support`
 
 # get architecture and major macOS version
 arch="$(uname -m)"
 os_major="$(sw_vers -productVersion | cut -d. -f1)"
+min_required=@CMAKE_OSX_DEPLOYMENT_TARGET@
 
 # set minimum required major version per arch
 if [ "$arch" = "arm64" ]; then
-  min_required=14
   arch_name="Apple Silicon (ARM64)"
 else
-  min_required=13
   arch_name="Intel (x86_64)"
 fi
 


### PR DESCRIPTION
Quick little QoL improvement to pass the `CMAKE_OSX_DEPLOYMENT_TARGET` to the preinstall script on macOS so we don't have to remember to update it.