### PR TITLE
[applevz] Basic vm functionality

### DIFF
--- a/include/multipass/format.h
+++ b/include/multipass/format.h
@@ -30,50 +30,32 @@
 namespace fmt
 {
 template <>
-struct formatter<QByteArray>
+struct formatter<QByteArray> : formatter<string_view>
 {
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-
     template <typename FormatContext>
     auto format(const QByteArray& a, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "{}", a.toStdString()); // TODO: remove the copy?
+        return formatter<string_view>::format(a.toStdString(), ctx); // TODO: remove the copy?
     }
 };
 
 template <>
-struct formatter<QString>
+struct formatter<QString> : formatter<string_view>
 {
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-
     template <typename FormatContext>
     auto format(const QString& a, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "{}", a.toStdString()); // TODO: remove the copy?
+        return formatter<string_view>::format(a.toStdString(), ctx); // TODO: remove the copy?
     }
 };
 
 template <>
-struct formatter<QProcess::ExitStatus>
+struct formatter<QProcess::ExitStatus> : formatter<int>
 {
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-
     template <typename FormatContext>
     auto format(const QProcess::ExitStatus& exit_status, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "{}", static_cast<int>(exit_status));
+        return formatter<int>::format(static_cast<int>(exit_status), ctx);
     }
 };
 

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -133,17 +133,9 @@ protected:
 };
 } // namespace multipass
 
-/**
- * Formatter type specialization for CreateComputeSystemParameters
- */
-template <typename Char>
-struct fmt::formatter<multipass::VirtualMachine::State, Char>
+template <>
+struct fmt::formatter<multipass::VirtualMachine::State, char> : fmt::formatter<string_view>
 {
-    constexpr auto parse(basic_format_parse_context<Char>& ctx)
-    {
-        return ctx.begin();
-    }
-
     template <typename FormatContext>
     auto format(multipass::VirtualMachine::State state, FormatContext& ctx) const
     {
@@ -179,6 +171,6 @@ struct fmt::formatter<multipass::VirtualMachine::State, Char>
             break;
         }
 
-        return format_to(ctx.out(), "{}", v);
+        return fmt::formatter<string_view>::format(v, ctx);
     }
 };

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -29,6 +29,8 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+
 namespace multipass
 {
 struct IPAddress;
@@ -74,7 +76,7 @@ public:
     virtual std::string ssh_hostname()
     {
         return ssh_hostname(std::chrono::minutes(2));
-    };
+    }
     virtual std::string ssh_hostname(std::chrono::milliseconds timeout) = 0;
     virtual std::string ssh_username() = 0;
     virtual std::optional<IPAddress> management_ipv4() = 0;
@@ -130,3 +132,53 @@ protected:
     }
 };
 } // namespace multipass
+
+/**
+ * Formatter type specialization for CreateComputeSystemParameters
+ */
+template <typename Char>
+struct fmt::formatter<multipass::VirtualMachine::State, Char>
+{
+    constexpr auto parse(basic_format_parse_context<Char>& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(multipass::VirtualMachine::State state, FormatContext& ctx) const
+    {
+        std::string_view v = "(undefined)";
+        switch (state)
+        {
+        case multipass::VirtualMachine::State::off:
+            v = "off";
+            break;
+        case multipass::VirtualMachine::State::stopped:
+            v = "stopped";
+            break;
+        case multipass::VirtualMachine::State::starting:
+            v = "starting";
+            break;
+        case multipass::VirtualMachine::State::restarting:
+            v = "restarting";
+            break;
+        case multipass::VirtualMachine::State::running:
+            v = "running";
+            break;
+        case multipass::VirtualMachine::State::delayed_shutdown:
+            v = "delayed_shutdown";
+            break;
+        case multipass::VirtualMachine::State::suspending:
+            v = "suspending";
+            break;
+        case multipass::VirtualMachine::State::suspended:
+            v = "suspended";
+            break;
+        case multipass::VirtualMachine::State::unknown:
+            v = "unknown";
+            break;
+        }
+
+        return format_to(ctx.out(), "{}", v);
+    }
+};

--- a/include/multipass/vm_mount.h
+++ b/include/multipass/vm_mount.h
@@ -88,18 +88,12 @@ VMMount tag_invoke(const boost::json::value_to_tag<VMMount>&, const boost::json:
 namespace fmt
 {
 template <>
-struct formatter<multipass::VMMount::MountType>
+struct formatter<multipass::VMMount::MountType> : formatter<int>
 {
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx)
-    {
-        return ctx.begin();
-    }
-
     template <typename FormatContext>
     auto format(const multipass::VMMount::MountType& mount_type, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "{}", static_cast<int>(mount_type));
+        return formatter<int>::format(static_cast<int>(mount_type), ctx);
     }
 };
 } // namespace fmt

--- a/packaging/macos/sign-and-notarize.sh
+++ b/packaging/macos/sign-and-notarize.sh
@@ -158,6 +158,13 @@ function codesign_binaries {
             --identifier com.canonical.multipass.qemu \
             --sign "${SIGN_APP}"
 
+    # sign multipass with additional entitlements for using the Apple Virtualization framework
+    find "${DIR}" -type f -name multipassd -print0 | xargs -0L1 \
+        codesign -v --timestamp --options runtime --force --strict \
+            $( entitlements com.apple.security.virtualization ) \
+            --identifier com.canonical.multipass.multipassd \
+            --sign "${SIGN_APP}"
+
     # sign every bundle in the directory
     find "${DIR}" -type d -name '*.app' -print0 | xargs -0L1 \
         codesign -v --timestamp --options runtime --force --strict --deep \

--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -603,7 +603,7 @@ mp::ReturnCodeVariant cmd::Launch::request_launch(const ArgParser* parser)
             std::unordered_map<int, std::string> progress_messages{
                 {LaunchProgress_ProgressTypes_IMAGE, "Retrieving image: "},
                 {LaunchProgress_ProgressTypes_EXTRACT, "Extracting image: "},
-                {LaunchProgress_ProgressTypes_VERIFY, "Verifying image: "},
+                {LaunchProgress_ProgressTypes_VERIFY, "Verifying image"},
                 {LaunchProgress_ProgressTypes_WAITING, "Preparing image: "}};
 
             if (!reply.log_line().empty())

--- a/src/platform/backends/applevz/CMakeLists.txt
+++ b/src/platform/backends/applevz/CMakeLists.txt
@@ -32,7 +32,9 @@ find_library(VIRTUALIZATION_FRAMEWORK Virtualization REQUIRED)
 
 target_link_libraries(applevz_backend
   PUBLIC
+    Qt6::Core
     fmt::fmt-header-only
+    logger
   PRIVATE
     daemon
     ${FOUNDATION_FRAMEWORK}

--- a/src/platform/backends/applevz/CMakeLists.txt
+++ b/src/platform/backends/applevz/CMakeLists.txt
@@ -31,6 +31,8 @@ find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
 find_library(VIRTUALIZATION_FRAMEWORK Virtualization REQUIRED)
 
 target_link_libraries(applevz_backend
+  PUBLIC
+    fmt::fmt-header-only
   PRIVATE
     daemon
     ${FOUNDATION_FRAMEWORK}

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -17,25 +17,23 @@
 
 #pragma once
 
-#include <multipass/virtual_machine_description.h>
+#include <applevz/cf_error.h>
 
-#include <CoreFoundation/CoreFoundation.h>
+#include <multipass/virtual_machine_description.h>
 
 namespace multipass::applevz
 {
 using VMHandle = std::shared_ptr<void>;
 
-extern "C"
-{
-CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
-                                   VMHandle& out_handle);
+CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                VMHandle& out_handle);
 
 // Starting and stopping VM
-CFErrorRef start_with_completion_handler(VMHandle& vm_handle);
-CFErrorRef stop_with_completion_handler(VMHandle& vm_handle);
-CFErrorRef request_stop_with_error(VMHandle& vm_handle);
-CFErrorRef pause_with_completion_handler(VMHandle& vm_handle);
-CFErrorRef resume_with_completion_handler(VMHandle& vm_handle);
+CFError start_with_completion_handler(VMHandle& vm_handle);
+CFError stop_with_completion_handler(VMHandle& vm_handle);
+CFError request_stop_with_error(VMHandle& vm_handle);
+CFError pause_with_completion_handler(VMHandle& vm_handle);
+CFError resume_with_completion_handler(VMHandle& vm_handle);
 
 // Getting the state of VM
 bool can_start(VMHandle& vm_handle);
@@ -43,5 +41,4 @@ bool can_pause(VMHandle& vm_handle);
 bool can_resume(VMHandle& vm_handle);
 bool can_stop(VMHandle& vm_handle);
 bool can_request_stop(VMHandle& vm_handle);
-}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -46,21 +46,21 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
                                 VMHandle& out_handle);
 
 // Starting and stopping VM
-CFError start_with_completion_handler(VMHandle& vm_handle);
-CFError stop_with_completion_handler(VMHandle& vm_handle);
-CFError request_stop_with_error(VMHandle& vm_handle);
-CFError pause_with_completion_handler(VMHandle& vm_handle);
-CFError resume_with_completion_handler(VMHandle& vm_handle);
+CFError start_with_completion_handler(const VMHandle& vm_handle);
+CFError stop_with_completion_handler(const VMHandle& vm_handle);
+CFError request_stop_with_error(const VMHandle& vm_handle);
+CFError pause_with_completion_handler(const VMHandle& vm_handle);
+CFError resume_with_completion_handler(const VMHandle& vm_handle);
 
 // Getting VM state
-AppleVMState get_state(VMHandle& vm_handle);
+AppleVMState get_state(const VMHandle& vm_handle);
 
 // Validate the state of VM
-bool can_start(VMHandle& vm_handle);
-bool can_pause(VMHandle& vm_handle);
-bool can_resume(VMHandle& vm_handle);
-bool can_stop(VMHandle& vm_handle);
-bool can_request_stop(VMHandle& vm_handle);
+bool can_start(const VMHandle& vm_handle);
+bool can_pause(const VMHandle& vm_handle);
+bool can_resume(const VMHandle& vm_handle);
+bool can_stop(const VMHandle& vm_handle);
+bool can_request_stop(const VMHandle& vm_handle);
 
 } // namespace multipass::applevz
 

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -29,5 +29,12 @@ extern "C"
 {
 CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
                                    VMHandle& out_handle);
+
+// Starting and stopping VM
+CFErrorRef start_with_completion_handler(VMHandle& vm_handle);
+CFErrorRef stop_with_completion_handler(VMHandle& vm_handle);
+CFErrorRef request_stop_with_error(VMHandle& vm_handle);
+CFErrorRef pause_with_completion_handler(VMHandle& vm_handle);
+CFErrorRef resume_with_completion_handler(VMHandle& vm_handle);
 }
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -49,7 +49,10 @@ CFError request_stop_with_error(VMHandle& vm_handle);
 CFError pause_with_completion_handler(VMHandle& vm_handle);
 CFError resume_with_completion_handler(VMHandle& vm_handle);
 
-// Getting the state of VM
+// Getting VM state
+AppleVMState get_state(VMHandle& vm_handle);
+
+// Validate the state of VM
 bool can_start(VMHandle& vm_handle);
 bool can_pause(VMHandle& vm_handle);
 bool can_resume(VMHandle& vm_handle);

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -21,8 +21,11 @@
 
 #include <multipass/virtual_machine_description.h>
 
+#include <fmt/format.h>
+
 namespace multipass::applevz
 {
+
 using VMHandle = std::shared_ptr<void>;
 
 enum class AppleVMState
@@ -58,4 +61,57 @@ bool can_pause(VMHandle& vm_handle);
 bool can_resume(VMHandle& vm_handle);
 bool can_stop(VMHandle& vm_handle);
 bool can_request_stop(VMHandle& vm_handle);
+
 } // namespace multipass::applevz
