### PR TITLE
Add shell completions for zsh, fish, and PowerShell

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -20,7 +20,7 @@ _multipass_complete()
     {
         local state=$1 instances
 
-        instances=$(multipass list --format=csv --no-ipv4 | \tail -n +2)
+        instances=$(multipass list --format=csv --no-ipv4 2>/dev/null | \tail -n +2)
         [ -n "$state" ] && instances=$(awk -F',' "\$2 == \"$state\"" <<< "$instances")
         instances=$(echo "$instances" | \cut -d',' -f 1  | \tr '\r\n' ' ')
 
@@ -47,7 +47,7 @@ _multipass_complete()
     _multipass_restorable_snapshots()
     {
         local instances
-        instances=$( multipass info --no-runtime-information --format=csv \
+        instances=$( multipass info --no-runtime-information --format=csv 2>/dev/null \
                      | \tail -n +2 \
                      | \awk -F',|\r?\n' '$2 == "Stopped" && $16 > 0' \
                      | \cut -d',' -f 1 \
@@ -82,7 +82,7 @@ _multipass_complete()
     {
         local keys
 
-        keys=$( multipass get --keys | \tr '\r\n' ' ' )
+        keys=$( multipass get --keys 2>/dev/null | \tr '\r\n' ' ' )
 
         for key in ${keys}; do
             if [[ "${COMP_WORDS[*]}" == *"${key}"* ]]; then
@@ -229,7 +229,7 @@ _multipass_complete()
     cmd="${COMP_WORDS[1]}"
     prev_opts=false
     multipass_cmds="authenticate transfer delete exec find help info launch list mount networks \
-                    purge recover restart restore shell snapshot start stop suspend umount version get set \
+                    prefer purge recover restart restore shell snapshot start stop suspend umount version get set \
                     clone alias aliases unalias"
 
     if [[ "${multipass_cmds}" =~ " ${cmd} " || "${multipass_cmds}" =~ ^${cmd} || "${multipass_cmds}" =~ \ ${cmd}$ ]];
@@ -255,24 +255,37 @@ _multipass_complete()
             _add_nonrepeating_args "--all --purge"
         ;;
         "launch")
-            _add_nonrepeating_args "--cpus --disk --memory --name --cloud-init --bridged --mount"
+            _add_nonrepeating_args "--cpus --disk --memory --name --cloud-init --bridged --mount --timeout"
             opts="${opts} --network --mount"
         ;;
         "mount")
-            opts="${opts} --gid-map --uid-map"
+            opts="${opts} --gid-map --uid-map --type"
         ;;
-        "recover"|"start"|"suspend"|"restart")
+        "recover"|"suspend")
             _add_nonrepeating_args "--all"
         ;;
+        "start"|"restart")
+            _add_nonrepeating_args "--all --timeout"
+        ;;
         "stop")
-            _add_nonrepeating_args "--all --cancel --time"
+            _add_nonrepeating_args "--all --cancel --time --force"
+        ;;
+        "shell"|"sh"|"connect")
+            _add_nonrepeating_args "--timeout"
         ;;
         "find")
             _add_nonrepeating_args "--show-unsupported --force-update --format"
         ;;
         "unalias")
             _multipass_aliases
+            _add_nonrepeating_args "$multipass_aliases --all"
+        ;;
+        "prefer")
+            _multipass_aliases
             _add_nonrepeating_args "$multipass_aliases"
+        ;;
+        "version")
+            _add_nonrepeating_args "--format"
         ;;
         "transfer"|"copy-files")
             _add_nonrepeating_args "--parents --recursive"

