### PR TITLE
[ci] Use different action to avoid rate limiting

### DIFF
--- a/.github/workflows/prune-packages.yml
+++ b/.github/workflows/prune-packages.yml
@@ -58,7 +58,7 @@ jobs:
           organization: ${{ github.repository_owner }}
           type: nuget
           names: ${{ needs.list-packages.outputs.names }}
-          keep: 1
+          keep: 2
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switching out the GitHub action used for deleting old package version as cached by vcpkg. The previous action, `actions/delete-package-versions`, can only handle one package at a time, so a matrix was used to apply the action to all the packages that Multipass uses. GitHub matrices, however, only support up to 256 entries and with moving more dependencies to vcpkg, we are already hitting this limits.

This PR instead uses the `smartsquaregmbh/delete-old-packages` action which takes a list of packages and apply the operation to all of them at once.

This may hit GitHub API rate limiting, but running the workflow again will pick where the last run failed.