+
+template <>
+struct fmt::formatter<multipass::applevz::AppleVMState>
+{
+    constexpr auto parse(format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(const multipass::applevz::AppleVMState& state, FormatContext& ctx) const
+    {
+        std::string_view v = "(undefined)";
+        switch (state)
+        {
+        case multipass::applevz::AppleVMState::stopped:
+            v = "stopped";
+            break;
+        case multipass::applevz::AppleVMState::running:
+            v = "running";
+            break;
+        case multipass::applevz::AppleVMState::paused:
+            v = "paused";
+            break;
+        case multipass::applevz::AppleVMState::error:
+            v = "error";
+            break;
+        case multipass::applevz::AppleVMState::starting:
+            v = "starting";
+            break;
+        case multipass::applevz::AppleVMState::pausing:
+            v = "pausing";
+            break;
+        case multipass::applevz::AppleVMState::resuming:
+            v = "resuming";
+            break;
+        case multipass::applevz::AppleVMState::stopping:
+            v = "stopping";
+            break;
+        case multipass::applevz::AppleVMState::saving:
+            v = "saving";
+            break;
+        case multipass::applevz::AppleVMState::restoring:
+            v = "restoring";
+            break;
+        default:
+            v = "unknown";
+            break;
+        }
+        return format_to(ctx.out(), "{}", v);
+    }
+};

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -18,15 +18,15 @@
 #pragma once
 
 #include <applevz/cf_error.h>
-
 #include <multipass/virtual_machine_description.h>
 
 #include <fmt/format.h>
 
 namespace multipass::applevz
 {
-
-using VMHandle = std::shared_ptr<void>;
+// Forward declare to keep Objective-C++ out of the header.
+struct VirtualMachineHandle;
+using VMHandle = std::shared_ptr<VirtualMachineHandle>;
 
 enum class AppleVMState
 {

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -25,6 +25,20 @@ namespace multipass::applevz
 {
 using VMHandle = std::shared_ptr<void>;
 
+enum class AppleVMState
+{
+    stopped,
+    running,
+    paused,
+    error,
+    starting,
+    pausing,
+    resuming,
+    stopping,
+    saving,
+    restoring
+};
+
 CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
                                 VMHandle& out_handle);
 

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -36,5 +36,12 @@ CFErrorRef stop_with_completion_handler(VMHandle& vm_handle);
 CFErrorRef request_stop_with_error(VMHandle& vm_handle);
 CFErrorRef pause_with_completion_handler(VMHandle& vm_handle);
 CFErrorRef resume_with_completion_handler(VMHandle& vm_handle);
+
+// Getting the state of VM
+bool can_start(VMHandle& vm_handle);
+bool can_pause(VMHandle& vm_handle);
+bool can_resume(VMHandle& vm_handle);
+bool can_stop(VMHandle& vm_handle);
+bool can_request_stop(VMHandle& vm_handle);
 }
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -17,6 +17,17 @@
 
 #pragma once
 
+#include <multipass/virtual_machine_description.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+
 namespace multipass::applevz
 {
+using VMHandle = std::shared_ptr<void>;
+
+extern "C"
+{
+CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                   VMHandle& out_handle);
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -66,13 +66,8 @@ bool is_supported();
 } // namespace multipass::applevz
 
 template <>
-struct fmt::formatter<multipass::applevz::AppleVMState>
+struct fmt::formatter<multipass::applevz::AppleVMState> : fmt::formatter<string_view>
 {
-    constexpr auto parse(format_parse_context& ctx)
-    {
-        return ctx.begin();
-    }
-
     template <typename FormatContext>
     auto format(const multipass::applevz::AppleVMState& state, FormatContext& ctx) const
     {
@@ -113,6 +108,6 @@ struct fmt::formatter<multipass::applevz::AppleVMState>
             v = "unknown";
             break;
         }
-        return format_to(ctx.out(), "{}", v);
+        return fmt::formatter<string_view>::format(v, ctx);
     }
 };

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -62,6 +62,7 @@ bool can_resume(const VMHandle& vm_handle);
 bool can_stop(const VMHandle& vm_handle);
 bool can_request_stop(const VMHandle& vm_handle);
 
+bool is_supported();
 } // namespace multipass::applevz
 
 template <>

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -234,6 +234,13 @@ CFError resume_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
+AppleVMState get_state(VMHandle& vm_handle)
+{
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return AppleVMState([vm state]);
+}
+
 bool can_start(VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -109,10 +109,18 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
         // Storage devices
         NSMutableArray<VZStorageDeviceConfiguration*>* storageDevices = [NSMutableArray array];
 
+        // cachingMode is set to VZDiskImageCachingModeCached so as to avoid disk corruption on ARM:
+        // - https://github.com/utmapp/UTM/issues/4840#issuecomment-1824340975
+        // - https://github.com/utmapp/UTM/issues/4840#issuecomment-1824542732
         NSString* diskPath = nsstring_from_qstring(desc.image.image_path);
         NSURL* diskURL = [NSURL fileURLWithPath:diskPath];
         VZDiskImageStorageDeviceAttachment* diskAttachment =
-            [[VZDiskImageStorageDeviceAttachment alloc] initWithURL:diskURL readOnly:NO error:&err];
+            [[VZDiskImageStorageDeviceAttachment alloc]
+                        initWithURL:diskURL
+                           readOnly:NO
+                        cachingMode:VZDiskImageCachingModeCached
+                synchronizationMode:VZDiskImageSynchronizationModeFsync
+                              error:&err];
         if (err)
             return CFError((__bridge_retained CFErrorRef)err);
 

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -280,4 +280,9 @@ bool can_request_stop(const VMHandle& vm_handle)
 
     return [vm canRequestStop];
 }
+
+bool is_supported()
+{
+    return [VZVirtualMachine isSupported];
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -17,6 +17,122 @@
 
 #include <applevz/applevz_bridge.h>
 
+#include <CoreFoundation/CoreFoundation.h>
+#include <Foundation/Foundation.h>
+#include <Virtualization/Virtualization.h>
+
+#include <QString>
+#include <QUrl>
+
+namespace
+{
+NSString* nsstring_from_qstring(const QString& s)
+{
+    QByteArray utf8 = s.toUtf8();
+    return [NSString stringWithUTF8String:utf8.constData()];
+}
+} // namespace
+
 namespace multipass::applevz
 {
+CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                   VMHandle& out_handle)
+{
+    @autoreleasepool
+    {
+        NSError* err = nil;
+
+        VZVirtualMachineConfiguration* config = [[VZVirtualMachineConfiguration alloc] init];
+
+        // CPU & memory
+        config.CPUCount = desc.num_cores;
+        config.memorySize = desc.mem_size.in_bytes();
+
+        // Storage devices
+        NSMutableArray<VZStorageDeviceConfiguration*>* storageDevices = [NSMutableArray array];
+
+        NSString* diskPath = nsstring_from_qstring(desc.image.image_path);
+        NSURL* diskURL = [NSURL fileURLWithPath:diskPath];
+        VZDiskImageStorageDeviceAttachment* diskAttachment =
+            [[VZDiskImageStorageDeviceAttachment alloc] initWithURL:diskURL readOnly:NO error:&err];
+        if (err)
+            return (CFErrorRef)CFBridgingRetain(err);
+
+        VZVirtioBlockDeviceConfiguration* disk =
+            [[VZVirtioBlockDeviceConfiguration alloc] initWithAttachment:diskAttachment];
+        [storageDevices addObject:disk];
+
+        // Cloud-init ISO
+        NSString* cloudIsoPath = nsstring_from_qstring(desc.cloud_init_iso);
+        NSURL* cloudIsoURL = [NSURL fileURLWithPath:cloudIsoPath];
+        VZDiskImageStorageDeviceAttachment* cloudAttachment =
+            [[VZDiskImageStorageDeviceAttachment alloc] initWithURL:cloudIsoURL
+                                                           readOnly:YES
+                                                              error:&err];
+        if (err)
+            return (CFErrorRef)CFBridgingRetain(err);
+
+        VZVirtioBlockDeviceConfiguration* cloudIso =
+            [[VZVirtioBlockDeviceConfiguration alloc] initWithAttachment:cloudAttachment];
+        [storageDevices addObject:cloudIso];
+
+        config.storageDevices = storageDevices;
+
+        // EFI Variable store
+        NSString* efivarsFilename = [NSString stringWithFormat:@"vm-efivars"];
+        NSString* efivarsPath =
+            [NSTemporaryDirectory() stringByAppendingPathComponent:efivarsFilename];
+
+        // EFI bootloader
+        NSURL* efivarsURL = [NSURL fileURLWithPath:efivarsPath];
+        VZEFIBootLoader* efi = [[VZEFIBootLoader alloc] init];
+        efi.variableStore = [[VZEFIVariableStore alloc]
+            initCreatingVariableStoreAtURL:efivarsURL
+                                   options:VZEFIVariableStoreInitializationOptionAllowOverwrite
+                                     error:&err];
+        if (err)
+            return (CFErrorRef)CFBridgingRetain(err);
+
+        config.bootLoader = efi;
+
+        // Entropy device
+        VZVirtioEntropyDeviceConfiguration* entropy =
+            [[VZVirtioEntropyDeviceConfiguration alloc] init];
+        config.entropyDevices = @[ entropy ];
+
+        // Network device
+        VZVirtioNetworkDeviceConfiguration* netDevice =
+            [[VZVirtioNetworkDeviceConfiguration alloc] init];
+
+        VZNATNetworkDeviceAttachment* natAttachment = [[VZNATNetworkDeviceAttachment alloc] init];
+        netDevice.attachment = natAttachment;
+
+        VZMACAddress* mac = [[VZMACAddress alloc]
+            initWithString:[NSString stringWithCString:desc.default_mac_address.c_str()
+                                              encoding:NSUTF8StringEncoding]];
+        [netDevice setMACAddress:mac];
+
+        config.networkDevices = @[ netDevice ];
+
+        // Memory balloon device
+        VZVirtioTraditionalMemoryBalloonDeviceConfiguration* balloon =
+            [[VZVirtioTraditionalMemoryBalloonDeviceConfiguration alloc] init];
+        config.memoryBalloonDevices = @[ balloon ];
+
+        // Validate configuration
+        if (![config validateWithError:&err])
+        {
+            if (err)
+                return (CFErrorRef)CFBridgingRetain(err);
+        }
+
+        // Create VM handle
+        VZVirtualMachine* virtualMachine = [[VZVirtualMachine alloc] initWithConfiguration:config];
+
+        void* cfRef = (void*)CFBridgingRetain(virtualMachine);
+        out_handle = VMHandle(cfRef, [](void* p) { CFRelease(p); });
+
+        return nullptr;
+    }
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -136,7 +136,7 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
     }
 }
 
-CFError start_with_completion_handler(VMHandle& vm_handle)
+CFError start_with_completion_handler(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -158,7 +158,7 @@ CFError start_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-CFError stop_with_completion_handler(VMHandle& vm_handle)
+CFError stop_with_completion_handler(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -180,7 +180,7 @@ CFError stop_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-CFError request_stop_with_error(VMHandle& vm_handle)
+CFError request_stop_with_error(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -195,7 +195,7 @@ CFError request_stop_with_error(VMHandle& vm_handle)
     return err ? CFError((__bridge_retained CFErrorRef)err) : CFError();
 }
 
-CFError pause_with_completion_handler(VMHandle& vm_handle)
+CFError pause_with_completion_handler(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -217,7 +217,7 @@ CFError pause_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-CFError resume_with_completion_handler(VMHandle& vm_handle)
+CFError resume_with_completion_handler(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
@@ -239,42 +239,42 @@ CFError resume_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-AppleVMState get_state(VMHandle& vm_handle)
+AppleVMState get_state(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return AppleVMState([vm state]);
 }
 
-bool can_start(VMHandle& vm_handle)
+bool can_start(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canStart];
 }
 
-bool can_pause(VMHandle& vm_handle)
+bool can_pause(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canPause];
 }
 
-bool can_resume(VMHandle& vm_handle)
+bool can_resume(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canResume];
 }
 
-bool can_stop(VMHandle& vm_handle)
+bool can_stop(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canStop];
 }
 
-bool can_request_stop(VMHandle& vm_handle)
+bool can_request_stop(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -135,4 +135,101 @@ CFErrorRef init_with_configuration(const multipass::VirtualMachineDescription& d
         return nullptr;
     }
 }
