### PR TITLE
[applevz] Unsupported ops

### DIFF
--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -319,7 +319,9 @@ void AppleVZVirtualMachine::set_state(applevz::AppleVMState vm_state)
     case applevz::AppleVMState::running:
     case applevz::AppleVMState::stopping:
         // No `stopping` state in Multipass yet
-        state = State::running;
+        // Let wait_until_ssh_up decide when we are running
+        if (state != State::starting)
+            state = State::running;
         break;
     case applevz::AppleVMState::paused:
         state = State::suspended;

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -54,6 +54,7 @@ AppleVZVirtualMachine::~AppleVZVirtualMachine()
 
     if (vm_handle)
     {
+        update_shutdown_status = false;
         mp::top_catch_all(vm_name, [this]() {
             if (state == State::running)
             {
@@ -282,7 +283,8 @@ std::optional<IPAddress> AppleVZVirtualMachine::management_ipv4()
 
 void AppleVZVirtualMachine::handle_state_update()
 {
-    monitor->persist_state_for(vm_name, state);
+    if (update_shutdown_status)
+        monitor->persist_state_for(vm_name, state);
 }
 
 void AppleVZVirtualMachine::update_cpus(int num_cores)
@@ -388,8 +390,6 @@ void AppleVZVirtualMachine::initialize_vm_handle()
         throw std::runtime_error(
             fmt::format("Failed to create VM handle for '{}': {}", vm_name, error));
     }
-
-    set_state(MP_APPLEVZ.get_state(vm_handle));
 
     mpl::trace(log_category, "initialize_vm_handle() -> Created handle for VM '{}'", vm_name);
 }

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -57,7 +57,8 @@ AppleVZVirtualMachine::~AppleVZVirtualMachine()
         mp::top_catch_all(vm_name, [this]() {
             if (state == State::running)
             {
-                suspend();
+                // TODO: Call suspend() once fully implemented
+                shutdown();
             }
             else
             {
@@ -208,6 +209,9 @@ void AppleVZVirtualMachine::shutdown(ShutdownPolicy shutdown_policy)
 
 void AppleVZVirtualMachine::suspend()
 {
+    throw NotImplementedOnThisBackendException{"suspend"};
+
+    // TODO: remove the throw above once suspend-to-disk is implemented
     if (!vm_handle)
     {
         assert(state == State::stopped);

--- a/src/platform/backends/applevz/applevz_virtual_machine.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine.h
@@ -56,6 +56,13 @@ public:
     void resize_memory(const MemorySize& new_size) override;
     void resize_disk(const MemorySize& new_size) override;
 
+    std::shared_ptr<const Snapshot> take_snapshot(const VMSpecs& /*specs*/,
+                                                  const std::string& /*snapshot_name*/,
+                                                  const std::string& /*comment*/) override
+    {
+        throw NotImplementedOnThisBackendException{"snapshots"};
+    }
+
 private:
     void initialize_vm_handle();
     void set_state(applevz::AppleVMState vm_state);

--- a/src/platform/backends/applevz/applevz_virtual_machine.h
+++ b/src/platform/backends/applevz/applevz_virtual_machine.h
@@ -72,5 +72,6 @@ private:
     VirtualMachineDescription desc;
     VMStatusMonitor* monitor;
     VMHandle vm_handle{nullptr};
+    bool update_shutdown_status{true};
 };
 } // namespace multipass::applevz

--- a/tests/unit/applevz/test_applevz_virtual_machine.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine.cpp
@@ -26,6 +26,7 @@
 #include "tests/unit/temp_file.h"
 
 #include <applevz/applevz_virtual_machine.h>
+#include <multipass/exceptions/not_implemented_on_this_backend_exception.h>
 #include <multipass/exceptions/virtual_machine_state_exceptions.h>
 
 namespace mp = multipass;
@@ -83,7 +84,7 @@ struct AppleVZVirtualMachine_UnitTests : public testing::Test
         EXPECT_CALL(mock_applevz, create_vm(_, _))
             .WillOnce(DoAll(SetArgReferee<1>(mock_handle), Return(applevz::CFError{})));
 
-        EXPECT_CALL(mock_applevz, get_state(_)).WillOnce(Return(initial_state));
+        EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(initial_state));
         EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, _)).Times(AnyNumber());
 
         EXPECT_CALL(mock_image_utils, convert_to_supported_format(_, _))
@@ -105,14 +106,13 @@ TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromStoppedSuccess)
     EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::running));
 
     EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::starting));
