### PR TITLE
[qemu] Fix adding virtual switch IP

### DIFF
--- a/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp
@@ -71,7 +71,9 @@ void create_virtual_switch(const mp::Subnet& subnet, const QString& bridge_name)
     if (!MP_UTILS.run_cmd_for_status("ip", {"addr", "show", bridge_name}))
     {
         const auto mac_address = mp::utils::generate_mac_address();
-        const auto cidr = subnet.to_cidr();
+        // "ip address add" expects a proper IP address with a subnet mask, but our Subnet class
+        // applies the mask to the IP address first. Work around this!
+        const auto cidr = fmt::format("{}/{}", subnet.min_address().as_string(), subnet.prefix_length());
         const auto broadcast = (subnet.max_address() + 1).as_string();
 
         MP_UTILS.run_cmd_for_status(


### PR DESCRIPTION
# Description

This fixes an issue starting up the Multipass daemon on the AZ branch with Trevor's Subnet refactor. Previously, we tried to add a CIDR address with the subnet mask applied to the IP. That doesn't work.

This is just a draft to demonstrate the problem and the fix, but it's probably not the cleanest way to go about this. One possibility would be to create a `CIDR` class that *just* holds an IPv4 address + subnet mask, and then `Subnet` would essentially be a `CIDR` object where we've already applied the subnet mask.

## Testing

Just run `sudo ./bin/multipassd` and see if it starts up correctly. (We should provide better tests here eventually.)