--- a/completions/fish/multipass.fish
+++ b/completions/fish/multipass.fish
@@ -1,0 +1,308 @@
+# Copyright (C) Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Fish completion script for Multipass
+
+# Helper functions for dynamic completions
+function __multipass_instances
+    set -l state_filter $argv[1]
+    multipass list --format=csv --no-ipv4 2>/dev/null | tail -n +2 | while read -l line
+        set -l parts (string split ',' $line)
+        set -l name $parts[1]
+        set -l status $parts[2]
+        if test -z "$state_filter"; or test "$status" = "$state_filter"
+            echo $name
+        end
+    end
+end
+
+function __multipass_instances_running
+    __multipass_instances Running
+end
+
+function __multipass_instances_stopped
+    __multipass_instances Stopped
+end
+
+function __multipass_instances_suspended
+    __multipass_instances Suspended
+end
+
+function __multipass_instances_deleted
+    __multipass_instances Deleted
+end
+
+function __multipass_instances_startable
+    __multipass_instances Stopped
+    __multipass_instances Suspended
+end
+
+function __multipass_instances_shellable
+    __multipass_instances Running
+    __multipass_instances Stopped
+    __multipass_instances Suspended
+end
+
+function __multipass_instances_stoppable
+    set -l has_force 0
+    for word in (commandline -opc)
+        if test "$word" = "--force" -o "$word" = "-f"
+            set has_force 1
+            break
+        end
+    end
+
+    __multipass_instances Running
+    if test $has_force -eq 1
+        __multipass_instances Starting
+        __multipass_instances Restarting
+        __multipass_instances Suspending
+        __multipass_instances Suspended
+    end
+end
+
+function __multipass_snapshots
+    set -l instance_filter $argv[1]
+    multipass list --snapshots --format=csv 2>/dev/null | tail -n +2 | while read -l line
+        set -l parts (string split ',' $line)
+        set -l instance $parts[1]
+        set -l snapshot $parts[2]
+        if test -z "$instance_filter"; or test "$instance" = "$instance_filter"
+            echo "$instance.$snapshot"
+        end
+    end
+end
+
+function __multipass_instances_and_snapshots
+    __multipass_instances
+    __multipass_snapshots
+end
+
+function __multipass_restorable_snapshots
+    for instance in (multipass info --no-runtime-information --format=csv 2>/dev/null | tail -n +2 | awk -F',' '$2 == "Stopped" && $16 > 0 {print $1}')
+        __multipass_snapshots $instance
+    end
+end
+
+function __multipass_networks
+    multipass networks --format=csv 2>/dev/null | tail -n +2 | cut -d',' -f1
+end
+
+function __multipass_settings_keys
+    multipass get --keys 2>/dev/null
+end
+
+function __multipass_aliases_list
+    multipass aliases --format=csv 2>/dev/null | tail -n +2 | cut -d',' -f1
+end
+
+function __multipass_needs_command
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -eq 1
+        return 0
+    end
+    return 1
+end
+
+function __multipass_using_command
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
+            return 0
+        end
+    end
+    return 1
+end
+
+# Disable file completion by default
+complete -c multipass -f
+
+# Global options
+complete -c multipass -s h -l help -d 'Display help information'
+complete -c multipass -s v -l verbose -d 'Increase logging verbosity'
+
+# Commands
+complete -c multipass -n __multipass_needs_command -a alias -d 'Create an alias to run a command in an instance'
+complete -c multipass -n __multipass_needs_command -a aliases -d 'List available aliases'
+complete -c multipass -n __multipass_needs_command -a authenticate -d 'Authenticate client'
+complete -c multipass -n __multipass_needs_command -a clone -d 'Clone an instance'
+complete -c multipass -n __multipass_needs_command -a delete -d 'Delete instances and snapshots'
+complete -c multipass -n __multipass_needs_command -a exec -d 'Run a command in an instance'
+complete -c multipass -n __multipass_needs_command -a find -d 'Search available images'
+complete -c multipass -n __multipass_needs_command -a get -d 'Get a configuration setting'
+complete -c multipass -n __multipass_needs_command -a help -d 'Display help about a command'
+complete -c multipass -n __multipass_needs_command -a info -d 'Display information about instances'
+complete -c multipass -n __multipass_needs_command -a launch -d 'Create and start an Ubuntu instance'
+complete -c multipass -n __multipass_needs_command -a list -d 'List all available instances'
+complete -c multipass -n __multipass_needs_command -a ls -d 'List all available instances (alias)'
+complete -c multipass -n __multipass_needs_command -a mount -d 'Mount a local directory in the instance'
+complete -c multipass -n __multipass_needs_command -a networks -d 'List available network interfaces'
+complete -c multipass -n __multipass_needs_command -a prefer -d 'Switch the current alias context'
+complete -c multipass -n __multipass_needs_command -a purge -d 'Purge all deleted instances permanently'
+complete -c multipass -n __multipass_needs_command -a recover -d 'Recover deleted instances'
+complete -c multipass -n __multipass_needs_command -a restart -d 'Restart instances'
+complete -c multipass -n __multipass_needs_command -a restore -d 'Restore an instance from a snapshot'
+complete -c multipass -n __multipass_needs_command -a set -d 'Set a configuration setting'
+complete -c multipass -n __multipass_needs_command -a shell -d 'Open a shell in an instance'
+complete -c multipass -n __multipass_needs_command -a sh -d 'Open a shell in an instance (alias)'
+complete -c multipass -n __multipass_needs_command -a connect -d 'Open a shell in an instance (alias)'
+complete -c multipass -n __multipass_needs_command -a snapshot -d 'Take a snapshot of an instance'
+complete -c multipass -n __multipass_needs_command -a start -d 'Start instances'
+complete -c multipass -n __multipass_needs_command -a stop -d 'Stop running instances'
+complete -c multipass -n __multipass_needs_command -a suspend -d 'Suspend running instances'
+complete -c multipass -n __multipass_needs_command -a transfer -d 'Transfer files between host and instance'
+complete -c multipass -n __multipass_needs_command -a "copy-files" -d 'Transfer files (alias)'
+complete -c multipass -n __multipass_needs_command -a umount -d 'Unmount a directory from an instance'
+complete -c multipass -n __multipass_needs_command -a unmount -d 'Unmount a directory (alias)'
+complete -c multipass -n __multipass_needs_command -a unalias -d 'Remove aliases'
+complete -c multipass -n __multipass_needs_command -a version -d 'Show version details'
+
+# Also complete user-defined aliases as commands
+complete -c multipass -n __multipass_needs_command -a '(__multipass_aliases_list)' -d 'User-defined alias'
+
+# alias command
+complete -c multipass -n '__multipass_using_command alias' -l no-map-working-directory -d 'Do not map working directory'
+complete -c multipass -n '__multipass_using_command alias' -a '(__multipass_instances)' -d 'Instance'
+
+# aliases command
+complete -c multipass -n '__multipass_using_command aliases' -s f -l format -xa 'table json csv yaml' -d 'Output format'
+
+# clone command
+complete -c multipass -n '__multipass_using_command clone' -s n -l name -d 'Name for the cloned instance'
+complete -c multipass -n '__multipass_using_command clone' -a '(__multipass_instances_stopped)' -d 'Instance'
+
+# delete command
+complete -c multipass -n '__multipass_using_command delete' -l all -d 'Delete all instances'
+complete -c multipass -n '__multipass_using_command delete' -s p -l purge -d 'Purge instances immediately'
+complete -c multipass -n '__multipass_using_command delete' -a '(__multipass_instances_and_snapshots)' -d 'Instance or snapshot'
+
+# exec command
+complete -c multipass -n '__multipass_using_command exec' -s d -l working-directory -rF -d 'Working directory'
+complete -c multipass -n '__multipass_using_command exec' -s n -l no-map-working-directory -d 'Do not map working directory'
+complete -c multipass -n '__multipass_using_command exec' -a '(__multipass_instances_running)' -d 'Instance'
+
+# find command
+complete -c multipass -n '__multipass_using_command find' -l show-unsupported -d 'Show unsupported images'
+complete -c multipass -n '__multipass_using_command find' -l force-update -d 'Force image list update'
+complete -c multipass -n '__multipass_using_command find' -s f -l format -xa 'table json csv yaml' -d 'Output format'
+
+# get command
+complete -c multipass -n '__multipass_using_command get' -l raw -d 'Output raw values'
+complete -c multipass -n '__multipass_using_command get' -l keys -d 'List available keys'
+complete -c multipass -n '__multipass_using_command get' -a '(__multipass_settings_keys)' -d 'Setting key'
+
+# help command
+complete -c multipass -n '__multipass_using_command help' -a 'alias aliases authenticate clone delete exec find get help info launch list mount networks purge recover restart restore set shell snapshot start stop suspend transfer umount unalias version' -d 'Command'
+
+# info command
+complete -c multipass -n '__multipass_using_command info' -s f -l format -xa 'table json csv yaml' -d 'Output format'
+complete -c multipass -n '__multipass_using_command info' -l snapshots -d 'Show snapshot information'
+complete -c multipass -n '__multipass_using_command info' -l no-runtime-information -d 'Skip runtime info'
+complete -c multipass -n '__multipass_using_command info' -a '(__multipass_instances_and_snapshots)' -d 'Instance or snapshot'
+
+# launch command
+complete -c multipass -n '__multipass_using_command launch' -s c -l cpus -d 'Number of CPUs'
+complete -c multipass -n '__multipass_using_command launch' -s d -l disk -d 'Disk space (e.g., 10G)'
+complete -c multipass -n '__multipass_using_command launch' -s m -l memory -d 'Memory size (e.g., 1G)'
+complete -c multipass -n '__multipass_using_command launch' -s n -l name -d 'Instance name'
+complete -c multipass -n '__multipass_using_command launch' -l cloud-init -rF -d 'Cloud-init config file'
+complete -c multipass -n '__multipass_using_command launch' -l network -xa '(__multipass_networks) bridged' -d 'Network specification'
+complete -c multipass -n '__multipass_using_command launch' -l bridged -d 'Use bridged network'
+complete -c multipass -n '__multipass_using_command launch' -l mount -rF -d 'Mount specification'
+complete -c multipass -n '__multipass_using_command launch' -s t -l timeout -d 'Timeout in seconds'
+
+# list command
+complete -c multipass -n '__multipass_using_command list' -s f -l format -xa 'table json csv yaml' -d 'Output format'
+complete -c multipass -n '__multipass_using_command list' -l snapshots -d 'List snapshots'
+complete -c multipass -n '__multipass_using_command list' -l no-ipv4 -d 'Omit IPv4 column'
+complete -c multipass -n '__multipass_using_command ls' -s f -l format -xa 'table json csv yaml' -d 'Output format'
+complete -c multipass -n '__multipass_using_command ls' -l snapshots -d 'List snapshots'
+complete -c multipass -n '__multipass_using_command ls' -l no-ipv4 -d 'Omit IPv4 column'
+
+# mount command
+complete -c multipass -n '__multipass_using_command mount' -s g -l gid-map -d 'GID mapping'
+complete -c multipass -n '__multipass_using_command mount' -s u -l uid-map -d 'UID mapping'
+complete -c multipass -n '__multipass_using_command mount' -s t -l type -xa 'classic native' -d 'Mount type'
+complete -c multipass -n '__multipass_using_command mount' -rF -d 'Source directory'
+complete -c multipass -n '__multipass_using_command mount' -a '(__multipass_instances_shellable)' -d 'Instance'
+
+# networks command
+complete -c multipass -n '__multipass_using_command networks' -s f -l format -xa 'table json csv yaml' -d 'Output format'
+
+# recover command
+complete -c multipass -n '__multipass_using_command recover' -l all -d 'Recover all deleted instances'
+complete -c multipass -n '__multipass_using_command recover' -a '(__multipass_instances_deleted)' -d 'Deleted instance'
+
+# restart command
+complete -c multipass -n '__multipass_using_command restart' -l all -d 'Restart all instances'
+complete -c multipass -n '__multipass_using_command restart' -s t -l timeout -d 'Timeout in seconds'
+complete -c multipass -n '__multipass_using_command restart' -a '(__multipass_instances_running)' -d 'Instance'
+
+# restore command
+complete -c multipass -n '__multipass_using_command restore' -l destructive -d 'Discard current state'
+complete -c multipass -n '__multipass_using_command restore' -a '(__multipass_restorable_snapshots)' -d 'Snapshot'
+
+# set command
+complete -c multipass -n '__multipass_using_command set' -a '(__multipass_settings_keys)' -d 'Setting key'
+
+# shell/sh/connect command
+complete -c multipass -n '__multipass_using_command shell' -s t -l timeout -d 'Timeout in seconds'
+complete -c multipass -n '__multipass_using_command shell' -a '(__multipass_instances_shellable)' -d 'Instance'
+complete -c multipass -n '__multipass_using_command sh' -s t -l timeout -d 'Timeout in seconds'
+complete -c multipass -n '__multipass_using_command sh' -a '(__multipass_instances_shellable)' -d 'Instance'
+complete -c multipass -n '__multipass_using_command connect' -s t -l timeout -d 'Timeout in seconds'
+complete -c multipass -n '__multipass_using_command connect' -a '(__multipass_instances_shellable)' -d 'Instance'
+
+# snapshot command
+complete -c multipass -n '__multipass_using_command snapshot' -s n -l name -d 'Snapshot name'
+complete -c multipass -n '__multipass_using_command snapshot' -s c -l comment -d 'Snapshot comment'
+complete -c multipass -n '__multipass_using_command snapshot' -a '(__multipass_instances_stopped)' -d 'Instance'
+
+# start command
+complete -c multipass -n '__multipass_using_command start' -l all -d 'Start all instances'
+complete -c multipass -n '__multipass_using_command start' -s t -l timeout -d 'Timeout in seconds'
+complete -c multipass -n '__multipass_using_command start' -a '(__multipass_instances_startable)' -d 'Instance'
+
+# stop command
+complete -c multipass -n '__multipass_using_command stop' -l all -d 'Stop all instances'
+complete -c multipass -n '__multipass_using_command stop' -s t -l time -d 'Delay shutdown by time'
+complete -c multipass -n '__multipass_using_command stop' -s c -l cancel -d 'Cancel scheduled stop'
+complete -c multipass -n '__multipass_using_command stop' -s f -l force -d 'Force stop'
+complete -c multipass -n '__multipass_using_command stop' -a '(__multipass_instances_stoppable)' -d 'Instance'
+
+# suspend command
+complete -c multipass -n '__multipass_using_command suspend' -l all -d 'Suspend all instances'
+complete -c multipass -n '__multipass_using_command suspend' -a '(__multipass_instances_running)' -d 'Instance'
+
+# transfer/copy-files command
+complete -c multipass -n '__multipass_using_command transfer' -s r -l recursive -d 'Transfer directories recursively'
+complete -c multipass -n '__multipass_using_command transfer' -s p -l parents -d 'Make parent directories as needed'
+complete -c multipass -n '__multipass_using_command transfer' -rF -d 'Source or destination'
+complete -c multipass -n '__multipass_using_command copy-files' -s r -l recursive -d 'Transfer directories recursively'
+complete -c multipass -n '__multipass_using_command copy-files' -s p -l parents -d 'Make parent directories as needed'
+complete -c multipass -n '__multipass_using_command copy-files' -rF -d 'Source or destination'
+
+# umount/unmount command
+complete -c multipass -n '__multipass_using_command umount' -a '(__multipass_instances)' -d 'Instance'
+complete -c multipass -n '__multipass_using_command unmount' -a '(__multipass_instances)' -d 'Instance'
+
+# unalias command
+complete -c multipass -n '__multipass_using_command unalias' -l all -d 'Remove all aliases'
+complete -c multipass -n '__multipass_using_command unalias' -a '(__multipass_aliases_list)' -d 'Alias'
+
+# prefer command
+complete -c multipass -n '__multipass_using_command prefer' -a '(__multipass_aliases_list)' -d 'Alias context'
+
+# version command
+complete -c multipass -n '__multipass_using_command version' -s f -l format -xa 'table json csv yaml' -d 'Output format'