-    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::running));
 
     EXPECT_CALL(mock_applevz, can_start(_)).WillOnce(Return(true));
     EXPECT_CALL(mock_applevz, start_vm(_));
 
     uut->start();
 
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::running);
+    EXPECT_EQ(uut->current_state(), VirtualMachine::State::starting);
 }
 
 TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromPausedSuccess)
@@ -125,11 +125,10 @@ TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromPausedSuccess)
     EXPECT_CALL(mock_applevz, resume_vm(_));
 
     EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, mp::VirtualMachine::State::starting));
-    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, mp::VirtualMachine::State::running));
 
     uut->start();
 
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::running);
+    EXPECT_EQ(uut->current_state(), VirtualMachine::State::starting);
 }
 
 TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromRunningStateNoOp)
@@ -143,7 +142,7 @@ TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromRunningStateNoOp)
 
     uut->start();
 
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::running);
+    EXPECT_EQ(uut->current_state(), VirtualMachine::State::starting);
 }
 
 TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromStoppedThrowsError)
@@ -152,7 +151,7 @@ TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromStoppedThrowsError)
 
     EXPECT_CALL(mock_applevz, get_state(_))
         .WillOnce(Return(applevz::AppleVMState::error))
-        .WillOnce(Return(applevz::AppleVMState{}));
+        .WillOnce(Return(applevz::AppleVMState::stopped));
 
     EXPECT_CALL(mock_applevz, can_start(_)).WillOnce(Return(true));
     EXPECT_CALL(mock_applevz, start_vm(_))
@@ -173,7 +172,7 @@ TEST_F(AppleVZVirtualMachine_UnitTests, startVMFromPausedThrowsError)
 
     EXPECT_CALL(mock_applevz, get_state(_))
         .WillOnce(Return(applevz::AppleVMState::error))
-        .WillOnce(Return(applevz::AppleVMState{}));
+        .WillOnce(Return(applevz::AppleVMState::stopped));
 
     EXPECT_CALL(mock_applevz, can_resume(_)).WillOnce(Return(true));
     EXPECT_CALL(mock_applevz, resume_vm(_))
@@ -273,7 +272,7 @@ TEST_F(AppleVZVirtualMachine_UnitTests, shutdownCannotStopReturnsEarly)
     auto uut = construct_vm(applevz::AppleVMState::running);
 
     EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::running));
-    EXPECT_CALL(mock_applevz, can_request_stop(_)).WillOnce(Return(false));
+    EXPECT_CALL(mock_applevz, can_request_stop(_)).WillRepeatedly(Return(false));
     EXPECT_CALL(mock_applevz, stop_vm(_, _)).Times(0);
 
     uut->shutdown();
@@ -292,97 +291,12 @@ TEST_F(AppleVZVirtualMachine_UnitTests, shutdownFromSuspendedStateWithHaltIsIdem
     EXPECT_EQ(uut->current_state(), VirtualMachine::State::suspended);
 }
 