+
+CFErrorRef start_with_completion_handler(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    // __block does not retain; we return ownership to caller.
+    __block CFErrorRef err = nullptr;
+
+    [vm startWithCompletionHandler:^(NSError* _Nullable error) {
+      if (err) {
+          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
+          err = (CFErrorRef)CFBridgingRetain(error);
+      }
+
+      dispatch_semaphore_signal(sema);
+    }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return err;
+}
+
+CFErrorRef stop_with_completion_handler(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    // __block does not retain; we return ownership to caller.
+    __block CFErrorRef err = nullptr;
+
+    [vm stopWithCompletionHandler:^(NSError* _Nullable error) {
+      if (err) {
+          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
+          err = (CFErrorRef)CFBridgingRetain(error);
+      }
+
+      dispatch_semaphore_signal(sema);
+    }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return err;
+}
+
+CFErrorRef request_stop_with_error(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    NSError* err = nil;
+    [vm requestStopWithError:&err];
+
+    return err ? (CFErrorRef)CFBridgingRetain(err) : nullptr;
+}
+
+CFErrorRef pause_with_completion_handler(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    // __block does not retain; we return ownership to caller.
+    __block CFErrorRef err = nullptr;
+
+    [vm pauseWithCompletionHandler:^(NSError* _Nullable error) {
+      if (err) {
+          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
+          err = (CFErrorRef)CFBridgingRetain(error);
+      }
+
+      dispatch_semaphore_signal(sema);
+    }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return err;
+}
+
+CFErrorRef resume_with_completion_handler(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    // __block does not retain; we return ownership to caller.
+    __block CFErrorRef err = nullptr;
+
+    [vm resumeWithCompletionHandler:^(NSError* _Nullable error) {
+      if (err) {
+          // Take ownership of NSError as CFErrorRef; caller must CFRelease().
+          err = (CFErrorRef)CFBridgingRetain(error);
+      }
+
+      dispatch_semaphore_signal(sema);
+    }];
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return err;
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -80,10 +80,10 @@ multipass::applevz::CFError call_on_vm_queue(const multipass::applevz::VMHandle&
     return multipass::applevz::CFError(err_ref);
 }
 
-template <typename ResultType, typename BlockType>
-ResultType query_on_vm_queue(const multipass::applevz::VMHandle& vm_handle, BlockType block)
+template <typename BlockType>
+auto query_on_vm_queue(const multipass::applevz::VMHandle& vm_handle, BlockType block)
 {
-    __block ResultType result{};
+    __block std::decay_t<decltype(block())> result{};
     dispatch_sync(vm_handle->queue, ^{
       result = block();
     });
@@ -265,38 +265,37 @@ CFError resume_with_completion_handler(const VMHandle& vm_handle)
 AppleVMState get_state(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle->vm.get();
-    return AppleVMState(
-        query_on_vm_queue<VZVirtualMachineState>(vm_handle, [&]() { return [vm state]; }));
+    return AppleVMState(query_on_vm_queue(vm_handle, [&]() { return [vm state]; }));
 }
 
 bool can_start(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle->vm.get();
-    return query_on_vm_queue<bool>(vm_handle, [&]() { return [vm canStart]; });
+    return query_on_vm_queue(vm_handle, [&]() { return [vm canStart]; });
 }
 
 bool can_pause(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle->vm.get();
-    return query_on_vm_queue<bool>(vm_handle, [&]() { return [vm canPause]; });
+    return query_on_vm_queue(vm_handle, [&]() { return [vm canPause]; });
 }
 
 bool can_resume(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle->vm.get();
-    return query_on_vm_queue<bool>(vm_handle, [&]() { return [vm canResume]; });
+    return query_on_vm_queue(vm_handle, [&]() { return [vm canResume]; });
 }
 
 bool can_stop(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle->vm.get();
-    return query_on_vm_queue<bool>(vm_handle, [&]() { return [vm canStop]; });
+    return query_on_vm_queue(vm_handle, [&]() { return [vm canStop]; });
 }
 
 bool can_request_stop(const VMHandle& vm_handle)
 {
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle->vm.get();
-    return query_on_vm_queue<bool>(vm_handle, [&]() { return [vm canRequestStop]; });
+    return query_on_vm_queue(vm_handle, [&]() { return [vm canRequestStop]; });
 }
 
 bool is_supported()

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -234,31 +234,36 @@ CFError resume_with_completion_handler(VMHandle& vm_handle)
     return CFError(err_ref);
 }
 
-bool can_start(VMHandle& vm_handle) {
+bool can_start(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canStart];
 }
 
-bool can_pause(VMHandle& vm_handle) {
+bool can_pause(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canPause];
 }
 
-bool can_resume(VMHandle& vm_handle) {
+bool can_resume(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canResume];
 }
 
-bool can_stop(VMHandle& vm_handle) {
+bool can_stop(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canStop];
 }
 
-bool can_request_stop(VMHandle& vm_handle) {
+bool can_request_stop(VMHandle& vm_handle)
+{
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     return [vm canRequestStop];

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -232,4 +232,34 @@ CFErrorRef resume_with_completion_handler(VMHandle& vm_handle) {
 
     return err;
 }
+
+bool can_start(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canStart];
+}
+
+bool can_pause(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canPause];
+}
+
+bool can_resume(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canResume];
+}
+
+bool can_stop(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canStop];
+}
+
+bool can_request_stop(VMHandle& vm_handle) {
+    VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
+
+    return [vm canRequestStop];
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -185,7 +185,12 @@ CFError request_stop_with_error(VMHandle& vm_handle)
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle.get();
 
     NSError* err = nil;
-    [vm requestStopWithError:&err];
+    if (![vm requestStopWithError:&err] && !err)
+    {
+        err = [NSError errorWithDomain:@"multipass.applevz.bridge"
+                                  code:-1
+                              userInfo:@{NSLocalizedDescriptionKey : @"Unknown error"}];
+    }
 
     return err ? CFError((__bridge_retained CFErrorRef)err) : CFError();
 }

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -24,6 +24,8 @@
 #import <objc/objc.h>
 #import <objc/runtime.h>
 
+#include <QDir>
+#include <QFileInfo>
 #include <QString>
 #include <QUrl>
 
@@ -145,12 +147,11 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
         config.storageDevices = storageDevices;
 
         // EFI Variable store
-        NSString* efivarsFilename = [NSString stringWithFormat:@"vm-efivars"];
-        NSString* efivarsPath =
-            [NSTemporaryDirectory() stringByAppendingPathComponent:efivarsFilename];
+        QFileInfo diskInfo(desc.image.image_path);
+        QString efivarsPath = diskInfo.dir().filePath("efivars");
 
         // EFI bootloader
-        NSURL* efivarsURL = [NSURL fileURLWithPath:efivarsPath];
+        NSURL* efivarsURL = [NSURL fileURLWithPath:nsstring_from_qstring(efivarsPath)];
         VZEFIBootLoader* efi = [[VZEFIBootLoader alloc] init];
         efi.variableStore = [[VZEFIVariableStore alloc]
             initCreatingVariableStoreAtURL:efivarsURL

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -31,10 +31,6 @@ AppleVZVirtualMachine::AppleVZVirtualMachine(const VirtualMachineDescription& de
 {
 }
 
-AppleVZVirtualMachine::~AppleVZVirtualMachine()
-{
-}
-
 void AppleVZVirtualMachine::start()
 {
 }

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -46,7 +46,7 @@ AppleVZVirtualMachine::AppleVZVirtualMachine(const VirtualMachineDescription& de
                "AppleVZVirtualMachine::AppleVZVirtualMachine() -> Created handle for VM '{}'",
                vm_name);
 
-    // Reflect compute system's state
+    // Reflect vm's state
     const auto curr_state = MP_APPLEVZ.get_state(vm_handle);
     set_state(curr_state);
     handle_state_update();
@@ -78,16 +78,13 @@ void AppleVZVirtualMachine::start()
     }
     else
     {
-        mpl::debug(log_category,
-                   "start() -> VM `{}` cannot be started from state `{}`",
-                   vm_name,
-                   curr_state);
-
-        throw VMStateIdempotentException(
-            fmt::format("VM `{}` cannot be started from state `{}`", vm_name, curr_state));
+        mpl::warn(log_category,
+                  "start() -> VM `{}` cannot be started from state `{}`",
+                  vm_name,
+                  curr_state);
     }
 
-    // Reflect compute system's state
+    // Reflect vm's state
     curr_state = MP_APPLEVZ.get_state(vm_handle);
     set_state(curr_state);
     handle_state_update();
@@ -99,7 +96,7 @@ void AppleVZVirtualMachine::start()
             fmt::format("VM '{}' failed to start, check logs for more details", vm_name));
     }
 
-    mpl::debug(log_category, "start() -> Started/resumed VM `{}`", vm_name);
+    mpl::debug(log_category, "start() -> VM `{}` running", vm_name);
 }
 
 void AppleVZVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
