### PR TITLE
[vault] Search by image hash

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -107,6 +107,7 @@ const std::unordered_set<std::string> no_bridging_release =
         "10.04",  "lucid", "11.10", "oneiric", "12.04",  "precise", "12.10",  "quantal", "13.04",
         "raring", "13.10", "saucy", "14.04",   "trusty", "14.10",   "utopic", "15.04",   "vivid",
         "15.10",  "wily",  "16.04", "xenial",  "16.10",  "yakkety", "17.04",  "zesty"};
+const std::unordered_set<std::string> no_bridging_core = {"core16"};
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
 {
@@ -356,6 +357,8 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(
 
         if (remote == mp::release_remote || remote == mp::daily_remote)
             dont_allow_auto = no_bridging_release.find(image) != no_bridging_release.end();
+        else if (remote == mp::core_remote)
+            dont_allow_auto = no_bridging_core.find(image) != no_bridging_core.end();
     }
 
     for (const auto& net : request->network_options())

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -107,7 +107,6 @@ const std::unordered_set<std::string> no_bridging_release =
         "10.04",  "lucid", "11.10", "oneiric", "12.04",  "precise", "12.10",  "quantal", "13.04",
         "raring", "13.10", "saucy", "14.04",   "trusty", "14.10",   "utopic", "15.04",   "vivid",
         "15.10",  "wily",  "16.04", "xenial",  "16.10",  "yakkety", "17.04",  "zesty"};
