### PR TITLE
[applevz] Additional networks

### DIFF
--- a/packaging/macos/sign-and-notarize.sh
+++ b/packaging/macos/sign-and-notarize.sh
@@ -161,7 +161,8 @@ function codesign_binaries {
     # sign multipass with additional entitlements for using the Apple Virtualization framework
     find "${DIR}" -type f -name multipassd -print0 | xargs -0L1 \
         codesign -v --timestamp --options runtime --force --strict \
-            $( entitlements com.apple.security.virtualization ) \
+            $( entitlements com.apple.security.virtualization \
+                            com.apple.vm.networking ) \
             --identifier com.canonical.multipass.multipassd \
             --sign "${SIGN_APP}"
 

--- a/packaging/macos/sign-and-notarize.sh
+++ b/packaging/macos/sign-and-notarize.sh
@@ -161,8 +161,7 @@ function codesign_binaries {
     # sign multipass with additional entitlements for using the Apple Virtualization framework
     find "${DIR}" -type f -name multipassd -print0 | xargs -0L1 \
         codesign -v --timestamp --options runtime --force --strict \
-            $( entitlements com.apple.security.virtualization \
-                            com.apple.vm.networking ) \
+            $( entitlements com.apple.security.virtualization ) \
             --identifier com.canonical.multipass.multipassd \
             --sign "${SIGN_APP}"
 

--- a/src/platform/backends/applevz/CMakeLists.txt
+++ b/src/platform/backends/applevz/CMakeLists.txt
@@ -21,11 +21,13 @@ add_library(applevz_backend STATIC
   applevz_bridge.mm
   applevz_wrapper.cpp
   applevz_utils.mm
+  applevz_vmnet.mm
 )
 
 set_source_files_properties(
   applevz_bridge.mm
   applevz_utils.mm
+  applevz_vmnet.mm
   PROPERTIES
   LANGUAGE OBJCXX
   COMPILE_FLAGS "-fobjc-arc"
@@ -33,6 +35,7 @@ set_source_files_properties(
 
 find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
 find_library(VIRTUALIZATION_FRAMEWORK Virtualization REQUIRED)
+find_library(VMNET_FRAMEWORK vmnet REQUIRED)
 
 target_link_libraries(applevz_backend
   PUBLIC
@@ -43,4 +46,5 @@ target_link_libraries(applevz_backend
     daemon
     ${FOUNDATION_FRAMEWORK}
     ${VIRTUALIZATION_FRAMEWORK}
+    ${VMNET_FRAMEWORK}
     Qt6::Core)

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <applevz/cf_error.h>
+#include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_description.h>
 
 #include <fmt/format.h>
@@ -63,6 +64,9 @@ bool can_stop(const VMHandle& vm_handle);
 bool can_request_stop(const VMHandle& vm_handle);
 
 bool is_supported();
+
+// Networking
+std::vector<NetworkInterfaceInfo> bridged_network_interfaces();
 } // namespace multipass::applevz
 
 template <>

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -29,6 +29,8 @@
 #include <QString>
 #include <QUrl>
 
+#include <cassert>
+
 namespace multipass::applevz
 {
 struct VirtualMachineHandle
@@ -172,18 +174,52 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
             [[VZVirtioEntropyDeviceConfiguration alloc] init];
         config.entropyDevices = @[ entropy ];
 
-        // Network device
+        // Network devices
+        // Primary NAT interface
+        NSMutableArray<VZNetworkDeviceConfiguration*>* networkDevices = [NSMutableArray array];
+
         VZVirtioNetworkDeviceConfiguration* netDevice =
             [[VZVirtioNetworkDeviceConfiguration alloc] init];
-
         VZNATNetworkDeviceAttachment* natAttachment = [[VZNATNetworkDeviceAttachment alloc] init];
         netDevice.attachment = natAttachment;
 
         VZMACAddress* mac =
             [[VZMACAddress alloc] initWithString:nsstring_from_stdstring(desc.default_mac_address)];
         [netDevice setMACAddress:mac];
+        [networkDevices addObject:netDevice];
 
-        config.networkDevices = @[ netDevice ];
+        // Extra bridged interfaces
+        NSArray<VZBridgedNetworkInterface*>* hostInterfaces =
+            [VZBridgedNetworkInterface networkInterfaces];
+        for (const auto& extra : desc.extra_interfaces)
+        {
+            NSString* targetId = [NSString stringWithCString:extra.id.c_str()
+                                                    encoding:NSUTF8StringEncoding];
+
+            VZBridgedNetworkInterface* found = nil;
+            for (VZBridgedNetworkInterface* hostIface in hostInterfaces)
+            {
+                if ([hostIface.identifier isEqualToString:targetId])
+                {
+                    found = hostIface;
+                    break;
+                }
+            }
+
+            assert(found && "Bridged interface not found - extra_interfaces must be validated "
+                            "before VM creation");
+
+            VZBridgedNetworkDeviceAttachment* bridgedAttachment =
+                [[VZBridgedNetworkDeviceAttachment alloc] initWithInterface:found];
+
+            VZVirtioNetworkDeviceConfiguration* bridgedDevice =
+                [[VZVirtioNetworkDeviceConfiguration alloc] init];
+            bridgedDevice.attachment = bridgedAttachment;
+
+            [networkDevices addObject:bridgedDevice];
+        }
+
+        config.networkDevices = networkDevices;
 
         // Memory balloon device
         VZVirtioTraditionalMemoryBalloonDeviceConfiguration* balloon =

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -306,4 +306,23 @@ bool is_supported()
 {
     return [VZVirtualMachine isSupported];
 }
+
+std::vector<NetworkInterfaceInfo> bridged_network_interfaces()
+{
+    std::vector<NetworkInterfaceInfo> result;
+
+    for (VZBridgedNetworkInterface* iface in [VZBridgedNetworkInterface networkInterfaces])
+    {
+        NetworkInterfaceInfo info;
+        info.id = iface.identifier.UTF8String;
+        info.type = "N/A";
+        info.description = iface.localizedDisplayName
+                               ? std::string(iface.localizedDisplayName.UTF8String)
+                               : info.id;
+
+        result.push_back(std::move(info));
+    }
+
+    return result;
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -199,6 +199,10 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
             VZVirtioNetworkDeviceConfiguration* bridgedDevice =
                 [[VZVirtioNetworkDeviceConfiguration alloc] init];
             bridgedDevice.attachment = bridge.attachment;
+            VZMACAddress* bridgedMac = [[VZMACAddress alloc]
+                initWithString:[NSString stringWithCString:extra.mac_address.c_str()
+                                                  encoding:NSUTF8StringEncoding]];
+            [bridgedDevice setMACAddress:bridgedMac];
 
             [networkDevices addObject:bridgedDevice];
 

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -36,9 +36,10 @@ namespace multipass::applevz
 {
 struct VirtualMachineHandle
 {
-    std::shared_ptr<void> vm; // Ownership transfer of VZVirtualMachine*
-    dispatch_queue_t queue;   // Dispatch queue for VM operations
-    uint64_t id;              // Unique VM ID
+    std::shared_ptr<void> vm;                        // Ownership transfer of VZVirtualMachine*
+    dispatch_queue_t queue;                          // Dispatch queue for VM operations
+    uint64_t id;                                     // Unique VM ID
+    std::vector<std::unique_ptr<VmnetRelay>> relays; // Vmnet relays
 };
 } // namespace multipass::applevz
 

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -16,6 +16,7 @@
  */
 
 #include <applevz/applevz_bridge.h>
+#include <applevz/applevz_vmnet.h>
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <Foundation/Foundation.h>

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -36,10 +36,10 @@ namespace multipass::applevz
 {
 struct VirtualMachineHandle
 {
-    std::shared_ptr<void> vm;                        // Ownership transfer of VZVirtualMachine*
-    dispatch_queue_t queue;                          // Dispatch queue for VM operations
-    uint64_t id;                                     // Unique VM ID
-    std::vector<std::unique_ptr<VmnetRelay>> relays; // Vmnet relays
+    std::shared_ptr<void> vm;             // Ownership transfer of VZVirtualMachine*
+    dispatch_queue_t queue;               // Dispatch queue for VM operations
+    uint64_t id;                          // Unique VM ID
+    std::vector<VmnetRelayHandle> relays; // vmnet relay lifetime handles
 };
 } // namespace multipass::applevz
 
@@ -191,34 +191,18 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
         [networkDevices addObject:netDevice];
 
         // Extra bridged interfaces
-        NSArray<VZBridgedNetworkInterface*>* hostInterfaces =
-            [VZBridgedNetworkInterface networkInterfaces];
+        std::vector<VmnetRelayHandle> relays;
         for (const auto& extra : desc.extra_interfaces)
         {
-            NSString* targetId = [NSString stringWithCString:extra.id.c_str()
-                                                    encoding:NSUTF8StringEncoding];
-
-            VZBridgedNetworkInterface* found = nil;
-            for (VZBridgedNetworkInterface* hostIface in hostInterfaces)
-            {
-                if ([hostIface.identifier isEqualToString:targetId])
-                {
-                    found = hostIface;
-                    break;
-                }
-            }
-
-            assert(found && "Bridged interface not found - extra_interfaces must be validated "
-                            "before VM creation");
-
-            VZBridgedNetworkDeviceAttachment* bridgedAttachment =
-                [[VZBridgedNetworkDeviceAttachment alloc] initWithInterface:found];
+            VmnetBridge bridge = create_vmnet_bridge(extra.id);
 
             VZVirtioNetworkDeviceConfiguration* bridgedDevice =
                 [[VZVirtioNetworkDeviceConfiguration alloc] init];
-            bridgedDevice.attachment = bridgedAttachment;
+            bridgedDevice.attachment = bridge.attachment;
 
             [networkDevices addObject:bridgedDevice];
+
+            relays.push_back(std::move(bridge.relay));
         }
 
         config.networkDevices = networkDevices;
@@ -235,7 +219,7 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
         }
 
         out_handle = std::make_shared<VirtualMachineHandle>();
-
+        out_handle->relays = std::move(relays);
         out_handle->id = vmIDCounter.fetch_add(1, std::memory_order_relaxed);
 
         // Create dispatch queue

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -339,14 +339,11 @@ std::vector<NetworkInterfaceInfo> bridged_network_interfaces()
 
     for (VZBridgedNetworkInterface* iface in [VZBridgedNetworkInterface networkInterfaces])
     {
-        NetworkInterfaceInfo info;
-        info.id = iface.identifier.UTF8String;
-        info.type = "N/A";
-        info.description = iface.localizedDisplayName
-                               ? std::string(iface.localizedDisplayName.UTF8String)
-                               : info.id;
-
-        result.push_back(std::move(info));
+        result.emplace_back(/* id = */ iface.identifier.UTF8String,
+                            /* type = */ "N/A",
+                            /* description = */ iface.localizedDisplayName
+                                ? std::string(iface.localizedDisplayName.UTF8String)
+                                : iface.identifier.UTF8String);
     }
 
     return result;

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -75,6 +75,11 @@ std::vector<NetworkInterfaceInfo> AppleVZVirtualMachineFactory::networks() const
     return MP_APPLEVZ.bridged_network_interfaces();
 }
 
+std::string AppleVZVirtualMachineFactory::create_bridge_with(const NetworkInterfaceInfo& interface)
+{
+    return interface.id;
+}
+
 VirtualMachine::UPtr AppleVZVirtualMachineFactory::clone_vm_impl(
     const std::string& /*source_vm_name*/,
     const multipass::VMSpecs& /*src_vm_specs*/,

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -70,6 +70,11 @@ void AppleVZVirtualMachineFactory::remove_resources_for_impl(const std::string& 
 {
 }
 
+std::vector<NetworkInterfaceInfo> AppleVZVirtualMachineFactory::networks() const
+{
+    return MP_APPLEVZ.bridged_network_interfaces();
+}
+
 VirtualMachine::UPtr AppleVZVirtualMachineFactory::clone_vm_impl(
     const std::string& /*source_vm_name*/,
     const multipass::VMSpecs& /*src_vm_specs*/,

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.h
@@ -48,6 +48,8 @@ public:
         return "applevz";
     };
 
+    std::vector<NetworkInterfaceInfo> networks() const override;
+
 protected:
     void remove_resources_for_impl(const std::string& name) override;
 

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.h
@@ -52,6 +52,7 @@ public:
 
 protected:
     void remove_resources_for_impl(const std::string& name) override;
+    std::string create_bridge_with(const NetworkInterfaceInfo& interface) override;
 
 private:
     VirtualMachine::UPtr clone_vm_impl(const std::string& source_vm_name,

--- a/src/platform/backends/applevz/applevz_vmnet.h
+++ b/src/platform/backends/applevz/applevz_vmnet.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once

--- a/src/platform/backends/applevz/applevz_vmnet.h
+++ b/src/platform/backends/applevz/applevz_vmnet.h
@@ -16,3 +16,22 @@
  */
 
 #pragma once
+
+#include <vmnet/vmnet.h>
+
+namespace multipass::applevz
+{
+struct VmnetRelay
+{
+    interface_ref iface;
+    int fd;
+    dispatch_source_t source;
+    dispatch_queue_t queue;
+
+    ~VmnetRelay();
+
+    VmnetRelay() = default;
+    VmnetRelay(const VmnetRelay&) = delete;
+    VmnetRelay& operator=(const VmnetRelay&) = delete;
+};
+} // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_vmnet.h
+++ b/src/platform/backends/applevz/applevz_vmnet.h
@@ -17,21 +17,22 @@
 
 #pragma once
 
-#include <vmnet/vmnet.h>
+#include <Virtualization/Virtualization.h>
+
+#include <memory>
 
 namespace multipass::applevz
 {
-struct VmnetRelay
+
+// Opaque handle whose lifetime must exceed that of the attachment it was created with.
+using VmnetRelayHandle = std::shared_ptr<void>;
+
+struct VmnetBridge
 {
-    interface_ref iface;
-    int fd;
-    dispatch_source_t source;
-    dispatch_queue_t queue;
-
-    ~VmnetRelay();
-
-    VmnetRelay() = default;
-    VmnetRelay(const VmnetRelay&) = delete;
-    VmnetRelay& operator=(const VmnetRelay&) = delete;
+    VZFileHandleNetworkDeviceAttachment* attachment;
+    VmnetRelayHandle relay;
 };
+
+VmnetBridge create_vmnet_bridge(const std::string& physical_iface);
+
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -27,7 +27,9 @@ namespace mpl = multipass::logging;
 
 namespace
 {
-constexpr auto kLogCategory = "vmnet";
+constexpr auto category = "vmnet";
+constexpr uint32_t kSendBufferSize{65 * 1024};
+constexpr uint32_t kRecvBufferSize{4 * 1024 * 1024};
 
 struct VmnetRelay
 {
@@ -100,7 +102,7 @@ void start_vmnet_interface(VmnetRelay& relay, const std::string& physical_iface)
                                              physical_iface));
     }
 
-    mpl::debug(kLogCategory, "vmnet bridged interface started on '{}'", physical_iface);
+    mpl::debug(category, "vmnet bridged interface started on '{}'", physical_iface);
 }
 
 void setup_relay(VmnetRelay& relay, int relay_fd)
@@ -109,7 +111,16 @@ void setup_relay(VmnetRelay& relay, int relay_fd)
 
 std::pair<int, int> create_socket_pair()
 {
-    return {-1, -1};
+    int fds[2];
+    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, fds) < 0)
+        throw std::runtime_error(fmt::format("socketpair() failed: {}", strerror(errno)));
+
+    setsockopt(fds[0], SOL_SOCKET, SO_RCVBUF, &kRecvBufferSize, sizeof(kRecvBufferSize));
+    setsockopt(fds[0], SOL_SOCKET, SO_SNDBUF, &kSendBufferSize, sizeof(kSendBufferSize));
+    setsockopt(fds[1], SOL_SOCKET, SO_RCVBUF, &kRecvBufferSize, sizeof(kRecvBufferSize));
+    setsockopt(fds[1], SOL_SOCKET, SO_SNDBUF, &kSendBufferSize, sizeof(kSendBufferSize));
+
+    return {fds[0], fds[1]};
 }
 } // namespace
 

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -55,8 +55,36 @@ struct VmnetRelay
     VmnetRelay(const VmnetRelay&) = delete;
     VmnetRelay& operator=(const VmnetRelay&) = delete;
 };
+
+void start_vmnet_interface(VmnetRelay& relay, const std::string& physical_iface)
+{
+}
+
+void setup_relay(VmnetRelay& relay, int relay_fd)
+{
+}
+
+std::pair<int, int> create_socket_pair()
+{
+    return {-1, -1};
+}
 } // namespace
 
 namespace multipass::applevz
 {
+VmnetBridge create_vmnet_bridge(const std::string& physical_iface)
+{
+    auto relay = std::make_unique<VmnetRelay>();
+    start_vmnet_interface(*relay, physical_iface);
+
+    auto [vz_fd, relay_fd] = create_socket_pair();
+    setup_relay(*relay, relay_fd);
+
+    NSFileHandle* vz_handle = [[NSFileHandle alloc] initWithFileDescriptor:vz_fd
+                                                            closeOnDealloc:YES];
+    VZFileHandleNetworkDeviceAttachment* attachment =
+        [[VZFileHandleNetworkDeviceAttachment alloc] initWithFileHandle:vz_handle];
+
+    return VmnetBridge{attachment, std::move(relay)};
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -17,23 +17,46 @@
 
 #include <applevz/applevz_vmnet.h>
 
-namespace multipass::applevz
-{
-VmnetRelay::~VmnetRelay()
-{
-    if (source)
-        dispatch_source_cancel(source);
+#include <vmnet/vmnet.h>
 
-    if (iface)
+namespace
+{
+constexpr uint32_t kDefaultMaxPacketBytes = 1518;
+
+struct VmnetRelay
+{
+    interface_ref iface{nullptr};
+    int fd{-1};
+    dispatch_source_t source{nullptr};
+    dispatch_queue_t queue{nullptr};
+    uint32_t max_packet_bytes{kDefaultMaxPacketBytes};
+
+    ~VmnetRelay()
     {
-        dispatch_semaphore_t s = dispatch_semaphore_create(0);
-        vmnet_stop_interface(iface, queue, ^(vmnet_return_t) {
-          dispatch_semaphore_signal(s);
-        });
-        dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+        if (source)
+            dispatch_source_cancel(source);
+
+        if (iface)
+        {
+            dispatch_semaphore_t s = dispatch_semaphore_create(0);
+            vmnet_stop_interface(iface,
+                                 dispatch_get_global_queue(QOS_CLASS_UTILITY, 0),
+                                 ^(vmnet_return_t) {
+                                   dispatch_semaphore_signal(s);
+                                 });
+            dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+        }
+
+        if (fd >= 0)
+            close(fd);
     }
 
-    if (fd >= 0)
-        close(fd);
-}
+    VmnetRelay() = default;
+    VmnetRelay(const VmnetRelay&) = delete;
+    VmnetRelay& operator=(const VmnetRelay&) = delete;
+};
+} // namespace
+
+namespace multipass::applevz
+{
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -16,12 +16,18 @@
  */
 
 #include <applevz/applevz_vmnet.h>
+#include <multipass/logging/log.h>
 
+#include <fmt/format.h>
+
+#include <errno.h>
 #include <vmnet/vmnet.h>
+
+namespace mpl = multipass::logging;
 
 namespace
 {
-constexpr uint32_t kDefaultMaxPacketBytes = 1518;
+constexpr auto kLogCategory = "vmnet";
 
 struct VmnetRelay
 {
@@ -29,7 +35,7 @@ struct VmnetRelay
     int fd{-1};
     dispatch_source_t source{nullptr};
     dispatch_queue_t queue{nullptr};
-    uint32_t max_packet_bytes{kDefaultMaxPacketBytes};
+    uint32_t max_packet_bytes{0};
 
     ~VmnetRelay()
     {
@@ -58,6 +64,43 @@ struct VmnetRelay
 
 void start_vmnet_interface(VmnetRelay& relay, const std::string& physical_iface)
 {
+    relay.queue = dispatch_queue_create(
+        fmt::format("com.canonical.multipassd.vmnet.{}", physical_iface).c_str(),
+        DISPATCH_QUEUE_SERIAL);
+
+    xpc_object_t iface_opts = xpc_dictionary_create(nullptr, nullptr, 0);
+    xpc_dictionary_set_uint64(iface_opts, vmnet_operation_mode_key, VMNET_BRIDGED_MODE);
+    xpc_dictionary_set_string(iface_opts, vmnet_shared_interface_name_key, physical_iface.c_str());
+
+    uuid_t iface_uuid;
+    uuid_generate_random(iface_uuid);
+    xpc_dictionary_set_uuid(iface_opts, vmnet_interface_id_key, iface_uuid);
+
+    dispatch_semaphore_t vmnet_sema = dispatch_semaphore_create(0);
+    __block vmnet_return_t vmnet_status = VMNET_FAILURE;
+
+    // Starting the vmnet interface requires root on macOS 15 and older
+    relay.iface = vmnet_start_interface(
+        iface_opts,
+        relay.queue,
+        ^(vmnet_return_t status, xpc_object_t params) {
+          vmnet_status = status;
+          if (status == VMNET_SUCCESS)
+              relay.max_packet_bytes =
+                  (uint32_t)xpc_dictionary_get_uint64(params, vmnet_max_packet_size_key);
+          dispatch_semaphore_signal(vmnet_sema);
+        });
+
+    dispatch_semaphore_wait(vmnet_sema, DISPATCH_TIME_FOREVER);
+
+    if (vmnet_status != VMNET_SUCCESS || !relay.iface)
+    {
+        throw std::runtime_error(fmt::format("vmnet_start_interface() failed (status {}) for '{}'",
+                                             static_cast<int>(vmnet_status),
+                                             physical_iface));
+    }
+
+    mpl::debug(kLogCategory, "vmnet bridged interface started on '{}'", physical_iface);
 }
 
 void setup_relay(VmnetRelay& relay, int relay_fd)

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -49,10 +49,15 @@ struct VmnetRelay
             dispatch_semaphore_t s = dispatch_semaphore_create(0);
             vmnet_stop_interface(iface,
                                  dispatch_get_global_queue(QOS_CLASS_UTILITY, 0),
-                                 ^(vmnet_return_t) {
+                                 ^(vmnet_return_t status) {
+                                   if (status != VMNET_SUCCESS)
+                                       mpl::info(category,
+                                                 "vmnet_stop_interface() failed (status {})",
+                                                 static_cast<int>(status));
                                    dispatch_semaphore_signal(s);
                                  });
-            dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+            if (dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC)) != 0)
+                mpl::info(category, "timed out waiting for vmnet_stop_interface() to complete");
         }
 
         if (fd >= 0)

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -74,10 +74,6 @@ void start_vmnet_interface(VmnetRelay& relay, const std::string& physical_iface)
     xpc_dictionary_set_uint64(iface_opts, vmnet_operation_mode_key, VMNET_BRIDGED_MODE);
     xpc_dictionary_set_string(iface_opts, vmnet_shared_interface_name_key, physical_iface.c_str());
 
-    uuid_t iface_uuid;
-    uuid_generate_random(iface_uuid);
-    xpc_dictionary_set_uuid(iface_opts, vmnet_interface_id_key, iface_uuid);
-
     dispatch_semaphore_t vmnet_sema = dispatch_semaphore_create(0);
     __block vmnet_return_t vmnet_status = VMNET_FAILURE;
 

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -36,6 +36,10 @@
 
 #include <fmt/format.h>
 
+#include <array>
+#include <chrono>
+#include <thread>
+
 #include <errno.h>
 #include <vmnet/vmnet.h>
 
@@ -260,8 +264,7 @@ bool forward_from_host(VmnetRelay& relay, bool bulk)
             {
                 if (errno == ENOBUFS)
                 {
-                    struct timespec t{0, kSendRetryDelayNs};
-                    nanosleep(&t, nullptr);
+                    std::this_thread::sleep_for(std::chrono::nanoseconds{kSendRetryDelayNs});
                     continue;
                 }
                 mpl::trace(category, "sendmsg_x() failed: {}", strerror(errno));
@@ -281,10 +284,7 @@ bool forward_from_host(VmnetRelay& relay, bool bulk)
             {
                 sent = send(relay.fd, data, pkt_size, 0);
                 if (sent < 0 && errno == ENOBUFS)
-                {
-                    struct timespec t{0, kSendRetryDelayNs};
-                    nanosleep(&t, nullptr);
-                }
+                    std::this_thread::sleep_for(std::chrono::nanoseconds{kSendRetryDelayNs});
             } while (sent < 0 && errno == ENOBUFS);
 
             if (sent < 0)
@@ -331,8 +331,8 @@ void start_forwarding_from_host(VmnetRelay& relay)
 
 std::pair<int, int> create_socket_pair()
 {
-    int fds[2];
-    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, fds) < 0)
+    std::array<int, 2> fds{};
+    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, fds.data()) < 0)
         throw std::runtime_error(fmt::format("socketpair() failed: {}", strerror(errno)));
 
     setsockopt(fds[0], SOL_SOCKET, SO_RCVBUF, &kRecvBufferSize, sizeof(kRecvBufferSize));

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) The vmnet-helper authors
  * Copyright (C) Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -13,6 +14,20 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
+ */
+
+/*
+   Portions of this file are derived from vmnet-helper by Nir Soffer
+   (https://github.com/nirs/vmnet-helper), originally licensed under the
+   Apache License, Version 2.0.  The combined work is distributed under
+   the terms of GPL-3.0.
+
+   The following adaptations were made for use with Multipass:
+   - rewritten in idiomatic Objective-C++ and integrated as a library;
+   - connected to Apple Virtualization framework via a socketpair and
+     VZFileHandleNetworkDeviceAttachment;
+   - removed unused network options
+   - Multipass logging;
  */
 
 #include <applevz/applevz_utils.h>

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -15,6 +15,7 @@
  *
  */
 
+#include <applevz/applevz_utils.h>
 #include <applevz/applevz_vmnet.h>
 #include <multipass/logging/log.h>
 
@@ -30,19 +31,77 @@ namespace
 constexpr auto category = "vmnet";
 constexpr uint32_t kSendBufferSize{65 * 1024};
 constexpr uint32_t kRecvBufferSize{4 * 1024 * 1024};
+constexpr int kMaxPacketCount{200};
+constexpr int kMaxPacketCountLarge{16};
+constexpr uint32_t kLargePacketThreshold{64 * 1024};
+constexpr uint64_t kSendRetryDelayNs{50 * 1000};
+
+struct msghdr_x
+{
+    struct msghdr msg_hdr;
+    size_t msg_len;
+};
+extern "C" ssize_t recvmsg_x(int s, const msghdr_x* msgp, unsigned int cnt, int flags);
+extern "C" ssize_t sendmsg_x(int s, const msghdr_x* msgp, unsigned int cnt, int flags);
 
 struct VmnetRelay
 {
     interface_ref iface{nullptr};
     int fd{-1};
-    dispatch_source_t source{nullptr};
     dispatch_queue_t queue{nullptr};
+    dispatch_queue_t vm_queue{nullptr};
     uint32_t max_packet_bytes{0};
+
+    // Pre-allocated buffers for host->vm (vmnet read / socket write).
+    std::vector<uint8_t> host_buffers;
+    std::vector<vmpktdesc> host_packets;
+    std::vector<iovec> host_iovs;
+    std::vector<msghdr_x> host_msgs;
+
+    // Pre-allocated buffers for vm->host (socket read / vmnet write).
+    std::vector<uint8_t> vm_buffers;
+    std::vector<vmpktdesc> vm_packets;
+    std::vector<iovec> vm_iovs;
+    std::vector<msghdr_x> vm_msgs;
+
+    void init_buffers()
+    {
+        const int packet_count =
+            (max_packet_bytes >= kLargePacketThreshold) ? kMaxPacketCountLarge : kMaxPacketCount;
+
+        auto bind_endpoint = [&](std::vector<uint8_t>& buffers,
+                                 std::vector<vmpktdesc>& packets,
+                                 std::vector<iovec>& iovs,
+                                 std::vector<msghdr_x>& msgs) {
+            buffers.resize((size_t)packet_count * max_packet_bytes);
+            packets.resize(packet_count);
+            iovs.resize(packet_count);
+            msgs.resize(packet_count);
+            for (int i = 0; i < packet_count; i++)
+            {
+                iovs[i].iov_base = buffers.data() + (size_t)i * max_packet_bytes;
+                iovs[i].iov_len = max_packet_bytes;
+                packets[i].vm_pkt_iov = &iovs[i];
+                packets[i].vm_pkt_iovcnt = 1;
+                msgs[i].msg_hdr.msg_iov = &iovs[i];
+                msgs[i].msg_hdr.msg_iovlen = 1;
+            }
+        };
+
+        bind_endpoint(host_buffers, host_packets, host_iovs, host_msgs);
+        bind_endpoint(vm_buffers, vm_packets, vm_iovs, vm_msgs);
+    }
 
     ~VmnetRelay()
     {
-        if (source)
-            dispatch_source_cancel(source);
+        if (fd >= 0)
+            close(fd);
+
+        // Wait for the vm->host forwarding loop to exit before stopping vmnet.
+        if (vm_queue)
+            dispatch_sync(vm_queue,
+                          ^{
+                          });
 
         if (iface)
         {
@@ -51,17 +110,14 @@ struct VmnetRelay
                                  dispatch_get_global_queue(QOS_CLASS_UTILITY, 0),
                                  ^(vmnet_return_t status) {
                                    if (status != VMNET_SUCCESS)
-                                       mpl::info(category,
+                                       mpl::warn(category,
                                                  "vmnet_stop_interface() failed (status {})",
                                                  static_cast<int>(status));
                                    dispatch_semaphore_signal(s);
                                  });
             if (dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC)) != 0)
-                mpl::info(category, "timed out waiting for vmnet_stop_interface() to complete");
+                mpl::warn(category, "timed out waiting for vmnet_stop_interface() to complete");
         }
-
-        if (fd >= 0)
-            close(fd);
     }
 
     VmnetRelay() = default;
@@ -106,58 +162,156 @@ void start_vmnet_interface(VmnetRelay& relay, const std::string& physical_iface)
     mpl::debug(category, "vmnet bridged interface started on '{}'", physical_iface);
 }
 
-void setup_relay(VmnetRelay& relay, int relay_fd)
+// Forward packets from the socket to the vmnet interface.
+// Runs as a blocking loop on a dedicated queue until the socket is closed.
+void forward_from_vm(VmnetRelay& relay, bool bulk)
 {
-    relay.fd = relay_fd;
+    for (;;)
+    {
+        int count = 0;
 
-    const auto iface = relay.iface;
-    const auto max_packet_bytes = relay.max_packet_bytes;
+        if (bulk)
+        {
+            int max_count = (int)relay.vm_msgs.size();
+            for (int i = 0; i < max_count; i++)
+                relay.vm_iovs[i].iov_len = relay.max_packet_bytes;
 
-    // read from socket, write to vmnet
-    relay.source =
-        dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)relay_fd, 0, relay.queue);
+            count = (int)recvmsg_x(relay.fd, relay.vm_msgs.data(), max_count, 0);
+            if (count < 0 && errno != EBADF && errno != ECONNRESET)
+                mpl::trace(category, "recvmsg_x() failed: {}", strerror(errno));
+        }
+        else
+        {
+            relay.vm_iovs[0].iov_len = relay.max_packet_bytes;
+            ssize_t n = recv(relay.fd, relay.vm_iovs[0].iov_base, relay.max_packet_bytes, 0);
+            if (n < 0 && errno != EBADF && errno != ECONNRESET)
+                mpl::trace(category, "recv() failed: {}", strerror(errno));
+            if (n > 0)
+            {
+                relay.vm_msgs[0].msg_len = (size_t)n;
+                count = 1;
+            }
+        }
 
-    dispatch_source_set_event_handler(relay.source, ^{
-      std::vector<uint8_t> buf(max_packet_bytes);
-      ssize_t n = recv(relay_fd, buf.data(), buf.size(), 0);
-      if (n <= 0)
-          return;
+        if (count <= 0)
+            break;
 
-      struct iovec iov{buf.data(), (size_t)n};
-      struct vmpktdesc pkt{};
-      pkt.vm_pkt_size = (size_t)n;
-      pkt.vm_pkt_iov = &iov;
-      pkt.vm_pkt_iovcnt = 1;
-      pkt.vm_flags = 0;
+        for (int i = 0; i < count; i++)
+        {
+            relay.vm_packets[i].vm_pkt_size = relay.vm_msgs[i].msg_len;
+            relay.vm_packets[i].vm_flags = 0;
+            relay.vm_iovs[i].iov_len = relay.vm_msgs[i].msg_len;
+        }
 
-      int count = 1;
-      vmnet_write(iface, &pkt, &count);
+        int write_count = count;
+        vmnet_return_t status = vmnet_write(relay.iface, relay.vm_packets.data(), &write_count);
+        if (status != VMNET_SUCCESS)
+            mpl::trace(category, "vmnet_write() failed (status {})", static_cast<int>(status));
+    }
+}
+
+// Forward one batch of packets from the vmnet interface to the socket.
+// Returns false when vmnet has no more packets to deliver this callback.
+bool forward_from_host(VmnetRelay& relay, bool bulk)
+{
+    int count = (int)relay.host_packets.size();
+    for (int i = 0; i < count; i++)
+    {
+        relay.host_packets[i].vm_pkt_size = relay.max_packet_bytes;
+        relay.host_packets[i].vm_flags = 0;
+        relay.host_iovs[i].iov_len = relay.max_packet_bytes;
+    }
+
+    vmnet_return_t read_status = vmnet_read(relay.iface, relay.host_packets.data(), &count);
+    if (read_status != VMNET_SUCCESS)
+    {
+        mpl::trace(category, "vmnet_read() failed (status {})", static_cast<int>(read_status));
+        return false;
+    }
+
+    if (bulk)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            relay.host_msgs[i].msg_len = relay.host_packets[i].vm_pkt_size;
+            relay.host_iovs[i].iov_len = relay.host_packets[i].vm_pkt_size;
+        }
+
+        int sent = 0;
+        while (sent < count)
+        {
+            ssize_t n = sendmsg_x(relay.fd, relay.host_msgs.data() + sent, count - sent, 0);
+            if (n < 0)
+            {
+                if (errno == ENOBUFS)
+                {
+                    struct timespec t{0, kSendRetryDelayNs};
+                    nanosleep(&t, nullptr);
+                    continue;
+                }
+                mpl::trace(category, "sendmsg_x() failed: {}", strerror(errno));
+                break;
+            }
+            sent += (int)n;
+        }
+    }
+    else
+    {
+        for (int i = 0; i < count; i++)
+        {
+            const auto* data = static_cast<const uint8_t*>(relay.host_iovs[i].iov_base);
+            size_t pkt_size = relay.host_packets[i].vm_pkt_size;
+            ssize_t sent;
+            do
+            {
+                sent = send(relay.fd, data, pkt_size, 0);
+                if (sent < 0 && errno == ENOBUFS)
+                {
+                    struct timespec t{0, kSendRetryDelayNs};
+                    nanosleep(&t, nullptr);
+                }
+            } while (sent < 0 && errno == ENOBUFS);
+
+            if (sent < 0)
+                mpl::trace(category, "send() failed: {}", strerror(errno));
+        }
+    }
+
+    return count > 0;
+}
+
+void start_forwarding_from_vm(VmnetRelay& relay)
+{
+    const bool bulk = MP_APPLEVZ_UTILS.macos_at_least(14, 0);
+
+    relay.vm_queue =
+        dispatch_queue_create("com.canonical.multipassd.vmnet.vm", DISPATCH_QUEUE_SERIAL);
+    dispatch_async(relay.vm_queue, ^{
+      forward_from_vm(relay, bulk);
     });
-    dispatch_resume(relay.source);
 
-    // read from vmnet, write to socket
-    vmnet_interface_set_event_callback(iface,
-                                       VMNET_INTERFACE_PACKETS_AVAILABLE,
-                                       relay.queue,
-                                       ^(interface_event_t /*event*/, xpc_object_t /*params*/) {
-                                         for (;;)
-                                         {
-                                             std::vector<uint8_t> buf(max_packet_bytes);
-                                             struct iovec iov{buf.data(), buf.size()};
-                                             struct vmpktdesc pkt{};
-                                             pkt.vm_pkt_size = buf.size();
-                                             pkt.vm_pkt_iov = &iov;
-                                             pkt.vm_pkt_iovcnt = 1;
-                                             pkt.vm_flags = 0;
+    mpl::debug(category, "vmnet vm->host forwarding started");
+}
 
-                                             int count = 1;
-                                             if (vmnet_read(iface, &pkt, &count) != VMNET_SUCCESS ||
-                                                 count == 0)
-                                                 break;
+void start_forwarding_from_host(VmnetRelay& relay)
+{
+    const bool bulk = MP_APPLEVZ_UTILS.macos_at_least(14, 0);
 
-                                             send(relay_fd, buf.data(), pkt.vm_pkt_size, 0);
-                                         }
-                                       });
+    vmnet_return_t status =
+        vmnet_interface_set_event_callback(relay.iface,
+                                           VMNET_INTERFACE_PACKETS_AVAILABLE,
+                                           relay.queue,
+                                           ^(interface_event_t /*event*/, xpc_object_t /*params*/) {
+                                             while (forward_from_host(relay, bulk))
+                                                 ;
+                                           });
+
+    if (status != VMNET_SUCCESS)
+        throw std::runtime_error(
+            fmt::format("vmnet_interface_set_event_callback() failed (status {})",
+                        static_cast<int>(status)));
+
+    mpl::debug(category, "vmnet host->vm forwarding started");
 }
 
 std::pair<int, int> create_socket_pair()