@@ -113,7 +110,7 @@ void AppleVZVirtualMachine::suspend()
 
 VirtualMachine::State AppleVZVirtualMachine::current_state()
 {
-    return VirtualMachine::State::unknown;
+    return state;
 }
 
 int AppleVZVirtualMachine::ssh_port()

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -115,6 +115,12 @@ void AppleVZVirtualMachine::start()
 
 void AppleVZVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 {
+    if (!vm_handle)
+    {
+        assert(state == State::stopped);
+        return;
+    }
+
     set_state(MP_APPLEVZ.get_state(vm_handle));
 
     mpl::debug(log_category,

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -89,15 +89,16 @@ void AppleVZVirtualMachine::start()
     }
     else
     {
-        mpl::warn(log_category,
-                  "start() -> VM `{}` cannot be started from state `{}`",
-                  vm_name,
-                  current_state());
+        mpl::error(log_category,
+                   "start() -> VM `{}` cannot be started from state `{}`",
+                   vm_name,
+                   current_state());
         return;
     }
 
     if (error)
     {
+        mpl::error(log_category, "start() -> VM '{}' failed to start: {}", vm_name, error);
         throw std::runtime_error(
             fmt::format("VM '{}' failed to start, check logs for more details", vm_name));
     }

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -52,6 +52,24 @@ AppleVZVirtualMachine::AppleVZVirtualMachine(const VirtualMachineDescription& de
     handle_state_update();
 }
 
+AppleVZVirtualMachine::~AppleVZVirtualMachine()
+{
+    mpl::debug(log_category,
+               "AppleVZVirtualMachine::~AppleVZVirtualMachine() -> Destructing VM `{}`",
+               vm_name);
+
+    multipass::top_catch_all(vm_name, [this]() {
+        if (state == State::running)
+        {
+            suspend();
+        }
+        else
+        {
+            shutdown();
+        }
+    });
+}
+
 void AppleVZVirtualMachine::start()
 {
     mpl::debug(log_category, "start() -> Starting VM `{}`, current state {}", vm_name, state);

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -157,7 +157,7 @@ void AppleVZVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
             if (const auto stop_error = MP_APPLEVZ.stop_vm(vm_handle, true); stop_error)
             {
                 mpl::warn(log_category,
-                          "shutdown() -> VM `{}` envountered an error while quiting, killing "
+                          "shutdown() -> VM `{}` encountered an error while quitting, killing "
                           "process instead: `{}`",
                           vm_name,
                           stop_error);

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -119,6 +119,68 @@ void AppleVZVirtualMachine::start()
 
 void AppleVZVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 {
+    mpl::debug(log_category,
+               "shutdown() -> Shutting down VM `{}`, current state {}",
+               vm_name,
+               state);
+
+    try
+    {
+        check_state_for_shutdown(shutdown_policy);
+    }
+    catch (const VMStateIdempotentException& e)
+    {
+        mpl::log_message(mpl::Level::info, vm_name, e.what());
+        return;
+    }
+
+    CFError error;
+
+    if (shutdown_policy == ShutdownPolicy::Poweroff)
+    {
+        mpl::debug(log_category, "shutdown() -> Forcing shutdown of VM `{}`", vm_name);
+        error = MP_APPLEVZ.stop_vm(vm_handle, true);
+    }
+    else if (MP_APPLEVZ.can_stop(vm_handle))
+    {
+        mpl::debug(log_category, "shutdown() -> Requesting shutdown of VM `{}`", vm_name);
+        error = MP_APPLEVZ.stop_vm(vm_handle);
+    }
+    else
+    {
+        mpl::warn(log_category,
+                  "shutdown() -> VM `{}` cannot be stopped from state `{}`",
+                  vm_name,
+                  state);
+        return;
+    }
+
+    // Reflect vm's state
+    set_state(MP_APPLEVZ.get_state(vm_handle));
+
+    if (error)
+    {
+        mpl::error(log_category, "shutdown() -> VM '{}' failed to stop: {}", vm_name, error);
+        throw std::runtime_error(
+            fmt::format("VM '{}' failed to stop, check logs for more details", vm_name));
+    }
+
+    // We need to wait here.
+    auto on_timeout = [] { throw std::runtime_error("timed out waiting for shutdown"); };
+
+    multipass::utils::try_action_for(on_timeout, std::chrono::seconds{180}, [this]() {
+        set_state(MP_APPLEVZ.get_state(vm_handle));
+        handle_state_update();
+
+        switch (current_state())
+        {
+        case VirtualMachine::State::stopped:
+            drop_ssh_session();
+            return multipass::utils::TimeoutAction::done;
+        default:
+            return multipass::utils::TimeoutAction::retry;
+        }
+    });
 }
 
 void AppleVZVirtualMachine::suspend()

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -136,12 +136,12 @@ void AppleVZVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 
     CFError error;
 
-    if (shutdown_policy == ShutdownPolicy::Poweroff)
+    if (shutdown_policy == ShutdownPolicy::Poweroff && MP_APPLEVZ.can_stop(vm_handle))
     {
         mpl::debug(log_category, "shutdown() -> Forcing shutdown of VM `{}`", vm_name);
         error = MP_APPLEVZ.stop_vm(vm_handle, true);
     }
-    else if (MP_APPLEVZ.can_stop(vm_handle))
+    else if (MP_APPLEVZ.can_request_stop(vm_handle))
     {
         mpl::debug(log_category, "shutdown() -> Requesting shutdown of VM `{}`", vm_name);
         error = MP_APPLEVZ.stop_vm(vm_handle);

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -268,7 +268,10 @@ void AppleVZVirtualMachine::resize_memory(const MemorySize& new_size)
 
 void AppleVZVirtualMachine::resize_disk(const MemorySize& new_size)
 {
-    // Must be able to handle RAW and ASIF disk images
+    assert(new_size > desc.disk_space);
+
+    multipass::backend::resize_instance_image(new_size, desc.image.image_path);
+    desc.disk_space = new_size;
 }
 
 void AppleVZVirtualMachine::set_state(applevz::AppleVMState vm_state)

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -40,6 +40,7 @@ AppleVZVirtualMachine::AppleVZVirtualMachine(const VirtualMachineDescription& de
                                              const Path& instance_dir)
     : BaseVirtualMachine{desc.vm_name, key_provider, instance_dir}, desc{desc}, monitor{&monitor}
 {
+    initialize_vm_handle();
 }
 
 AppleVZVirtualMachine::~AppleVZVirtualMachine()
@@ -67,8 +68,6 @@ AppleVZVirtualMachine::~AppleVZVirtualMachine()
 void AppleVZVirtualMachine::start()
 {
     mpl::debug(log_category, "start() -> Starting VM `{}`, current state {}", vm_name, state);
-
-    initialize_vm_handle();
 
     state = State::starting;
     handle_state_update();

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -36,6 +36,20 @@ AppleVZVirtualMachine::AppleVZVirtualMachine(const VirtualMachineDescription& de
                                              const Path& instance_dir)
     : BaseVirtualMachine{desc.vm_name, key_provider, instance_dir}, desc{desc}, monitor{&monitor}
 {
+    vm_handle.reset();
+    if (const auto& error = MP_APPLEVZ.create_vm(desc, vm_handle); error)
+    {
+        mpl::error(log_category, "Failed to create handle for VM '{}': ", vm_name, error);
+    }
+
+    mpl::debug(log_category,
+               "AppleVZVirtualMachine::AppleVZVirtualMachine() -> Created handle for VM '{}'",
+               vm_name);
+
+    // Reflect compute system's state
+    const auto curr_state = MP_APPLEVZ.get_state(vm_handle);
+    set_state(curr_state);
+    handle_state_update();
 }
 
 void AppleVZVirtualMachine::start()

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -269,6 +269,7 @@ void AppleVZVirtualMachine::set_state(applevz::AppleVMState vm_state)
         break;
     case applevz::AppleVMState::running:
     case applevz::AppleVMState::stopping:
+        // No `stopping` state in Multipass yet
         state = State::running;
         break;
     case applevz::AppleVMState::paused:

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -247,14 +247,18 @@ void AppleVZVirtualMachine::handle_state_update()
 
 void AppleVZVirtualMachine::update_cpus(int num_cores)
 {
+    assert(num_cores > 0);
+    desc.num_cores = num_cores;
 }
 
 void AppleVZVirtualMachine::resize_memory(const MemorySize& new_size)
 {
+    desc.mem_size = new_size;
 }
 
 void AppleVZVirtualMachine::resize_disk(const MemorySize& new_size)
 {
+    // Must be able to handle RAW and ASIF disk images
 }
 
 void AppleVZVirtualMachine::set_state(applevz::AppleVMState vm_state)

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -90,7 +90,7 @@ void AppleVZVirtualMachine::start()
     else
     {
         mpl::error(log_category,
-                   "start() -> VM `{}` cannot be started from state `{}`",
+                   "start() -> VM `{}` cannot be started. Current state `{}`",
                    vm_name,
                    current_state());
         return;
@@ -224,7 +224,7 @@ void AppleVZVirtualMachine::suspend()
     else
     {
         mpl::warn(log_category,
-                  "suspend() -> VM `{}` cannot be suspended from state `{}`",
+                  "suspend() -> VM `{}` cannot be suspended. Current state `{}`",
                   vm_name,
                   current_state());
     }

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -92,6 +92,7 @@ std::optional<IPAddress> AppleVZVirtualMachine::management_ipv4()
 
 void AppleVZVirtualMachine::handle_state_update()
 {
+    monitor->persist_state_for(vm_name, state);
 }
 
 void AppleVZVirtualMachine::update_cpus(int num_cores)

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -225,7 +225,7 @@ void AppleVZVirtualMachine::suspend()
         mpl::warn(log_category,
                   "suspend() -> VM `{}` cannot be suspended from state `{}`",
                   vm_name,
-                  state);
+                  current_state());
     }
 
     if (error)

--- a/src/platform/backends/applevz/applevz_virtual_machine.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine.h
@@ -56,6 +56,7 @@ public:
     void resize_disk(const MemorySize& new_size) override;
 
 private:
+    void initialize_vm_handle();
     void set_state(applevz::AppleVMState vm_state);
     void fetch_ip(std::chrono::milliseconds timeout);
 

--- a/src/platform/backends/applevz/applevz_virtual_machine.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine.h
@@ -17,9 +17,10 @@
 
 #pragma once
 
-#include <shared/base_virtual_machine.h>
+#include <applevz/applevz_wrapper.h>
 
 #include <multipass/virtual_machine_description.h>
+#include <shared/base_virtual_machine.h>
 
 namespace multipass
 {
@@ -39,15 +40,22 @@ public:
     void start() override;
     void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;
     void suspend() override;
+
     State current_state() override;
+
     int ssh_port() override;
     std::string ssh_hostname(std::chrono::milliseconds timeout) override;
     std::string ssh_username() override;
     std::optional<IPAddress> management_ipv4() override;
+
     void handle_state_update() override;
+
     void update_cpus(int num_cores) override;
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
+
+private:
+    void set_state(applevz::AppleVMState vm_state);
 
 private:
     VirtualMachineDescription desc;

--- a/src/platform/backends/applevz/applevz_virtual_machine.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine.h
@@ -35,7 +35,6 @@ public:
                           VMStatusMonitor& monitor,
                           const SSHKeyProvider& key_provider,
                           const Path& instance_dir);
-    ~AppleVZVirtualMachine();
 
     void start() override;
     void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;

--- a/src/platform/backends/applevz/applevz_virtual_machine.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine.h
@@ -57,6 +57,7 @@ public:
 
 private:
     void set_state(applevz::AppleVMState vm_state);
+    void fetch_ip(std::chrono::milliseconds timeout);
 
 private:
     VirtualMachineDescription desc;

--- a/src/platform/backends/applevz/applevz_virtual_machine.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine.h
@@ -36,6 +36,7 @@ public:
                           VMStatusMonitor& monitor,
                           const SSHKeyProvider& key_provider,
                           const Path& instance_dir);
+    ~AppleVZVirtualMachine();
 
     void start() override;
     void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) override;

--- a/src/platform/backends/applevz/applevz_virtual_machine.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine.h
@@ -60,5 +60,6 @@ private:
 private:
     VirtualMachineDescription desc;
     VMStatusMonitor* monitor;
+    VMHandle vm_handle{nullptr};
 };
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -51,6 +51,7 @@ VMImage AppleVZVirtualMachineFactory::prepare_source_image(const VMImage& source
 void AppleVZVirtualMachineFactory::prepare_instance_image(const VMImage& instance_image,
                                                           const VirtualMachineDescription& desc)
 {
+    backend::resize_instance_image(desc.disk_space, instance_image.image_path);
 }
 
 void AppleVZVirtualMachineFactory::hypervisor_health_check()

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -67,12 +67,16 @@ void AppleVZVirtualMachineFactory::remove_resources_for_impl(const std::string& 
 }
 
 VirtualMachine::UPtr AppleVZVirtualMachineFactory::clone_vm_impl(
-    const std::string& source_vm_name,
-    const multipass::VMSpecs& src_vm_specs,
+    const std::string& /*source_vm_name*/,
+    const multipass::VMSpecs& /*src_vm_specs*/,
     const VirtualMachineDescription& desc,
     VMStatusMonitor& monitor,
     const SSHKeyProvider& key_provider)
 {
-    return nullptr;
+    return std::make_unique<mp::applevz::AppleVZVirtualMachine>(
+        desc,
+        monitor,
+        key_provider,
+        get_instance_directory(desc.vm_name));
 }
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -45,6 +45,10 @@ void AppleVZVirtualMachineFactory::prepare_instance_image(const VMImage& instanc
 
 void AppleVZVirtualMachineFactory::hypervisor_health_check()
 {
+    if (!MP_APPLEVZ.is_supported())
+    {
+        throw std::runtime_error("Virtualization is not supported on this system.");
+    }
 }
 
 void AppleVZVirtualMachineFactory::remove_resources_for_impl(const std::string& name)

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -17,6 +17,7 @@
 
 #include <applevz/applevz_virtual_machine.h>
 #include <applevz/applevz_virtual_machine_factory.h>
+#include <qemu/qemu_img_utils.h>
 
 namespace mp = multipass;
 
@@ -42,7 +43,9 @@ VirtualMachine::UPtr AppleVZVirtualMachineFactory::create_virtual_machine(
 
 VMImage AppleVZVirtualMachineFactory::prepare_source_image(const VMImage& source_image)
 {
-    return VMImage{};
+    VMImage image{source_image};
+    image.image_path = backend::convert_to_raw(source_image.image_path);
+    return image;
 }
 
 void AppleVZVirtualMachineFactory::prepare_instance_image(const VMImage& instance_image,

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -15,7 +15,10 @@
  *
  */
 
+#include <applevz/applevz_virtual_machine.h>
 #include <applevz/applevz_virtual_machine_factory.h>
+
+namespace mp = multipass;
 
 namespace multipass::applevz
 {
@@ -30,7 +33,11 @@ VirtualMachine::UPtr AppleVZVirtualMachineFactory::create_virtual_machine(
     const SSHKeyProvider& key_provider,
     VMStatusMonitor& monitor)
 {
-    return nullptr;
+    return std::make_unique<mp::applevz::AppleVZVirtualMachine>(
+        desc,
+        monitor,
+        key_provider,
+        get_instance_directory(desc.vm_name));
 }
 
 VMImage AppleVZVirtualMachineFactory::prepare_source_image(const VMImage& source_image)

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -111,4 +111,39 @@ CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
 
     return err;
 }
+
+bool AppleVZ::can_start(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_start(...)");
+
+    return multipass::applevz::can_start(vm_handle);
+}
+
+bool AppleVZ::can_pause(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_pause(...)");
+
+    return multipass::applevz::can_pause(vm_handle);
+}
+
+bool AppleVZ::can_resume(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_resume(...)");
+
+    return multipass::applevz::can_resume(vm_handle);
+}
+
+bool AppleVZ::can_stop(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_stop(...)");
+
+    return multipass::applevz::can_stop(vm_handle);
+}
+
+bool AppleVZ::can_request_stop(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::can_request_stop(...)");
+
+    return multipass::applevz::can_request_stop(vm_handle);
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -31,31 +31,31 @@ namespace multipass::applevz
 {
 CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::create_vm(...)");
+    mpl::trace(kLogCategory, "AppleVZ::create_vm(...)");
 
     auto err = init_with_configuration(desc, out_handle);
 
     if (!err)
-        mpl::debug(kLogCategory, "AppleVZ::create_vm(...) succeeded");
+        mpl::trace(kLogCategory, "AppleVZ::create_vm(...) succeeded");
 
     return err;
 }
 
 CFError AppleVZ::start_vm(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
+    mpl::trace(kLogCategory, "AppleVZ::start_vm(...)");
 
     auto err = start_with_completion_handler(vm_handle);
 
     if (!err)
-        mpl::debug(kLogCategory, "AppleVZ::start_vm(...) succeeded");
+        mpl::trace(kLogCategory, "AppleVZ::start_vm(...) succeeded");
 
     return err;
 }
 
 CFError AppleVZ::stop_vm(const VMHandle& vm_handle, bool force) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::stop_vm(...)");
+    mpl::trace(kLogCategory, "AppleVZ::stop_vm(...)");
 
     CFError err;
     if (force)
@@ -64,80 +64,80 @@ CFError AppleVZ::stop_vm(const VMHandle& vm_handle, bool force) const
         err = request_stop_with_error(vm_handle);
 
     if (!err)
-        mpl::debug(kLogCategory, "AppleVZ::stop_vm(...) succeeded");
+        mpl::trace(kLogCategory, "AppleVZ::stop_vm(...) succeeded");
 
     return err;
 }
 
 CFError AppleVZ::pause_vm(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::pause_vm(...)");
+    mpl::trace(kLogCategory, "AppleVZ::pause_vm(...)");
 
     auto err = pause_with_completion_handler(vm_handle);
 
     if (!err)
-        mpl::debug(kLogCategory, "AppleVZ::pause_vm(...) succeeded");
+        mpl::trace(kLogCategory, "AppleVZ::pause_vm(...) succeeded");
 
     return err;
 }
 
 CFError AppleVZ::resume_vm(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::resume_vm(...)");
+    mpl::trace(kLogCategory, "AppleVZ::resume_vm(...)");
 
     auto err = resume_with_completion_handler(vm_handle);
 
     if (!err)
-        mpl::debug(kLogCategory, "AppleVZ::resume_vm(...) succeeded");
+        mpl::trace(kLogCategory, "AppleVZ::resume_vm(...) succeeded");
 
     return err;
 }
 
 AppleVMState AppleVZ::get_state(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::get_state(...)");
+    mpl::trace(kLogCategory, "AppleVZ::get_state(...)");
 
     return multipass::applevz::get_state(vm_handle);
 }
 
 bool AppleVZ::can_start(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::can_start(...)");
+    mpl::trace(kLogCategory, "AppleVZ::can_start(...)");
 
     return multipass::applevz::can_start(vm_handle);
 }
 
 bool AppleVZ::can_pause(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::can_pause(...)");
+    mpl::trace(kLogCategory, "AppleVZ::can_pause(...)");
 
     return multipass::applevz::can_pause(vm_handle);
 }
 
 bool AppleVZ::can_resume(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::can_resume(...)");
+    mpl::trace(kLogCategory, "AppleVZ::can_resume(...)");
 
     return multipass::applevz::can_resume(vm_handle);
 }
 
 bool AppleVZ::can_stop(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::can_stop(...)");
+    mpl::trace(kLogCategory, "AppleVZ::can_stop(...)");
 
     return multipass::applevz::can_stop(vm_handle);
 }
 
 bool AppleVZ::can_request_stop(const VMHandle& vm_handle) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::can_request_stop(...)");
+    mpl::trace(kLogCategory, "AppleVZ::can_request_stop(...)");
 
     return multipass::applevz::can_request_stop(vm_handle);
 }
 
 bool AppleVZ::is_supported() const
 {
-    mpl::debug(kLogCategory, "AppleVZ::is_supported(...)");
+    mpl::trace(kLogCategory, "AppleVZ::is_supported(...)");
 
     return multipass::applevz::is_supported();
 }

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -40,4 +40,45 @@ CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_
 
     return CFError(err);
 }
+
+CFError AppleVZ::start_vm(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
+
+    if (!can_start(vm_handle))
+        mpl::debug(kLogCategory, "VM not in a state that allows starting");
+
+    auto err = start_with_completion_handler(vm_handle);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::start_vm(...) succeeded");
+
+    return CFError(err);
+}
+
+CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
+
+    CFError err;
+    if (force)
+    {
+        if (!can_stop(vm_handle))
+            mpl::debug(kLogCategory, "VM not in a state that allows stopping");
+
+        err = CFError(stop_with_completion_handler(vm_handle));
+    }
+    else
+    {
+        if (!can_request_stop(vm_handle))
+            mpl::debug(kLogCategory, "VM not in a state that allows stopping");
+
+        err = CFError(request_stop_with_error(vm_handle));
+    }
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::stop_vm(...) succeeded");
+
+    return err;
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -93,6 +93,13 @@ CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
     return err;
 }
 
+AppleVMState AppleVZ::get_state(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::get_state(...)");
+
+    return multipass::applevz::get_state(vm_handle);
+}
+
 bool AppleVZ::can_start(VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_start(...)");

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -134,4 +134,11 @@ bool AppleVZ::can_request_stop(const VMHandle& vm_handle) const
 
     return multipass::applevz::can_request_stop(vm_handle);
 }
+
+bool AppleVZ::is_supported() const
+{
+    mpl::debug(kLogCategory, "AppleVZ::is_supported(...)");
+
+    return multipass::applevz::is_supported();
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -81,4 +81,34 @@ CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
 
     return err;
 }
+
+CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::pause_vm(...)");
+
+    if (!can_pause(vm_handle))
+        mpl::debug(kLogCategory, "VM not in a state that allows pausing");
+
+    auto err = pause_with_completion_handler(vm_handle);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::pause_vm(...) succeeded");
+
+    return err;
+}
+
+CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::resume_vm(...)");
+
+    if (!can_resume(vm_handle))
+        mpl::debug(kLogCategory, "VM not in a state that allows resuming");
+
+    auto err = resume_with_completion_handler(vm_handle);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::resume_vm(...) succeeded");
+
+    return err;
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -41,7 +41,7 @@ CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_
     return err;
 }
 
