### PR TITLE
[utils] Remove QT from generate_scrypt_hash_for

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -248,7 +248,7 @@ public:
     virtual std::string get_kernel_version() const;
 
     // scrypt hash generator
-    virtual QString generate_scrypt_hash_for(const QString& passphrase) const;
+    virtual std::string generate_scrypt_hash_for(const std::string& passphrase) const;
 
     // virtual machine helpers
     [[nodiscard]] virtual bool is_running(const VirtualMachine::State& state) const;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2656,8 +2656,7 @@ try
             "automatically authenticated."));
     }
 
-    auto hashed_passphrase =
-        MP_UTILS.generate_scrypt_hash_for(QString::fromStdString(request->passphrase()));
+    auto hashed_passphrase = MP_UTILS.generate_scrypt_hash_for(request->passphrase());
 
     if (stored_hash != hashed_passphrase)
     {

--- a/src/daemon/daemon_init_settings.cpp
+++ b/src/daemon/daemon_init_settings.cpp
@@ -117,7 +117,9 @@ void mp::daemon::register_global_settings_handlers()
                                                         MP_PLATFORM.default_driver(),
                                                         driver_interpreter));
     settings.insert(std::make_unique<CustomSettingSpec>(mp::passphrase_key, "", [](QString val) {
-        return val.isEmpty() ? val : MP_UTILS.generate_scrypt_hash_for(val);
+        return val.isEmpty()
+                   ? val
+                   : QString::fromStdString(MP_UTILS.generate_scrypt_hash_for(val.toStdString()));
     }));
     settings.insert(
         std::make_unique<CustomSettingSpec>(mp::mirror_key, "", image_mirror_interpreter));

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -57,7 +57,6 @@ namespace mpl = multipass::logging;
 namespace
 {
 constexpr auto category = "utils";
-constexpr auto scrypt_hash_size{64};
 } // namespace
 mp::Utils::Utils(const Singleton<Utils>::PrivatePass& pass) noexcept
     : Singleton<Utils>::Singleton{pass}
@@ -137,11 +136,12 @@ std::string mp::Utils::get_kernel_version() const
     return QSysInfo::kernelVersion().toStdString();
 }
 
-QString mp::Utils::generate_scrypt_hash_for(const QString& passphrase) const
+std::string mp::Utils::generate_scrypt_hash_for(const std::string& passphrase) const
 {
-    QByteArray hash(scrypt_hash_size, '\0');
+    unsigned char digest[EVP_MAX_MD_SIZE] = {0};
 
-    if (!EVP_PBE_scrypt(passphrase.toStdString().c_str(),
+    // TODO: Move to openssl singleton when we have one
+    if (!EVP_PBE_scrypt(passphrase.c_str(),
                         passphrase.size(),
                         nullptr,
                         0,
@@ -149,11 +149,11 @@ QString mp::Utils::generate_scrypt_hash_for(const QString& passphrase) const
                         8,
                         1,
                         0,
-                        reinterpret_cast<unsigned char*>(hash.data()),
-                        scrypt_hash_size))
+                        digest,
+                        sizeof(digest)))
         throw std::runtime_error("Cannot generate passphrase hash");
 
-    return QString(hash.toHex());
+    return fmt::format("{:02x}", fmt::join(digest, digest + sizeof(digest), ""));
 }
 
 QDir mp::utils::base_dir(const QString& path)

--- a/tests/unit/mock_utils.h
+++ b/tests/unit/mock_utils.h
@@ -52,7 +52,7 @@ public:
                 (const override));
     MOCK_METHOD(Path, make_dir, (const QDir&, std::filesystem::perms), (const override));
     MOCK_METHOD(std::string, get_kernel_version, (), (const, override));
-    MOCK_METHOD(QString, generate_scrypt_hash_for, (const QString&), (const, override));
+    MOCK_METHOD(std::string, generate_scrypt_hash_for, (const std::string&), (const, override));
     MOCK_METHOD(bool, client_certs_exist, (const QString&), (const));
     MOCK_METHOD(void, copy_client_certs_to_common_dir, (const QString&, const QString&), (const));
     MOCK_METHOD(bool, is_running, (const VirtualMachine::State& state), (const, override));

--- a/tests/unit/test_daemon_authenticate.cpp
+++ b/tests/unit/test_daemon_authenticate.cpp
@@ -64,7 +64,7 @@ TEST_F(TestDaemonAuthenticate, authenticateNoErrorReturnsOk)
 
     EXPECT_CALL(mock_settings, get(Eq(mp::passphrase_key))).WillOnce(Return(saved_hash));
 
-    EXPECT_CALL(*mock_utils, generate_scrypt_hash_for(Eq(QString("foo"))))
+    EXPECT_CALL(*mock_utils, generate_scrypt_hash_for(Eq(std::string("foo"))))
         .WillOnce(Return(good_hash));
 
     mp::AuthenticateRequest request;
@@ -104,7 +104,7 @@ TEST_F(TestDaemonAuthenticate, authenticatePassphraseMismatchReturnsError)
 
     EXPECT_CALL(mock_settings, get(Eq(mp::passphrase_key))).WillOnce(Return(saved_hash));
 
-    EXPECT_CALL(*mock_utils, generate_scrypt_hash_for(Eq(QString("foo"))))
+    EXPECT_CALL(*mock_utils, generate_scrypt_hash_for(Eq(std::string("foo"))))
         .WillOnce(Return(bad_hash));
 
     mp::AuthenticateRequest request;


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
Replaces QT types in the generate_scrypt_hash_for function.
- Why is this change needed?
std-ification efforts.

MULTI-2517