### PR TITLE
[vm-image-vault] Check for empty json before parse

### DIFF
--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -53,7 +53,7 @@ std::unordered_map<std::string, mp::VaultRecord> load_db(const QString& db_name)
 {
     QFile db_file{db_name};
     auto opened = db_file.open(QIODevice::ReadOnly);
-    if (!opened)
+    if (!opened || db_file.size() == 0)
         return {};
 
     auto records = boost::json::parse(std::string_view(db_file.readAll()));


### PR DESCRIPTION
boost::json::parse throws an exception if the input is empty so guard against that.