@@ -183,7 +337,12 @@ VmnetBridge create_vmnet_bridge(const std::string& physical_iface)
     start_vmnet_interface(*relay, physical_iface);
 
     auto [vz_fd, relay_fd] = create_socket_pair();
-    setup_relay(*relay, relay_fd);
+
+    relay->fd = relay_fd;
+    relay->init_buffers();
+
+    start_forwarding_from_host(*relay);
+    start_forwarding_from_vm(*relay);
 
     NSFileHandle* vz_handle = [[NSFileHandle alloc] initWithFileDescriptor:vz_fd
                                                             closeOnDealloc:YES];

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -14,3 +14,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
+#include <applevz/applevz_vmnet.h>
+
+namespace multipass::applevz
+{
+VmnetRelay::~VmnetRelay()
+{
+    if (source)
+        dispatch_source_cancel(source);
+
+    if (iface)
+    {
+        dispatch_semaphore_t s = dispatch_semaphore_create(0);
+        vmnet_stop_interface(iface, queue, ^(vmnet_return_t) {
+          dispatch_semaphore_signal(s);
+        });
+        dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+    }
+
+    if (fd >= 0)
+        close(fd);
+}
+} // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -107,6 +107,56 @@ void start_vmnet_interface(VmnetRelay& relay, const std::string& physical_iface)
 
 void setup_relay(VmnetRelay& relay, int relay_fd)
 {
+    relay.fd = relay_fd;
+
+    const auto iface = relay.iface;
+    const auto max_packet_bytes = relay.max_packet_bytes;
+
+    // read from socket, write to vmnet
+    relay.source =
+        dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)relay_fd, 0, relay.queue);
+
+    dispatch_source_set_event_handler(relay.source, ^{
+      std::vector<uint8_t> buf(max_packet_bytes);
+      ssize_t n = recv(relay_fd, buf.data(), buf.size(), 0);
+      if (n <= 0)
+          return;
+
+      struct iovec iov{buf.data(), (size_t)n};
+      struct vmpktdesc pkt{};
+      pkt.vm_pkt_size = (size_t)n;
+      pkt.vm_pkt_iov = &iov;
+      pkt.vm_pkt_iovcnt = 1;
+      pkt.vm_flags = 0;
+
+      int count = 1;
+      vmnet_write(iface, &pkt, &count);
+    });
+    dispatch_resume(relay.source);
+
+    // read from vmnet, write to socket
+    vmnet_interface_set_event_callback(iface,
+                                       VMNET_INTERFACE_PACKETS_AVAILABLE,
+                                       relay.queue,
+                                       ^(interface_event_t /*event*/, xpc_object_t /*params*/) {
+                                         for (;;)
+                                         {
+                                             std::vector<uint8_t> buf(max_packet_bytes);
+                                             struct iovec iov{buf.data(), buf.size()};
+                                             struct vmpktdesc pkt{};
+                                             pkt.vm_pkt_size = buf.size();
+                                             pkt.vm_pkt_iov = &iov;
+                                             pkt.vm_pkt_iovcnt = 1;
+                                             pkt.vm_flags = 0;
+
+                                             int count = 1;
+                                             if (vmnet_read(iface, &pkt, &count) != VMNET_SUCCESS ||
+                                                 count == 0)
+                                                 break;
+
+                                             send(relay_fd, buf.data(), pkt.vm_pkt_size, 0);
+                                         }
+                                       });
 }
 
 std::pair<int, int> create_socket_pair()

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -53,7 +53,7 @@ constexpr uint32_t kRecvBufferSize{4 * 1024 * 1024};
 constexpr int kMaxPacketCount{200};
 constexpr int kMaxPacketCountLarge{16};
 constexpr uint32_t kLargePacketThreshold{64 * 1024};
