### PR TITLE
[ci] Fix name typo

### DIFF
--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -241,6 +241,8 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
       continue-on-error: true
+      with:
+        version: "v0.12.0"
 
     - name: Install Windows ADK
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -338,7 +338,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main' }}
       with:
         path: ${{ env.SCCACHE_DIR }}
-        key: "sccache-${{ matrix.runs-on }}-${{ steps.setup-ccache.outputs.cache-key }}"
+        key: "sccache-${{ matrix.runs-on }}-${{ steps.cache-key.outputs.cache-key }}"
 
   CombineAndPublishMacOSPackage:
     # Want to run even if one of the builds above failed


### PR DESCRIPTION
Note: There is no officially distributed sccache binary for x86_64-darwin in the latest version of sccache so I hardcoded the next latest version. A [PR](https://github.com/Mozilla-Actions/sccache-action/pull/237) is up in the GitHub Action repository that finds the latest distributed binary for a given architecture, but until that lands we'll use `0.12`.