-TEST_F(AppleVZVirtualMachine_UnitTests, suspendFromRunningStateCallsPauseVm)
+TEST_F(AppleVZVirtualMachine_UnitTests, suspendThrowsNotImplemented)
 {
     auto uut = construct_vm(applevz::AppleVMState::running);
 
-    EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::paused));
-
-    EXPECT_CALL(mock_applevz, can_pause(_)).WillOnce(Return(true));
-    EXPECT_CALL(mock_applevz, pause_vm(_));
-
-    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::suspending));
-    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::suspended));
-
-    uut->suspend();
-
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::suspended);
-}
-
-TEST_F(AppleVZVirtualMachine_UnitTests, suspendFromStoppedStateReturnsEarly)
-{
-    auto uut = construct_vm(applevz::AppleVMState::stopped);
-
-    EXPECT_CALL(mock_applevz, can_pause(_)).Times(AtLeast(1)).WillRepeatedly(Return(false));
-    EXPECT_CALL(mock_applevz, pause_vm(_)).Times(0);
-    EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::stopped));
-
-    uut->suspend();
-
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::stopped);
-}
-
-TEST_F(AppleVZVirtualMachine_UnitTests, suspendCannotPauseReturnsEarly)
-{
-    auto uut = construct_vm(applevz::AppleVMState::running);
-
-    EXPECT_CALL(mock_applevz, can_pause(_)).Times(AtLeast(1)).WillRepeatedly(Return(false));
-    EXPECT_CALL(mock_applevz, pause_vm(_)).Times(0);
     EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::running));
 
-    uut->suspend();
-
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::running);
-}
-
-TEST_F(AppleVZVirtualMachine_UnitTests, suspendErrorLogsWarning)
-{
-    auto uut = construct_vm(applevz::AppleVMState::running);
-
-    EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::error));
-
-    EXPECT_CALL(mock_applevz, can_pause(_)).Times(AtLeast(1)).WillRepeatedly(Return(true));
-    EXPECT_CALL(mock_applevz, can_request_stop(_)).Times(AtLeast(0)).WillRepeatedly(Return(false));
-    EXPECT_CALL(mock_applevz, pause_vm(_)).Times(AtLeast(1)).WillRepeatedly(Invoke([](auto&) {
-        return applevz::CFError{
-            CFErrorCreate(kCFAllocatorDefault, CFSTR("TestDomain"), 789, nullptr)};
-    }));
-
-    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::suspending));
-    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::unknown));
-
-    uut->suspend();
-
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::unknown);
-}
-
-TEST_F(AppleVZVirtualMachine_UnitTests, suspendTransitionsToSuspendingState)
-{
-    auto uut = construct_vm(applevz::AppleVMState::running);
-
-    EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::paused));
-
-    EXPECT_CALL(mock_applevz, can_pause(_)).WillOnce(Return(true));
-    EXPECT_CALL(mock_applevz, pause_vm(_));
-
-    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::suspending));
-    EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, VirtualMachine::State::suspended));
-
-    uut->suspend();
-
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::suspended);
-}
-
-TEST_F(AppleVZVirtualMachine_UnitTests, suspendFromAlreadySuspendedStateIsIdempotent)
-{
-    auto uut = construct_vm(applevz::AppleVMState::paused);
-
-    EXPECT_CALL(mock_applevz, can_pause(_)).WillRepeatedly(Return(false));
-    EXPECT_CALL(mock_applevz, pause_vm(_)).Times(0);
-    EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(applevz::AppleVMState::paused));
-
-    uut->suspend();
-
-    EXPECT_EQ(uut->current_state(), VirtualMachine::State::suspended);
+    EXPECT_THROW(uut->suspend(), mp::NotImplementedOnThisBackendException);
 }
 }; // namespace multipass::test


### PR DESCRIPTION
This PR adds some polishing touches to the `applevz` backend in Multipass. Specifically:

- `multipass snapshot` throws `NotImplementedOnThisBackendException`
- `multipass suspend foo` throws `NotImplementedOnThisBackendException`
- VMs are returned to their original state after the daemon reboots
- AppleVZ will report a VM running as soon as the kernel has booted. Let `wait_until_ssh_up` transition state to `Running`

---

MULTI-2256
MULTI-2269