### PR TITLE
[ci] Update clang-format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run clang-format through the diff
         shell: bash
         run: |
+          # Print out version of clang-format being used
+          clang-format --version
+
           # Ensure that the .clang-format configuration is valid
           clang-format --dump-config > /dev/null
 


### PR DESCRIPTION
Use the default version of clang-format so we be consistent in the version that we use across workflows and we don't have to manually update it from time to time.