-constexpr uint64_t kSendRetryDelayNs{50 * 1000};
+constexpr std::chrono::microseconds kSendRetryDelay{50};
 
 struct msghdr_x
 {
@@ -268,7 +268,7 @@ bool forward_from_host(VmnetRelay& relay, bool bulk)
             {
                 if (errno == ENOBUFS)
                 {
-                    std::this_thread::sleep_for(std::chrono::nanoseconds{kSendRetryDelayNs});
+                    std::this_thread::sleep_for(kSendRetryDelay);
                     continue;
                 }
                 mpl::trace(category, "sendmsg_x() failed: {}", strerror(errno));
@@ -288,7 +288,7 @@ bool forward_from_host(VmnetRelay& relay, bool bulk)
             {
                 sent = send(relay.fd, data, pkt_size, 0);
                 if (sent < 0 && errno == ENOBUFS)
-                    std::this_thread::sleep_for(std::chrono::nanoseconds{kSendRetryDelayNs});
+                    std::this_thread::sleep_for(kSendRetryDelay);
             } while (sent < 0 && errno == ENOBUFS);
 
             if (sent < 0)

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -281,16 +281,16 @@ bool forward_from_host(VmnetRelay& relay, bool bulk)
         {
             const auto* data = static_cast<const uint8_t*>(relay.host_endpoint.iovs[i].iov_base);
             size_t pkt_size = relay.host_endpoint.packets[i].vm_pkt_size;
-            ssize_t sent;
-            do
+            while (send(relay.fd, data, pkt_size, 0) < 0)
             {
-                sent = send(relay.fd, data, pkt_size, 0);
-                if (sent < 0 && errno == ENOBUFS)
+                if (errno == ENOBUFS)
                     std::this_thread::sleep_for(kSendRetryDelay);
-            } while (sent < 0 && errno == ENOBUFS);
-
-            if (sent < 0)
-                mpl::trace(category, "send() failed: {}", strerror(errno));
+                else
+                {
+                    mpl::trace(category, "send() failed: {}", strerror(errno));
+                    break;
+                }
+            }
         }
     }
 

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -332,7 +332,7 @@ void start_forwarding_from_host(VmnetRelay& relay)
     mpl::debug(category, "vmnet host->vm forwarding started");
 }
 
