### PR TITLE
Purge QT from vm image vault

### DIFF
--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -108,7 +108,7 @@ public:
 
     // std operations
     virtual void open(std::fstream& stream,
-                      const std::filesystem::path& filename,
+                      const fs::path& filename,
                       std::ios_base::openmode mode) const;
     virtual bool is_open(const std::ifstream& file) const;
     virtual std::ifstream& read(std::ifstream& file, char* buffer, std::streamsize size) const;

--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -119,6 +119,11 @@ public:
     virtual void copy(const fs::path& src,
                       const fs::path& dist,
                       fs::copy_options copy_options) const;
+    virtual void copy(const fs::path& src,
+                      const fs::path& dist,
+                      fs::copy_options copy_options,
+                      std::error_code& ec) const;
+    virtual bool exists(const fs::path& path) const;
     virtual bool exists(const fs::path& path, std::error_code& err) const;
     virtual bool is_directory(const fs::path& path, std::error_code& err) const;
     virtual bool create_directory(const fs::path& path, std::error_code& err) const;

--- a/include/multipass/file_ops.h
+++ b/include/multipass/file_ops.h
@@ -108,7 +108,7 @@ public:
 
     // std operations
     virtual void open(std::fstream& stream,
-                      const char* filename,
+                      const std::filesystem::path& filename,
                       std::ios_base::openmode mode) const;
     virtual bool is_open(const std::ifstream& file) const;
     virtual std::ifstream& read(std::ifstream& file, char* buffer, std::streamsize size) const;

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -80,6 +80,9 @@ public:
 
     [[nodiscard]] virtual std::filesystem::path get_root_cert_dir() const;
     [[nodiscard]] std::filesystem::path get_root_cert_path() const;
+    // Converts QString to path, using appropriate string functions depending on the platform
+    [[nodiscard]] virtual std::filesystem::path qstr_to_path(const QString& qstr) const;
+    [[nodiscard]] virtual QString path_to_qstr(const std::filesystem::path& path) const;
 };
 
 QString interpret_setting(const QString& key, const QString& val);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -78,9 +78,6 @@ std::string contents_of(const multipass::Path& file_path);
 std::filesystem::path normalize_path(const std::filesystem::path& path);
 std::string normalize_path(const std::string& path);
 QString normalize_path(const QString& path);
-// Converts QString to path, using appropriate string functions depending on the platform
-[[nodiscard]] std::filesystem::path qstr_to_path(const QString& qstr);
-[[nodiscard]] QString path_to_qstr(const std::filesystem::path& path);
 
 // filesystem mount helpers
 void make_target_dir(SSHSession& session,

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -78,6 +78,9 @@ std::string contents_of(const multipass::Path& file_path);
 std::filesystem::path normalize_path(const std::filesystem::path& path);
 std::string normalize_path(const std::string& path);
 QString normalize_path(const QString& path);
+// Converts QString to path, using appropriate string functions depending on the platform
+[[nodiscard]] std::filesystem::path qstr_to_path(const QString& qstr);
+[[nodiscard]] QString path_to_qstr(const std::filesystem::path& path);
 
 // filesystem mount helpers
 void make_target_dir(SSHSession& session,

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -327,16 +327,6 @@ inline bool multipass::utils::iequals(std::string_view lhs, std::string_view rhs
     });
 }
 
-inline bool multipass::utils::istarts_with(std::string_view str, std::string_view prefix)
-{
-    if (prefix.size() > str.size())
-        return false;
-    return std::ranges::equal(
-        str | std::views::take(prefix.size()),
-        prefix,
-        [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); });
-}
-
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>
 void multipass::utils::try_action_for(OnTimeoutCallable&& on_timeout,
                                       std::chrono::milliseconds timeout,

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -32,6 +32,7 @@
 #include <filesystem>
 #include <functional>
 #include <future>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -133,6 +134,7 @@ Str&& trim(Str&& s, Filter&& filter);
 template <typename Str>
 Str&& trim(Str&& s);
 bool iequals(std::string_view lhs, std::string_view rhs);
+bool istarts_with(std::string_view str, std::string_view prefix);
 std::string& trim_newline(std::string& s);
 std::string escape_for_shell(const std::string& s);
 std::vector<std::string> split(const std::string& string, const std::string& delimiter);
@@ -320,6 +322,16 @@ inline bool multipass::utils::iequals(std::string_view lhs, std::string_view rhs
     return std::ranges::equal(lhs, rhs, [](char c1, char c2) {
         return tolower(c1) == tolower(c2);
     });
+}
+
+inline bool multipass::utils::istarts_with(std::string_view str, std::string_view prefix)
+{
+    if (prefix.size() > str.size())
+        return false;
+    return std::ranges::equal(
+        str | std::views::take(prefix.size()),
+        prefix,
+        [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); });
 }
 
 template <typename OnTimeoutCallable, typename TryAction, typename... Args>

--- a/include/multipass/vm_image_vault_utils.h
+++ b/include/multipass/vm_image_vault_utils.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
-#include "file_ops.h"
 #include "xz_image_decoder.h"
 
+#include <filesystem>
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -38,28 +38,29 @@ class ImageVaultUtils : public Singleton<ImageVaultUtils>
 public:
     ImageVaultUtils(const PrivatePass&) noexcept;
 
-    using Decoder = std::function<void(const QString&, const QString&)>;
+    using Decoder = std::function<void(const std::string&, const std::string&)>;
     using DefaultDecoderT = XzImageDecoder;
 
