### PR TITLE
[cli-tests] Unpin pywinpty to unblock python3.14

### DIFF
--- a/tests/cli/pyproject.toml
+++ b/tests/cli/pyproject.toml
@@ -2,8 +2,7 @@
 name = "multipass-cli-tests"
 version = "1.0.0"
 readme = "README.md"
-# pywinpty 3 hangs when "pty_proc.pty.iseof()" is called. Remove the pin when it's fixed.
-dependencies = ["pytest", "pexpect", "jq", "pywinpty==2.0.15; sys_platform == 'win32'", "pywin32; sys_platform == 'win32'" ]
+dependencies = ["pytest", "pexpect", "jq", "pywinpty; sys_platform == 'win32'", "pywin32; sys_platform == 'win32'" ]
 
 # This project is not intended for packaging.
 [tool.setuptools]

--- a/tests/cli/utilities/pexpectutils.py
+++ b/tests/cli/utilities/pexpectutils.py
@@ -23,6 +23,7 @@ if not sys.platform == "win32":
 
 import threading
 import time
+import socket
 from queue import Empty, Queue
 
 from pexpect.exceptions import EOF
@@ -65,8 +66,19 @@ class WinptySpawn(SpawnBase):
 
     def _read_incoming(self):
         """Run in a thread to move output from a pipe to a queue."""
-        while not self.pty_proc.pty.iseof():
-            self._read_queue.put(self.pty_proc.read())
+
+        # Set timeout so read won't block forever.
+        self.pty_proc.fileobj.settimeout(1.0)
+
+        while True:
+            try:
+                data = self.pty_proc.read()
+                self._read_queue.put(data)
+            except socket.timeout:
+                if not self.pty_proc.isalive():
+                    break
+            except EOFError:
+                break
         self._read_queue.put(None)
 
     def read_nonblocking(self, size=1024, timeout=1):


### PR DESCRIPTION

# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
Pinning pywinpty to v2 blocked Python 3.14 upgrade due to a wheel build failure. Now that's no longer an issue.
- Why is this change needed?
pywinpty was pinned to v2 due to the iseof() blocking forever bug. This patch uses an alternative approach in _read_incoming, so end-of-stream detection no longer relies on iseof(), so the code can finally use v3.

