### PR TITLE
[gui] Fix top bar flicker on resize

### DIFF
--- a/src/client/gui/lib/window_size.dart
+++ b/src/client/gui/lib/window_size.dart
@@ -16,14 +16,24 @@ String resolutionString(Size? size) {
 }
 
 final saveWindowSizeTimer = RestartableTimer(1.seconds, () async {
-  if (await windowManager.isMaximized()) return;
+  if (await windowManager.isMaximized() || await windowManager.isMinimized()) {
+    return;
+  }
   final currentSize = await windowManager.getSize();
   final sharedPreferences = await SharedPreferences.getInstance();
   final screenSize = await getCurrentScreenSize();
+
+  final prefix = resolutionString(screenSize);
+  final savedWidth = sharedPreferences.getDouble('$prefix$windowWidthKey');
+  final savedHeight = sharedPreferences.getDouble('$prefix$windowHeightKey');
+
+  if (savedWidth == currentSize.width && savedHeight == currentSize.height) {
+    return;
+  }
+
   logger.d(
     'Saving window size ${currentSize.s()} for screen size ${screenSize?.s()}',
   );
-  final prefix = resolutionString(screenSize);
   sharedPreferences.setDouble('$prefix$windowWidthKey', currentSize.width);
   sharedPreferences.setDouble('$prefix$windowHeightKey', currentSize.height);
 });

--- a/src/client/gui/lib/window_size.dart
+++ b/src/client/gui/lib/window_size.dart
@@ -16,6 +16,7 @@ String resolutionString(Size? size) {
 }
 
 final saveWindowSizeTimer = RestartableTimer(1.seconds, () async {
+  if (await windowManager.isMaximized()) return;
   final currentSize = await windowManager.getSize();
   final sharedPreferences = await SharedPreferences.getInstance();
   final screenSize = await getCurrentScreenSize();


### PR DESCRIPTION
# Description

Avoid saving window size when the window is maximized. This prevents a feedback loop where querying or saving the size during a maximized state causes the window to flicker continuously.

- **What does this PR do?**
  - Adds a check to the `saveWindowSizeTimer` in the Flutter GUI to skip size persistence when `windowManager.isMaximized()` is true.
- **Why is this change needed?**
  - On Linux/X11, persisting the window size while maximized triggers a race condition or feedback loop with the window manager, causing the top bar to flicker incessantly.

## Related Issue(s)

Closes #4590

## Testing

- **Static Analysis**: Verified with `flutter analyze` ensuring the new check on `windowManager.isMaximized()` is correct.
- **Formatting**: Verified with `dart format`.
- **Manual testing steps**:
  1. Open the Multipass GUI on Linux.
  2. Launch a VM (or trigger an operation that shows a bottom-right notification).
  3. Maximize the window (e.g., drag to the top).
  4. Observe that the window no longer enters a flickering state.

## Checklist

- [x] My code follows the [contributing guidelines](https://github.com/canonical/multipass/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Canonical CLA](https://canonical.com/legal/contributors)
- [ ] I have added necessary tests
- [ ] I have updated documentation (if needed)
- [x] I have tested the changes locally

## Additional Notes
The fix specifically addresses the oscillation between the "saved" size and the "maximized" size by pausing the save timer logic entirely when the window is maximized.