### PR TITLE
[gui] Mark latest LTS release as default image

### DIFF
--- a/src/client/gui/lib/catalogue/catalogue.dart
+++ b/src/client/gui/lib/catalogue/catalogue.dart
@@ -122,7 +122,10 @@ List<Widget> _groupAndCreateCards(List<ImageInfo> images, double cardWidth) {
     if (ubuntuImages.isNotEmpty)
       ImageCard(
         imageKey: 'ubuntu-${ubuntuImages.first.release}',
-        parentImage: ubuntuImages.first,
+        parentImage: ubuntuImages.firstWhere(
+          (i) => i.aliases.any((a) => a == 'lts'),
+          orElse: () => ubuntuImages.first,
+        ),
         versions: ubuntuImages.toList(),
         width: cardWidth,
       ),


### PR DESCRIPTION
`multipass launch` will create a VM using the image that is marked as the current LTS in simplestreams. However, when I go to launch an Ubuntu instance in the GUI, the most recently released image is the image that is prefilled in the dropdown box. This PR changed the behaviour of the dropdown box to be prefilled with the latest LTS release.

<img width="1512" height="934" alt="image" src="https://github.com/user-attachments/assets/5b351ca8-8d07-4608-b059-564ced1a7e51" />