-    virtual QString copy_to_dir(const QString& file, const QDir& output_dir) const;
-    [[nodiscard]] virtual QString compute_hash(
-        QIODevice& device,
+    virtual std::filesystem::path copy_to_dir(const std::filesystem::path& file,
+                                              const QDir& output_dir) const;
+    [[nodiscard]] virtual std::string compute_hash(
+        std::istream& stream,
         const QCryptographicHash::Algorithm algo = QCryptographicHash::Sha256) const;
-    [[nodiscard]] virtual QString compute_file_hash(
-        const QString& file,
+    [[nodiscard]] virtual std::string compute_file_hash(
+        const std::filesystem::path& file,
         const QCryptographicHash::Algorithm algo = QCryptographicHash::Sha256) const;
 
-    virtual void verify_file_hash(const QString& file, const QString& hash) const;
+    virtual void verify_file_hash(const std::filesystem::path& file, const std::string& hash) const;
 
-    virtual QString extract_file(const QString& file,
-                                 const Decoder& decoder,
-                                 bool delete_original = false) const;
+    virtual std::filesystem::path extract_file(const std::filesystem::path& file,
+                                               const Decoder& decoder,
+                                               bool delete_original = false) const;
 
     template <class DecoderT = DefaultDecoderT>
-    QString extract_file(const QString& file,
-                         const ProgressMonitor& monitor,
-                         bool delete_original = false,
-                         const DecoderT& = DecoderT{}) const;
+    std::filesystem::path extract_file(const std::filesystem::path& file,
+                                       const ProgressMonitor& monitor,
+                                       bool delete_original = false,
+                                       const DecoderT& = DecoderT{}) const;
 
     using HostMap = std::unordered_map<std::string, VMImageHost*>;
     using Hosts = std::vector<VMImageHost*>;
@@ -68,14 +69,14 @@ public:
 };
 
 template <class DecoderT>
-QString ImageVaultUtils::extract_file(const QString& file,
-                                      const ProgressMonitor& monitor,
-                                      bool delete_original,
-                                      const DecoderT& decoder) const
+std::filesystem::path ImageVaultUtils::extract_file(const std::filesystem::path& file,
+                                                    const ProgressMonitor& monitor,
+                                                    bool delete_original,
+                                                    const DecoderT& decoder) const
 {
-    auto decoder_fn = [&monitor, &decoder](const QString& encoded_file,
-                                           const QString& destination) {
-        return decoder.decode_to(encoded_file.toStdString(), destination.toStdString(), monitor);
+    auto decoder_fn = [&monitor, &decoder](const std::string& encoded_file,
+                                           const std::string& destination) {
+        return decoder.decode_to(encoded_file, destination, monitor);
     };
 
     return extract_file(file, decoder_fn, delete_original);

--- a/include/multipass/vm_image_vault_utils.h
+++ b/include/multipass/vm_image_vault_utils.h
@@ -42,7 +42,7 @@ public:
     using DefaultDecoderT = XzImageDecoder;
 
     virtual std::filesystem::path copy_to_dir(const std::filesystem::path& file,
-                                              const QDir& output_dir) const;
+                                              const std::filesystem::path& output_dir) const;
     [[nodiscard]] virtual std::string compute_hash(
         std::istream& stream,
         const QCryptographicHash::Algorithm algo = QCryptographicHash::Sha256) const;

--- a/include/multipass/vm_image_vault_utils.h
+++ b/include/multipass/vm_image_vault_utils.h
@@ -38,7 +38,7 @@ class ImageVaultUtils : public Singleton<ImageVaultUtils>
 public:
     ImageVaultUtils(const PrivatePass&) noexcept;
 
-    using Decoder = std::function<void(const std::string&, const std::string&)>;
+    using Decoder = std::function<void(const std::filesystem::path&, const std::filesystem::path&)>;
     using DefaultDecoderT = XzImageDecoder;
 
     virtual std::filesystem::path copy_to_dir(const std::filesystem::path& file,
@@ -74,8 +74,8 @@ std::filesystem::path ImageVaultUtils::extract_file(const std::filesystem::path&
                                                     bool delete_original,
                                                     const DecoderT& decoder) const
 {
-    auto decoder_fn = [&monitor, &decoder](const std::string& encoded_file,
-                                           const std::string& destination) {
+    auto decoder_fn = [&monitor, &decoder](const std::filesystem::path& encoded_file,
+                                           const std::filesystem::path& destination) {
         return decoder.decode_to(encoded_file, destination, monitor);
     };
 

--- a/include/multipass/vm_image_vault_utils.h
+++ b/include/multipass/vm_image_vault_utils.h
@@ -25,8 +25,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <QCryptographicHash>
-
 #define MP_IMAGE_VAULT_UTILS multipass::ImageVaultUtils::instance()
 
 namespace multipass
@@ -36,6 +34,12 @@ class VMImageHost;
 class ImageVaultUtils : public Singleton<ImageVaultUtils>
 {
 public:
+    enum class EHashAlgorithm : std::uint8_t
+    {
+        sha256,
+        sha512
+    };
+
     ImageVaultUtils(const PrivatePass&) noexcept;
 
     using Decoder = std::function<void(const std::filesystem::path&, const std::filesystem::path&)>;
@@ -43,12 +47,12 @@ public:
 
     virtual std::filesystem::path copy_to_dir(const std::filesystem::path& file,
                                               const std::filesystem::path& output_dir) const;
-    [[nodiscard]] virtual std::string compute_hash(
-        std::istream& stream,
-        const QCryptographicHash::Algorithm algo = QCryptographicHash::Sha256) const;
+    [[nodiscard]] virtual std::string
+    compute_hash(std::istream& stream, EHashAlgorithm algo = EHashAlgorithm::sha256) const;
+
     [[nodiscard]] virtual std::string compute_file_hash(
         const std::filesystem::path& file,
-        const QCryptographicHash::Algorithm algo = QCryptographicHash::Sha256) const;
+        EHashAlgorithm algo = EHashAlgorithm::sha256) const;
 
     virtual void verify_file_hash(const std::filesystem::path& file, const std::string& hash) const;
 

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -659,15 +659,15 @@ mp::VMImage mp::DefaultVMImageVault::image_instance_from(const VMImage& prepared
 {
     MP_UTILS.make_dir(dest_dir);
 
-    return {
-        QString::fromStdString(
-            MP_IMAGE_VAULT_UTILS.copy_to_dir(prepared_image.image_path.toStdString(), dest_dir)),
-        prepared_image.id,
-        prepared_image.original_release,
-        prepared_image.current_release,
-        prepared_image.release_date,
-        prepared_image.os,
-        {}};
+    return {QString::fromStdString(
+                MP_IMAGE_VAULT_UTILS.copy_to_dir(prepared_image.image_path.toStdString(),
+                                                 dest_dir.toStdString())),
+            prepared_image.id,
+            prepared_image.original_release,
+            prepared_image.current_release,
+            prepared_image.release_date,
+            prepared_image.os,
+            {}};
 }
 
 std::optional<QFuture<mp::VMImage>> mp::DefaultVMImageVault::get_image_future(const std::string& id)

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -224,7 +224,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
 
         vm_image = prepare(source_image);
         vm_image.id =
-            MP_IMAGE_VAULT_UTILS.compute_file_hash(mp::utils::qstr_to_path(vm_image.image_path));
+            MP_IMAGE_VAULT_UTILS.compute_file_hash(MP_PLATFORM.qstr_to_path(vm_image.image_path));
 
         remove_source_images(source_image, vm_image);
 
@@ -615,14 +615,14 @@ mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
         {
             mpl::debug(category, "Verifying hash \"{}\"", id);
             monitor(LaunchProgress::VERIFY, -1);
-            MP_IMAGE_VAULT_UTILS.verify_file_hash(mp::utils::qstr_to_path(source_image.image_path),
+            MP_IMAGE_VAULT_UTILS.verify_file_hash(MP_PLATFORM.qstr_to_path(source_image.image_path),
                                                   id.toStdString());
         }
 
         if (source_image.image_path.endsWith(".xz"))
         {
-            source_image.image_path = mp::utils::path_to_qstr(
-                MP_IMAGE_VAULT_UTILS.extract_file(utils::qstr_to_path(source_image.image_path),
+            source_image.image_path = MP_PLATFORM.path_to_qstr(
+                MP_IMAGE_VAULT_UTILS.extract_file(MP_PLATFORM.qstr_to_path(source_image.image_path),
                                                   monitor,
                                                   true));
         }
@@ -651,8 +651,8 @@ QString mp::DefaultVMImageVault::extract_image_from(const VMImage& source_image,
     const auto image_name = file_info.fileName().remove(".xz");
     const auto image_path = QDir(dest_dir).filePath(image_name);
 
-    return utils::path_to_qstr(
-        MP_IMAGE_VAULT_UTILS.extract_file(utils::qstr_to_path(image_path), monitor));
+    return MP_PLATFORM.path_to_qstr(
+        MP_IMAGE_VAULT_UTILS.extract_file(MP_PLATFORM.qstr_to_path(image_path), monitor));
 }
 
 mp::VMImage mp::DefaultVMImageVault::image_instance_from(const VMImage& prepared_image,
@@ -660,9 +660,9 @@ mp::VMImage mp::DefaultVMImageVault::image_instance_from(const VMImage& prepared
 {
     MP_UTILS.make_dir(dest_dir);
 
-    return {utils::path_to_qstr(
-                MP_IMAGE_VAULT_UTILS.copy_to_dir(utils::qstr_to_path(prepared_image.image_path),
-                                                 utils::qstr_to_path(dest_dir))),
+    return {MP_PLATFORM.path_to_qstr(MP_IMAGE_VAULT_UTILS.copy_to_dir(
+                MP_PLATFORM.qstr_to_path(prepared_image.image_path),
+                MP_PLATFORM.qstr_to_path(dest_dir))),
             prepared_image.id,
             prepared_image.original_release,
             prepared_image.current_release,

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -621,9 +621,9 @@ mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
         if (source_image.image_path.endsWith(".xz"))
         {
             source_image.image_path = QString::fromStdString(
-                MP_IMAGE_VAULT_UTILS.extract_file(source_image.image_path.toStdString(),
-                                                  monitor,
-                                                  true));
+                MP_IMAGE_VAULT_UTILS
+                    .extract_file(source_image.image_path.toStdString(), monitor, true)
+                    .string());
         }
 
         auto prepared_image = prepare(source_image);
@@ -660,8 +660,9 @@ mp::VMImage mp::DefaultVMImageVault::image_instance_from(const VMImage& prepared
     MP_UTILS.make_dir(dest_dir);
 
     return {QString::fromStdString(
-                MP_IMAGE_VAULT_UTILS.copy_to_dir(prepared_image.image_path.toStdString(),
-                                                 dest_dir.toStdString())),
+                MP_IMAGE_VAULT_UTILS
+                    .copy_to_dir(prepared_image.image_path.toStdString(), dest_dir.toStdString())
+                    .string()),
             prepared_image.id,
             prepared_image.original_release,
             prepared_image.current_release,

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -223,7 +223,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
         }
 
         vm_image = prepare(source_image);
-        vm_image.id = MP_IMAGE_VAULT_UTILS.compute_file_hash(vm_image.image_path).toStdString();
+        vm_image.id = MP_IMAGE_VAULT_UTILS.compute_file_hash(vm_image.image_path.toStdString());
 
         remove_source_images(source_image, vm_image);
 
@@ -614,13 +614,16 @@ mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
         {
             mpl::debug(category, "Verifying hash \"{}\"", id);
             monitor(LaunchProgress::VERIFY, -1);
-            MP_IMAGE_VAULT_UTILS.verify_file_hash(source_image.image_path, id);
+            MP_IMAGE_VAULT_UTILS.verify_file_hash(source_image.image_path.toStdString(),
+                                                  id.toStdString());
         }
 
         if (source_image.image_path.endsWith(".xz"))
         {
-            source_image.image_path =
-                MP_IMAGE_VAULT_UTILS.extract_file(source_image.image_path, monitor, true);
+            source_image.image_path = QString::fromStdString(
+                MP_IMAGE_VAULT_UTILS.extract_file(source_image.image_path.toStdString(),
+                                                  monitor,
+                                                  true));
         }
 
         auto prepared_image = prepare(source_image);
@@ -647,7 +650,8 @@ QString mp::DefaultVMImageVault::extract_image_from(const VMImage& source_image,
     const auto image_name = file_info.fileName().remove(".xz");
     const auto image_path = QDir(dest_dir).filePath(image_name);
 
-    return MP_IMAGE_VAULT_UTILS.extract_file(image_path, monitor);
+    return QString::fromStdString(
+        MP_IMAGE_VAULT_UTILS.extract_file(image_path.toStdString(), monitor).string());
 }
 
 mp::VMImage mp::DefaultVMImageVault::image_instance_from(const VMImage& prepared_image,
@@ -655,13 +659,15 @@ mp::VMImage mp::DefaultVMImageVault::image_instance_from(const VMImage& prepared
 {
     MP_UTILS.make_dir(dest_dir);
 
-    return {MP_IMAGE_VAULT_UTILS.copy_to_dir(prepared_image.image_path, dest_dir),
-            prepared_image.id,
-            prepared_image.original_release,
-            prepared_image.current_release,
-            prepared_image.release_date,
-            prepared_image.os,
-            {}};
+    return {
+        QString::fromStdString(
+            MP_IMAGE_VAULT_UTILS.copy_to_dir(prepared_image.image_path.toStdString(), dest_dir)),
+        prepared_image.id,
+        prepared_image.original_release,
+        prepared_image.current_release,
+        prepared_image.release_date,
+        prepared_image.os,
+        {}};
 }
 
 std::optional<QFuture<mp::VMImage>> mp::DefaultVMImageVault::get_image_future(const std::string& id)

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -223,7 +223,8 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
         }
 
         vm_image = prepare(source_image);
-        vm_image.id = MP_IMAGE_VAULT_UTILS.compute_file_hash(vm_image.image_path.toStdString());
+        vm_image.id =
+            MP_IMAGE_VAULT_UTILS.compute_file_hash(mp::utils::qstr_to_path(vm_image.image_path));
 
         remove_source_images(source_image, vm_image);
 
@@ -614,16 +615,16 @@ mp::VMImage mp::DefaultVMImageVault::download_and_prepare_source_image(
         {
             mpl::debug(category, "Verifying hash \"{}\"", id);
             monitor(LaunchProgress::VERIFY, -1);
-            MP_IMAGE_VAULT_UTILS.verify_file_hash(source_image.image_path.toStdString(),
+            MP_IMAGE_VAULT_UTILS.verify_file_hash(mp::utils::qstr_to_path(source_image.image_path),
                                                   id.toStdString());
         }
 
         if (source_image.image_path.endsWith(".xz"))
         {
-            source_image.image_path = QString::fromStdString(
-                MP_IMAGE_VAULT_UTILS
-                    .extract_file(source_image.image_path.toStdString(), monitor, true)
-                    .string());
+            source_image.image_path = mp::utils::path_to_qstr(
+                MP_IMAGE_VAULT_UTILS.extract_file(utils::qstr_to_path(source_image.image_path),
+                                                  monitor,
+                                                  true));
         }
 
         auto prepared_image = prepare(source_image);
@@ -650,8 +651,8 @@ QString mp::DefaultVMImageVault::extract_image_from(const VMImage& source_image,
     const auto image_name = file_info.fileName().remove(".xz");
     const auto image_path = QDir(dest_dir).filePath(image_name);
 
-    return QString::fromStdString(
-        MP_IMAGE_VAULT_UTILS.extract_file(image_path.toStdString(), monitor).string());
+    return utils::path_to_qstr(
+        MP_IMAGE_VAULT_UTILS.extract_file(utils::qstr_to_path(image_path), monitor));
 }
 
 mp::VMImage mp::DefaultVMImageVault::image_instance_from(const VMImage& prepared_image,
@@ -659,10 +660,9 @@ mp::VMImage mp::DefaultVMImageVault::image_instance_from(const VMImage& prepared
 {
     MP_UTILS.make_dir(dest_dir);
 
-    return {QString::fromStdString(
-                MP_IMAGE_VAULT_UTILS
-                    .copy_to_dir(prepared_image.image_path.toStdString(), dest_dir.toStdString())
-                    .string()),
+    return {utils::path_to_qstr(
+                MP_IMAGE_VAULT_UTILS.copy_to_dir(utils::qstr_to_path(prepared_image.image_path),
+                                                 utils::qstr_to_path(dest_dir))),
             prepared_image.id,
             prepared_image.original_release,
             prepared_image.current_release,

--- a/src/platform/platform_unix.cpp
+++ b/src/platform/platform_unix.cpp
@@ -270,3 +270,13 @@ long long mp::platform::Platform::get_total_ram() const
 {
     return static_cast<long long>(sysconf(_SC_PHYS_PAGES)) * sysconf(_SC_PAGESIZE);
 }
+
+std::filesystem::path mp::platform::Platform::qstr_to_path(const QString& qstr) const
+{
+    return std::filesystem::path{qstr.toStdString()};
+}
+
+QString mp::platform::Platform::path_to_qstr(const std::filesystem::path& path) const
+{
+    return QString::fromStdString(path.generic_string());
+}

--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -1076,3 +1076,13 @@ std::filesystem::path mp::platform::Platform::get_root_cert_dir() const
     // Windows doesn't use `daemon_name` for the data directory (see `program_data_multipass_path`)
     return base_dir / "Multipass" / "data";
 }
+
+std::filesystem::path mp::platform::Platform::qstr_to_path(const QString& qstr) const
+{
+    return std::filesystem::path{qstr.toStdWString()};
+}
+
+QString mp::platform::Platform::path_to_qstr(const std::filesystem::path& path) const
+{
+    return QString::fromStdWString(path.generic_wstring());
+}

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -370,6 +370,19 @@ void mp::FileOps::copy(const fs::path& src,
     fs::copy(src, dist, copy_options);
 }
 
+void mp::FileOps::copy(const fs::path& src,
+                       const fs::path& dist,
+                       fs::copy_options copy_options,
+                       std::error_code& ec) const
+{
+    fs::copy(src, dist, copy_options, ec);
+}
+
+bool mp::FileOps::exists(const fs::path& path) const
+{
+    return fs::exists(path);
+}
+
 bool mp::FileOps::exists(const fs::path& path, std::error_code& err) const
 {
     return fs::exists(path, err);

--- a/src/utils/file_ops.cpp
+++ b/src/utils/file_ops.cpp
@@ -320,7 +320,7 @@ off_t mp::FileOps::lseek(int fd, off_t offset, int whence) const
 }
 
 void mp::FileOps::open(std::fstream& stream,
-                       const char* filename,
+                       const std::filesystem::path& filename,
                        std::ios_base::openmode mode) const
 {
     stream.open(filename, mode);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -181,6 +181,25 @@ QString mp::utils::normalize_path(const QString& path)
     return QString::fromStdString(normalize_path(path.toStdString()));
 }
 
+std::filesystem::path mp::utils::qstr_to_path(const QString& qstr)
+{
+#ifdef _WIN32
+    return std::filesystem::path{qstr.toStdWString()};
+#else
+    // On Linux/macOS the native encoding is UTF-8
+    return std::filesystem::path{qstr.toStdString()};
+#endif
+}
+
+QString mp::utils::path_to_qstr(const std::filesystem::path& path)
+{
+#ifdef _WIN32
+    return QString::fromStdWString(path.generic_wstring());
+#else
+    return QString::fromStdString(path.generic_string());
+#endif
+}
+
 bool mp::utils::valid_hostname(const std::string& name_string)
 {
     QRegularExpression matcher{

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -181,25 +181,6 @@ QString mp::utils::normalize_path(const QString& path)
     return QString::fromStdString(normalize_path(path.toStdString()));
 }
 
-std::filesystem::path mp::utils::qstr_to_path(const QString& qstr)
-{
-#ifdef _WIN32
-    return std::filesystem::path{qstr.toStdWString()};
-#else
-    // On Linux/macOS the native encoding is UTF-8
-    return std::filesystem::path{qstr.toStdString()};
-#endif
-}
-
-QString mp::utils::path_to_qstr(const std::filesystem::path& path)
-{
-#ifdef _WIN32
-    return QString::fromStdWString(path.generic_wstring());
-#else
-    return QString::fromStdString(path.generic_string());
-#endif
-}
-
 bool mp::utils::valid_hostname(const std::string& name_string)
 {
     QRegularExpression matcher{

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -234,6 +234,17 @@ std::string& mp::utils::trim_newline(std::string& s)
     return s;
 }
 
+bool mp::utils::istarts_with(std::string_view str, std::string_view prefix)
+{
+    if (prefix.size() > str.size())
+        return false;
+    // TODO(C++23): Use std::ranges::starts_with
+    return std::ranges::equal(
+        str | std::views::take(prefix.size()),
+        prefix,
+        [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); });
+}
+
 // Escape all characters which need to be escaped in the shell.
 std::string mp::utils::escape_for_shell(const std::string& in)
 {

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -23,14 +23,31 @@
 #include <multipass/vm_image_vault_utils.h>
 #include <multipass/xz_image_decoder.h>
 
-#include <QByteArray>
-#include <QFileInfo>
-
 #include <fmt/std.h>
+#include <openssl/evp.h>
 
 #include <stdexcept>
 
 namespace mp = multipass;
+
+namespace
+{
+
+const EVP_MD* to_evp_md(mp::ImageVaultUtils::EHashAlgorithm algo)
+{
+    using enum mp::ImageVaultUtils::EHashAlgorithm;
+    switch (algo)
+    {
+    case sha256:
+        return EVP_sha256();
+    case sha512:
+        return EVP_sha512();
+    default:
+        throw std::runtime_error("Unsupported hash algorithm");
+    }
+}
+
+} // namespace
 
 mp::ImageVaultUtils::ImageVaultUtils(const PrivatePass& pass) noexcept : Singleton{pass}
 {
@@ -57,10 +74,13 @@ std::filesystem::path mp::ImageVaultUtils::copy_to_dir(
     return new_location;
 }
 
-std::string mp::ImageVaultUtils::compute_hash(std::istream& stream,
-                                              const QCryptographicHash::Algorithm algo) const
+std::string mp::ImageVaultUtils::compute_hash(std::istream& stream, EHashAlgorithm algo) const
 {
-    QCryptographicHash hash{algo};
+    auto ctx =
+        std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+
+    if (!ctx || EVP_DigestInit_ex(ctx.get(), to_evp_md(algo), nullptr) != 1)
+        throw std::runtime_error("Failed to initialize hash context");
 
     constexpr std::size_t buf_size = 8192;
     char buf[buf_size] = {0};
@@ -70,14 +90,28 @@ std::string mp::ImageVaultUtils::compute_hash(std::istream& stream,
         if (stream.bad())
             throw std::runtime_error("Failed to read data from device to hash");
         if (auto count = stream.gcount(); count > 0)
-            hash.addData(QByteArrayView{buf, static_cast<qsizetype>(count)});
+        {
+            if (EVP_DigestUpdate(ctx.get(), buf, static_cast<size_t>(count)) != 1)
+                throw std::runtime_error("Failed to update hash");
+        }
+
     } while (stream);
 
-    return hash.result().toHex().toStdString();
+    unsigned char digest[EVP_MAX_MD_SIZE]{};
+    unsigned int digest_len = 0;
+    if (EVP_DigestFinal_ex(ctx.get(), digest, &digest_len) != 1)
+        throw std::runtime_error("Failed to finalize hash");
+
+    std::string hex;
+    hex.reserve(digest_len * 2);
+    for (unsigned int i = 0; i < digest_len; ++i)
+        fmt::format_to(std::back_inserter(hex), "{:02x}", digest[i]);
+
+    return hex;
 }
 
 std::string mp::ImageVaultUtils::compute_file_hash(const std::filesystem::path& path,
-                                                   const QCryptographicHash::Algorithm algo) const
+                                                   EHashAlgorithm algo) const
 {
     std::fstream file;
     MP_FILEOPS.open(file, path, std::ios::in | std::ios::binary);
@@ -92,12 +126,12 @@ void mp::ImageVaultUtils::verify_file_hash(const std::filesystem::path& file,
 {
     const std::string sha512_prefix = "sha512:";
     std::string hash_to_check = hash;
-    QCryptographicHash::Algorithm algo = QCryptographicHash::Sha256;
+    EHashAlgorithm algo = EHashAlgorithm::sha256;
 
     if (utils::istarts_with(hash, sha512_prefix))
     {
         hash_to_check = hash.substr(sha512_prefix.length());
-        algo = QCryptographicHash::Sha512;
+        algo = EHashAlgorithm::sha512;
     }
 
     const auto file_hash = compute_file_hash(file, algo);

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -63,17 +63,13 @@ std::string mp::ImageVaultUtils::compute_hash(std::istream& stream,
 
     constexpr std::size_t buf_size = 8192;
     char buf[buf_size] = {0};
-
     do
     {
         stream.read(buf, buf_size);
-
         if (stream.bad())
             throw std::runtime_error("Failed to read data from device to hash");
-
         if (auto count = stream.gcount(); count > 0)
             hash.addData(QByteArrayView{buf, static_cast<qsizetype>(count)});
-
     } while (stream);
 
     return hash.result().toHex().toStdString();

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -80,7 +80,7 @@ std::string mp::ImageVaultUtils::compute_file_hash(const std::filesystem::path& 
                                                    const QCryptographicHash::Algorithm algo) const
 {
     std::fstream file;
-    MP_FILEOPS.open(file, path.c_str(), std::ios::in | std::ios::binary);
+    MP_FILEOPS.open(file, path, std::ios::in | std::ios::binary);
     if (!file)
         throw std::runtime_error(fmt::format("Failed to open {}", path));
 

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -102,12 +102,7 @@ std::string mp::ImageVaultUtils::compute_hash(std::istream& stream, EHashAlgorit
     if (EVP_DigestFinal_ex(ctx.get(), digest, &digest_len) != 1)
         throw std::runtime_error("Failed to finalize hash");
 
-    std::string hex;
-    hex.reserve(digest_len * 2);
-    for (unsigned int i = 0; i < digest_len; ++i)
-        fmt::format_to(std::back_inserter(hex), "{:02x}", digest[i]);
-
-    return hex;
+    return fmt::format("{:02x}", fmt::join(digest, digest + digest_len, ""));
 }
 
 std::string mp::ImageVaultUtils::compute_file_hash(const std::filesystem::path& path,

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -36,8 +36,9 @@ mp::ImageVaultUtils::ImageVaultUtils(const PrivatePass& pass) noexcept : Singlet
 {
 }
 
-std::filesystem::path mp::ImageVaultUtils::copy_to_dir(const std::filesystem::path& file,
-                                                       const QDir& output_dir) const
+std::filesystem::path mp::ImageVaultUtils::copy_to_dir(
+    const std::filesystem::path& file,
+    const std::filesystem::path& output_dir) const
 {
     if (file.empty())
         return "";
@@ -45,7 +46,7 @@ std::filesystem::path mp::ImageVaultUtils::copy_to_dir(const std::filesystem::pa
     if (!MP_FILEOPS.exists(file))
         throw std::runtime_error(fmt::format("File {} not found", file));
 
-    auto new_location = output_dir.filesystemPath() / file.filename();
+    const auto new_location = output_dir / file.filename();
 
     std::error_code ec{};
     std::filesystem::copy_options options{};

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -67,12 +67,8 @@ std::filesystem::path mp::ImageVaultUtils::copy_to_dir(
 
     // Normalize the path to platform's preferred slashes
     new_location.make_preferred();
-    std::error_code ec{};
-    std::filesystem::copy_options options{};
-    MP_FILEOPS.copy(file, new_location, options, ec);
-    if (ec)
-        throw std::runtime_error(fmt::format("Failed to copy {} to {}", file, new_location));
 
+    MP_FILEOPS.copy(file, new_location, {});
     return new_location;
 }
 

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -15,13 +15,18 @@
  *
  */
 
+#include <multipass/file_ops.h>
 #include <multipass/format.h>
 #include <multipass/image_host/vm_image_host.h>
+#include <multipass/utils.h>
 #include <multipass/vm_image_vault.h>
 #include <multipass/vm_image_vault_utils.h>
 #include <multipass/xz_image_decoder.h>
 
+#include <QByteArray>
 #include <QFileInfo>
+
+#include <fmt/std.h>
 
 #include <stdexcept>
 
@@ -31,79 +36,95 @@ mp::ImageVaultUtils::ImageVaultUtils(const PrivatePass& pass) noexcept : Singlet
 {
 }
 
-QString mp::ImageVaultUtils::copy_to_dir(const QString& file, const QDir& output_dir) const
+std::filesystem::path mp::ImageVaultUtils::copy_to_dir(const std::filesystem::path& file,
+                                                       const QDir& output_dir) const
 {
-    if (file.isEmpty())
+    if (file.empty())
         return "";
 
-    const QFileInfo info{file};
-    if (!MP_FILEOPS.exists(info))
+    if (!MP_FILEOPS.exists(file))
         throw std::runtime_error(fmt::format("File {} not found", file));
 
-    auto new_location = output_dir.filePath(info.fileName());
+    auto new_location = output_dir.filesystemPath() / file.filename();
 
-    if (!MP_FILEOPS.copy(file, new_location))
+    std::error_code ec{};
+    std::filesystem::copy_options options{};
+    MP_FILEOPS.copy(file, new_location, options, ec);
+    if (ec)
         throw std::runtime_error(fmt::format("Failed to copy {} to {}", file, new_location));
 
     return new_location;
 }
 
-QString mp::ImageVaultUtils::compute_hash(QIODevice& device,
-                                          const QCryptographicHash::Algorithm algo) const
+std::string mp::ImageVaultUtils::compute_hash(std::istream& stream,
+                                              const QCryptographicHash::Algorithm algo) const
 {
     QCryptographicHash hash{algo};
-    if (!hash.addData(std::addressof(device)))
-        throw std::runtime_error("Failed to read data from device to hash");
 
-    return hash.result().toHex();
+    constexpr std::size_t buf_size = 8192;
+    char buf[buf_size] = {0};
+
+    do
+    {
+        stream.read(buf, buf_size);
+
+        if (stream.bad())
+            throw std::runtime_error("Failed to read data from device to hash");
+
+        if (auto count = stream.gcount(); count > 0)
+            hash.addData(QByteArrayView{buf, static_cast<qsizetype>(count)});
+
+    } while (stream);
+
+    return hash.result().toHex().toStdString();
 }
 
-QString mp::ImageVaultUtils::compute_file_hash(const QString& path,
-                                               const QCryptographicHash::Algorithm algo) const
+std::string mp::ImageVaultUtils::compute_file_hash(const std::filesystem::path& path,
+                                                   const QCryptographicHash::Algorithm algo) const
 {
-    QFile file{path};
-    if (!MP_FILEOPS.open(file, QFile::ReadOnly))
+    std::fstream file;
+    MP_FILEOPS.open(file, path.c_str(), std::ios::in | std::ios::binary);
+    if (!file)
         throw std::runtime_error(fmt::format("Failed to open {}", path));
 
     return compute_hash(file, algo);
 }
 
-void mp::ImageVaultUtils::verify_file_hash(const QString& file, const QString& hash) const
+void mp::ImageVaultUtils::verify_file_hash(const std::filesystem::path& file,
+                                           const std::string& hash) const
 {
-    const QString sha512_prefix = QStringLiteral("sha512:");
-    QString hash_to_check = hash;
+    const std::string sha512_prefix = "sha512:";
+    std::string hash_to_check = hash;
     QCryptographicHash::Algorithm algo = QCryptographicHash::Sha256;
 
-    if (hash.startsWith(sha512_prefix, Qt::CaseInsensitive))
+    if (utils::istarts_with(hash, sha512_prefix))
     {
-        hash_to_check = hash.mid(sha512_prefix.length());
+        hash_to_check = hash.substr(sha512_prefix.length());
         algo = QCryptographicHash::Sha512;
     }
 
     const auto file_hash = compute_file_hash(file, algo);
 
-    if (file_hash.compare(hash_to_check, Qt::CaseInsensitive) != 0)
+    if (!utils::iequals(file_hash, hash_to_check))
     {
         throw std::runtime_error(fmt::format("Hash of {} does not match (expected {} but got {})",
-                                             file.toStdString(),
-                                             hash_to_check.toStdString(),
-                                             file_hash.toStdString()));
+                                             file,
+                                             hash_to_check,
+                                             file_hash));
     }
 }
 
-QString mp::ImageVaultUtils::extract_file(const QString& file,
-                                          const Decoder& decoder,
-                                          bool delete_original) const
+std::filesystem::path mp::ImageVaultUtils::extract_file(const std::filesystem::path& file,
+                                                        const Decoder& decoder,
+                                                        bool delete_original) const
 {
-    const auto fs_new_path = MP_FILEOPS.remove_extension(file.toStdU16String());
-    auto new_path = QString::fromStdString(fs_new_path.string());
-
+    const auto new_path = MP_FILEOPS.remove_extension(file);
     decoder(file, new_path);
 
     if (delete_original)
     {
-        QFile qfile{file};
-        MP_FILEOPS.remove(qfile);
+        std::error_code ec{};
+        MP_FILEOPS.remove(file, ec);
     }
 
     return new_path;

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -95,7 +95,7 @@ std::string mp::ImageVaultUtils::compute_hash(std::istream& stream, EHashAlgorit
 
     } while (stream);
 
-    unsigned char digest[EVP_MAX_MD_SIZE]{};
+    unsigned char digest[EVP_MAX_MD_SIZE] = {0};
     unsigned int digest_len = 0;
     if (EVP_DigestFinal_ex(ctx.get(), digest, &digest_len) != 1)
         throw std::runtime_error("Failed to finalize hash");

--- a/src/utils/vm_image_vault_utils.cpp
+++ b/src/utils/vm_image_vault_utils.cpp
@@ -63,8 +63,10 @@ std::filesystem::path mp::ImageVaultUtils::copy_to_dir(
     if (!MP_FILEOPS.exists(file))
         throw std::runtime_error(fmt::format("File {} not found", file));
 
-    const auto new_location = output_dir / file.filename();
+    auto new_location = output_dir / file.filename();
 
+    // Normalize the path to platform's preferred slashes
+    new_location.make_preferred();
     std::error_code ec{};
     std::filesystem::copy_options options{};
     MP_FILEOPS.copy(file, new_location, options, ec);

--- a/tests/unit/mock_file_ops.h
+++ b/tests/unit/mock_file_ops.h
@@ -91,7 +91,7 @@ public:
     // Mock std methods
     MOCK_METHOD(void,
                 open,
-                (std::fstream&, const char*, std::ios_base::openmode),
+                (std::fstream&, const std::filesystem::path&, std::ios_base::openmode),
                 (const, override));
     MOCK_METHOD(bool, is_open, (const std::ifstream&), (const, override));
     MOCK_METHOD(std::ifstream&, read, (std::ifstream&, char*, std::streamsize), (const, override));

--- a/tests/unit/mock_file_ops.h
+++ b/tests/unit/mock_file_ops.h
@@ -103,6 +103,20 @@ public:
                 open_read,
                 (const fs::path& path, std::ios_base::openmode mode),
                 (override, const));
+    MOCK_METHOD(void,
+                copy,
+                (const std::filesystem::path&,
+                 const std::filesystem::path&,
+                 fs::copy_options copy_options),
+                (const, override));
+    MOCK_METHOD(void,
+                copy,
+                (const std::filesystem::path&,
+                 const std::filesystem::path&,
+                 fs::copy_options,
+                 std::error_code&),
+                (const, override));
+    MOCK_METHOD(bool, exists, (const fs::path& path), (override, const));
     MOCK_METHOD(bool, exists, (const fs::path& path, std::error_code& err), (override, const));
     MOCK_METHOD(bool,
                 is_directory,

--- a/tests/unit/mock_image_vault_utils.h
+++ b/tests/unit/mock_image_vault_utils.h
@@ -31,7 +31,7 @@ public:
 
     MOCK_METHOD(std::filesystem::path,
                 copy_to_dir,
-                (const std::filesystem::path&, const QDir&),
+                (const std::filesystem::path&, const std::filesystem::path&),
                 (const, override));
 
     MOCK_METHOD(std::string,

--- a/tests/unit/mock_image_vault_utils.h
+++ b/tests/unit/mock_image_vault_utils.h
@@ -34,10 +34,7 @@ public:
                 (const std::filesystem::path&, const std::filesystem::path&),
                 (const, override));
 
-    MOCK_METHOD(std::string,
-                compute_hash,
-                (std::istream&, EHashAlgorithm),
-                (const, override));
+    MOCK_METHOD(std::string, compute_hash, (std::istream&, EHashAlgorithm), (const, override));
     MOCK_METHOD(std::string,
                 compute_file_hash,
                 (const std::filesystem::path&, EHashAlgorithm),

--- a/tests/unit/mock_image_vault_utils.h
+++ b/tests/unit/mock_image_vault_utils.h
@@ -36,11 +36,11 @@ public:
 
     MOCK_METHOD(std::string,
                 compute_hash,
-                (std::istream&, const QCryptographicHash::Algorithm),
+                (std::istream&, EHashAlgorithm),
                 (const, override));
     MOCK_METHOD(std::string,
                 compute_file_hash,
-                (const std::filesystem::path&, const QCryptographicHash::Algorithm),
+                (const std::filesystem::path&, EHashAlgorithm),
                 (const, override));
     MOCK_METHOD(void,
                 verify_file_hash,

--- a/tests/unit/mock_image_vault_utils.h
+++ b/tests/unit/mock_image_vault_utils.h
@@ -29,19 +29,28 @@ class MockImageVaultUtils : public ImageVaultUtils
 public:
     using ImageVaultUtils::ImageVaultUtils;
 
-    MOCK_METHOD(QString, copy_to_dir, (const QString&, const QDir&), (const, override));
+    MOCK_METHOD(std::filesystem::path,
+                copy_to_dir,
+                (const std::filesystem::path&, const QDir&),
+                (const, override));
 
-    MOCK_METHOD(QString,
+    MOCK_METHOD(std::string,
                 compute_hash,
-                (QIODevice&, const QCryptographicHash::Algorithm),
+                (std::istream&, const QCryptographicHash::Algorithm),
                 (const, override));
-    MOCK_METHOD(QString,
+    MOCK_METHOD(std::string,
                 compute_file_hash,
-                (const QString&, const QCryptographicHash::Algorithm),
+                (const std::filesystem::path&, const QCryptographicHash::Algorithm),
                 (const, override));
-    MOCK_METHOD(void, verify_file_hash, (const QString&, const QString&), (const, override));
+    MOCK_METHOD(void,
+                verify_file_hash,
+                (const std::filesystem::path&, const std::string&),
+                (const, override));
 
-    MOCK_METHOD(QString, extract_file, (const QString&, const Decoder&, bool), (const, override));
+    MOCK_METHOD(std::filesystem::path,
+                extract_file,
+                (const std::filesystem::path&, const Decoder&, bool),
+                (const, override));
 
     MOCK_METHOD(HostMap, configure_image_host_map, (const Hosts&), (const, override));
 

--- a/tests/unit/test_image_vault.cpp
+++ b/tests/unit/test_image_vault.cpp
@@ -208,6 +208,26 @@ TEST_F(ImageVault, downloadsImage)
     EXPECT_TRUE(url_downloader.downloaded_urls.contains(host.image.url()));
 }
 
+TEST_F(ImageVault, downloadsImageXz)
+{
+    mp::DefaultVMImageVault vault{hosts,
+                                  &url_downloader,
+                                  cache_dir.path(),
+                                  data_dir.path(),
+                                  mp::days{0}};
+    auto query = default_query;
+    query.release = "xenial.xz";
+    auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly,
+                                      query,
+                                      stub_prepare,
+                                      stub_monitor,
+                                      std::nullopt,
+                                      instance_dir);
+
+    EXPECT_THAT(url_downloader.downloaded_files.size(), Eq(1));
+    EXPECT_TRUE(url_downloader.downloaded_urls.contains(host.image.url()));
+}
+
 TEST_F(ImageVault, returnedImageContainsInstanceName)
 {
     mp::DefaultVMImageVault vault{hosts,

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -110,10 +110,11 @@ TEST_F(TestImageVaultUtils, computeHashComputesSha256)
 
 TEST_F(TestImageVaultUtils, computeFileHashThrowsWhenCantOpen)
 {
-    EXPECT_CALL(mock_file_ops, open(_, StrEq(test_path.c_str()), Truly([](const auto& mode) {
-                                        return (mode & std::ios_base::in) != 0;
-                                    })))
-        .WillOnce([](std::fstream& stream, const char*, std::ios_base::openmode) {
+    EXPECT_CALL(mock_file_ops,
+                open(_,
+                     Matcher<const std::filesystem::path&>(Eq(test_path)),
+                     Truly([](const auto& mode) { return (mode & std::ios_base::in) != 0; })))
+        .WillOnce([](std::fstream& stream, const std::filesystem::path&, std::ios_base::openmode) {
             stream.setstate(std::ios::failbit);
         });
 

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -68,25 +68,24 @@ TEST_F(TestImageVaultUtils, copyToDirThrowsOnFailToCopy)
 {
     EXPECT_CALL(mock_file_ops, exists(test_path)).WillOnce(Return(true));
 
-    EXPECT_CALL(mock_file_ops, copy(test_path, test_output, _, _))
-        .WillOnce([](const std::filesystem::path&,
-                     const std::filesystem::path&,
-                     std::filesystem::copy_options,
-                     std::error_code& ec) {
-            ec = std::make_error_code(std::errc::no_such_file_or_directory);
-        });
+    EXPECT_CALL(mock_file_ops, copy(test_path, test_output, _))
+        .WillOnce(Throw(
+            std::filesystem::filesystem_error("copy failed",
+                                              test_path,
+                                              test_output,
+                                              std::make_error_code(std::errc::permission_denied))));
 
     MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir),
                          std::runtime_error,
                          mpt::match_what(AllOf(HasSubstr(test_path.string()),
-                                               HasSubstr("Failed to copy"),
+                                               HasSubstr("copy failed"),
                                                HasSubstr(test_output.string()))));
 }
 
 TEST_F(TestImageVaultUtils, copyToDirCopysToDir)
 {
     EXPECT_CALL(mock_file_ops, exists(test_path)).WillOnce(Return(true));
-    EXPECT_CALL(mock_file_ops, copy(test_path, test_output, _, _));
+    EXPECT_CALL(mock_file_ops, copy(test_path, test_output, _));
 
     auto result = MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir);
     EXPECT_EQ(result, test_output);

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -38,7 +38,7 @@ struct TestImageVaultUtils : public ::testing::Test
     const mpt::MockFileOps::GuardedMock mock_file_ops_guard{mpt::MockFileOps::inject<NiceMock>()};
     mpt::MockFileOps& mock_file_ops{*mock_file_ops_guard.first};
 
-    const QDir test_dir{"secrets/secret_filled_folder"};
+    const std::filesystem::path test_dir{"secrets/secret_filled_folder"};
     const std::filesystem::path test_path{"not_secrets/a_secret.txt"};
     const std::filesystem::path test_output{"secrets/secret_filled_folder/a_secret.txt"};
 };

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -126,7 +126,8 @@ TEST_F(TestImageVaultUtils, computeFileHashThrowsWhenCantOpen)
 TEST_F(TestImageVaultUtils, verifyFileHashThrowsOnBadHash)
 {
     auto [mock_utils, _] = mpt::MockImageVaultUtils::inject<StrictMock>();
-    EXPECT_CALL(*mock_utils, compute_file_hash(test_path, QCryptographicHash::Sha256))
+    EXPECT_CALL(*mock_utils,
+                compute_file_hash(test_path, mp::ImageVaultUtils::EHashAlgorithm::sha256))
         .WillOnce(Return(":("));
 
     MP_EXPECT_THROW_THAT(
@@ -139,7 +140,8 @@ TEST_F(TestImageVaultUtils, verifyFileHashThrowsOnBadHash)
 TEST_F(TestImageVaultUtils, verifyFileHashDoesntThrowOnGoodHash)
 {
     auto [mock_utils, _] = mpt::MockImageVaultUtils::inject<StrictMock>();
-    EXPECT_CALL(*mock_utils, compute_file_hash(test_path, QCryptographicHash::Sha256))
+    EXPECT_CALL(*mock_utils,
+                compute_file_hash(test_path, mp::ImageVaultUtils::EHashAlgorithm::sha256))
         .WillOnce(Return(":)"));
 
     EXPECT_NO_THROW(mock_utils->ImageVaultUtils::verify_file_hash(test_path, ":)"));
@@ -148,7 +150,8 @@ TEST_F(TestImageVaultUtils, verifyFileHashDoesntThrowOnGoodHash)
 TEST_F(TestImageVaultUtils, verifyFileHashParsesAlgo)
 {
     auto [mock_utils, _] = mpt::MockImageVaultUtils::inject<StrictMock>();
-    EXPECT_CALL(*mock_utils, compute_file_hash(test_path, QCryptographicHash::Sha512))
+    EXPECT_CALL(*mock_utils,
+                compute_file_hash(test_path, mp::ImageVaultUtils::EHashAlgorithm::sha512))
         .WillOnce(Return("1234567890abcdef"));
 
     EXPECT_NO_THROW(

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -119,6 +119,16 @@ TEST_F(TestImageVaultUtils, computeHashComputesSha512)
               "d72a39b3724be768d69250cafd30fef947fe829711f2");
 }
 
+TEST_F(TestImageVaultUtils, computeHashUnsupportedHashAlgorithm)
+{
+    std::istringstream stream{":)"};
+    MP_EXPECT_THROW_THAT(std::ignore = MP_IMAGE_VAULT_UTILS.compute_hash(
+                             stream,
+                             static_cast<mp::ImageVaultUtils::EHashAlgorithm>(-1)),
+                         std::runtime_error,
+                         mpt::match_what(StrEq("Unsupported hash algorithm")));
+}
+
 TEST_F(TestImageVaultUtils, computeFileHashThrowsWhenCantOpen)
 {
     EXPECT_CALL(mock_file_ops,

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -37,9 +37,16 @@ struct TestImageVaultUtils : public ::testing::Test
     const mpt::MockFileOps::GuardedMock mock_file_ops_guard{mpt::MockFileOps::inject<NiceMock>()};
     mpt::MockFileOps& mock_file_ops{*mock_file_ops_guard.first};
 
-    const std::filesystem::path test_dir{"secrets/secret_filled_folder"};
-    const std::filesystem::path test_path{"not_secrets/a_secret.txt"};
-    const std::filesystem::path test_output{"secrets/secret_filled_folder/a_secret.txt"};
+    void SetUp() override
+    {
+        test_dir.make_preferred();
+        test_path.make_preferred();
+        test_output.make_preferred();
+    }
+
+    std::filesystem::path test_dir{"secrets/secret_filled_folder"};
+    std::filesystem::path test_path{"not_secrets/a_secret.txt"};
+    std::filesystem::path test_output{"secrets/secret_filled_folder/a_secret.txt"};
 };
 
 TEST_F(TestImageVaultUtils, copyToDirHandlesEmptyFile)

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -21,7 +21,6 @@
 #include "mock_image_host.h"
 #include "mock_image_vault_utils.h"
 
-#include <QBuffer>
 #include <multipass/progress_monitor.h>
 #include <multipass/vm_image_vault_utils.h>
 
@@ -52,9 +51,10 @@ TEST_F(TestImageVaultUtils, copyToDirThrowsOnNonexistantFile)
 {
     EXPECT_CALL(mock_file_ops, exists(test_path)).WillOnce(Return(false));
 
-    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir),
-                         std::runtime_error,
-                         mpt::match_what(AllOf(HasSubstr(test_path), HasSubstr("not found"))));
+    MP_EXPECT_THROW_THAT(
+        MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir),
+        std::runtime_error,
+        mpt::match_what(AllOf(HasSubstr(test_path.string()), HasSubstr("not found"))));
 }
 
 TEST_F(TestImageVaultUtils, copyToDirThrowsOnFailToCopy)
@@ -181,7 +181,7 @@ TEST_F(TestImageVaultUtils, verifyFileHashParsesAlgo)
 
 TEST_F(TestImageVaultUtils, extractFileWillDeleteFile)
 {
-    auto decoder = [](const std::string&, const std::string&) {};
+    auto decoder = [](const std::filesystem::path&, const std::filesystem::path&) {};
 
     EXPECT_CALL(mock_file_ops, remove(test_path, _));
 
@@ -193,7 +193,7 @@ TEST_F(TestImageVaultUtils, extractFileWontDeleteFile)
     EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(test_output));
 
     int calls = 0;
-    auto decoder = [&](const std::filesystem::path& path, const std::string& target) {
+    auto decoder = [&](const std::filesystem::path& path, const std::filesystem::path& target) {
         EXPECT_EQ(test_path, path);
         EXPECT_EQ(test_output, target);
         ++calls;
@@ -210,7 +210,7 @@ TEST_F(TestImageVaultUtils, extractFileExtractsFile)
     EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(test_output));
 
     int calls = 0;
-    auto decoder = [&](const std::filesystem::path& path, const std::string& target) {
+    auto decoder = [&](const std::filesystem::path& path, const std::filesystem::path& target) {
         EXPECT_EQ(test_path, path);
         EXPECT_EQ(test_output, target);
         ++calls;

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -61,11 +61,11 @@ TEST_F(TestImageVaultUtils, copyToDirThrowsOnFailToCopy)
 {
     EXPECT_CALL(mock_file_ops, exists(test_path)).WillOnce(Return(true));
 
-    ON_CALL(mock_file_ops, copy(test_path, test_output, _, _))
-        .WillByDefault([](const std::filesystem::path&,
-                          const std::filesystem::path&,
-                          std::filesystem::copy_options,
-                          std::error_code& ec) {
+    EXPECT_CALL(mock_file_ops, copy(test_path, test_output, _, _))
+        .WillOnce([](const std::filesystem::path&,
+                     const std::filesystem::path&,
+                     std::filesystem::copy_options,
+                     std::error_code& ec) {
             ec = std::make_error_code(std::errc::no_such_file_or_directory);
         });
 
@@ -106,6 +106,17 @@ TEST_F(TestImageVaultUtils, computeHashComputesSha256)
 
     auto hash = MP_IMAGE_VAULT_UTILS.compute_hash(stream);
     EXPECT_EQ(hash, "54d626e08c1c802b305dad30b7e54a82f102390cc92c7d4db112048935236e9c");
+}
+
+TEST_F(TestImageVaultUtils, computeHashComputesSha512)
+{
+    std::istringstream stream{":)"};
+
+    auto hash =
+        MP_IMAGE_VAULT_UTILS.compute_hash(stream, mp::ImageVaultUtils::EHashAlgorithm::sha512);
+    EXPECT_EQ(hash,
+              "fec799ae04ebe814db7f1d9d21dbca0e834c175e2177ac98c8ee2c2219b3687b8d931f290209a2a6c6cf"
+              "d72a39b3724be768d69250cafd30fef947fe829711f2");
 }
 
 TEST_F(TestImageVaultUtils, computeFileHashThrowsWhenCantOpen)

--- a/tests/unit/test_image_vault_utils.cpp
+++ b/tests/unit/test_image_vault_utils.cpp
@@ -39,12 +39,8 @@ struct TestImageVaultUtils : public ::testing::Test
     mpt::MockFileOps& mock_file_ops{*mock_file_ops_guard.first};
 
     const QDir test_dir{"secrets/secret_filled_folder"};
-    const QString test_path{"not_secrets/a_secret.txt"};
-    const mp::fs::path fs_test_path{test_path.toStdU16String()};
-    const QFileInfo test_info{test_path};
-
-    const QString test_output{"secrets/secret_filled_folder/a_secret.txt"};
-    const mp::fs::path fs_test_output{test_output.toStdU16String()};
+    const std::filesystem::path test_path{"not_secrets/a_secret.txt"};
+    const std::filesystem::path test_output{"secrets/secret_filled_folder/a_secret.txt"};
 };
 
 TEST_F(TestImageVaultUtils, copyToDirHandlesEmptyFile)
@@ -54,30 +50,36 @@ TEST_F(TestImageVaultUtils, copyToDirHandlesEmptyFile)
 
 TEST_F(TestImageVaultUtils, copyToDirThrowsOnNonexistantFile)
 {
-    EXPECT_CALL(mock_file_ops, exists(test_info)).WillOnce(Return(false));
+    EXPECT_CALL(mock_file_ops, exists(test_path)).WillOnce(Return(false));
 
-    MP_EXPECT_THROW_THAT(
-        MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir),
-        std::runtime_error,
-        mpt::match_what(AllOf(HasSubstr(test_path.toStdString()), HasSubstr("not found"))));
+    MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir),
+                         std::runtime_error,
+                         mpt::match_what(AllOf(HasSubstr(test_path), HasSubstr("not found"))));
 }
 
 TEST_F(TestImageVaultUtils, copyToDirThrowsOnFailToCopy)
 {
-    EXPECT_CALL(mock_file_ops, exists(test_info)).WillOnce(Return(true));
-    EXPECT_CALL(mock_file_ops, copy(test_path, test_output)).WillOnce(Return(false));
+    EXPECT_CALL(mock_file_ops, exists(test_path)).WillOnce(Return(true));
+
+    ON_CALL(mock_file_ops, copy(test_path, test_output, _, _))
+        .WillByDefault([](const std::filesystem::path&,
+                          const std::filesystem::path&,
+                          std::filesystem::copy_options,
+                          std::error_code& ec) {
+            ec = std::make_error_code(std::errc::no_such_file_or_directory);
+        });
 
     MP_EXPECT_THROW_THAT(MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir),
                          std::runtime_error,
-                         mpt::match_what(AllOf(HasSubstr(test_path.toStdString()),
+                         mpt::match_what(AllOf(HasSubstr(test_path.string()),
                                                HasSubstr("Failed to copy"),
-                                               HasSubstr(test_output.toStdString()))));
+                                               HasSubstr(test_output.string()))));
 }
 
 TEST_F(TestImageVaultUtils, copyToDirCopysToDir)
 {
-    EXPECT_CALL(mock_file_ops, exists(test_info)).WillOnce(Return(true));
-    EXPECT_CALL(mock_file_ops, copy(test_path, test_output)).WillOnce(Return(true));
+    EXPECT_CALL(mock_file_ops, exists(test_path)).WillOnce(Return(true));
+    EXPECT_CALL(mock_file_ops, copy(test_path, test_output, _, _));
 
     auto result = MP_IMAGE_VAULT_UTILS.copy_to_dir(test_path, test_dir);
     EXPECT_EQ(result, test_output);
@@ -85,47 +87,52 @@ TEST_F(TestImageVaultUtils, copyToDirCopysToDir)
 
 TEST_F(TestImageVaultUtils, computeHashThrowsWhenCantRead)
 {
-    QBuffer buffer{}; // note: buffer is not opened
-    MP_EXPECT_THROW_THAT(std::ignore = MP_IMAGE_VAULT_UTILS.compute_hash(buffer),
+    struct BadBuf : std::streambuf
+    {
+        int_type underflow() override
+        {
+            throw std::runtime_error("simulated I/O error");
+        }
+    } buf;
+    std::istream stream(&buf);
+    MP_EXPECT_THROW_THAT(std::ignore = MP_IMAGE_VAULT_UTILS.compute_hash(stream),
                          std::runtime_error,
                          mpt::match_what(HasSubstr("Failed to read")));
 }
 
 TEST_F(TestImageVaultUtils, computeHashComputesSha256)
 {
-    QByteArray data = ":)";
-    QBuffer buffer{&data};
+    std::istringstream stream{":)"};
 
-    ASSERT_TRUE(buffer.open(QIODevice::ReadOnly));
-
-    auto hash = MP_IMAGE_VAULT_UTILS.compute_hash(buffer);
+    auto hash = MP_IMAGE_VAULT_UTILS.compute_hash(stream);
     EXPECT_EQ(hash, "54d626e08c1c802b305dad30b7e54a82f102390cc92c7d4db112048935236e9c");
 }
 
 TEST_F(TestImageVaultUtils, computeFileHashThrowsWhenCantOpen)
 {
-    EXPECT_CALL(mock_file_ops,
-                open(mpt::FileNameMatches(Eq(test_path)),
-                     Truly([](const auto& mode) { return (mode & QFile::ReadOnly) > 0; })))
-        .WillOnce(Return(false));
+    EXPECT_CALL(mock_file_ops, open(_, StrEq(test_path.c_str()), Truly([](const auto& mode) {
+                                        return (mode & std::ios_base::in) != 0;
+                                    })))
+        .WillOnce([](std::fstream& stream, const char*, std::ios_base::openmode) {
+            stream.setstate(std::ios::failbit);
+        });
 
     MP_EXPECT_THROW_THAT(
         std::ignore = MP_IMAGE_VAULT_UTILS.compute_file_hash(test_path),
         std::runtime_error,
-        mpt::match_what(AllOf(HasSubstr(test_path.toStdString()), HasSubstr("Failed to open"))));
+        mpt::match_what(AllOf(HasSubstr(test_path.string()), HasSubstr("Failed to open"))));
 }
-
 TEST_F(TestImageVaultUtils, verifyFileHashThrowsOnBadHash)
 {
     auto [mock_utils, _] = mpt::MockImageVaultUtils::inject<StrictMock>();
     EXPECT_CALL(*mock_utils, compute_file_hash(test_path, QCryptographicHash::Sha256))
         .WillOnce(Return(":("));
 
-    MP_EXPECT_THROW_THAT(mock_utils->ImageVaultUtils::verify_file_hash(test_path, ":)"),
-                         std::runtime_error,
-                         mpt::match_what(AllOf(HasSubstr(test_path.toStdString()),
-                                               HasSubstr(":)"),
-                                               HasSubstr("does not match"))));
+    MP_EXPECT_THROW_THAT(
+        mock_utils->ImageVaultUtils::verify_file_hash(test_path, ":)"),
+        std::runtime_error,
+        mpt::match_what(
+            AllOf(HasSubstr(test_path.string()), HasSubstr(":)"), HasSubstr("does not match"))));
 }
 
 TEST_F(TestImageVaultUtils, verifyFileHashDoesntThrowOnGoodHash)
@@ -149,19 +156,19 @@ TEST_F(TestImageVaultUtils, verifyFileHashParsesAlgo)
 
 TEST_F(TestImageVaultUtils, extractFileWillDeleteFile)
 {
-    auto decoder = [](const QString&, const QString&) {};
+    auto decoder = [](const std::string&, const std::string&) {};
 
-    EXPECT_CALL(mock_file_ops, remove(Property(&QFile::fileName, test_path)));
+    EXPECT_CALL(mock_file_ops, remove(test_path, _));
 
     MP_IMAGE_VAULT_UTILS.extract_file(test_path, decoder, true);
 }
 
 TEST_F(TestImageVaultUtils, extractFileWontDeleteFile)
 {
-    EXPECT_CALL(mock_file_ops, remove_extension(fs_test_path)).WillOnce(Return(fs_test_output));
+    EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(test_output));
 
     int calls = 0;
-    auto decoder = [&](const QString& path, const QString& target) {
+    auto decoder = [&](const std::filesystem::path& path, const std::string& target) {
         EXPECT_EQ(test_path, path);
         EXPECT_EQ(test_output, target);
         ++calls;
@@ -175,10 +182,10 @@ TEST_F(TestImageVaultUtils, extractFileWontDeleteFile)
 
 TEST_F(TestImageVaultUtils, extractFileExtractsFile)
 {
-    EXPECT_CALL(mock_file_ops, remove_extension(fs_test_path)).WillOnce(Return(fs_test_output));
+    EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(test_output));
 
     int calls = 0;
-    auto decoder = [&](const QString& path, const QString& target) {
+    auto decoder = [&](const std::filesystem::path& path, const std::string& target) {
         EXPECT_EQ(test_path, path);
         EXPECT_EQ(test_output, target);
         ++calls;
@@ -191,7 +198,7 @@ TEST_F(TestImageVaultUtils, extractFileExtractsFile)
 
 TEST_F(TestImageVaultUtils, extractFileWithDecoderBindsMonitor)
 {
-    EXPECT_CALL(mock_file_ops, remove_extension(fs_test_path)).WillOnce(Return(fs_test_output));
+    EXPECT_CALL(mock_file_ops, remove_extension(test_path)).WillOnce(Return(test_output));
 
     int type = 1337;
     int progress = 42;
@@ -204,7 +211,7 @@ TEST_F(TestImageVaultUtils, extractFileWithDecoderBindsMonitor)
     };
 
     mpt::MockImageDecoder decoder{};
-    EXPECT_CALL(decoder, decode_to(fs_test_path, fs_test_output, Truly([&](const auto& m) {
+    EXPECT_CALL(decoder, decode_to(test_path, test_output, Truly([&](const auto& m) {
                                        return m(type, progress);
                                    })));
 

--- a/tests/unit/test_persistent_settings_handler.cpp
+++ b/tests/unit/test_persistent_settings_handler.cpp
@@ -21,6 +21,7 @@
 
 #include <multipass/constants.h>
 #include <multipass/exceptions/settings_exceptions.h>
+#include <multipass/platform.h>
 #include <multipass/settings/basic_setting_spec.h>
 #include <multipass/settings/custom_setting_spec.h>
 #include <multipass/settings/persistent_settings_handler.h>
@@ -76,7 +77,7 @@ public:
         fstream.setstate(std::ios_base::failbit);
 
         EXPECT_CALL(*mock_file_ops,
-                    open(_, Eq(mp::utils::qstr_to_path(fake_filename)), Eq(std::ios_base::in)))
+                    open(_, Eq(MP_PLATFORM.qstr_to_path(fake_filename)), Eq(std::ios_base::in)))
             .WillOnce(
                 DoAll(WithArg<0>([](auto& stream) { stream.setstate(std::ios_base::failbit); }),
                       Assign(&errno, EACCES)));

--- a/tests/unit/test_persistent_settings_handler.cpp
+++ b/tests/unit/test_persistent_settings_handler.cpp
@@ -24,6 +24,7 @@
 #include <multipass/settings/basic_setting_spec.h>
 #include <multipass/settings/custom_setting_spec.h>
 #include <multipass/settings/persistent_settings_handler.h>
+#include <multipass/utils.h>
 
 #include <QString>
 
@@ -75,7 +76,7 @@ public:
         fstream.setstate(std::ios_base::failbit);
 
         EXPECT_CALL(*mock_file_ops,
-                    open(_, StrEq(qPrintable(fake_filename)), Eq(std::ios_base::in)))
+                    open(_, Eq(mp::utils::qstr_to_path(fake_filename)), Eq(std::ios_base::in)))
             .WillOnce(
                 DoAll(WithArg<0>([](auto& stream) { stream.setstate(std::ios_base::failbit); }),
                       Assign(&errno, EACCES)));

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -394,6 +394,13 @@ TEST(Utils, escapeForShellQuotesEmptyString)
     EXPECT_THAT(res, ::testing::StrEq("''"));
 }
 
+TEST(Utils, checkIstartswithComparesCaseInsensitively)
+{
+    constexpr std::string_view expected_pfx = "tHe hObBit$";
+    constexpr std::string_view content = "ThE HOBbIT$ aRe gOiNg to 1s3ng4rd!";
+    EXPECT_TRUE(mp::utils::istarts_with(content, expected_pfx));
+}
+
 TEST(Utils, tryActionActuallyTimesOut)
 {
     bool on_timeout_called{false};

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -643,28 +643,6 @@ TEST(Utils, checkFilesystemBytesAvailableReturnsNonNegative)
     EXPECT_GE(bytes_available, 0);
 }
 
-TEST(Utils, test_qstr_path_conversion)
-{
-    // ASCII
-    QString ascii = QStringLiteral("/some/plain/path.txt");
-    EXPECT_EQ(mp::utils::path_to_qstr(mp::utils::qstr_to_path(ascii)), ascii);
-
-    // BMP Unicode (Turkish, CJK)
-    QString bmp = QStringLiteral("/belgeler/İzmir/日本語.txt");
-    EXPECT_EQ(mp::utils::path_to_qstr(mp::utils::qstr_to_path(bmp)), bmp);
-
-    // Astral plane (emoji – surrogate pair in UTF-16)
-    QString astral = QStringLiteral("/tmp/\U0001F600/file.txt");
-    EXPECT_EQ(mp::utils::path_to_qstr(mp::utils::qstr_to_path(astral)), astral);
-
-    // Empty
-    EXPECT_EQ(mp::utils::qstr_to_path(QString{}), std::filesystem::path{});
-
-    // Spaces and special filesystem characters
-    QString special = QStringLiteral("/path with spaces/file (1).txt");
-    EXPECT_EQ(mp::utils::path_to_qstr(mp::utils::qstr_to_path(special)), special);
-}
-
 using PathPairParam = std::tuple<std::filesystem::path, std::filesystem::path>;
 
 class NormalizePathTest : public TestWithParam<PathPairParam>

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -643,6 +643,28 @@ TEST(Utils, checkFilesystemBytesAvailableReturnsNonNegative)
     EXPECT_GE(bytes_available, 0);
 }
 
+TEST(Utils, test_qstr_path_conversion)
+{
+    // ASCII
+    QString ascii = QStringLiteral("/some/plain/path.txt");
+    EXPECT_EQ(mp::utils::path_to_qstr(mp::utils::qstr_to_path(ascii)), ascii);
+
+    // BMP Unicode (Turkish, CJK)
+    QString bmp = QStringLiteral("/belgeler/İzmir/日本語.txt");
+    EXPECT_EQ(mp::utils::path_to_qstr(mp::utils::qstr_to_path(bmp)), bmp);
+
+    // Astral plane (emoji – surrogate pair in UTF-16)
+    QString astral = QStringLiteral("/tmp/\U0001F600/file.txt");
+    EXPECT_EQ(mp::utils::path_to_qstr(mp::utils::qstr_to_path(astral)), astral);
+
+    // Empty
+    EXPECT_EQ(mp::utils::qstr_to_path(QString{}), std::filesystem::path{});
+
+    // Spaces and special filesystem characters
+    QString special = QStringLiteral("/path with spaces/file (1).txt");
+    EXPECT_EQ(mp::utils::path_to_qstr(mp::utils::qstr_to_path(special)), special);
+}
+
 using PathPairParam = std::tuple<std::filesystem::path, std::filesystem::path>;
 
 class NormalizePathTest : public TestWithParam<PathPairParam>

--- a/tests/unit/unix/test_platform_unix.cpp
+++ b/tests/unit/unix/test_platform_unix.cpp
@@ -334,3 +334,25 @@ TEST_F(TestPlatformUnix, quitWatchdogSignalsItselfAsynchronously)
               std::nullopt);
     EXPECT_GE(times.load(std::memory_order_acquire), 10);
 }
+
+TEST_F(TestPlatformUnix, test_qstr_path_conversion)
+{
+    // ASCII
+    QString ascii = QStringLiteral("/some/plain/path.txt");
+    EXPECT_EQ(MP_PLATFORM.path_to_qstr(MP_PLATFORM.qstr_to_path(ascii)), ascii);
+
+    // BMP Unicode (Turkish, CJK)
+    QString bmp = QStringLiteral("/belgeler/İzmir/日本語.txt");
+    EXPECT_EQ(MP_PLATFORM.path_to_qstr(MP_PLATFORM.qstr_to_path(bmp)), bmp);
+
+    // Astral plane (emoji – surrogate pair in UTF-16)
+    QString astral = QStringLiteral("/tmp/\U0001F600/file.txt");
+    EXPECT_EQ(MP_PLATFORM.path_to_qstr(MP_PLATFORM.qstr_to_path(astral)), astral);
+
+    // Empty
+    EXPECT_EQ(MP_PLATFORM.qstr_to_path(QString{}), std::filesystem::path{});
+
+    // Spaces and special filesystem characters
+    QString special = QStringLiteral("/path with spaces/file (1).txt");
+    EXPECT_EQ(MP_PLATFORM.path_to_qstr(MP_PLATFORM.qstr_to_path(special)), special);
+}

--- a/tests/unit/windows/test_platform_win.cpp
+++ b/tests/unit/windows/test_platform_win.cpp
@@ -701,4 +701,26 @@ TEST(PlatformWin, getTotalRamReturnsGreaterThanZero)
     EXPECT_GT(MP_PLATFORM.get_total_ram(), 0LL);
 }
 
+TEST_F(PlatformWin, test_qstr_path_conversion)
+{
+    // ASCII
+    QString ascii = QStringLiteral("/some/plain/path.txt");
+    EXPECT_EQ(MP_PLATFORM.path_to_qstr(MP_PLATFORM.qstr_to_path(ascii)), ascii);
+
+    // BMP Unicode (Turkish, CJK)
+    QString bmp = QStringLiteral("/belgeler/İzmir/日本語.txt");
+    EXPECT_EQ(MP_PLATFORM.path_to_qstr(MP_PLATFORM.qstr_to_path(bmp)), bmp);
+
+    // Astral plane (emoji – surrogate pair in UTF-16)
+    QString astral = QStringLiteral("/tmp/\U0001F600/file.txt");
+    EXPECT_EQ(MP_PLATFORM.path_to_qstr(MP_PLATFORM.qstr_to_path(astral)), astral);
+
+    // Empty
+    EXPECT_EQ(MP_PLATFORM.qstr_to_path(QString{}), std::filesystem::path{});
+
+    // Spaces and special filesystem characters
+    QString special = QStringLiteral("/path with spaces/file (1).txt");
+    EXPECT_EQ(MP_PLATFORM.path_to_qstr(MP_PLATFORM.qstr_to_path(special)), special);
+}
+
 } // namespace

--- a/tests/unit/windows/test_platform_win.cpp
+++ b/tests/unit/windows/test_platform_win.cpp
@@ -701,7 +701,7 @@ TEST(PlatformWin, getTotalRamReturnsGreaterThanZero)
     EXPECT_GT(MP_PLATFORM.get_total_ram(), 0LL);
 }
 
-TEST_F(PlatformWin, test_qstr_path_conversion)
+TEST(PlatformWin, test_qstr_path_conversion)
 {
     // ASCII
     QString ascii = QStringLiteral("/some/plain/path.txt");


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
~~Partially replaces~~Purges QT types used in VM image vault with std types
- Why is this change needed?
The more we converge towards the std, the better.