-std::pair<int, int> create_socket_pair()
+std::array<int, 2> create_socket_pair()
 {
     std::array<int, 2> fds{};
     if (socketpair(AF_UNIX, SOCK_DGRAM, 0, fds.data()) < 0)
@@ -343,7 +343,7 @@ std::pair<int, int> create_socket_pair()
     setsockopt(fds[1], SOL_SOCKET, SO_RCVBUF, &kRecvBufferSize, sizeof(kRecvBufferSize));
     setsockopt(fds[1], SOL_SOCKET, SO_SNDBUF, &kSendBufferSize, sizeof(kSendBufferSize));
 
-    return {fds[0], fds[1]};
+    return fds;
 }
 } // namespace
 

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -181,54 +181,52 @@ void start_vmnet_interface(VmnetRelay& relay, const std::string& physical_iface)
     mpl::debug(category, "vmnet bridged interface started on '{}'", physical_iface);
 }
 
-// Forward packets from the socket to the vmnet interface.
-// Runs as a blocking loop on a dedicated queue until the socket is closed.
-void forward_from_vm(VmnetRelay& relay, bool bulk)
+// Forward one batch of packets from the socket to the vmnet interface.
+// Returns false when the socket is closed.
+bool forward_from_vm(VmnetRelay& relay, bool bulk)
 {
-    for (;;)
+    int count = 0;
+
+    if (bulk)
     {
-        int count = 0;
+        int max_count = (int)relay.vm_endpoint.msgs.size();
+        for (int i = 0; i < max_count; i++)
+            relay.vm_endpoint.iovs[i].iov_len = relay.max_packet_bytes;
 
-        if (bulk)
-        {
-            int max_count = (int)relay.vm_endpoint.msgs.size();
-            for (int i = 0; i < max_count; i++)
-                relay.vm_endpoint.iovs[i].iov_len = relay.max_packet_bytes;
-
-            count = (int)recvmsg_x(relay.fd, relay.vm_endpoint.msgs.data(), max_count, 0);
-            if (count < 0 && errno != EBADF && errno != ECONNRESET)
-                mpl::trace(category, "recvmsg_x() failed: {}", strerror(errno));
-        }
-        else
-        {
-            relay.vm_endpoint.iovs[0].iov_len = relay.max_packet_bytes;
-            ssize_t n =
-                recv(relay.fd, relay.vm_endpoint.iovs[0].iov_base, relay.max_packet_bytes, 0);
-            if (n < 0 && errno != EBADF && errno != ECONNRESET)
-                mpl::trace(category, "recv() failed: {}", strerror(errno));
-            if (n > 0)
-            {
-                relay.vm_endpoint.msgs[0].msg_len = (size_t)n;
-                count = 1;
-            }
-        }
-
-        if (count <= 0)
-            break;
-
-        for (int i = 0; i < count; i++)
-        {
-            relay.vm_endpoint.packets[i].vm_pkt_size = relay.vm_endpoint.msgs[i].msg_len;
-            relay.vm_endpoint.packets[i].vm_flags = 0;
-            relay.vm_endpoint.iovs[i].iov_len = relay.vm_endpoint.msgs[i].msg_len;
-        }
-
-        int write_count = count;
-        vmnet_return_t status =
-            vmnet_write(relay.iface, relay.vm_endpoint.packets.data(), &write_count);
-        if (status != VMNET_SUCCESS)
-            mpl::trace(category, "vmnet_write() failed (status {})", static_cast<int>(status));
+        count = (int)recvmsg_x(relay.fd, relay.vm_endpoint.msgs.data(), max_count, 0);
+        if (count < 0 && errno != EBADF && errno != ECONNRESET)
+            mpl::trace(category, "recvmsg_x() failed: {}", strerror(errno));
     }
+    else
+    {
+        relay.vm_endpoint.iovs[0].iov_len = relay.max_packet_bytes;
+        ssize_t n = recv(relay.fd, relay.vm_endpoint.iovs[0].iov_base, relay.max_packet_bytes, 0);
+        if (n < 0 && errno != EBADF && errno != ECONNRESET)
+            mpl::trace(category, "recv() failed: {}", strerror(errno));
+        if (n > 0)
+        {
+            relay.vm_endpoint.msgs[0].msg_len = (size_t)n;
+            count = 1;
+        }
+    }
+
+    if (count <= 0)
+        return false;
+
+    for (int i = 0; i < count; i++)
+    {
+        relay.vm_endpoint.packets[i].vm_pkt_size = relay.vm_endpoint.msgs[i].msg_len;
+        relay.vm_endpoint.packets[i].vm_flags = 0;
+        relay.vm_endpoint.iovs[i].iov_len = relay.vm_endpoint.msgs[i].msg_len;
+    }
+
+    int write_count = count;
+    vmnet_return_t status =
+        vmnet_write(relay.iface, relay.vm_endpoint.packets.data(), &write_count);
+    if (status != VMNET_SUCCESS)
+        mpl::trace(category, "vmnet_write() failed (status {})", static_cast<int>(status));
+
+    return true;
 }
 
 // Forward one batch of packets from the vmnet interface to the socket.
