### PR TITLE
[ci] Make sure snapd in a proper state to use lxd

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -144,6 +144,8 @@ jobs:
         /snap/bin/snapcraft pull --use-lxd inject-apt-mirrors
         /snap/bin/snapcraft pull --use-lxd configure-nuget-cache
         /snap/bin/snapcraft pull --use-lxd multipass
+      env:
+        SNAPCRAFT_HAS_ALREADY_UPDATED_SNAPS: 1
 
     - name: Run clang-tidy through the diff
       if: ${{ false && matrix.build-type == 'Debug' }}


### PR DESCRIPTION
Should fix the apparent issue found in #4587 CI runs for linux.