-const std::unordered_set<std::string> no_bridging_remote = {}; // images with other remote specified
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
 {
@@ -355,9 +354,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(
     {
         specified_image = remote + ":" + image;
 
-        dont_allow_auto = no_bridging_remote.find(specified_image) != no_bridging_remote.end();
-
-        if (!dont_allow_auto && (remote == mp::release_remote || remote == mp::daily_remote))
+        if (remote == mp::release_remote || remote == mp::daily_remote)
             dont_allow_auto = no_bridging_release.find(image) != no_bridging_release.end();
     }
 
@@ -371,16 +368,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(
         }
 
         if (!factory_networks)
-        {
-            try
-            {
-                factory_networks = factory.networks();
-            }
-            catch (const mp::NotImplementedOnThisBackendException&)
-            {
-                throw mp::NotImplementedOnThisBackendException("networks");
-            }
-        }
+            factory_networks = factory.networks();
 
         if (dont_allow_auto && net.mode() == multipass::LaunchRequest_NetworkOptions_Mode_AUTO)
         {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -108,9 +108,6 @@ const std::unordered_set<std::string> no_bridging_release =
         "raring", "13.10", "saucy", "14.04",   "trusty", "14.10",   "utopic", "15.04",   "vivid",
         "15.10",  "wily",  "16.04", "xenial",  "16.10",  "yakkety", "17.04",  "zesty"};
 const std::unordered_set<std::string> no_bridging_remote = {}; // images with other remote specified
-const std::unordered_set<std::string> no_bridging_remoteless = {
-    "core",
-    "core16"}; // images which do not use remote
 
 mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
 {
@@ -352,8 +349,7 @@ std::vector<mp::NetworkInterface> validate_extra_interfaces(
     {
         specified_image = image;
 
-        dont_allow_auto = (no_bridging_remoteless.find(image) != no_bridging_remoteless.end()) ||
-                          (no_bridging_release.find(image) != no_bridging_release.end());
+        dont_allow_auto = no_bridging_release.find(image) != no_bridging_release.end();
     }
     else
     {

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -323,30 +323,16 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
             std::lock_guard<decltype(fetch_mutex)> lock{fetch_mutex};
             if (!query.name.empty())
             {
-                for (auto& record : prepared_image_records)
+                if (auto entry = prepared_image_records.find(id);
+                    entry != prepared_image_records.end())
                 {
-                    if (record.second.query.remote_name != query.remote_name)
-                        continue;
-
-                    const auto aliases = record.second.image.aliases;
-                    if (id == record.first ||
-                        std::find(aliases.cbegin(), aliases.cend(), query.release) !=
-                            aliases.cend())
+                    try
                     {
-                        const auto prepared_image = record.second.image;
-                        try
-                        {
-                            return finalize_image_records(query,
-                                                          prepared_image,
-                                                          record.first,
-                                                          save_dir);
-                        }
-                        catch (const std::exception& e)
-                        {
-                            mpl::warn(category, "Cannot create instance image: {}", e.what());
-
-                            break;
-                        }
+                        return finalize_image_records(query, entry->second.image, id, save_dir);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        mpl::warn(category, "Cannot create instance image: {}", e.what());
                     }
                 }
             }

--- a/tests/unit/test_daemon.cpp
+++ b/tests/unit/test_daemon.cpp
@@ -1372,14 +1372,9 @@ std::vector<std::string> old_releases{
     "raring", "13.10", "saucy", "14.04",   "trusty", "14.10",   "utopic", "15.04",   "vivid",
     "15.10",  "wily",  "16.04", "xenial",  "16.10",  "yakkety", "17.04",  "zesty"};
 
-std::vector<std::string> old_remoteless_rels{"core", "core16"};
-
 INSTANTIATE_TEST_SUITE_P(DaemonRefuseRelease,
                          RefuseBridging,
                          Combine(Values("release", "daily", ""), ValuesIn(old_releases)));
-INSTANTIATE_TEST_SUITE_P(DaemonRefuseRemoteless,
-                         RefuseBridging,
-                         Combine(Values(""), ValuesIn(old_remoteless_rels)));
 
 TEST_F(Daemon, failsWithImageNotFoundAlsoIfImageIsAlsoNonBridgeable)
 {

--- a/tests/unit/test_image_vault.cpp
+++ b/tests/unit/test_image_vault.cpp
@@ -444,6 +444,86 @@ TEST_F(ImageVault, cachesPreparedImages)
     EXPECT_THAT(vm_image1.id, Eq(vm_image2.id));
 }
 
+TEST_F(ImageVault, emptyAndReleaseRemoteNamesShareCache)
+{
+    mp::DefaultVMImageVault vault{hosts,
+                                  &url_downloader,
+                                  cache_dir.path(),
+                                  data_dir.path(),
+                                  mp::days{0}};
+    int prepare_called_count{0};
+    auto prepare = [&prepare_called_count](const mp::VMImage& source_image) -> mp::VMImage {
+        ++prepare_called_count;
+        return source_image;
+    };
+
+    auto cli_query = default_query;
+    cli_query.remote_name = "";
+    vault.fetch_image(mp::FetchType::ImageOnly,
+                      cli_query,
+                      prepare,
+                      stub_monitor,
+                      std::nullopt,
+                      instance_dir);
+
+    auto gui_query = default_query;
+    gui_query.name = "valley-pied-piper-gui";
+    gui_query.remote_name = mpt::release_remote;
+    vault.fetch_image(mp::FetchType::ImageOnly,
+                      gui_query,
+                      prepare,
+                      stub_monitor,
+                      std::nullopt,
+                      save_dir.filePath(QString::fromStdString(gui_query.name)));
+
+    EXPECT_THAT(url_downloader.downloaded_files.size(), Eq(1));
+    EXPECT_THAT(prepare_called_count, Eq(1));
+}
+
+TEST_F(ImageVault, sameImageIdFromDifferentRemotesSharesCache)
+{
+    NiceMock<mpt::MockImageHost> daily_host;
+    ON_CALL(daily_host, supported_remotes())
+        .WillByDefault(Return(std::vector<std::string>{"daily"}));
+    ON_CALL(daily_host, info_for(_)).WillByDefault([this](const auto&) {
+        return host.mock_bionic_image_info;
+    });
+    hosts.push_back(&daily_host);
+
+    mp::DefaultVMImageVault vault{hosts,
+                                  &url_downloader,
+                                  cache_dir.path(),
+                                  data_dir.path(),
+                                  mp::days{0}};
+    int prepare_called_count{0};
+    auto prepare = [&prepare_called_count](const mp::VMImage& source_image) -> mp::VMImage {
+        ++prepare_called_count;
+        return source_image;
+    };
+
+    auto release_query = default_query;
+    release_query.remote_name = mpt::release_remote;
+    vault.fetch_image(mp::FetchType::ImageOnly,
+                      release_query,
+                      prepare,
+                      stub_monitor,
+                      std::nullopt,
+                      instance_dir);
+
+    auto daily_query = default_query;
+    daily_query.name = "valley-pied-piper-daily";
+    daily_query.remote_name = "daily";
+    vault.fetch_image(mp::FetchType::ImageOnly,
+                      daily_query,
+                      prepare,
+                      stub_monitor,
+                      std::nullopt,
+                      save_dir.filePath(QString::fromStdString(daily_query.name)));
+
+    EXPECT_THAT(url_downloader.downloaded_files.size(), Eq(1));
+    EXPECT_THAT(prepare_called_count, Eq(1));
+}
+
 TEST_F(ImageVault, remembersInstanceImages)
 {
     int prepare_called_count{0};


### PR DESCRIPTION
This PR changes how the image vault searches for images in the cache by comparing the image hash/id instead of remote name + image name. This prevents some odd behaviours such as `multipass launch 26.04` and `multipass launch daily:26.04` which use the same image but causes it to be downloaded again.

Also cleaned up some dead code while I was at it.