@@ -306,7 +304,8 @@ void start_forwarding_from_vm(VmnetRelay& relay)
     relay.vm_queue =
         dispatch_queue_create("com.canonical.multipassd.vmnet.vm", DISPATCH_QUEUE_SERIAL);
     dispatch_async(relay.vm_queue, ^{
-      forward_from_vm(relay, bulk);
+      while (forward_from_vm(relay, bulk))
+          ;
     });
 
     mpl::debug(category, "vmnet vm->host forwarding started");

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -71,32 +71,21 @@ struct VmnetRelay
     dispatch_queue_t vm_queue{nullptr};
     uint32_t max_packet_bytes{0};
 
-    // Pre-allocated buffers for host->vm (vmnet read / socket write).
-    std::vector<uint8_t> host_buffers;
-    std::vector<vmpktdesc> host_packets;
-    std::vector<iovec> host_iovs;
-    std::vector<msghdr_x> host_msgs;
-
-    // Pre-allocated buffers for vm->host (socket read / vmnet write).
-    std::vector<uint8_t> vm_buffers;
-    std::vector<vmpktdesc> vm_packets;
-    std::vector<iovec> vm_iovs;
-    std::vector<msghdr_x> vm_msgs;
-
-    void init_buffers()
+    struct EndpointBuffers
     {
-        const int packet_count =
-            (max_packet_bytes >= kLargePacketThreshold) ? kMaxPacketCountLarge : kMaxPacketCount;
+        std::vector<uint8_t> buffers;
+        std::vector<vmpktdesc> packets;
+        std::vector<iovec> iovs;
+        std::vector<msghdr_x> msgs;
 
-        auto bind_endpoint = [&](std::vector<uint8_t>& buffers,
-                                 std::vector<vmpktdesc>& packets,
-                                 std::vector<iovec>& iovs,
-                                 std::vector<msghdr_x>& msgs) {
-            buffers.resize((size_t)packet_count * max_packet_bytes);
-            packets.resize(packet_count);
-            iovs.resize(packet_count);
-            msgs.resize(packet_count);
-            for (int i = 0; i < packet_count; i++)
+        void bind_endpoint(int max_packet_count, uint32_t max_packet_bytes)
+        {
+            buffers.resize((size_t)max_packet_count * max_packet_bytes);
+            packets.resize(max_packet_count);
+            iovs.resize(max_packet_count);
+            msgs.resize(max_packet_count);
+
+            for (int i = 0; i < max_packet_count; i++)
             {
                 iovs[i].iov_base = buffers.data() + (size_t)i * max_packet_bytes;
                 iovs[i].iov_len = max_packet_bytes;
@@ -105,10 +94,21 @@ struct VmnetRelay
                 msgs[i].msg_hdr.msg_iov = &iovs[i];
                 msgs[i].msg_hdr.msg_iovlen = 1;
             }
-        };
+        }
+    };
 
