### PR TITLE
[tics] TICS hardening

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -87,6 +87,9 @@ jobs:
 
     - name: Run TICS Analysis
       uses: tiobe/tics-github-action@v3
+      env:
+        # Add environment variables to optimize TICS performance
+        TICS_NUM_THREADS: 4  # Adjust based on runner's capabilities
       with:
         mode: qserver
         project: multipass


### PR DESCRIPTION
Clean up stale TICS clients from old runs before running analysis.

Also, give the TICS process a few more threads to speed things up a bit. Trims an hour off of analysis time.

Fixes https://github.com/canonical/multipass/actions/runs/21326962846