### PR TITLE
[gha-linux] Add retry to the Configure step

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -169,10 +169,11 @@ jobs:
 
             exit $exit_code
           }
-
+          # The auto-refresh race would manifest itself in the first pull attempt.
+          # Hence wrapping only the first call.
           run_snapcraft /snap/bin/snapcraft pull --use-lxd inject-apt-mirrors
-          run_snapcraft /snap/bin/snapcraft pull --use-lxd configure-nuget-cache
-          run_snapcraft /snap/bin/snapcraft pull --use-lxd multipass
+          /snap/bin/snapcraft pull --use-lxd configure-nuget-cache
+          /snap/bin/snapcraft pull --use-lxd multipass
 
     - name: Run clang-tidy through the diff
       if: ${{ false && matrix.build-type == 'Debug' }}


### PR DESCRIPTION
To alleviate the race condition in Snapcraft's LXD integration.

# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
It tries to fix a intermittent snapcraft pull failure in the configure step.
- Why is this change needed?
To have a better CI experience.