-        bind_endpoint(host_buffers, host_packets, host_iovs, host_msgs);
-        bind_endpoint(vm_buffers, vm_packets, vm_iovs, vm_msgs);
+    // Pre-allocated buffers for host->vm (vmnet read / socket write).
+    EndpointBuffers host_endpoint;
+    // Pre-allocated buffers for vm->host (socket read / vmnet write).
+    EndpointBuffers vm_endpoint;
+
+    void init_buffers()
+    {
+        const int packet_count =
+            (max_packet_bytes >= kLargePacketThreshold) ? kMaxPacketCountLarge : kMaxPacketCount;
+
+        host_endpoint.bind_endpoint(packet_count, max_packet_bytes);
+        vm_endpoint.bind_endpoint(packet_count, max_packet_bytes);
     }
 
     ~VmnetRelay()
@@ -191,23 +191,24 @@ void forward_from_vm(VmnetRelay& relay, bool bulk)
 
         if (bulk)
         {
-            int max_count = (int)relay.vm_msgs.size();
+            int max_count = (int)relay.vm_endpoint.msgs.size();
             for (int i = 0; i < max_count; i++)
-                relay.vm_iovs[i].iov_len = relay.max_packet_bytes;
+                relay.vm_endpoint.iovs[i].iov_len = relay.max_packet_bytes;
 
-            count = (int)recvmsg_x(relay.fd, relay.vm_msgs.data(), max_count, 0);
+            count = (int)recvmsg_x(relay.fd, relay.vm_endpoint.msgs.data(), max_count, 0);
             if (count < 0 && errno != EBADF && errno != ECONNRESET)
                 mpl::trace(category, "recvmsg_x() failed: {}", strerror(errno));
         }
         else
         {
-            relay.vm_iovs[0].iov_len = relay.max_packet_bytes;
-            ssize_t n = recv(relay.fd, relay.vm_iovs[0].iov_base, relay.max_packet_bytes, 0);
+            relay.vm_endpoint.iovs[0].iov_len = relay.max_packet_bytes;
+            ssize_t n =
+                recv(relay.fd, relay.vm_endpoint.iovs[0].iov_base, relay.max_packet_bytes, 0);
             if (n < 0 && errno != EBADF && errno != ECONNRESET)
                 mpl::trace(category, "recv() failed: {}", strerror(errno));
             if (n > 0)
             {
-                relay.vm_msgs[0].msg_len = (size_t)n;
+                relay.vm_endpoint.msgs[0].msg_len = (size_t)n;
                 count = 1;
             }
         }