--- a/completions/powershell/multipass.ps1
+++ b/completions/powershell/multipass.ps1
@@ -1,0 +1,597 @@
+# Copyright (C) Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# PowerShell completion script for Multipass
+
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+# Helper functions for dynamic completions
+function Get-MultipassInstances {
+    param([string]$StateFilter = "")
+
+    try {
+        $output = multipass list --format=csv --no-ipv4 2>$null
+        if ($LASTEXITCODE -ne 0) { return @() }
+
+        $lines = $output -split "`n" | Select-Object -Skip 1
+        $instances = @()
+
+        foreach ($line in $lines) {
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $parts = $line -split ','
+            $name = $parts[0].Trim()
+            $status = $parts[1].Trim()
+
+            if ([string]::IsNullOrEmpty($StateFilter) -or $status -eq $StateFilter) {
+                $instances += $name
+            }
+        }
+        return $instances
+    }
+    catch {
+        return @()
+    }
+}
+
+function Get-MultipassSnapshots {
+    param([string]$InstanceFilter = "")
+
+    try {
+        $output = multipass list --snapshots --format=csv 2>$null
+        if ($LASTEXITCODE -ne 0) { return @() }
+
+        $lines = $output -split "`n" | Select-Object -Skip 1
+        $snapshots = @()
+
+        foreach ($line in $lines) {
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $parts = $line -split ','
+            $instance = $parts[0].Trim()
+            $snapshot = $parts[1].Trim()
+
+            if ([string]::IsNullOrEmpty($InstanceFilter) -or $instance -eq $InstanceFilter) {
+                $snapshots += "$instance.$snapshot"
+            }
+        }
+        return $snapshots
+    }
+    catch {
+        return @()
+    }
+}
+
+function Get-MultipassNetworks {
+    try {
+        $output = multipass networks --format=csv 2>$null
+        if ($LASTEXITCODE -ne 0) { return @() }
+
+        $lines = $output -split "`n" | Select-Object -Skip 1
+        $networks = @()
+
+        foreach ($line in $lines) {
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $parts = $line -split ','
+            $networks += $parts[0].Trim()
+        }
+        return $networks
+    }
+    catch {
+        return @()
+    }
+}
+
+function Get-MultipassSettingsKeys {
+    try {
+        $output = multipass get --keys 2>$null
+        if ($LASTEXITCODE -ne 0) { return @() }
+        return ($output -split "`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+    catch {
+        return @()
+    }
+}
+
+function Get-MultipassAliases {
+    try {
+        $output = multipass aliases --format=csv 2>$null
+        if ($LASTEXITCODE -ne 0) { return @() }
+
+        $lines = $output -split "`n" | Select-Object -Skip 1
+        $aliases = @()
+
+        foreach ($line in $lines) {
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $parts = $line -split ','
+            $aliases += $parts[0].Trim()
+        }
+        return $aliases
+    }
+    catch {
+        return @()
+    }
+}
+
+# Command definitions with their options
+$script:MultipassCommands = @{
+    'alias' = @{
+        Description = 'Create an alias to run a command in an instance'
+        Options = @(
+            @{ Name = '--no-map-working-directory'; Description = 'Do not map working directory' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'aliases' = @{
+        Description = 'List available aliases'
+        Options = @(
+            @{ Name = '--format'; Short = '-f'; Description = 'Output format'; Values = @('table', 'json', 'csv', 'yaml') }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'authenticate' = @{
+        Description = 'Authenticate client'
+        Options = @(
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'clone' = @{
+        Description = 'Clone an instance'
+        Options = @(
+            @{ Name = '--name'; Short = '-n'; Description = 'Name for the cloned instance' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'delete' = @{
+        Description = 'Delete instances and snapshots'
+        Options = @(
+            @{ Name = '--all'; Description = 'Delete all instances' }
+            @{ Name = '--purge'; Short = '-p'; Description = 'Purge instances immediately' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'exec' = @{
+        Description = 'Run a command in an instance'
+        Options = @(
+            @{ Name = '--working-directory'; Short = '-d'; Description = 'Working directory' }
+            @{ Name = '--no-map-working-directory'; Short = '-n'; Description = 'Do not map working directory' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'find' = @{
+        Description = 'Search available images'
+        Options = @(
+            @{ Name = '--show-unsupported'; Description = 'Show unsupported images' }
+            @{ Name = '--force-update'; Description = 'Force image list update' }
+            @{ Name = '--format'; Short = '-f'; Description = 'Output format'; Values = @('table', 'json', 'csv', 'yaml') }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'get' = @{
+        Description = 'Get a configuration setting'
+        Options = @(
+            @{ Name = '--raw'; Description = 'Output raw values' }
+            @{ Name = '--keys'; Description = 'List available keys' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'help' = @{
+        Description = 'Display help about a command'
+        Options = @()
+    }
+    'info' = @{
+        Description = 'Display information about instances'
+        Options = @(
+            @{ Name = '--format'; Short = '-f'; Description = 'Output format'; Values = @('table', 'json', 'csv', 'yaml') }
+            @{ Name = '--snapshots'; Description = 'Show snapshot information' }
+            @{ Name = '--no-runtime-information'; Description = 'Skip runtime info' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'launch' = @{
+        Description = 'Create and start an Ubuntu instance'
+        Options = @(
+            @{ Name = '--cpus'; Short = '-c'; Description = 'Number of CPUs' }
+            @{ Name = '--disk'; Short = '-d'; Description = 'Disk space (e.g., 10G)' }
+            @{ Name = '--memory'; Short = '-m'; Description = 'Memory size (e.g., 1G)' }
+            @{ Name = '--name'; Short = '-n'; Description = 'Instance name' }
+            @{ Name = '--cloud-init'; Description = 'Cloud-init config file' }
+            @{ Name = '--network'; Description = 'Network specification' }
+            @{ Name = '--bridged'; Description = 'Use bridged network' }
+            @{ Name = '--mount'; Description = 'Mount specification' }
+            @{ Name = '--timeout'; Short = '-t'; Description = 'Timeout in seconds' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'list' = @{
+        Description = 'List all available instances'
+        Options = @(
+            @{ Name = '--format'; Short = '-f'; Description = 'Output format'; Values = @('table', 'json', 'csv', 'yaml') }
+            @{ Name = '--snapshots'; Description = 'List snapshots' }
+            @{ Name = '--no-ipv4'; Description = 'Omit IPv4 column' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'mount' = @{
+        Description = 'Mount a local directory in the instance'
+        Options = @(
+            @{ Name = '--gid-map'; Short = '-g'; Description = 'GID mapping' }
+            @{ Name = '--uid-map'; Short = '-u'; Description = 'UID mapping' }
+            @{ Name = '--type'; Short = '-t'; Description = 'Mount type'; Values = @('classic', 'native') }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'networks' = @{
+        Description = 'List available network interfaces'
+        Options = @(
+            @{ Name = '--format'; Short = '-f'; Description = 'Output format'; Values = @('table', 'json', 'csv', 'yaml') }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'prefer' = @{
+        Description = 'Switch the current alias context'
+        Options = @(
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'purge' = @{
+        Description = 'Purge all deleted instances permanently'
+        Options = @(
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'recover' = @{
+        Description = 'Recover deleted instances'
+        Options = @(
+            @{ Name = '--all'; Description = 'Recover all deleted instances' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'restart' = @{
+        Description = 'Restart instances'
+        Options = @(
+            @{ Name = '--all'; Description = 'Restart all instances' }
+            @{ Name = '--timeout'; Short = '-t'; Description = 'Timeout in seconds' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'restore' = @{
+        Description = 'Restore an instance from a snapshot'
+        Options = @(
+            @{ Name = '--destructive'; Description = 'Discard current state' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'set' = @{
+        Description = 'Set a configuration setting'
+        Options = @(
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'shell' = @{
+        Description = 'Open a shell in an instance'
+        Options = @(
+            @{ Name = '--timeout'; Short = '-t'; Description = 'Timeout in seconds' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'snapshot' = @{
+        Description = 'Take a snapshot of an instance'
+        Options = @(
+            @{ Name = '--name'; Short = '-n'; Description = 'Snapshot name' }
+            @{ Name = '--comment'; Short = '-c'; Description = 'Snapshot comment' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'start' = @{
+        Description = 'Start instances'
+        Options = @(
+            @{ Name = '--all'; Description = 'Start all instances' }
+            @{ Name = '--timeout'; Short = '-t'; Description = 'Timeout in seconds' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'stop' = @{
+        Description = 'Stop running instances'
+        Options = @(
+            @{ Name = '--all'; Description = 'Stop all instances' }
+            @{ Name = '--time'; Short = '-t'; Description = 'Delay shutdown by time' }
+            @{ Name = '--cancel'; Short = '-c'; Description = 'Cancel scheduled stop' }
+            @{ Name = '--force'; Short = '-f'; Description = 'Force stop' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'suspend' = @{
+        Description = 'Suspend running instances'
+        Options = @(
+            @{ Name = '--all'; Description = 'Suspend all instances' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'transfer' = @{
+        Description = 'Transfer files between host and instance'
+        Options = @(
+            @{ Name = '--recursive'; Short = '-r'; Description = 'Transfer directories recursively' }
+            @{ Name = '--parents'; Short = '-p'; Description = 'Make parent directories as needed' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'umount' = @{
+        Description = 'Unmount a directory from an instance'
+        Options = @(
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'unalias' = @{
+        Description = 'Remove aliases'
+        Options = @(
+            @{ Name = '--all'; Description = 'Remove all aliases' }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+    'version' = @{
+        Description = 'Show version details'
+        Options = @(
+            @{ Name = '--format'; Short = '-f'; Description = 'Output format'; Values = @('table', 'json', 'csv', 'yaml') }
+            @{ Name = '--help'; Short = '-h'; Description = 'Display help' }
+            @{ Name = '--verbose'; Short = '-v'; Description = 'Increase verbosity' }
+        )
+    }
+}
+
+# Command aliases
+$script:CommandAliases = @{
+    'ls' = 'list'
+    'sh' = 'shell'
+    'connect' = 'shell'
+    'copy-files' = 'transfer'
+    'unmount' = 'umount'
+}
+
+# Register the argument completer
+Register-ArgumentCompleter -Native -CommandName multipass -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commandElements = $commandAst.CommandElements
+    $command = @()
+
+    # Build the command array
+    for ($i = 1; $i -lt $commandElements.Count; $i++) {
+        $element = $commandElements[$i]
+        if ($element.Extent.EndOffset -gt $cursorPosition) { break }
+        $command += $element.ToString()
+    }
+
+    $completions = @()
+
+    # Determine what to complete
+    if ($command.Count -eq 0) {
+        # Complete commands
+        foreach ($cmd in $script:MultipassCommands.Keys) {
+            if ($cmd -like "$wordToComplete*") {
+                $desc = $script:MultipassCommands[$cmd].Description
+                $completions += [CompletionResult]::new($cmd, $cmd, 'ParameterValue', $desc)
+            }
+        }
+        # Add command aliases
+        foreach ($alias in $script:CommandAliases.Keys) {
+            if ($alias -like "$wordToComplete*") {
+                $target = $script:CommandAliases[$alias]
+                $desc = "$alias (alias for $target)"
+                $completions += [CompletionResult]::new($alias, $alias, 'ParameterValue', $desc)
+            }
+        }
+        # Add user-defined aliases
+        foreach ($userAlias in (Get-MultipassAliases)) {
+            if ($userAlias -like "$wordToComplete*") {
+                $completions += [CompletionResult]::new($userAlias, $userAlias, 'ParameterValue', 'User-defined alias')
+            }
+        }
+    }
+    else {
+        # Get the actual command (resolve aliases)
+        $subCommand = $command[0]
+        if ($script:CommandAliases.ContainsKey($subCommand)) {
+            $subCommand = $script:CommandAliases[$subCommand]
+        }
+
+        # Check if completing an option value
+        $lastArg = if ($command.Count -gt 1) { $command[-1] } else { "" }
+
+        if ($script:MultipassCommands.ContainsKey($subCommand)) {
+            $cmdDef = $script:MultipassCommands[$subCommand]
+
+            # Check if we're completing a value for an option
+            $optionNeedingValue = $null
+            foreach ($opt in $cmdDef.Options) {
+                if ($lastArg -eq $opt.Name -or $lastArg -eq $opt.Short) {
+                    if ($opt.Values) {
+                        foreach ($val in $opt.Values) {
+                            if ($val -like "$wordToComplete*") {
+                                $completions += [CompletionResult]::new($val, $val, 'ParameterValue', $val)
+                            }
+                        }
+                        return $completions
+                    }
+                    $optionNeedingValue = $opt
+                    break
+                }
+            }
+
+            # Complete options
+            if ($wordToComplete -like '-*') {
+                foreach ($opt in $cmdDef.Options) {
+                    if ($opt.Name -like "$wordToComplete*") {
+                        $completions += [CompletionResult]::new($opt.Name, $opt.Name, 'ParameterValue', $opt.Description)
+                    }
+                    if ($opt.Short -and $opt.Short -like "$wordToComplete*") {
+                        $completions += [CompletionResult]::new($opt.Short, $opt.Short, 'ParameterValue', $opt.Description)
+                    }
+                }
+            }
+
+            # Complete dynamic values based on command
+            switch ($subCommand) {
+                'exec' {
+                    foreach ($inst in (Get-MultipassInstances -StateFilter 'Running')) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Running instance')
+                        }
+                    }
+                }
+                'start' {
+                    foreach ($inst in (Get-MultipassInstances -StateFilter 'Stopped')) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Stopped instance')
+                        }
+                    }
+                    foreach ($inst in (Get-MultipassInstances -StateFilter 'Suspended')) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Suspended instance')
+                        }
+                    }
+                }
+                'stop' {
+                    foreach ($inst in (Get-MultipassInstances -StateFilter 'Running')) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Running instance')
+                        }
+                    }
+                }
+                { $_ -in 'shell', 'mount' } {
+                    foreach ($state in @('Running', 'Stopped', 'Suspended')) {
+                        foreach ($inst in (Get-MultipassInstances -StateFilter $state)) {
+                            if ($inst -like "$wordToComplete*") {
+                                $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', "$state instance")
+                            }
+                        }
+                    }
+                }
+                { $_ -in 'suspend', 'restart' } {
+                    foreach ($inst in (Get-MultipassInstances -StateFilter 'Running')) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Running instance')
+                        }
+                    }
+                }
+                { $_ -in 'delete', 'info' } {
+                    foreach ($inst in (Get-MultipassInstances)) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Instance')
+                        }
+                    }
+                    foreach ($snap in (Get-MultipassSnapshots)) {
+                        if ($snap -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($snap, $snap, 'ParameterValue', 'Snapshot')
+                        }
+                    }
+                }
+                'recover' {
+                    foreach ($inst in (Get-MultipassInstances -StateFilter 'Deleted')) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Deleted instance')
+                        }
+                    }
+                }
+                { $_ -in 'snapshot', 'clone' } {
+                    foreach ($inst in (Get-MultipassInstances -StateFilter 'Stopped')) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Stopped instance')
+                        }
+                    }
+                }
+                'umount' {
+                    foreach ($inst in (Get-MultipassInstances)) {
+                        if ($inst -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($inst, $inst, 'ParameterValue', 'Instance')
+                        }
+                    }
+                }
+                { $_ -in 'get', 'set' } {
+                    foreach ($key in (Get-MultipassSettingsKeys)) {
+                        if ($key -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($key, $key, 'ParameterValue', 'Setting key')
+                        }
+                    }
+                }
+                'unalias' {
+                    foreach ($alias in (Get-MultipassAliases)) {
+                        if ($alias -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($alias, $alias, 'ParameterValue', 'Alias')
+                        }
+                    }
+                }
+                'prefer' {
+                    foreach ($alias in (Get-MultipassAliases)) {
+                        if ($alias -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($alias, $alias, 'ParameterValue', 'Alias context')
+                        }
+                    }
+                }
+                'help' {
+                    foreach ($cmd in $script:MultipassCommands.Keys) {
+                        if ($cmd -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new($cmd, $cmd, 'ParameterValue', 'Command')
+                        }
+                    }
+                }
+                'launch' {
+                    if ($lastArg -eq '--network') {
+                        foreach ($net in (Get-MultipassNetworks)) {
+                            if ($net -like "$wordToComplete*") {
+                                $completions += [CompletionResult]::new($net, $net, 'ParameterValue', 'Network')
+                            }
+                        }
+                        if ('bridged' -like "$wordToComplete*") {
+                            $completions += [CompletionResult]::new('bridged', 'bridged', 'ParameterValue', 'Bridged network')
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return $completions
+}
+
+# Display usage information when sourced
+Write-Host "Multipass PowerShell completions loaded." -ForegroundColor Green
+Write-Host "To enable permanently, add the following to your PowerShell profile:" -ForegroundColor Cyan
+Write-Host "  . `"<path-to-this-script>/multipass.ps1`"" -ForegroundColor Yellow

--- a/completions/zsh/_multipass
+++ b/completions/zsh/_multipass
@@ -1,0 +1,433 @@
+#compdef multipass
+
+# Copyright (C) Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Zsh completion script for Multipass
+
+_multipass() {
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    local -a commands
+    commands=(
+        'alias:Create an alias to run a command in an instance'
+        'aliases:List available aliases'
+        'authenticate:Authenticate client'
+        'clone:Clone an instance'
+        'delete:Delete instances and snapshots'
+        'exec:Run a command in an instance'
+        'find:Search available images'
+        'get:Get a configuration setting'
+        'help:Display help about a command'
+        'info:Display information about instances'
+        'launch:Create and start an Ubuntu instance'
+        'list:List all available instances'
+        'mount:Mount a local directory in the instance'
+        'networks:List available network interfaces'
+        'prefer:Switch the current alias context'
+        'purge:Purge all deleted instances permanently'
+        'recover:Recover deleted instances'
+        'restart:Restart instances'
+        'restore:Restore an instance from a snapshot'
+        'set:Set a configuration setting'
+        'shell:Open a shell in an instance'
+        'snapshot:Take a snapshot of an instance'
+        'start:Start instances'
+        'stop:Stop running instances'
+        'suspend:Suspend running instances'
+        'transfer:Transfer files between host and instance'
+        'umount:Unmount a directory from an instance'
+        'unalias:Remove aliases'
+        'version:Show version details'
+    )
+
+    # Helper functions for dynamic completions
+    _multipass_instances() {
+        local state_filter="$1"
+        local instances
+        instances=(${(f)"$(multipass list --format=csv --no-ipv4 2>/dev/null | tail -n +2 | while IFS=',' read -r name status rest; do
+            if [[ -z "$state_filter" ]] || [[ "$status" == "$state_filter" ]]; then
+                echo "$name"
+            fi
+        done)"})
+        _describe -t instances 'instances' instances
+    }
+
+    _multipass_instances_running() {
+        _multipass_instances "Running"
+    }
+
+    _multipass_instances_stopped() {
+        _multipass_instances "Stopped"
+    }
+
+    _multipass_instances_suspended() {
+        _multipass_instances "Suspended"
+    }
+
+    _multipass_instances_deleted() {
+        _multipass_instances "Deleted"
+    }
+
+    _multipass_instances_startable() {
+        local instances
+        instances=(${(f)"$(multipass list --format=csv --no-ipv4 2>/dev/null | tail -n +2 | while IFS=',' read -r name status rest; do
+            if [[ "$status" == "Stopped" ]] || [[ "$status" == "Suspended" ]]; then
+                echo "$name"
+            fi
+        done)"})
+        _describe -t instances 'instances' instances
+    }
+
+    _multipass_instances_shellable() {
+        local instances
+        instances=(${(f)"$(multipass list --format=csv --no-ipv4 2>/dev/null | tail -n +2 | while IFS=',' read -r name status rest; do
+            if [[ "$status" == "Running" ]] || [[ "$status" == "Stopped" ]] || [[ "$status" == "Suspended" ]]; then
+                echo "$name"
+            fi
+        done)"})
+        _describe -t instances 'instances' instances
+    }
+
+    _multipass_instances_mountable() {
+        _multipass_instances_shellable
+    }
+
+    _multipass_instances_stoppable() {
+        local instances force_mode=0
+        for word in "${words[@]}"; do
+            [[ "$word" == "--force" ]] && force_mode=1 && break
+        done
+
+        instances=(${(f)"$(multipass list --format=csv --no-ipv4 2>/dev/null | tail -n +2 | while IFS=',' read -r name status rest; do
+            if [[ "$status" == "Running" ]]; then
+                echo "$name"
+            elif [[ $force_mode -eq 1 ]]; then
+                if [[ "$status" == "Starting" ]] || [[ "$status" == "Restarting" ]] || \
+                   [[ "$status" == "Suspending" ]] || [[ "$status" == "Suspended" ]]; then
+                    echo "$name"
+                fi
+            fi
+        done)"})
+        _describe -t instances 'instances' instances
+    }
+
+    _multipass_snapshots() {
+        local instance_filter="$1"
+        local snapshots
+        snapshots=(${(f)"$(multipass list --snapshots --format=csv 2>/dev/null | tail -n +2 | while IFS=',' read -r instance snapshot rest; do
+            if [[ -z "$instance_filter" ]] || [[ "$instance" == "$instance_filter" ]]; then
+                echo "${instance}.${snapshot}"
+            fi
+        done)"})
+        _describe -t snapshots 'snapshots' snapshots
+    }
+
+    _multipass_instances_and_snapshots() {
+        _multipass_instances
+        _multipass_snapshots
+    }
+
+    _multipass_restorable_snapshots() {
+        local instances snapshots
+        instances=(${(f)"$(multipass info --no-runtime-information --format=csv 2>/dev/null | tail -n +2 | \
+            awk -F',' '$2 == "Stopped" && $16 > 0 {print $1}')"})
+        for instance in "${instances[@]}"; do
+            _multipass_snapshots "$instance"
+        done
+    }
+
+    _multipass_networks() {
+        local networks
+        networks=(${(f)"$(multipass networks --format=csv 2>/dev/null | tail -n +2 | cut -d',' -f1)"})
+        _describe -t networks 'networks' networks
+    }
+
+    _multipass_settings_keys() {
+        local keys
+        keys=(${(f)"$(multipass get --keys 2>/dev/null)"})
+        _describe -t settings 'settings keys' keys
+    }
+
+    _multipass_aliases_list() {
+        local aliases
+        aliases=(${(f)"$(multipass aliases --format=csv 2>/dev/null | tail -n +2 | cut -d',' -f1)"})
+        _describe -t aliases 'aliases' aliases
+    }
+
+    _multipass_format_options() {
+        local formats=(table json csv yaml)
+        _describe -t formats 'output format' formats
+    }
+
+    _multipass_network_spec() {
+        local -a network_opts
+        network_opts=(
+            'id=:Network interface ID'
+            'mode=:Network mode (auto or manual)'
+            'mac=:MAC address'
+        )
+        _describe -t network-opts 'network options' network_opts
+    }
+
+    # Main argument parsing
+    _arguments -C \
+        '(-h --help)'{-h,--help}'[Display help information]' \
+        '(-v --verbose)'{-v,--verbose}'[Increase logging verbosity]' \
+        '1: :->command' \
+        '*:: :->args'
+
+    case $state in
+        command)
+            # Also include aliases as potential commands
+            local -a all_commands
+            all_commands=("${commands[@]}")
+            local -a user_aliases
+            user_aliases=(${(f)"$(multipass aliases --format=csv 2>/dev/null | tail -n +2 | cut -d',' -f1)"})
+            for alias in "${user_aliases[@]}"; do
+                [[ -n "$alias" ]] && all_commands+=("$alias:User-defined alias")
+            done
+            _describe -t commands 'multipass commands' all_commands
+            ;;
+        args)
+            case $line[1] in
+                alias)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--no-map-working-directory[Do not map working directory]' \
+                        '*:instance\:command:_multipass_instances'
+                    ;;
+                aliases)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-f --format)'{-f,--format}'[Output format]:format:_multipass_format_options'
+                    ;;
+                authenticate)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        ':passphrase:'
+                    ;;
+                clone)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-n --name)'{-n,--name}'[Name for the cloned instance]:name:' \
+                        '*:source instance:_multipass_instances_stopped'
+                    ;;
+                delete)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--all[Delete all instances]' \
+                        '(-p --purge)'{-p,--purge}'[Purge instances immediately]' \
+                        '*:instance or snapshot:_multipass_instances_and_snapshots'
+                    ;;
+                exec)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-d --working-directory)'{-d,--working-directory}'[Working directory]:directory:_files -/' \
+                        '(-n --no-map-working-directory)'{-n,--no-map-working-directory}'[Do not map working directory]' \
+                        '1:instance:_multipass_instances_running' \
+                        '*:command:'
+                    ;;
+                find)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--show-unsupported[Show unsupported images]' \
+                        '--force-update[Force image list update]' \
+                        '(-f --format)'{-f,--format}'[Output format]:format:_multipass_format_options' \
+                        ':search filter:'
+                    ;;
+                get)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--raw[Output raw values]' \
+                        '--keys[List available keys]' \
+                        '*:setting key:_multipass_settings_keys'
+                    ;;
+                help)
+                    _arguments \
+                        '*:command:((${commands[@]%:*}))'
+                    ;;
+                info)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-f --format)'{-f,--format}'[Output format]:format:_multipass_format_options' \
+                        '--snapshots[Show snapshot information]' \
+                        '--no-runtime-information[Skip runtime info]' \
+                        '*:instance or snapshot:_multipass_instances_and_snapshots'
+                    ;;
+                launch)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-c --cpus)'{-c,--cpus}'[Number of CPUs]:cpus:' \
+                        '(-d --disk)'{-d,--disk}'[Disk space (e.g., 10G)]:disk size:' \
+                        '(-m --memory)'{-m,--memory}'[Memory size (e.g., 1G)]:memory size:' \
+                        '(-n --name)'{-n,--name}'[Instance name]:name:' \
+                        '--cloud-init[Cloud-init config file]:config file:_files' \
+                        '*--network[Network specification]:network:_multipass_networks' \
+                        '--bridged[Use bridged network]' \
+                        '*--mount[Mount specification]:mount path:_files -/' \
+                        '(-t --timeout)'{-t,--timeout}'[Timeout in seconds]:timeout:' \
+                        ':image:'
+                    ;;
+                list|ls)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-f --format)'{-f,--format}'[Output format]:format:_multipass_format_options' \
+                        '--snapshots[List snapshots]' \
+                        '--no-ipv4[Omit IPv4 column]'
+                    ;;
+                mount)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '*'{-g,--gid-map}'[GID mapping]:gid map:' \
+                        '*'{-u,--uid-map}'[UID mapping]:uid map:' \
+                        '(-t --type)'{-t,--type}'[Mount type (classic or native)]:type:(classic native)' \
+                        '1:source directory:_files -/' \
+                        '*:target (instance\:path):_multipass_instances_mountable'
+                    ;;
+                networks)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-f --format)'{-f,--format}'[Output format]:format:_multipass_format_options'
+                    ;;
+                purge)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]'
+                    ;;
+                recover)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--all[Recover all deleted instances]' \
+                        '*:instance:_multipass_instances_deleted'
+                    ;;
+                restart)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--all[Restart all instances]' \
+                        '(-t --timeout)'{-t,--timeout}'[Timeout in seconds]:timeout:' \
+                        '*:instance:_multipass_instances_running'
+                    ;;
+                restore)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--destructive[Discard current state]' \
+                        ':snapshot:_multipass_restorable_snapshots'
+                    ;;
+                set)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '*:setting=value:_multipass_settings_keys'
+                    ;;
+                shell|sh|connect)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-t --timeout)'{-t,--timeout}'[Timeout in seconds]:timeout:' \
+                        ':instance:_multipass_instances_shellable'
+                    ;;
+                snapshot)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-n --name)'{-n,--name}'[Snapshot name]:name:' \
+                        '(-c --comment)'{-c,--comment}'[Snapshot comment]:comment:' \
+                        ':instance:_multipass_instances_stopped'
+                    ;;
+                start)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--all[Start all instances]' \
+                        '(-t --timeout)'{-t,--timeout}'[Timeout in seconds]:timeout:' \
+                        '*:instance:_multipass_instances_startable'
+                    ;;
+                stop)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--all[Stop all instances]' \
+                        '(-t --time)'{-t,--time}'[Delay shutdown by time]:time:' \
+                        '(-c --cancel)'{-c,--cancel}'[Cancel scheduled stop]' \
+                        '(-f --force)'{-f,--force}'[Force stop]' \
+                        '*:instance:_multipass_instances_stoppable'
+                    ;;
+                suspend)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--all[Suspend all instances]' \
+                        '*:instance:_multipass_instances_running'
+                    ;;
+                transfer|copy-files)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-r --recursive)'{-r,--recursive}'[Transfer directories recursively]' \
+                        '(-p --parents)'{-p,--parents}'[Make parent directories as needed]' \
+                        '*:source or destination:_files'
+                    ;;
+                umount|unmount)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '*:mount:_multipass_instances'
+                    ;;
+                unalias)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '--all[Remove all aliases]' \
+                        '*:alias:_multipass_aliases_list'
+                    ;;
+                prefer)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        ':context:_multipass_aliases_list'
+                    ;;
+                version)
+                    _arguments \
+                        '(-h --help)'{-h,--help}'[Display help]' \
+                        '(-v --verbose)'{-v,--verbose}'[Increase verbosity]' \
+                        '(-f --format)'{-f,--format}'[Output format]:format:_multipass_format_options'
+                    ;;
+                *)
+                    # Handle user-defined aliases - run exec on running instances
+                    _multipass_instances_running
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_multipass "$@"

--- a/packaging/macos/postinstall-multipass.sh.in
+++ b/packaging/macos/postinstall-multipass.sh.in
@@ -15,7 +15,9 @@ mkdir -p ${3}usr/local/bin
 ### Set up symlink to new multipass binary
 ln -fsv "${3}@CPACK_PACKAGING_INSTALL_PREFIX@/bin/multipass" "${3}usr/local/bin/multipass"
 
-### Set up symlink for bash competions
+### Set up symlinks for shell completions
+
+# Bash completions
 # If HomeBrew installed (only looking for default path)
 if [ -d "${3}$(brew --prefix)/etc/bash_completion.d" ]; then
     ln -fsv "${3}@CPACK_PACKAGING_INSTALL_PREFIX@/Resources/completions/bash/multipass" \
@@ -33,5 +35,47 @@ if [ -d "${3}opt/local/share/bash-completion/completions/" ]; then
 else
     echo "MacPorts is not installed"
 fi
+
+# Zsh completions
+# HomeBrew zsh completions
+if [ -d "${3}$(brew --prefix)/share/zsh/site-functions" ]; then
+    ln -fsv "${3}@CPACK_PACKAGING_INSTALL_PREFIX@/Resources/completions/zsh/_multipass" \
+            "${3}$(brew --prefix)/share/zsh/site-functions/_multipass"
+    echo "Installed Zsh completion file for HomeBrew"
+fi
+
+# MacPorts zsh completions
+if [ -d "${3}opt/local/share/zsh/site-functions" ]; then
+    ln -fsv "${3}@CPACK_PACKAGING_INSTALL_PREFIX@/Resources/completions/zsh/_multipass" \
+            "${3}opt/local/share/zsh/site-functions/_multipass"
+    echo "Installed Zsh completion for MacPorts"
+fi
+
+# Fish completions
+# HomeBrew fish completions
+if [ -d "${3}$(brew --prefix)/share/fish/vendor_completions.d" ]; then
+    ln -fsv "${3}@CPACK_PACKAGING_INSTALL_PREFIX@/Resources/completions/fish/multipass.fish" \
+            "${3}$(brew --prefix)/share/fish/vendor_completions.d/multipass.fish"
+    echo "Installed Fish completion file for HomeBrew"
+fi
+
+# MacPorts fish completions
+if [ -d "${3}opt/local/share/fish/vendor_completions.d" ]; then
+    ln -fsv "${3}@CPACK_PACKAGING_INSTALL_PREFIX@/Resources/completions/fish/multipass.fish" \
+            "${3}opt/local/share/fish/vendor_completions.d/multipass.fish"
+    echo "Installed Fish completion for MacPorts"
+fi
+
+# User-level completions (fallback if not using package managers)
+# Create user completion directories if they don't exist
+MULTIPASS_COMP_DIR="${3}@CPACK_PACKAGING_INSTALL_PREFIX@/Resources/completions"
+
+# Print instructions for manual setup if package managers not found
+echo ""
+echo "Shell completions are installed at: @CPACK_PACKAGING_INSTALL_PREFIX@/Resources/completions/"
+echo "If completions were not automatically configured, you can set them up manually:"
+echo "  Bash: source ${MULTIPASS_COMP_DIR}/bash/multipass"
+echo "  Zsh:  Add ${MULTIPASS_COMP_DIR}/zsh to your fpath"
+echo "  Fish: cp ${MULTIPASS_COMP_DIR}/fish/multipass.fish ~/.config/fish/completions/"
 
 echo 0

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -64,9 +64,18 @@ rm -rfv "$HOME/Library/Application Support/multipass-client-certificate"
 rm -rfv "$HOME/Library/Application Support/com.canonical.multipassGui"
 rm -rfv "$HOME/Library/Preferences/multipass"
 
+# Shell completions
 # Bash completions
-rm -rfv "/usr/local/etc/bash_completion.d/multipass"
-rm -rf "/opt/local/share/bash-completion/completions/multipass"
+rm -fv "/usr/local/etc/bash_completion.d/multipass"
+rm -fv "/opt/local/share/bash-completion/completions/multipass"
+
+# Zsh completions
+rm -fv "/usr/local/share/zsh/site-functions/_multipass"
+rm -fv "/opt/local/share/zsh/site-functions/_multipass"
+
+# Fish completions
+rm -fv "/usr/local/share/fish/vendor_completions.d/multipass.fish"
+rm -fv "/opt/local/share/fish/vendor_completions.d/multipass.fish"
 
 # Log files
 rm -rfv "/Library/Logs/Multipass"

--- a/packaging/windows/wix/CLIClientComponents.wxs
+++ b/packaging/windows/wix/CLIClientComponents.wxs
@@ -11,6 +11,10 @@
                 <File Source="icon_wt.ico" Name="multipass_wt.ico" />
             </Component>
 
+            <Component Id="MultipassPowerShellCompletion" Subdirectory="completions">
+                <File Source="completions\powershell\multipass.ps1" />
+            </Component>
+
             <Component Id="AddToUserPath" Condition="ENVIRONMENT = &quot;user&quot;"
                 Guid="59df60c1-f2a9-4199-97b5-8b1cf6638df7">
                 <Environment Name="PATH" System="no" Value="[INSTALLFOLDER]bin" Action="set"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -219,9 +219,18 @@ parts:
       cmake --build . -- -j"${SNAPCRAFT_PARALLEL_BUILD_COUNT}"
       DESTDIR="${SNAPCRAFT_PART_INSTALL}" cmake --build . --target install
 
+      # Install bash completion
       mkdir -p ${CRAFT_PART_INSTALL}/etc/bash_completion.d/
       echo 'export PATH="${PATH}:/snap/bin:/var/lib/snapd/snap/bin"' > ${CRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
       cat ../src/completions/bash/multipass >> ${CRAFT_PART_INSTALL}/etc/bash_completion.d/snap.multipass
+
+      # Install zsh completion
+      mkdir -p ${CRAFT_PART_INSTALL}/share/zsh/vendor-completions/
+      cp ../src/completions/zsh/_multipass ${CRAFT_PART_INSTALL}/share/zsh/vendor-completions/_multipass
+
+      # Install fish completion
+      mkdir -p ${CRAFT_PART_INSTALL}/share/fish/vendor_completions.d/
+      cp ../src/completions/fish/multipass.fish ${CRAFT_PART_INSTALL}/share/fish/vendor_completions.d/multipass.fish
       VERSION=$( awk -F\" '/version_string/ { print $2 }' gen/multipass/version.h )
       craftctl set version=${VERSION}
       craftctl set grade=$( echo ${VERSION} | grep -qe '^[0-9]\+\.[0-9]\+\.[0-9]\+\($\|-rc\)' && echo stable || echo devel )

--- a/src/client/cli/CMakeLists.txt
+++ b/src/client/cli/CMakeLists.txt
@@ -51,6 +51,11 @@ if(MSVC)
     include(BundleUtilities)
     fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/bin/multipass.exe\"  \"\"  \"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}\")
     " COMPONENT multipass)
+
+  # Install PowerShell completion for Windows
+  install(DIRECTORY "${CMAKE_SOURCE_DIR}/completions/powershell"
+    DESTINATION completions
+    COMPONENT multipass)
 endif()
 
 add_subdirectory(cmd)


### PR DESCRIPTION
## Summary

This PR adds comprehensive shell completion support for **zsh**, **fish**, and **PowerShell**, and enhances the existing **bash** completion script. All completion scripts have been thoroughly tested against the CLI source code to ensure complete command and option coverage.

**Key additions:**
- New zsh completion script (`completions/zsh/_multipass`) - 433 lines
- New fish completion script (`completions/fish/multipass.fish`) - 308 lines  
- New PowerShell completion script (`completions/powershell/multipass.ps1`) - 597 lines
- Enhanced existing bash completion with missing commands/options
- Packaging updates for all platforms (macOS, Linux Snap, Windows)

## Motivation

Shell completions significantly improve the developer/user experience by:
- Reducing typing errors and speeding up command entry
- Helping users discover available commands and options
- Providing context-aware suggestions (e.g., only showing running instances for `exec`)

While Multipass had bash completions, users of other popular shells (zsh is default on macOS, fish is popular among developers, PowerShell is essential for Windows) had no completion support.

## Implementation Details

### Completion Features (all shells)

| Feature | Description |
|---------|-------------|
| **Dynamic instance completion** | Fetches live instance list from daemon |
| **State-aware filtering** | Shows only relevant instances (e.g., `start` shows Stopped/Suspended, `exec` shows Running) |
| **Snapshot completion** | Completes `instance.snapshot` format for commands like `delete`, `info`, `restore` |
| **Network completion** | Fetches available networks for `launch --network` |
| **Settings keys** | Completes all settings keys for `get`/`set` commands |
| **Alias completion** | Completes defined aliases for `unalias` and `prefer` |
| **Full option coverage** | All 29 commands with their complete option sets |

### Commands Supported (29 total)

```
alias, aliases, authenticate, clone, delete, exec, find, get, help,
info, launch, list, mount, networks, prefer, purge, recover, restart,
restore, set, shell, snapshot, start, stop, suspend, transfer,
umount, unalias, version
```

### Shell-Specific Implementation

#### Zsh (`completions/zsh/_multipass`)
- Uses `_arguments` with state machine pattern
- Proper `#compdef multipass` header for autoload
- Helper functions: `_multipass_instances`, `_multipass_snapshots`, `_multipass_networks`, etc.
- Supports the `instance.snapshot` completion format

#### Fish (`completions/fish/multipass.fish`)
- Native fish completion syntax with `complete -c multipass`
- Helper functions using fish's `string` builtins for CSV parsing
- Condition functions for context-aware completions (`__multipass_needs_command`, `__multipass_using_command`)

#### PowerShell (`completions/powershell/multipass.ps1`)
- Uses `Register-ArgumentCompleter -Native` for native command completion
- Hashtable-based command/option definitions for maintainability
- Helper functions with proper error handling and CSV parsing
- Compatible with PowerShell 5.1+ and PowerShell Core

#### Bash Enhancements
- Added missing `prefer` command
- Added missing options: `--timeout` (launch/start/restart/shell), `--force` (stop), `--type` (mount), `--format` (version)
- Added `--all` option to `unalias`
- Added error suppression (`2>/dev/null`) to daemon query commands for cleaner completion

### Packaging Updates

| Platform | Changes |
|----------|---------|
| **macOS** | `postinstall-multipass.sh.in`: Added symlinks for zsh/fish completions to Homebrew and MacPorts paths |
| **macOS** | `uninstall.sh`: Added cleanup for zsh/fish completion symlinks |
| **Linux Snap** | `snapcraft.yaml`: Install zsh to `share/zsh/vendor-completions/`, fish to `share/fish/vendor_completions.d/` |
| **Windows** | `CLIClientComponents.wxs`: Added PowerShell completion component to WiX installer |
| **Windows** | `CMakeLists.txt`: Added install rule for PowerShell completions directory |

## File Changes

```
completions/bash/multipass                    |  29 +-    (enhanced)
completions/fish/multipass.fish               | 308 +++   (new)
completions/powershell/multipass.ps1          | 597 +++    (new)
completions/zsh/_multipass                    | 433 +++   (new)
packaging/macos/postinstall-multipass.sh.in   |  46 +-    (modified)
packaging/macos/uninstall.sh                  |  13 +-    (modified)
packaging/windows/wix/CLIClientComponents.wxs |   4 +     (modified)
snap/snapcraft.yaml                           |   9 +     (modified)
src/client/cli/CMakeLists.txt                 |   5 +     (modified)
─────────────────────────────────────────────────────────
9 files changed, 1433 insertions(+), 11 deletions(-)
```

## Test Plan

- [x] **Syntax validation**: All scripts pass shell-specific syntax checks
  - Bash: `bash -n completions/bash/multipass`
  - Zsh: `zsh -n completions/zsh/_multipass`
  - Fish: `fish -n completions/fish/multipass.fish`
  - PowerShell: `pwsh -Command "Get-Content ... | Invoke-Expression"` (no parse errors)

- [x] **Command coverage**: Verified all 29 commands present in each script

- [x] **Option validation**: Cross-referenced options against CLI source code in `src/client/cli/cmd/`
  - Verified `shell` command does NOT have `--working-directory` (only `exec` does)
  - Verified `mount --type` option exists (classic/native)
  - Verified `unalias --all` option exists

- [x] **Dynamic completion sources**: Verified daemon query commands include error suppression

- [ ] **Manual testing**: Test completion behavior in each shell environment
  - [ ] Zsh on macOS/Linux
  - [ ] Fish on macOS/Linux  
  - [ ] PowerShell on Windows
  - [ ] Bash on Linux

- [ ] **Package installation testing**:
  - [ ] macOS pkg installation creates correct symlinks
  - [ ] Snap package includes completions in correct paths
  - [ ] Windows MSI includes PowerShell completion

## Installation Instructions (for users)

### Zsh
```zsh
# If installed via Homebrew (macOS) - automatic via symlink
# Manual: Add to ~/.zshrc
fpath=(/path/to/completions/zsh $fpath)
autoload -Uz compinit && compinit
```

### Fish
```fish
# If installed via package manager - automatic
# Manual: Copy to fish completions directory
cp completions/fish/multipass.fish ~/.config/fish/completions/
```

### PowerShell
```powershell
# Add to $PROFILE
. "C:\Program Files\Multipass\completions\powershell\multipass.ps1"
```

### Bash
```bash
# Usually automatic via /etc/bash_completion.d/ or package manager
# Manual:
source /path/to/completions/bash/multipass
```

---

🤖 Generated with [Claude Code](https://claude.ai/code)