### PR TITLE
[platform-win] Add null check to pOldDACL

### DIFF
--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -716,7 +716,7 @@ auto new_ACL(LPSTR path)
         return newACL;
     }
 
-    if(nullptr == pOldDACL)
+    if (nullptr == pOldDACL)
         return newACL;
 
     DWORD size = sizeof(ACL);

--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -703,7 +703,7 @@ auto new_ACL(LPSTR path)
     PSECURITY_DESCRIPTOR pSD;
     auto pSD_guard = sg::make_scope_guard([&pSD]() noexcept { LocalFree((HLOCAL)(pSD)); });
 
-    PACL pOldDACL = NULL;
+    PACL pOldDACL = nullptr;
     if (GetNamedSecurityInfo(path,
                              SE_FILE_OBJECT,
                              DACL_SECURITY_INFORMATION,
@@ -715,6 +715,9 @@ auto new_ACL(LPSTR path)
     {
         return newACL;
     }
+
+    if(nullptr == pOldDACL)
+        return newACL;
 
     DWORD size = sizeof(ACL);
     std::vector<ACCESS_ALLOWED_ACE*> aces{};


### PR DESCRIPTION
The new_ACL function assumes that pOldDACL ptr would be non-empty after a successful `GetNamedSecurityInfo` call, but that premise does not exist

Excerpt from `GetNamedSecurityInfo` docs:

> A pointer to a variable that receives a pointer to the DACL in the
> returned security descriptor or NULL if the security descriptor has
> no DACL. The returned pointer is valid only if you set the DACL_SECURITY_INFORMATION
> flag. Also, this parameter can be NULL if you do not need the DACL.

NULL DACL is a valid return value, indicating that the queried security info has no DACL (i.e., no access restrictions).

The patch adds a null check to fix that.

MULTI-2519