### PR TITLE
[clang-format] Override json column width

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,4 +46,5 @@ Language: Proto
 DisableFormat: true
 ---
 Language: Json
+ColumnLimit: 0
 ...


### PR DESCRIPTION
Fix json formatting for cloud-images data.