### PR TITLE
[debian-control] Replace clang with llvm

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: multipass
 Build-Depends: build-essential,
-               clang,
+               llvm,
                cmake,
                curl,
                google-mock,


### PR DESCRIPTION
The Flutter build depends on lld and llvm-ar, which are not included in the clang package.

Closes #4737
