### PR TITLE
[scraper] Check for `None` before validating

### DIFF
--- a/tools/distro-scraper/scraper/cli.py
+++ b/tools/distro-scraper/scraper/cli.py
@@ -100,6 +100,7 @@ async def run_scraper(scraper_instance: BaseScraper) -> tuple[str, dict | None]:
         result = await scraper_instance.fetch()
     except Exception as e:
         logger.exception("Scraper '%s' failed: %s", name, e)
+        return name, None
 
     # Validate JSON structure
     try:
@@ -108,6 +109,8 @@ async def run_scraper(scraper_instance: BaseScraper) -> tuple[str, dict | None]:
         return name, validated.model_dump()
     except ValidationError as e:
         logger.error("Scraper '%s' returned invalid structure:\n%s", name, e)
+    except Exception as e:
+        logger.exception("Unexpected error validating scraper '%s': %s", name, e)
 
     return name, None
 


### PR DESCRIPTION
Latest run of the distro scraper [failed](https://github.com/canonical/multipass/actions/runs/20202613409/job/57996599670#step:6:83) because the Fedora scraper timed out and returned `None`. Added some addition error handling to account for this case.