### PR TITLE
[new-release-monitor] Replace QString with std

### DIFF
--- a/include/multipass/new_release_info.h
+++ b/include/multipass/new_release_info.h
@@ -17,25 +17,22 @@
 
 #pragma once
 
-#include <QMetaType>
-#include <QUrl>
-
 #include <boost/json.hpp>
+
+#include <string>
 
 namespace multipass
 {
 
 struct NewReleaseInfo
 {
-    QString version;
-    QUrl url;
-    QString title;
-    QString description;
+    std::string version;
+    std::string url;
+    std::string title;
+    std::string description;
 };
 
 NewReleaseInfo tag_invoke(const boost::json::value_to_tag<NewReleaseInfo>&,
                           const boost::json::value& json);
 
 } // namespace multipass
-
-Q_DECLARE_METATYPE(multipass::NewReleaseInfo)

--- a/src/platform/update/default_update_prompt.cpp
+++ b/src/platform/update/default_update_prompt.cpp
@@ -50,10 +50,10 @@ void mp::DefaultUpdatePrompt::populate(mp::UpdateInfo* update_info)
     auto new_release = monitor->get_new_release();
     if (new_release)
     {
-        update_info->set_version(new_release->version.toStdString());
-        update_info->set_url(new_release->url.toEncoded());
-        update_info->set_title(new_release->title.toStdString());
-        update_info->set_description(new_release->description.toStdString());
+        update_info->set_version(new_release->version);
+        update_info->set_url(new_release->url);
+        update_info->set_title(new_release->title);
+        update_info->set_description(new_release->description);
         last_shown = std::chrono::system_clock::now();
     }
 }

--- a/src/platform/update/new_release_monitor.cpp
+++ b/src/platform/update/new_release_monitor.cpp
@@ -40,33 +40,32 @@ constexpr auto json_description = "description";
 mp::NewReleaseInfo mp::tag_invoke(const boost::json::value_to_tag<mp::NewReleaseInfo>&,
                                   const boost::json::value& json)
 {
-    return {value_to<QString>(json.at(::json_tag_name)),
-            value_to<QString>(json.at(::json_html_url)),
-            mp::lookup_or<QString>(json, ::json_title, ""),
-            mp::lookup_or<QString>(json, ::json_description, "")};
+    return {value_to<std::string>(json.at(::json_tag_name)),
+            value_to<std::string>(json.at(::json_html_url)),
+            mp::lookup_or<std::string>(json, ::json_title, ""),
+            mp::lookup_or<std::string>(json, ::json_description, "")};
 }
 
 class mp::LatestReleaseChecker : public QThread
 {
     Q_OBJECT
 public:
-    LatestReleaseChecker(QString update_url) : update_url(update_url)
+    LatestReleaseChecker(std::string url) : update_url(QString::fromStdString(url))
     {
     }
 
     void run() override
     {
-        QUrl url(update_url);
         try
         {
             mp::URLDownloader downloader(::timeout);
-            QByteArray json = downloader.download(url);
+            QByteArray json = downloader.download(update_url);
             const auto manifest = boost::json::parse(std::string_view{json});
             auto release = value_to<mp::NewReleaseInfo>(manifest);
 
             mpl::debug("update",
                        "Latest Multipass release available is version {}",
-                       qUtf8Printable(release.version));
+                       release.version);
 
             emit latest_release_found(release);
         }
@@ -83,12 +82,12 @@ signals:
     void latest_release_found(const multipass::NewReleaseInfo& release);
 
 private:
-    const QString update_url;
+    const QUrl update_url;
 };
 
