### PR TITLE
[ci] Perform actions as multipass-ci-bot

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -15,8 +15,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MULTIPASS_CI_BOT_ID }}
+          private-key: ${{ secrets.MULTIPASS_CI_BOT_KEY }}
+
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -38,6 +47,7 @@ jobs:
       - name: Create PR
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "[distro] Update Cloud Images info"
           branch: "update-cloud-images"
           title: "[distro] Update Cloud Images information"


### PR DESCRIPTION
This PR changes the actor of the [Update Cloud Images](https://github.com/canonical/multipass/actions/workflows/update-images.yaml) workflow so that commits and PRs are authored by the [Multipass CI](https://github.com/apps/multipass-ci) bot. This allows workflows to run upon PR creation reducing the hassle of merging said PRs.

#4746 is an example of a PR created the Multipass CI bot.