-CFError AppleVZ::start_vm(VMHandle& vm_handle) const
+CFError AppleVZ::start_vm(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
 
@@ -53,9 +53,9 @@ CFError AppleVZ::start_vm(VMHandle& vm_handle) const
     return err;
 }
 
-CFError AppleVZ::stop_vm(VMHandle& vm_handle, bool force) const
+CFError AppleVZ::stop_vm(const VMHandle& vm_handle, bool force) const
 {
-    mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
+    mpl::debug(kLogCategory, "AppleVZ::stop_vm(...)");
 
     CFError err;
     if (force)
@@ -69,7 +69,7 @@ CFError AppleVZ::stop_vm(VMHandle& vm_handle, bool force) const
     return err;
 }
 
-CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
+CFError AppleVZ::pause_vm(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::pause_vm(...)");
 
@@ -81,7 +81,7 @@ CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
     return err;
 }
 
-CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
+CFError AppleVZ::resume_vm(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::resume_vm(...)");
 
@@ -93,42 +93,42 @@ CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
     return err;
 }
 
-AppleVMState AppleVZ::get_state(VMHandle& vm_handle) const
+AppleVMState AppleVZ::get_state(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::get_state(...)");
 
     return multipass::applevz::get_state(vm_handle);
 }
 
-bool AppleVZ::can_start(VMHandle& vm_handle) const
+bool AppleVZ::can_start(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_start(...)");
 
     return multipass::applevz::can_start(vm_handle);
 }
 
-bool AppleVZ::can_pause(VMHandle& vm_handle) const
+bool AppleVZ::can_pause(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_pause(...)");
 
     return multipass::applevz::can_pause(vm_handle);
 }
 
-bool AppleVZ::can_resume(VMHandle& vm_handle) const
+bool AppleVZ::can_resume(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_resume(...)");
 
     return multipass::applevz::can_resume(vm_handle);
 }
 
-bool AppleVZ::can_stop(VMHandle& vm_handle) const
+bool AppleVZ::can_stop(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_stop(...)");
 
     return multipass::applevz::can_stop(vm_handle);
 }
 
-bool AppleVZ::can_request_stop(VMHandle& vm_handle) const
+bool AppleVZ::can_request_stop(const VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::can_request_stop(...)");
 

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -53,7 +53,7 @@ CFError AppleVZ::start_vm(VMHandle& vm_handle) const
     return err;
 }
 
-CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
+CFError AppleVZ::stop_vm(VMHandle& vm_handle, bool force) const
 {
     mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
 

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -15,8 +15,29 @@
  *
  */
 
+#include <applevz/applevz_bridge.h>
 #include <applevz/applevz_wrapper.h>
+
+#include <multipass/logging/log.h>
+
+namespace mpl = multipass::logging;
+
+namespace
+{
+constexpr static auto kLogCategory = "vz-wrapper";
+} // namespace
 
 namespace multipass::applevz
 {
+CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const
+{
+    mpl::debug(kLogCategory, "AppleVZ::create_vm(...)");
+
+    auto err = init_with_configuration(desc, out_handle);
+
+    if (!err)
+        mpl::debug(kLogCategory, "AppleVZ::create_vm(...) succeeded");
+
+    return CFError(err);
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -45,9 +45,6 @@ CFError AppleVZ::start_vm(VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::start_vm(...)");
 
-    if (!can_start(vm_handle))
-        mpl::debug(kLogCategory, "VM not in a state that allows starting");
-
     auto err = start_with_completion_handler(vm_handle);
 
     if (!err)
@@ -62,19 +59,9 @@ CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
 
     CFError err;
     if (force)
-    {
-        if (!can_stop(vm_handle))
-            mpl::debug(kLogCategory, "VM not in a state that allows stopping");
-
         err = stop_with_completion_handler(vm_handle);
-    }
     else
-    {
-        if (!can_request_stop(vm_handle))
-            mpl::debug(kLogCategory, "VM not in a state that allows stopping");
-
         err = request_stop_with_error(vm_handle);
-    }
 
     if (!err)
         mpl::debug(kLogCategory, "AppleVZ::stop_vm(...) succeeded");
@@ -85,9 +72,6 @@ CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
 CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::pause_vm(...)");
-
-    if (!can_pause(vm_handle))
-        mpl::debug(kLogCategory, "VM not in a state that allows pausing");
 
     auto err = pause_with_completion_handler(vm_handle);
 
@@ -100,9 +84,6 @@ CFError AppleVZ::pause_vm(VMHandle& vm_handle) const
 CFError AppleVZ::resume_vm(VMHandle& vm_handle) const
 {
     mpl::debug(kLogCategory, "AppleVZ::resume_vm(...)");
-
-    if (!can_resume(vm_handle))
-        mpl::debug(kLogCategory, "VM not in a state that allows resuming");
 
     auto err = resume_with_completion_handler(vm_handle);
 

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -38,7 +38,7 @@ CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_
     if (!err)
         mpl::debug(kLogCategory, "AppleVZ::create_vm(...) succeeded");
 
-    return CFError(err);
+    return err;
 }
 
 CFError AppleVZ::start_vm(VMHandle& vm_handle) const
@@ -53,7 +53,7 @@ CFError AppleVZ::start_vm(VMHandle& vm_handle) const
     if (!err)
         mpl::debug(kLogCategory, "AppleVZ::start_vm(...) succeeded");
 
-    return CFError(err);
+    return err;
 }
 
 CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
@@ -66,14 +66,14 @@ CFError AppleVZ::stop_vm(bool force, VMHandle& vm_handle) const
         if (!can_stop(vm_handle))
             mpl::debug(kLogCategory, "VM not in a state that allows stopping");
 
-        err = CFError(stop_with_completion_handler(vm_handle));
+        err = stop_with_completion_handler(vm_handle);
     }
     else
     {
         if (!can_request_stop(vm_handle))
             mpl::debug(kLogCategory, "VM not in a state that allows stopping");
 
-        err = CFError(request_stop_with_error(vm_handle));
+        err = request_stop_with_error(vm_handle);
     }
 
     if (!err)

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -18,127 +18,71 @@
 #include <applevz/applevz_bridge.h>
 #include <applevz/applevz_wrapper.h>
 
-#include <multipass/logging/log.h>
-
-namespace mpl = multipass::logging;
-
-namespace
-{
-constexpr static auto kLogCategory = "vz-wrapper";
-} // namespace
-
 namespace multipass::applevz
 {
 CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::create_vm(...)");
-
-    auto err = init_with_configuration(desc, out_handle);
-
-    if (!err)
-        mpl::trace(kLogCategory, "AppleVZ::create_vm(...) succeeded");
-
-    return err;
+    return init_with_configuration(desc, out_handle);
 }
 
 CFError AppleVZ::start_vm(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::start_vm(...)");
-
-    auto err = start_with_completion_handler(vm_handle);
-
-    if (!err)
-        mpl::trace(kLogCategory, "AppleVZ::start_vm(...) succeeded");
-
-    return err;
+    return start_with_completion_handler(vm_handle);
 }
 
 CFError AppleVZ::stop_vm(const VMHandle& vm_handle, bool force) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::stop_vm(...)");
-
     CFError err;
     if (force)
         err = stop_with_completion_handler(vm_handle);
     else
         err = request_stop_with_error(vm_handle);
 
-    if (!err)
-        mpl::trace(kLogCategory, "AppleVZ::stop_vm(...) succeeded");
-
     return err;
 }
 
 CFError AppleVZ::pause_vm(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::pause_vm(...)");
-
-    auto err = pause_with_completion_handler(vm_handle);
-
-    if (!err)
-        mpl::trace(kLogCategory, "AppleVZ::pause_vm(...) succeeded");
-
-    return err;
+    return pause_with_completion_handler(vm_handle);
 }
 
 CFError AppleVZ::resume_vm(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::resume_vm(...)");
-
-    auto err = resume_with_completion_handler(vm_handle);
-
-    if (!err)
-        mpl::trace(kLogCategory, "AppleVZ::resume_vm(...) succeeded");
-
-    return err;
+    return resume_with_completion_handler(vm_handle);
 }
 
 AppleVMState AppleVZ::get_state(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::get_state(...)");
-
     return multipass::applevz::get_state(vm_handle);
 }
 
 bool AppleVZ::can_start(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::can_start(...)");
-
     return multipass::applevz::can_start(vm_handle);
 }
 
 bool AppleVZ::can_pause(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::can_pause(...)");
-
     return multipass::applevz::can_pause(vm_handle);
 }
 
 bool AppleVZ::can_resume(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::can_resume(...)");
-
     return multipass::applevz::can_resume(vm_handle);
 }
 
 bool AppleVZ::can_stop(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::can_stop(...)");
-
     return multipass::applevz::can_stop(vm_handle);
 }
 
 bool AppleVZ::can_request_stop(const VMHandle& vm_handle) const
 {
-    mpl::trace(kLogCategory, "AppleVZ::can_request_stop(...)");
-
     return multipass::applevz::can_request_stop(vm_handle);
 }
 
 bool AppleVZ::is_supported() const
 {
-    mpl::trace(kLogCategory, "AppleVZ::is_supported(...)");
-
     return multipass::applevz::is_supported();
 }
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -37,5 +37,11 @@ public:
     virtual CFError stop_vm(bool force, VMHandle& vm_handle) const;
     virtual CFError pause_vm(VMHandle& vm_handle) const;
     virtual CFError resume_vm(VMHandle& vm_handle) const;
+
+    virtual bool can_start(VMHandle& vm_handle) const;
+    virtual bool can_pause(VMHandle& vm_handle) const;
+    virtual bool can_resume(VMHandle& vm_handle) const;
+    virtual bool can_stop(VMHandle& vm_handle) const;
+    virtual bool can_request_stop(VMHandle& vm_handle) const;
 };
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -33,17 +33,21 @@ public:
     using Singleton<AppleVZ>::Singleton;
 
     virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