-mp::NewReleaseMonitor::NewReleaseMonitor(const QString& current_version,
+mp::NewReleaseMonitor::NewReleaseMonitor(const std::string& current_version,
                                          std::chrono::steady_clock::duration refresh_rate,
-                                         const QString& update_url)
+                                         const std::string& update_url)
     : current_version(current_version), update_url(update_url)
 {
     qRegisterMetaType<multipass::NewReleaseInfo>(); // necessary to allow custom type be passed in
@@ -112,24 +111,22 @@ void mp::NewReleaseMonitor::latest_release_found(const NewReleaseInfo& latest_re
 {
     try
     {
-        const multipass::opaque_semver current{current_version.toStdString()};
-        const multipass::opaque_semver latest{latest_release.version.toStdString()};
+        const multipass::opaque_semver current{current_version};
+        const multipass::opaque_semver latest{latest_release.version};
         // Deliberately keeping all version string parsing here. If any version string
         // not of correct form, throw.
         if (current < latest)
         {
             new_release = latest_release;
-            mpl::info("update",
-                      "A New Multipass release is available: {}",
-                      qUtf8Printable(new_release->version));
+            mpl::info("update", "A New Multipass release is available: {}", new_release->version);
         }
     }
     catch (const std::invalid_argument& e)
     {
         mpl::warn("update",
                   "Version strings {} and {} not comparable: {}",
-                  qUtf8Printable(current_version),
-                  qUtf8Printable(latest_release.version),
+                  current_version,
+                  latest_release.version,
                   e.what());
     }
 }

--- a/src/platform/update/new_release_monitor.h
+++ b/src/platform/update/new_release_monitor.h
@@ -21,7 +21,6 @@
 #include <multipass/qt_delete_later_unique_ptr.h>
 
 #include <QObject>
-#include <QString>
 #include <QTimer>
 
 #include <optional>
@@ -47,9 +46,9 @@ public:
     static constexpr auto default_update_url =
         "https://canonical.com/static/files/latest-multipass-releases.json";
 
-    NewReleaseMonitor(const QString& current_version,
+    NewReleaseMonitor(const std::string& current_version,
                       std::chrono::steady_clock::duration refresh_rate,
-                      const QString& update_url = default_update_url);
+                      const std::string& update_url = default_update_url);
     ~NewReleaseMonitor();
 
     std::optional<NewReleaseInfo> get_new_release() const;
@@ -59,7 +58,7 @@ private slots:
     void latest_release_found(const NewReleaseInfo& latest_release);
 
 private:
-    const QString current_version, update_url;
+    const std::string current_version, update_url;
     std::optional<NewReleaseInfo> new_release;
     QTimer refresh_timer;
 

--- a/tests/unit/test_new_release_monitor.cpp
+++ b/tests/unit/test_new_release_monitor.cpp
@@ -45,7 +45,7 @@ const QString json_template = R"END({
 class StubUpdateJson
 {
 public:
-    StubUpdateJson(QString version, QString url)
+    StubUpdateJson(std::string version, std::string url)
     {
         if (!json_file.open())
             throw std::runtime_error("test failed to create temporary file");
@@ -62,12 +62,12 @@ private:
     QTemporaryFile json_file;
 };
 
-auto check_for_new_release(QString currentVersion, QString newVersion, QString newVersionUrl = "")
+auto check_for_new_release(std::string currentVersion, std::string newVersion, std::string newVersionUrl = "")
 {
     QEventLoop e;
     StubUpdateJson json(newVersion, newVersionUrl);
 
-    mp::NewReleaseMonitor monitor(currentVersion, std::chrono::hours(1), json.url());
+    mp::NewReleaseMonitor monitor(currentVersion, std::chrono::hours(1), json.url().toStdString());
 
     // TODO replace with a thread sync mechanism (e.g. condition)
     QTimer::singleShot(timeout, &e, &QEventLoop::quit);
@@ -83,8 +83,8 @@ TEST(NewReleaseMonitor, checksNewRelease)
     auto new_release = check_for_new_release("0.1.0", "0.2.0", "https://something_unique.com");
 
     ASSERT_TRUE(new_release);
-    EXPECT_EQ("0.2.0", new_release->version.toStdString());
-    EXPECT_EQ("https://something_unique.com", new_release->url.toString().toStdString());
+    EXPECT_EQ("0.2.0", new_release->version);
+    EXPECT_EQ("https://something_unique.com", new_release->url);
 }
 
 TEST(NewReleaseMonitor, checksNewReleaseWhenNothingNew)
@@ -128,7 +128,7 @@ TEST(NewReleaseMonitor, devPrereleaseOrderingCorrect1)
     auto new_release = check_for_new_release("0.6.0-dev.238+g5c642f4", "0.6.0");
 
     ASSERT_TRUE(new_release);
-    EXPECT_EQ("0.6.0", new_release->version.toStdString());
+    EXPECT_EQ("0.6.0", new_release->version);
 }
 
 TEST(NewReleaseMonitor, rcPrereleaseOrderingCorrect)

--- a/tests/unit/test_new_release_monitor.cpp
+++ b/tests/unit/test_new_release_monitor.cpp
@@ -62,7 +62,9 @@ private:
     QTemporaryFile json_file;
 };
 
-auto check_for_new_release(std::string currentVersion, std::string newVersion, std::string newVersionUrl = "")
+auto check_for_new_release(std::string currentVersion,
+                           std::string newVersion,
+                           std::string newVersionUrl = "")
 {
     QEventLoop e;
     StubUpdateJson json(newVersion, newVersionUrl);


### PR DESCRIPTION
Replace QT QString with std::string for new release monitor code.