### PR TITLE
[lint] Upgrade to clang-format-19

### DIFF
--- a/.github/actions/read-snapcraft-yml-params/action.yml
+++ b/.github/actions/read-snapcraft-yml-params/action.yml
@@ -1,0 +1,24 @@
+name: Read snapcraft.yml parameters
+description: Extracts parameters from snap/snapcraft.yaml for CI comsumption
+
+outputs:
+  clang-version:
+    description: The CLANG_VERSION value
+    value: ${{ steps.extract.outputs.clang_version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install yq
+      shell: bash
+      run: go install github.com/mikefarah/yq/v4@latest
+
+    - name: Extract CLANG_VERSION
+      id: extract
+      shell: bash
+      run: |
+        # Extract CLANG_VERSION from snapcraft.yaml (single source of truth)
+        CLANG_VERSION=$(yq '.parts.multipass.build-environment[] | select(has("CLANG_VERSION")) | .CLANG_VERSION' snap/snapcraft.yaml | tr -d '"')
+        [ -z "$CLANG_VERSION" ] && { echo "::error::CLANG_VERSION not found in snapcraft.yaml"; exit 1; }
+        echo "clang_version=$CLANG_VERSION" >> "$GITHUB_OUTPUT"
+        echo "SNAP_CLANG_VERSION=$CLANG_VERSION" >> "$GITHUB_ENV"

--- a/.github/actions/read-snapcraft-yml-params/action.yml
+++ b/.github/actions/read-snapcraft-yml-params/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         # Extract CLANG_VERSION from snapcraft.yaml (single source of truth)
-        CLANG_VERSION=$(yq '.parts.multipass.build-environment[] | select(has("CLANG_VERSION")) | .CLANG_VERSION' snap/snapcraft.yaml | tr -d '"')
+        CLANG_VERSION=$(yq -r '.parts.multipass.build-environment[] | select(has("CLANG_VERSION")) | .CLANG_VERSION' snap/snapcraft.yaml)
         [ -z "$CLANG_VERSION" ] && { echo "::error::CLANG_VERSION not found in snapcraft.yaml"; exit 1; }
         echo "clang_version=$CLANG_VERSION" >> "$GITHUB_OUTPUT"
         echo "SNAP_CLANG_VERSION=$CLANG_VERSION" >> "$GITHUB_ENV"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,6 @@ jobs:
 
           # On pull requests, HEAD^1 will always be the merge base, so consider that diff for formatting.
           git diff -U0 --no-color HEAD^1 \
-            | grep -vE '^\+\+\+ b/tests/unit/test_data/formatters/' \
             | clang-format-diff-$SNAP_CLANG_VERSION -p1 \
             | tee ${HOME}/clang-diff
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,31 +45,25 @@ jobs:
         shell: bash
         run: curl --fail-with-body -X POST --data-binary @.github/.codecov.yml https://codecov.io/validate
 
+      - uses: ./.github/actions/read-snapcraft-yml-params
+
       - name: Install clang-format
         shell: bash
-        run: sudo apt-get install --no-install-recommends --yes clang-format
+        run: sudo apt-get install --no-install-recommends --yes clang-format-$SNAP_CLANG_VERSION
 
       - name: Run clang-format through the diff
         shell: bash
         run: |
-          # WORKAROUND: clang-format-diff script in LLVM 18 is buggy -- it bails out on the first file
-          # when there are multiple files with format diffs.
-          # Pull and use LLVM 19's clang-format-diff for now.
-          # Remove after upgrading the LLVM.
-          curl -sL https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-19.1.0/clang/tools/clang-format/clang-format-diff.py \
-            -o /tmp/clang-format-diff
-          chmod +x /tmp/clang-format-diff
-
           # Print out version of clang-format being used
-          clang-format --version
+          clang-format-$SNAP_CLANG_VERSION --version
 
           # Ensure that the .clang-format configuration is valid
-          clang-format --dump-config > /dev/null
+          clang-format-$SNAP_CLANG_VERSION --dump-config > /dev/null
 
           # On pull requests, HEAD^1 will always be the merge base, so consider that diff for formatting.
           git diff -U0 --no-color HEAD^1 \
             | grep -vE '^\+\+\+ b/tests/unit/test_data/formatters/' \
-            | /tmp/clang-format-diff -p1 \
+            | clang-format-diff-$SNAP_CLANG_VERSION -p1 \
             | tee ${HOME}/clang-diff
 
           if [ "$( stat --printf='%s' ${HOME}/clang-diff )" -ne 0 ]; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,8 @@ jobs:
         shell: bash
         run: curl --fail-with-body -X POST --data-binary @.github/.codecov.yml https://codecov.io/validate
 
-      - uses: ./.github/actions/read-snapcraft-yml-params
+      - name: Read snapcraft.yml parameters
+        uses: ./.github/actions/read-snapcraft-yml-params
 
       - name: Install clang-format
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Run clang-format through the diff
         shell: bash
         run: |
+          # WORKAROUND: clang-format-diff script in LLVM 18 is buggy -- it bails out on the first file
+          # when there are multiple files with format diffs.
+          # Pull and use LLVM 19's clang-format-diff for now.
+          # Remove after upgrading the LLVM.
+          curl -sL https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-19.1.0/clang/tools/clang-format/clang-format-diff.py \
+            -o /tmp/clang-format-diff
+          chmod +x /tmp/clang-format-diff
+
           # Print out version of clang-format being used
           clang-format --version
 
@@ -61,7 +69,7 @@ jobs:
           # On pull requests, HEAD^1 will always be the merge base, so consider that diff for formatting.
           git diff -U0 --no-color HEAD^1 \
             | grep -vE '^\+\+\+ b/tests/unit/test_data/formatters/' \
-            | clang-format-diff -p1 \
+            | /tmp/clang-format-diff -p1 \
             | tee ${HOME}/clang-diff
 
           if [ "$( stat --printf='%s' ${HOME}/clang-diff )" -ne 0 ]; then

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,8 @@ jobs:
       id: build-params
       uses: ./.github/actions/build-params
 
-    - uses: ./.github/actions/read-snapcraft-yml-params
+    - name: Read snapcraft.yml parameters
+      uses: ./.github/actions/read-snapcraft-yml-params
 
     - name: Apply snapcraft-ci-override.yaml
       env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,6 +101,8 @@ jobs:
       id: build-params
       uses: ./.github/actions/build-params
 
+    - uses: ./.github/actions/read-snapcraft-yml-params
+
     - name: Apply snapcraft-ci-override.yaml
       env:
         MULTIPASS_BUILD_LABEL:  ${{ steps.build-params.outputs.label }}
@@ -110,11 +112,6 @@ jobs:
 
       run: |
         go install github.com/mikefarah/yq/v4@latest
-
-        # Extract CLANG_VERSION from snapcraft.yaml (single source of truth)
-        CLANG_VERSION=$(yq '.parts.multipass.build-environment[] | select(has("CLANG_VERSION")) | .CLANG_VERSION' snap/snapcraft.yaml | tr -d '"')
-        [ -z "$CLANG_VERSION" ] && { echo "::error::CLANG_VERSION not found in snapcraft.yaml"; exit 1; }
-        export CLANG_VERSION
 
         # Substitute the environment variables in the snapcraft-ci-override.yaml
         envsubst < snap/local/snapcraft-ci-override.yaml.in | yq eval 'del(.. | select(. == null or . == "")) | del(.. | select((tag == "!!map" or tag == "!!seq") and length == 0))' -P > snap/local/snapcraft-ci-override.yaml

--- a/snap/local/snapcraft-ci-override.yaml.in
+++ b/snap/local/snapcraft-ci-override.yaml.in
@@ -39,7 +39,7 @@ parts:
   run-clang-tidy:
     plugin: nil
     build-packages:
-      - clang-tidy-${CLANG_VERSION}
+      - clang-tidy-${SNAP_CLANG_VERSION}
     override-pull: |
       set -e
       if [ "$CMAKE_PRESET" != "ci-snap-debug" ]; then
@@ -48,7 +48,7 @@ parts:
       fi
       cd /root/parts/multipass/src
       cmake --build ../build --target rpc
-      git diff -U0 --no-color HEAD^1 | clang-tidy-diff-${CLANG_VERSION}.py -p1 -path ../build/ -clang-tidy-binary=clang-tidy-${CLANG_VERSION} -j$(nproc) -quiet | sed '/^$/d' | tee clang-tidy-diff
+      git diff -U0 --no-color HEAD^1 | clang-tidy-diff-${SNAP_CLANG_VERSION}.py -p1 -path ../build/ -clang-tidy-binary=clang-tidy-${SNAP_CLANG_VERSION} -j$(nproc) -quiet | sed '/^$/d' | tee clang-tidy-diff
 
       # I don't think clang-tidy knows what "quiet" means.
       sed -i '/No relevant changes found\./d' clang-tidy-diff

--- a/tests/unit/test_data/formatters/.clang-format
+++ b/tests/unit/test_data/formatters/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION
clang-format-diff-18 seems to emit only the first file in the diff when there are multiple, which makes it really cumbersome to iterate over the lint failures.

~~This patch temporarily introduces clang-format-diff-19 as a workaround. The script still uses clang-format-18 for producing the diff, so the format output should be the same.~~

This patch upgrades the clang-format to 19 by reading the snapcraft.yml's CLANG_VERSION variable and installing the specific clang-format version.

# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
Fixes a CI lint step bug.
- Why is this change needed?
It's really hard to iterate over lint bugs as the tool emits one diff at a time.