-    virtual CFError start_vm(VMHandle& vm_handle) const;
-    virtual CFError stop_vm(VMHandle& vm_handle, bool force = false) const;
-    virtual CFError pause_vm(VMHandle& vm_handle) const;
-    virtual CFError resume_vm(VMHandle& vm_handle) const;
 
-    virtual AppleVMState get_state(VMHandle& vm_handle) const;
+    // Starting and stopping VM
+    virtual CFError start_vm(const VMHandle& vm_handle) const;
+    virtual CFError stop_vm(const VMHandle& vm_handle, bool force = false) const;
+    virtual CFError pause_vm(const VMHandle& vm_handle) const;
+    virtual CFError resume_vm(const VMHandle& vm_handle) const;
 
-    virtual bool can_start(VMHandle& vm_handle) const;
-    virtual bool can_pause(VMHandle& vm_handle) const;
-    virtual bool can_resume(VMHandle& vm_handle) const;
-    virtual bool can_stop(VMHandle& vm_handle) const;
-    virtual bool can_request_stop(VMHandle& vm_handle) const;
+    // Getting VM state
+    virtual AppleVMState get_state(const VMHandle& vm_handle) const;
+
+    // Validate the state of VM
+    virtual bool can_start(const VMHandle& vm_handle) const;
+    virtual bool can_pause(const VMHandle& vm_handle) const;
+    virtual bool can_resume(const VMHandle& vm_handle) const;
+    virtual bool can_stop(const VMHandle& vm_handle) const;
+    virtual bool can_request_stop(const VMHandle& vm_handle) const;
 };
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -33,5 +33,7 @@ public:
     using Singleton<AppleVZ>::Singleton;
 
     virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
+    virtual CFError start_vm(VMHandle& vm_handle) const;
+    virtual CFError stop_vm(bool force, VMHandle& vm_handle) const;
 };
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -34,7 +34,7 @@ public:
 
     virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
     virtual CFError start_vm(VMHandle& vm_handle) const;
-    virtual CFError stop_vm(bool force, VMHandle& vm_handle) const;
+    virtual CFError stop_vm(VMHandle& vm_handle, bool force = false) const;
     virtual CFError pause_vm(VMHandle& vm_handle) const;
     virtual CFError resume_vm(VMHandle& vm_handle) const;
 

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -49,5 +49,7 @@ public:
     virtual bool can_resume(const VMHandle& vm_handle) const;
     virtual bool can_stop(const VMHandle& vm_handle) const;
     virtual bool can_request_stop(const VMHandle& vm_handle) const;
+
+    virtual bool is_supported() const;
 };
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -17,7 +17,11 @@
 
 #pragma once
 
+#include <applevz/applevz_bridge.h>
+#include <applevz/cf_error.h>
+
 #include <multipass/singleton.h>
+#include <multipass/virtual_machine_description.h>
 
 #define MP_APPLEVZ multipass::applevz::AppleVZ::instance()
 
@@ -27,5 +31,7 @@ class AppleVZ : public Singleton<AppleVZ>
 {
 public:
     using Singleton<AppleVZ>::Singleton;
+
+    virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
 };
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -35,5 +35,7 @@ public:
     virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
     virtual CFError start_vm(VMHandle& vm_handle) const;
     virtual CFError stop_vm(bool force, VMHandle& vm_handle) const;
+    virtual CFError pause_vm(VMHandle& vm_handle) const;
+    virtual CFError resume_vm(VMHandle& vm_handle) const;
 };
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -38,6 +38,8 @@ public:
     virtual CFError pause_vm(VMHandle& vm_handle) const;
     virtual CFError resume_vm(VMHandle& vm_handle) const;
 
+    virtual AppleVMState get_state(VMHandle& vm_handle) const;
+
     virtual bool can_start(VMHandle& vm_handle) const;
     virtual bool can_pause(VMHandle& vm_handle) const;
     virtual bool can_resume(VMHandle& vm_handle) const;

--- a/src/platform/backends/applevz/cf_error.h
+++ b/src/platform/backends/applevz/cf_error.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <CoreFoundation/CoreFoundation.h>
+
+namespace multipass::applevz
+{
+struct CFError
+{
+    CFErrorRef ref = nullptr;
+
+    explicit CFError(CFErrorRef r = nullptr) : ref(r)
+    {
+    }
+
+    CFError(const CFError&) = delete;
+
+    CFError(CFError&& other) noexcept : ref(other.ref)
+    {
+        other.ref = nullptr;
+    }
+
+    CFError& operator=(const CFError&) = delete;
+
+    CFError& operator=(CFError&& other) noexcept
+    {
+        if (this != &other)
+        {
+            CFRelease(ref);
+
+            ref = other.ref;
+            other.ref = nullptr;
+        }
+        return *this;
+    }
+
+    ~CFError() noexcept
+    {
+        CFRelease(ref);
+    }
+
+    // Allow implicit conversion to CFErrorRef for easy passing
+    operator CFErrorRef() const
+    {
+        return ref;
+    }
+};
+} // namespace multipass::applevz

--- a/src/platform/backends/applevz/cf_error.h
+++ b/src/platform/backends/applevz/cf_error.h
@@ -17,10 +17,41 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <CoreFoundation/CoreFoundation.h>
 
 namespace multipass::applevz
 {
+
+namespace
+{
+
+inline std::string cfstring_to_std_string(CFStringRef s)
+{
+    if (!s)
+        return {};
+
+    CFIndex len = CFStringGetLength(s);
+    CFIndex maxSize = CFStringGetMaximumSizeForEncoding(len, kCFStringEncodingUTF8) + 1;
+
+    auto buffer = std::make_unique<char[]>(maxSize);
+    if (!buffer)
+    {
+        return std::string();
+    }
+
+    if (CFStringGetCString(s, buffer.get(), maxSize, kCFStringEncodingUTF8))
+    {
+        std::string result(buffer.get());
+        return result;
+    }
+
+    return std::string();
+}
+
+} // namespace
+
 struct CFError
 {
     CFErrorRef ref = nullptr;
@@ -61,4 +92,40 @@ struct CFError
         return ref;
     }
 };
+
 } // namespace multipass::applevz
+
+namespace fmt
+{
+template <>
+struct formatter<CFErrorRef>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(CFErrorRef e, FormatContext& ctx)
+    {
+        if (!e)
+            return format_to(ctx.out(), "<null CFErrorRef>");
+
+        CFIndex code = CFErrorGetCode(e);
+        CFStringRef domain = CFErrorGetDomain(e);
+        CFStringRef desc = CFErrorCopyDescription(e);
+        std::string sdomain = multipass::applevz::cfstring_to_std_string(domain);
+        std::string sdesc = multipass::applevz::cfstring_to_std_string(desc);
+
+        CFRelease(desc);
+
+        return format_to(ctx.out(),
+                         "{} ({}): {}",
+                         sdomain.empty() ? "CFError" : sdomain,
+                         code,
+                         sdesc);
+    }
+};
+
+} // namespace fmt

--- a/src/platform/backends/qemu/qemu_img_utils.cpp
+++ b/src/platform/backends/qemu/qemu_img_utils.cpp
@@ -43,9 +43,8 @@ QString get_image_format(const mp::Path& image_path)
         "Cannot read image format");
 
     auto image_info = qemuimg_info_process->read_all_standard_output();
-    auto image_record = QJsonDocument::fromJson(QString(image_info).toUtf8(), nullptr).object();
-
-    return image_record["format"].toString();
+    auto image_record = boost::json::parse(std::string_view(image_info));
+    return mp::lookup_or<QString>(image_record, "format", "");
 }
 } // namespace
 