@@ -217,13 +218,14 @@ void forward_from_vm(VmnetRelay& relay, bool bulk)
 
         for (int i = 0; i < count; i++)
         {
-            relay.vm_packets[i].vm_pkt_size = relay.vm_msgs[i].msg_len;
-            relay.vm_packets[i].vm_flags = 0;
-            relay.vm_iovs[i].iov_len = relay.vm_msgs[i].msg_len;
+            relay.vm_endpoint.packets[i].vm_pkt_size = relay.vm_endpoint.msgs[i].msg_len;
+            relay.vm_endpoint.packets[i].vm_flags = 0;
+            relay.vm_endpoint.iovs[i].iov_len = relay.vm_endpoint.msgs[i].msg_len;
         }
 
         int write_count = count;
-        vmnet_return_t status = vmnet_write(relay.iface, relay.vm_packets.data(), &write_count);
+        vmnet_return_t status =
+            vmnet_write(relay.iface, relay.vm_endpoint.packets.data(), &write_count);
         if (status != VMNET_SUCCESS)
             mpl::trace(category, "vmnet_write() failed (status {})", static_cast<int>(status));
     }
@@ -233,15 +235,16 @@ void forward_from_vm(VmnetRelay& relay, bool bulk)
 // Returns false when vmnet has no more packets to deliver this callback.
 bool forward_from_host(VmnetRelay& relay, bool bulk)
 {
-    int count = (int)relay.host_packets.size();
+    int count = (int)relay.host_endpoint.packets.size();
     for (int i = 0; i < count; i++)
     {
-        relay.host_packets[i].vm_pkt_size = relay.max_packet_bytes;
-        relay.host_packets[i].vm_flags = 0;
-        relay.host_iovs[i].iov_len = relay.max_packet_bytes;
+        relay.host_endpoint.packets[i].vm_pkt_size = relay.max_packet_bytes;
+        relay.host_endpoint.packets[i].vm_flags = 0;
+        relay.host_endpoint.iovs[i].iov_len = relay.max_packet_bytes;
     }
 
-    vmnet_return_t read_status = vmnet_read(relay.iface, relay.host_packets.data(), &count);
+    vmnet_return_t read_status =
+        vmnet_read(relay.iface, relay.host_endpoint.packets.data(), &count);
     if (read_status != VMNET_SUCCESS)
     {
         mpl::trace(category, "vmnet_read() failed (status {})", static_cast<int>(read_status));
@@ -252,14 +255,15 @@ bool forward_from_host(VmnetRelay& relay, bool bulk)
     {
         for (int i = 0; i < count; i++)
         {
-            relay.host_msgs[i].msg_len = relay.host_packets[i].vm_pkt_size;
-            relay.host_iovs[i].iov_len = relay.host_packets[i].vm_pkt_size;
+            relay.host_endpoint.msgs[i].msg_len = relay.host_endpoint.packets[i].vm_pkt_size;
+            relay.host_endpoint.iovs[i].iov_len = relay.host_endpoint.packets[i].vm_pkt_size;
         }
 
         int sent = 0;
         while (sent < count)
         {
-            ssize_t n = sendmsg_x(relay.fd, relay.host_msgs.data() + sent, count - sent, 0);
+            ssize_t n =
+                sendmsg_x(relay.fd, relay.host_endpoint.msgs.data() + sent, count - sent, 0);
             if (n < 0)
             {
                 if (errno == ENOBUFS)
@@ -277,8 +281,8 @@ bool forward_from_host(VmnetRelay& relay, bool bulk)
     {
         for (int i = 0; i < count; i++)
         {
-            const auto* data = static_cast<const uint8_t*>(relay.host_iovs[i].iov_base);
-            size_t pkt_size = relay.host_packets[i].vm_pkt_size;
+            const auto* data = static_cast<const uint8_t*>(relay.host_endpoint.iovs[i].iov_base);
+            size_t pkt_size = relay.host_endpoint.packets[i].vm_pkt_size;
             ssize_t sent;
             do
             {

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -85,4 +85,9 @@ bool AppleVZ::is_supported() const
 {
     return multipass::applevz::is_supported();
 }
+
+std::vector<NetworkInterfaceInfo> AppleVZ::bridged_network_interfaces() const
+{
+    return multipass::applevz::bridged_network_interfaces();
+}
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -21,7 +21,6 @@
 #include <applevz/cf_error.h>
 
 #include <multipass/singleton.h>
-#include <multipass/virtual_machine_description.h>
 
 #define MP_APPLEVZ multipass::applevz::AppleVZ::instance()
 
@@ -51,5 +50,8 @@ public:
     virtual bool can_request_stop(const VMHandle& vm_handle) const;
 
     virtual bool is_supported() const;
+
+    // Networking
+    virtual std::vector<NetworkInterfaceInfo> bridged_network_interfaces() const;
 };
 } // namespace multipass::applevz

--- a/tests/unit/applevz/CMakeLists.txt
+++ b/tests/unit/applevz/CMakeLists.txt
@@ -17,4 +17,5 @@ target_sources(multipass_tests
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/test_applevz_utils.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_applevz_virtual_machine.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_applevz_virtual_machine_factory.cpp
 )

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -21,6 +21,7 @@
 #include "tests/unit/mock_singleton_helpers.h"
 
 #include <applevz/applevz_wrapper.h>
+#include <multipass/network_interface_info.h>
 
 namespace multipass::test
 {
@@ -71,6 +72,10 @@ public:
                 (const multipass::applevz::VMHandle& vm_handle),
                 (const, override));
     MOCK_METHOD(bool, is_supported, (), (const, override));
+    MOCK_METHOD(std::vector<multipass::NetworkInterfaceInfo>,
+                bridged_network_interfaces,
+                (),
+                (const, override));
 
     MP_MOCK_SINGLETON_BOILERPLATE(MockAppleVZWrapper, AppleVZ);
 };

--- a/tests/unit/applevz/test_applevz_virtual_machine_factory.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine_factory.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mock_applevz_utils.h"
+#include "mock_applevz_wrapper.h"
+#include "tests/unit/common.h"
+#include "tests/unit/mock_logger.h"
+#include "tests/unit/stub_availability_zone_manager.h"
+#include "tests/unit/stub_ssh_key_provider.h"
+#include "tests/unit/stub_status_monitor.h"
+#include "tests/unit/temp_dir.h"
+
+#include <applevz/applevz_virtual_machine_factory.h>
+#include <multipass/memory_size.h>
+#include <multipass/network_interface_info.h>
+#include <multipass/virtual_machine_description.h>
+#include <multipass/vm_image.h>
+
+#include <QDir>
+
+#include <stdexcept>
+
+namespace mp = multipass;
+namespace mpt = multipass::test;
+
+using namespace testing;
+
+namespace
+{
+struct AppleVZVirtualMachineFactory_UnitTests : public ::testing::Test
+{
+    mpt::TempDir dummy_data_dir;
+    mpt::StubAvailabilityZoneManager stub_az_manager{};
+    mpt::StubSSHKeyProvider stub_key_provider{};
+    mpt::StubVMStatusMonitor stub_monitor{};
+
+    mpt::MockLogger::Scope logger_scope = mpt::MockLogger::inject();
+
+    mpt::MockAppleVZWrapper::GuardedMock mock_applevz_wrapper_injection{
+        mpt::MockAppleVZWrapper::inject<NiceMock>()};
+    mpt::MockAppleVZWrapper& mock_applevz = *mock_applevz_wrapper_injection.first;
+
+    mpt::MockAppleVZUtils::GuardedMock mock_applevz_utils_injection{
+        mpt::MockAppleVZUtils::inject<NiceMock>()};
+    mpt::MockAppleVZUtils& mock_applevz_utils = *mock_applevz_utils_injection.first;
+
+    inline static auto mock_handle_raw =
+        reinterpret_cast<mp::applevz::VirtualMachineHandle*>(0xbadf00d);
+    mp::applevz::VMHandle mock_handle{mock_handle_raw, [](mp::applevz::VirtualMachineHandle*) {}};
+
+    auto construct_factory()
+    {
+        return std::make_shared<mp::applevz::AppleVZVirtualMachineFactory>(dummy_data_dir.path(),
+                                                                           stub_az_manager);
+    }
+};
+} // namespace
+
+// ---------------------------------------------------------
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, prepareSourceImage)
+{
+    const std::filesystem::path source_path = "/original/image.img";
+    const std::filesystem::path converted_path = "/converted/image.raw";
+
+    mp::VMImage source_image;
+    source_image.image_path = source_path;
+
+    EXPECT_CALL(mock_applevz_utils, convert_to_supported_format(source_path, _))
+        .WillOnce(Return(converted_path));
+
+    auto uut = construct_factory();
+    const auto result = uut->prepare_source_image(source_image);
+
+    EXPECT_EQ(result.image_path, converted_path);
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, prepareInstanceImage)
+{
+    mp::VMImage instance_image;
+    instance_image.image_path = "/instance/image.raw";
+
+    mp::VirtualMachineDescription desc;
+    desc.disk_space = mp::MemorySize::from_bytes(10 * 1024 * 1024);
+
+    EXPECT_CALL(mock_applevz_utils, resize_image(desc.disk_space, instance_image.image_path));
+
+    auto uut = construct_factory();
+    EXPECT_NO_THROW(uut->prepare_instance_image(instance_image, desc));
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, prepareInstanceImageResizeFails)
+{
+    mp::VMImage instance_image;
+    instance_image.image_path = "/instance/image.raw";
+
+    mp::VirtualMachineDescription desc;
+    desc.disk_space = mp::MemorySize::from_bytes(10 * 1024 * 1024);
+
+    EXPECT_CALL(mock_applevz_utils, resize_image(desc.disk_space, instance_image.image_path))
+        .WillOnce(Throw(std::runtime_error{"resize failed"}));
+
+    auto uut = construct_factory();
+    EXPECT_THROW(uut->prepare_instance_image(instance_image, desc), std::runtime_error);
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, hypervisorHealthCheckSupported)
+{
+    EXPECT_CALL(mock_applevz, is_supported()).WillOnce(Return(true));
+
+    auto uut = construct_factory();
+    EXPECT_NO_THROW(uut->hypervisor_health_check());
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, hypervisorHealthCheckNotSupported)
+{
+    EXPECT_CALL(mock_applevz, is_supported()).WillOnce(Return(false));
+
+    auto uut = construct_factory();
+    EXPECT_THROW(uut->hypervisor_health_check(), std::runtime_error);
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, removeResourcesForDeletesInstanceDirectory)
+{
+    const std::string vm_name = "test-vm";
+    auto uut = construct_factory();
+
+    QDir instance_dir{uut->get_instance_directory(vm_name)};
+    ASSERT_TRUE(instance_dir.mkpath("."));
+    ASSERT_TRUE(instance_dir.exists());
+
+    EXPECT_NO_THROW(uut->remove_resources_for(vm_name));
+
+    EXPECT_FALSE(instance_dir.exists());
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, removeResourcesForNonExistentVmDoesNotThrow)
+{
+    auto uut = construct_factory();
+    EXPECT_NO_THROW(uut->remove_resources_for("does-not-exist"));
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, networksReturnsBridgedInterfaces)
+{
+    const std::vector<mp::NetworkInterfaceInfo> expected_interfaces = {
+        {.id = "en0", .type = "Ethernet", .description = "Built-in Ethernet"},
+        {.id = "en1", .type = "Wi-Fi", .description = "Wi-Fi"}};
+
+    EXPECT_CALL(mock_applevz, bridged_network_interfaces()).WillOnce(Return(expected_interfaces));
+
+    auto uut = construct_factory();
+    EXPECT_EQ(uut->networks(), expected_interfaces);
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, createVirtualMachine)
+{
+    mp::VirtualMachineDescription desc;
+    desc.vm_name = "test-vm";
+
+    EXPECT_CALL(mock_applevz_utils, convert_to_supported_format(_, _))
+        .WillRepeatedly(ReturnArg<0>());
+
+    EXPECT_CALL(mock_applevz, create_vm(_, _))
+        .WillOnce(DoAll(SetArgReferee<1>(mock_handle), Return(mp::applevz::CFError{})));
+
+    EXPECT_CALL(mock_applevz, get_state(_))
+        .WillRepeatedly(Return(mp::applevz::AppleVMState::stopped));
+
+    auto uut = construct_factory();
+    auto vm = uut->create_virtual_machine(desc, stub_key_provider, stub_monitor);
+
+    EXPECT_NE(vm, nullptr);
+}

--- a/tests/unit/applevz/test_applevz_virtual_machine_factory.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine_factory.cpp
@@ -18,6 +18,7 @@
 #include "mock_applevz_utils.h"
 #include "mock_applevz_wrapper.h"
 #include "tests/unit/common.h"
+#include "tests/unit/mock_cloud_init_file_ops.h"
 #include "tests/unit/mock_logger.h"
 #include "tests/unit/stub_availability_zone_manager.h"
 #include "tests/unit/stub_ssh_key_provider.h"
@@ -29,6 +30,7 @@
 #include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_description.h>
 #include <multipass/vm_image.h>
+#include <multipass/vm_specs.h>
 
 #include <QDir>
 
@@ -184,4 +186,52 @@ TEST_F(AppleVZVirtualMachineFactory_UnitTests, createVirtualMachine)
     auto vm = uut->create_virtual_machine(desc, stub_key_provider, stub_monitor);
 
     EXPECT_NE(vm, nullptr);
+}
+
+TEST_F(AppleVZVirtualMachineFactory_UnitTests, cloneCopiesRelevantFiles)
+{
+    auto uut = construct_factory();
+
+    const mpt::MockCloudInitFileOps::GuardedMock mock_cloud_init_file_ops_injection =
+        mpt::MockCloudInitFileOps::inject<NiceMock>();
+    EXPECT_CALL(*mock_cloud_init_file_ops_injection.first, update_identifiers(_, _, _, _)).Times(1);
+
+    namespace fs = std::filesystem;
+    const fs::path instances_dir{dummy_data_dir.filePath("applevz/vault/instances").toStdString()};
+    constexpr auto* src_vm_name = "dummy_src_name";
+    constexpr auto* dest_vm_name = "dummy_dest_name";
+
+    const fs::path src_vm_dir = instances_dir / src_vm_name;
+    const fs::path dest_vm_dir = instances_dir / dest_vm_name;
+
+    const std::list<std::string> source_files{"dummy.iso", "dummy.raw"};
+    const std::unordered_set<std::string> expected_files{"dummy.iso", "dummy.raw"};
+
+    fs::create_directories(src_vm_dir);
+    for (const auto& file : source_files)
+    {
+        std::ofstream(src_vm_dir / file);
+    }
+
+    EXPECT_CALL(mock_applevz, create_vm(_, _))
+        .WillOnce(DoAll(SetArgReferee<1>(mock_handle), Return(mp::applevz::CFError{})));
+    EXPECT_CALL(mock_applevz, get_state(_))
+        .WillRepeatedly(Return(mp::applevz::AppleVMState::stopped));
+    EXPECT_CALL(mock_applevz_utils, convert_to_supported_format(_, _))
+        .WillRepeatedly(ReturnArg<0>());
+    EXPECT_CALL(mock_applevz_utils, resize_image(_, _)).WillRepeatedly(Return());
+
+    EXPECT_TRUE(
+        uut->clone_bare_vm({}, {}, src_vm_name, dest_vm_name, {}, stub_key_provider, stub_monitor));
+
+    std::unordered_set<std::string> actual_files;
+    for (const auto& file : fs::directory_iterator(dest_vm_dir))
+    {
+        if (fs::is_regular_file(file.status()))
+        {
+            actual_files.insert(file.path().filename().string());
+        }
+    }
+
+    EXPECT_EQ(actual_files, expected_files);
 }


### PR DESCRIPTION
This PR adds supports for using additional network interfaces when using the `applevz` backend driver.

This implementation of vmnet network interfaces was largely inspired by the following existing works:

- https://github.com/nirs/vmnet-helper
- https://github.com/lima-vm/socket_vmnet
- https://github.com/oven-sh/bun/blob/main/packages/bun-usockets/src/internal/networking/bsd.h

Necessary modifications to integrate this code into Multipass is outlined at the top of `applevz_vmnet.mm`, but all credit for unmodified code goes to the original author.

See the [vmnet documentation](https://developer.apple.com/documentation/vmnet?language=objc) for more reading on vmnet API usage.

Once #4312 is merged into `main` and the interactions with the `AvailabilityZoneManager` is more finalized, this implementation can be easily extended to support shared network interfaces.

---

MULTI-2259
MULTI-2263