--- a/src/platform/backends/qemu/qemu_img_utils.cpp
+++ b/src/platform/backends/qemu/qemu_img_utils.cpp
@@ -74,7 +74,7 @@ void mp::backend::resize_instance_image(const MemorySize& disk_space, const mp::
 
     auto disk_size = QString::number(
         disk_space.in_bytes()); // format documented in `man qemu-img` (look for "size")
-    QStringList qemuimg_parameters{{"-f", image_format, "resize", image_path, disk_size}};
+    QStringList qemuimg_parameters{{"resize", "-f", image_format, image_path, disk_size}};
 
     checked_exec_qemu_img(
         std::make_unique<mp::QemuImgProcessSpec>(qemuimg_parameters, "", image_path),

--- a/src/platform/backends/qemu/qemu_img_utils.cpp
+++ b/src/platform/backends/qemu/qemu_img_utils.cpp
@@ -118,8 +118,6 @@ mp::Path mp::backend::convert_to_raw(const mp::Path& image_path)
 {
     const auto raw_img_path{image_path + ".raw"};
 
-    QStringList qemuimg_parameters{{"convert", "-p", "-O", "raw", image_path, raw_img_path}};
-
     auto qemuimg_convert_spec = std::make_unique<mp::QemuImgProcessSpec>(
         QStringList{"convert", "-p", "-O", "raw", image_path, raw_img_path},
         image_path,

--- a/src/platform/backends/qemu/qemu_img_utils.h
+++ b/src/platform/backends/qemu/qemu_img_utils.h
@@ -42,6 +42,7 @@ Process::UPtr checked_exec_qemu_img(std::unique_ptr<QemuImgProcessSpec> spec,
 void resize_instance_image(const MemorySize& disk_space, const multipass::Path& image_path);
 Path convert_to_qcow_if_necessary(const Path& image_path);
 void amend_to_qcow2_v3(const Path& image_path);
+Path convert_to_raw(const Path& image_path);
 bool instance_image_has_snapshot(const Path& image_path, QString snapshot_tag);
 QByteArray snapshot_list_output(const Path& image_path);
 void delete_snapshot_from_image(const Path& image_path, const QString& snapshot_tag);

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -784,22 +784,22 @@ auto mp::QemuVirtualMachine::make_specific_snapshot(const QString& filename)
 
 void mp::QemuVirtualMachine::fetch_ip(std::chrono::milliseconds timeout)
 {
-    if (!management_ip)
-    {
-        auto action = [this] {
-            detect_aborted_start();
-            return ((management_ip = qemu_platform->get_ip_for(desc.default_mac_address)))
-                       ? mpu::TimeoutAction::done
-                       : mpu::TimeoutAction::retry;
-        };
+    if (management_ip)
+        return;
 
-        auto on_timeout = [this, &timeout] {
-            state = State::unknown;
-            throw InternalTimeoutException{"determine IP address", timeout};
-        };
+    auto action = [this] {
+        detect_aborted_start();
+        return ((management_ip = qemu_platform->get_ip_for(desc.default_mac_address)))
+                   ? mpu::TimeoutAction::done
+                   : mpu::TimeoutAction::retry;
+    };
 
-        mpu::try_action_for(on_timeout, timeout, action);
-    }
+    auto on_timeout = [this, &timeout] {
+        state = State::unknown;
+        throw InternalTimeoutException{"determine IP address", timeout};
+    };
+
+    mpu::try_action_for(on_timeout, timeout, action);
 }
 
 void mp::QemuVirtualMachine::refresh_start()

--- a/src/platform/backends/shared/base_virtual_machine_factory.cpp
+++ b/src/platform/backends/shared/base_virtual_machine_factory.cpp
@@ -140,11 +140,10 @@ void mp::BaseVirtualMachineFactory::copy_instance_dir_with_essential_files(
     for (const auto& entry : fs::directory_iterator(source_instance_dir_path))
     {
         // snapshot files are intentionally skipped;
-        // .iso cloud init file is included for all,
-        // .img or .qcow2 file here is not relevant for non-qemu backends.
         if (entry.path().extension().string() == ".iso" ||
             entry.path().extension().string() == ".img" ||
-            entry.path().extension().string() == ".qcow2")
+            entry.path().extension().string() == ".qcow2" ||
+            entry.path().extension().string() == ".raw")
         {
             const fs::path dest_file_path = dest_instance_dir_path / entry.path().filename();
             fs::copy(entry.path(), dest_file_path, fs::copy_options::update_existing);

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -39,7 +39,7 @@ public:
                 (const, override));
     MOCK_METHOD(applevz::CFError,
                 stop_vm,
-                (bool force, multipass::applevz::VMHandle& vm_handle),
+                (multipass::applevz::VMHandle & vm_handle, bool force),
                 (const, override));
     MOCK_METHOD(applevz::CFError,
                 pause_vm,

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -53,9 +53,18 @@ public:
                 get_state,
                 (const multipass::applevz::VMHandle& vm_handle),
                 (const, override));
-    MOCK_METHOD(bool, can_start, (const multipass::applevz::VMHandle& vm_handle), (const, override));
-    MOCK_METHOD(bool, can_pause, (const multipass::applevz::VMHandle& vm_handle), (const, override));
-    MOCK_METHOD(bool, can_resume, (const multipass::applevz::VMHandle& vm_handle), (const, override));
+    MOCK_METHOD(bool,
+                can_start,
+                (const multipass::applevz::VMHandle& vm_handle),
+                (const, override));
+    MOCK_METHOD(bool,
+                can_pause,
+                (const multipass::applevz::VMHandle& vm_handle),
+                (const, override));
+    MOCK_METHOD(bool,
+                can_resume,
+                (const multipass::applevz::VMHandle& vm_handle),
+                (const, override));
     MOCK_METHOD(bool, can_stop, (const multipass::applevz::VMHandle& vm_handle), (const, override));
     MOCK_METHOD(bool,
                 can_request_stop,

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -49,6 +49,10 @@ public:
                 resume_vm,
                 (multipass::applevz::VMHandle & vm_handle),
                 (const, override));
+    MOCK_METHOD(applevz::AppleVMState,
+                get_state,
+                (multipass::applevz::VMHandle & vm_handle),
+                (const, override));
     MOCK_METHOD(bool, can_start, (multipass::applevz::VMHandle & vm_handle), (const, override));
     MOCK_METHOD(bool, can_pause, (multipass::applevz::VMHandle & vm_handle), (const, override));
     MOCK_METHOD(bool, can_resume, (multipass::applevz::VMHandle & vm_handle), (const, override));

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -35,31 +35,31 @@ public:
                 (const, override));
     MOCK_METHOD(applevz::CFError,
                 start_vm,
-                (multipass::applevz::VMHandle & vm_handle),
+                (const multipass::applevz::VMHandle& vm_handle),
                 (const, override));
     MOCK_METHOD(applevz::CFError,
                 stop_vm,
-                (multipass::applevz::VMHandle & vm_handle, bool force),
+                (const multipass::applevz::VMHandle& vm_handle, bool force),
                 (const, override));
     MOCK_METHOD(applevz::CFError,
                 pause_vm,
-                (multipass::applevz::VMHandle & vm_handle),
+                (const multipass::applevz::VMHandle& vm_handle),
                 (const, override));
     MOCK_METHOD(applevz::CFError,
                 resume_vm,
-                (multipass::applevz::VMHandle & vm_handle),
+                (const multipass::applevz::VMHandle& vm_handle),
                 (const, override));
     MOCK_METHOD(applevz::AppleVMState,
                 get_state,
-                (multipass::applevz::VMHandle & vm_handle),
+                (const multipass::applevz::VMHandle& vm_handle),
                 (const, override));
-    MOCK_METHOD(bool, can_start, (multipass::applevz::VMHandle & vm_handle), (const, override));
-    MOCK_METHOD(bool, can_pause, (multipass::applevz::VMHandle & vm_handle), (const, override));
-    MOCK_METHOD(bool, can_resume, (multipass::applevz::VMHandle & vm_handle), (const, override));
-    MOCK_METHOD(bool, can_stop, (multipass::applevz::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool, can_start, (const multipass::applevz::VMHandle& vm_handle), (const, override));
+    MOCK_METHOD(bool, can_pause, (const multipass::applevz::VMHandle& vm_handle), (const, override));
+    MOCK_METHOD(bool, can_resume, (const multipass::applevz::VMHandle& vm_handle), (const, override));
+    MOCK_METHOD(bool, can_stop, (const multipass::applevz::VMHandle& vm_handle), (const, override));
     MOCK_METHOD(bool,
                 can_request_stop,
-                (multipass::applevz::VMHandle & vm_handle),
+                (const multipass::applevz::VMHandle& vm_handle),
                 (const, override));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockAppleVZ, AppleVZ);

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -24,7 +24,7 @@
 
 namespace multipass::test
 {
-class MockAppleVZ : public multipass::applevz::AppleVZ
+class MockAppleVZWrapper : public multipass::applevz::AppleVZ
 {
 public:
     using AppleVZ::AppleVZ;
@@ -72,6 +72,6 @@ public:
                 (const, override));
     MOCK_METHOD(bool, is_supported, (), (const, override));
 
-    MP_MOCK_SINGLETON_BOILERPLATE(MockAppleVZ, AppleVZ);
+    MP_MOCK_SINGLETON_BOILERPLATE(MockAppleVZWrapper, AppleVZ);
 };
 } // namespace multipass::test

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "tests/common.h"
-#include "tests/mock_singleton_helpers.h"
+#include "tests/unit/common.h"
+#include "tests/unit/mock_singleton_helpers.h"
 
 #include <applevz/applevz_wrapper.h>
 

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -41,5 +41,23 @@ public:
                 stop_vm,
                 (bool force, multipass::applevz::VMHandle& vm_handle),
                 (const, override));
+    MOCK_METHOD(applevz::CFError,
+                pause_vm,
+                (multipass::applevz::VMHandle & vm_handle),
+                (const, override));
+    MOCK_METHOD(applevz::CFError,
+                resume_vm,
+                (multipass::applevz::VMHandle & vm_handle),
+                (const, override));
+    MOCK_METHOD(bool, can_start, (multipass::applevz::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool, can_pause, (multipass::applevz::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool, can_resume, (multipass::applevz::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool, can_stop, (multipass::applevz::VMHandle & vm_handle), (const, override));
+    MOCK_METHOD(bool,
+                can_request_stop,
+                (multipass::applevz::VMHandle & vm_handle),
+                (const, override));
+
+    MP_MOCK_SINGLETON_BOILERPLATE(MockAppleVZ, AppleVZ);
 };
 } // namespace multipass::test

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -61,6 +61,7 @@ public:
                 can_request_stop,
                 (const multipass::applevz::VMHandle& vm_handle),
                 (const, override));
+    MOCK_METHOD(bool, is_supported, (), (const, override));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockAppleVZ, AppleVZ);
 };

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "tests/common.h"
+#include "tests/mock_singleton_helpers.h"
+
+#include <applevz/applevz_wrapper.h>
+
+namespace multipass::test
+{
+class MockAppleVZ : public multipass::applevz::AppleVZ
+{
+public:
+    using AppleVZ::AppleVZ;
+    MOCK_METHOD(applevz::CFError,
+                create_vm,
+                (const multipass::VirtualMachineDescription& desc,
+                 multipass::applevz::VMHandle& out_handle),
+                (const, override));
+    MOCK_METHOD(applevz::CFError,
+                start_vm,
+                (multipass::applevz::VMHandle & vm_handle),
+                (const, override));
+    MOCK_METHOD(applevz::CFError,
+                stop_vm,
+                (bool force, multipass::applevz::VMHandle& vm_handle),
+                (const, override));
+};
+} // namespace multipass::test

--- a/tests/unit/applevz/test_applevz_virtual_machine.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine.cpp
@@ -141,10 +141,9 @@ TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromStoppedThrowsError)
         .WillOnce(Return(applevz::AppleVMState{}));
 
     EXPECT_CALL(mock_applevz, can_start(_)).WillOnce(Return(true));
-    EXPECT_CALL(mock_applevz, start_vm(_)).WillOnce(Invoke([](auto&) {
-        return applevz::CFError{
-            CFErrorCreate(kCFAllocatorDefault, CFSTR("UnitTestDomain"), 42, nullptr)};
-    }));
+    EXPECT_CALL(mock_applevz, start_vm(_))
+        .WillOnce(Return(applevz::CFError{
+            CFErrorCreate(kCFAllocatorDefault, CFSTR("UnitTestDomain"), 42, nullptr)}));
 
     EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
 
@@ -163,10 +162,9 @@ TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromPausedThrowsError)
         .WillOnce(Return(applevz::AppleVMState{}));
 
     EXPECT_CALL(mock_applevz, can_resume(_)).WillOnce(Return(true));
-    EXPECT_CALL(mock_applevz, resume_vm(_)).WillOnce(Invoke([](auto&) {
-        return applevz::CFError{
-            CFErrorCreate(kCFAllocatorDefault, CFSTR("UnitTestDomain"), 42, nullptr)};
-    }));
+    EXPECT_CALL(mock_applevz, resume_vm(_))
+        .WillOnce(Return(applevz::CFError{
+            CFErrorCreate(kCFAllocatorDefault, CFSTR("UnitTestDomain"), 42, nullptr)}));
 
     EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
 
@@ -186,9 +184,7 @@ TEST_F(AppleVZVirtualMachine_UnitTests, shutdownVMFromRunningWithPowerdownSucces
         .WillRepeatedly(Return(applevz::AppleVMState::stopped));
 
     EXPECT_CALL(mock_applevz, can_request_stop(_)).WillOnce(Return(true));
-    EXPECT_CALL(mock_applevz, stop_vm(_, false)).WillOnce(Invoke([](auto&, bool) {
-        return applevz::CFError{};
-    }));
+    EXPECT_CALL(mock_applevz, stop_vm(_, false)).WillOnce(Return(applevz::CFError{}));
 
     uut->shutdown(VirtualMachine::ShutdownPolicy::Powerdown);
 
@@ -204,9 +200,7 @@ TEST_F(AppleVZVirtualMachine_UnitTests, shutdownVMFromRunningWithPoweroffSuccess
         .WillRepeatedly(Return(applevz::AppleVMState::stopped));
 
     EXPECT_CALL(mock_applevz, can_stop(_)).WillOnce(Return(true));
-    EXPECT_CALL(mock_applevz, stop_vm(_, true)).WillOnce(Invoke([](auto&, bool) {
-        return applevz::CFError{};
-    }));
+    EXPECT_CALL(mock_applevz, stop_vm(_, true)).WillOnce(Return(applevz::CFError{}));
 
     uut->shutdown(VirtualMachine::ShutdownPolicy::Poweroff);
 
@@ -252,10 +246,9 @@ TEST_F(AppleVZVirtualMachine_UnitTests, shutdownForcedStopError)
     EXPECT_CALL(mock_applevz, get_state(_)).WillOnce(Return(applevz::AppleVMState::running));
 
     EXPECT_CALL(mock_applevz, can_stop(_)).WillOnce(Return(true));
-    EXPECT_CALL(mock_applevz, stop_vm(_, true)).WillOnce(Invoke([](auto&, bool) {
-        return applevz::CFError{
-            CFErrorCreate(kCFAllocatorDefault, CFSTR("TestDomain"), 456, nullptr)};
-    }));
+    EXPECT_CALL(mock_applevz, stop_vm(_, true))
+        .WillOnce(Return(applevz::CFError{
+            CFErrorCreate(kCFAllocatorDefault, CFSTR("UnitTestDomain"), 42, nullptr)}));
 
     EXPECT_NO_THROW(uut->shutdown(VirtualMachine::ShutdownPolicy::Poweroff));
     EXPECT_EQ(uut->current_state(), VirtualMachine::State::stopped);

--- a/tests/unit/applevz/test_applevz_virtual_machine.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine.cpp
@@ -17,12 +17,160 @@
 
 #include "mock_applevz_wrapper.h"
 #include "tests/common.h"
+#include "tests/mock_logger.h"
+#include "tests/mock_status_monitor.h"
+#include "tests/stub_ssh_key_provider.h"
+#include "tests/temp_dir.h"
+#include "tests/temp_file.h"
 
 #include <applevz/applevz_virtual_machine.h>
+#include <multipass/exceptions/virtual_machine_state_exceptions.h>
+
+namespace mp = multipass;
+namespace mpl = multipass::logging;
+namespace mpt = multipass::test;
+using namespace testing;
 
 namespace multipass::test
 {
 struct AppleVZVirtualMachine_UnitTests : public testing::Test
 {
+    mpt::TempFile dummy_image;
+    mpt::TempFile dummy_cloud_init_iso;
+    mpt::TempDir dummy_instances_dir;
+    const std::string dummy_vm_name{"lord-of-the-pings"};
+
+    mp::VirtualMachineDescription desc{2,
+                                       mp::MemorySize{"3M"},
+                                       mp::MemorySize{}, // not used
+                                       dummy_vm_name,
+                                       "aa:bb:cc:dd:ee:ff",
+                                       {},
+                                       "",
+                                       {dummy_image.name(), "", "", "", {}, {}},
+                                       dummy_cloud_init_iso.name(),
+                                       {},
+                                       {},
+                                       {},
+                                       {}};
+
+    mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject();
+
+    mpt::StubSSHKeyProvider stub_key_provider{};
+    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+
+    mpt::MockAppleVZ::GuardedMock mock_applevz_injection{mpt::MockAppleVZ::inject<NiceMock>()};
+    mpt::MockAppleVZ& mock_applevz = *mock_applevz_injection.first;
+
+    mpt::TempDir instance_dir;
 };
-} // namespace multipass::test
+
+TEST_F(AppleVZVirtualMachine_UnitTests, startFromStoppedStateCallsStartVm)
+{
+    mp::applevz::AppleVZVirtualMachine vm{desc,
+                                          mock_monitor,
+                                          stub_key_provider,
+                                          instance_dir.path()};
+
+    EXPECT_CALL(mock_applevz, get_state(_))
+        .WillOnce(Return(applevz::AppleVMState::stopped))
+        .WillOnce(Return(applevz::AppleVMState::running));
+    EXPECT_CALL(mock_applevz, can_start(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_applevz, start_vm(_)).WillOnce(Invoke([](auto&) {
+        return applevz::CFError{};
+    }));
+    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::starting));
+    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::running));
+
+    vm.start();
+
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::running);
+}
+
+TEST_F(AppleVZVirtualMachine_UnitTests, startFromPausedStateCallsResumeVm)
+{
+    mp::applevz::AppleVZVirtualMachine vm{desc,
+                                          mock_monitor,
+                                          stub_key_provider,
+                                          instance_dir.path()};
+
+    EXPECT_CALL(mock_applevz, get_state(_))
+        .WillOnce(Return(applevz::AppleVMState::paused))
+        .WillOnce(Return(applevz::AppleVMState::running));
+    EXPECT_CALL(mock_applevz, can_resume(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_applevz, resume_vm(_)).WillOnce(Invoke([](auto&) {
+        return applevz::CFError{};
+    }));
+    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, mp::VirtualMachine::State::starting));
+    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, mp::VirtualMachine::State::running));
+
+    vm.start();
+
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::running);
+}
+
+TEST_F(AppleVZVirtualMachine_UnitTests, startFromRunningStateNoOp)
+{
+    mp::applevz::AppleVZVirtualMachine vm{desc,
+                                          mock_monitor,
+                                          stub_key_provider,
+                                          instance_dir.path()};
+
+    EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::running));
+    EXPECT_CALL(mock_applevz, can_resume(_)).Times(0);
+    EXPECT_CALL(mock_applevz, can_start(_)).WillOnce(Return(false));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
+    logger_scope.mock_logger->expect_log(mpl::Level::warning,
+                                         fmt::format("VM `{}` cannot be started from state `{}`",
+                                                     desc.vm_name,
+                                                     mp::applevz::AppleVMState::running));
+
+    vm.start();
+
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::running);
+}
+
+TEST_F(AppleVZVirtualMachine_UnitTests, startVmErrorThrowsRuntimeError)
+{
+    mp::applevz::AppleVZVirtualMachine vm{desc,
+                                          mock_monitor,
+                                          stub_key_provider,
+                                          instance_dir.path()};
+
+    CFErrorRef error_ref = CFErrorCreate(kCFAllocatorDefault, CFSTR("TestDomain"), 42, nullptr);
+    applevz::CFError error{error_ref};
+
+    EXPECT_CALL(mock_applevz, get_state(_))
+        .WillOnce(Return(applevz::AppleVMState::stopped))
+        .WillOnce(Return(applevz::AppleVMState::error));
+    EXPECT_CALL(mock_applevz, can_start(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_applevz, start_vm(_)).WillOnce(Return(ByMove(std::move(error))));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
+
+    EXPECT_THROW(vm.start(), std::runtime_error);
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::unknown);
+}
+
+TEST_F(AppleVZVirtualMachine_UnitTests, startResumeErrorThrowsRuntimeError)
+{
+    mp::applevz::AppleVZVirtualMachine vm{desc,
+                                          mock_monitor,
+                                          stub_key_provider,
+                                          instance_dir.path()};
+
+    CFErrorRef error_ref = CFErrorCreate(kCFAllocatorDefault, CFSTR("TestDomain"), 42, nullptr);
+    applevz::CFError error{error_ref};
+
+    EXPECT_CALL(mock_applevz, get_state(_))
+        .WillOnce(Return(applevz::AppleVMState::paused))
+        .WillOnce(Return(applevz::AppleVMState::error));
+    EXPECT_CALL(mock_applevz, can_resume(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_applevz, resume_vm(_)).WillOnce(Return(ByMove(std::move(error))));
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
+
+    EXPECT_THROW(vm.start(), std::runtime_error);
+    EXPECT_EQ(vm.current_state(), VirtualMachine::State::unknown);
+}
+}; // namespace multipass::test

--- a/tests/unit/applevz/test_applevz_virtual_machine.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine.cpp
@@ -121,12 +121,6 @@ TEST_F(AppleVZVirtualMachine_UnitTests, startFromRunningStateNoOp)
     EXPECT_CALL(mock_applevz, can_start(_)).WillOnce(Return(false));
     EXPECT_CALL(mock_monitor, persist_state_for(_, _)).Times(AtLeast(1));
 
-    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
-    logger_scope.mock_logger->expect_log(mpl::Level::warning,
-                                         fmt::format("VM `{}` cannot be started from state `{}`",
-                                                     desc.vm_name,
-                                                     mp::applevz::AppleVMState::running));
-
     vm.start();
 
     EXPECT_EQ(vm.current_state(), VirtualMachine::State::running);

--- a/tests/unit/applevz/test_applevz_virtual_machine.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine.cpp
@@ -15,9 +15,10 @@
  *
  */
 
-#include <applevz/applevz_virtual_machine.h>
+#include "mock_applevz_wrapper.h"
+#include "tests/common.h"
 
-#include "tests/unit/common.h"
+#include <applevz/applevz_virtual_machine.h>
 
 namespace multipass::test
 {

--- a/tests/unit/qemu/test_qemu_img_utils.cpp
+++ b/tests/unit/qemu/test_qemu_img_utils.cpp
@@ -78,9 +78,9 @@ void simulate_qemuimg_resize(mpt::MockProcess* process,
     const auto args = process->arguments();
     ASSERT_EQ(args.size(), 5);
 
-    EXPECT_EQ(args.at(0), "-f");
-    EXPECT_EQ(args.at(1), "qcow2"); // default format from info
-    EXPECT_EQ(args.at(2), "resize");
+    EXPECT_EQ(args.at(0), "resize");
+    EXPECT_EQ(args.at(1), "-f");
+    EXPECT_EQ(args.at(2), "qcow2"); // default format from info
     EXPECT_EQ(args.at(3), expect_img);
     EXPECT_THAT(args.at(4),
                 ResultOf([](const auto& val) { return mp::MemorySize{val.toStdString()}; },


### PR DESCRIPTION
This PR implement the creation of virtual machines as well as some of the basic functions for manipulating the state of a virtual machine using the Apple Virtualization Framework. This includes:

- `start()`
- `shutdown(ShutdownPolicy shutdown_policy)`
- `suspend()` to memory for now

All Objective-C++ code, other helper functions needed to perform these actions, and unit tests for these functions are also included.

On top of being able to manually manage memory, Objective-C uses Automatic Reference Counting (ARC) where the system reference counting to automatically insert appropriate memory management method calls for you at compile-time. However, in order for objects to persist across the Objective-C/C++ boundary, we must use some types from the `CoreFoundation` library instead of the `Foundation` library, i.e., `CFErrorRef` over `NSError`, also known as Toll-Free Bridged Types. This allows us to control who owns the object and avoids having ARC and the Objective-C memory management system release memory before we are done with it. There are several macros that are used to tell the compiler about the ownership semantics of an object, but we mainly use:

- `__bridge`; for objects such as the `VMHandle` which were declared on the C++ side and where we don't want ownership to transfer when casting the `std::shared_ptr<void>` to virtualization framework virtual machine type; `VZVirtualMachine`.

- `__bridge_retained`: for objects that were created on the Objective-C side and for which we want to persist even after the block in which they were created finishes. We are responsible for manually freeing this type of object, so care must be taken in order when using this macro to prevent memory leaks. The use of this macro here is limited to returning errors from the Objective-C side to the C++ side through the use of the custom C++ type; `CFError`, which automatically calls `CFRelease` when destructed.

The other unique memory management mechanism that is used is the `autoreleasepool` block. This is used in special circumstances when a large number of temporary autoreleased object. The `autoreleasepool` sends an `autorelease` message to all objects in that block which are immediately released instead of at the end of the current event-loop iteration. This prevents temporary objects from unnecessarily accumulating and causing excessive overhead.

Additional reading:
- [Toll-Free Bridged Types](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFDesignConcepts/Articles/tollFreeBridgedTypes.html)
- [Core Foundation Memory Management](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/CFMemoryMgmt.html)
- [About Memory Management](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/MemoryMgmt.html)

---

MULTI-2257
MULTI-2258
MULTI-2260
MULTI-2261
MULTI-2266
MULTI-2267
MULTI-2268