### PR TITLE
Bugfix/remove footgun from trim functions

### DIFF
--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -121,17 +121,21 @@ std::optional<NetworkInterfaceInfo> find_bridge_with(
 
 // string helpers
 bool has_only_digits(const std::string& value);
-template <typename Str, typename Filter>
+
+template <typename Str>
+concept mutable_type = !std::is_const_v<std::remove_reference_t<Str>>;
+
+template <mutable_type Str, typename Filter>
 Str trim_begin(Str&& s, Filter&& filter);
-template <typename Str>
+template <mutable_type Str>
 Str trim_begin(Str&& s);
-template <typename Str, typename Filter>
+template <mutable_type Str, typename Filter>
 Str trim_end(Str&& s, Filter&& filter);
-template <typename Str>
+template <mutable_type Str>
 Str trim_end(Str&& s);
-template <typename Str, typename Filter>
+template <mutable_type Str, typename Filter>
 Str trim(Str&& s, Filter&& filter);
-template <typename Str>
+template <mutable_type Str>
 Str trim(Str&& s);
 bool iequals(std::string_view lhs, std::string_view rhs);
 bool istarts_with(std::string_view str, std::string_view prefix);
@@ -276,7 +280,7 @@ namespace multipass::utils::detail
 inline constexpr auto is_space = [](unsigned char c) { return std::isspace(c); };
 } // namespace multipass::utils::detail
 
-template <typename Str, typename Filter>
+template <multipass::utils::mutable_type Str, typename Filter>
 Str multipass::utils::trim_begin(Str&& s, Filter&& filter)
 {
     const auto it = std::find_if_not(s.begin(), s.end(), std::forward<Filter>(filter));
@@ -284,13 +288,13 @@ Str multipass::utils::trim_begin(Str&& s, Filter&& filter)
     return std::forward<Str>(s);
 }
 
-template <typename Str>
+template <multipass::utils::mutable_type Str>
 Str multipass::utils::trim_begin(Str&& s)
 {
     return trim_begin(std::forward<Str>(s), detail::is_space);
 }
 
-template <typename Str, typename Filter>
+template <multipass::utils::mutable_type Str, typename Filter>
 Str multipass::utils::trim_end(Str&& s, Filter&& filter)
 {
     auto rev_it = std::find_if_not(s.rbegin(), s.rend(), std::forward<Filter>(filter));
@@ -298,20 +302,20 @@ Str multipass::utils::trim_end(Str&& s, Filter&& filter)
     return std::forward<Str>(s);
 }
 
-template <typename Str>
+template <multipass::utils::mutable_type Str>
 Str multipass::utils::trim_end(Str&& s)
 {
     return trim_end(std::forward<Str>(s), detail::is_space);
 }
 
-template <typename Str, typename Filter>
+template <multipass::utils::mutable_type Str, typename Filter>
 Str multipass::utils::trim(Str&& s, Filter&& filter)
 {
     auto&& ret = trim_end(std::forward<Str>(s), filter);
     return trim_begin(std::forward<decltype(ret)>(ret), std::forward<Filter>(filter));
 }
 
-template <typename Str>
+template <multipass::utils::mutable_type Str>
 Str multipass::utils::trim(Str&& s)
 {
     return trim(std::forward<Str>(s), detail::is_space);

--- a/include/multipass/utils.h
+++ b/include/multipass/utils.h
@@ -122,17 +122,17 @@ std::optional<NetworkInterfaceInfo> find_bridge_with(
 // string helpers
 bool has_only_digits(const std::string& value);
 template <typename Str, typename Filter>
-Str&& trim_begin(Str&& s, Filter&& filter);
+Str trim_begin(Str&& s, Filter&& filter);
 template <typename Str>
-Str&& trim_begin(Str&& s);
+Str trim_begin(Str&& s);
 template <typename Str, typename Filter>
-Str&& trim_end(Str&& s, Filter&& filter);
+Str trim_end(Str&& s, Filter&& filter);
 template <typename Str>
-Str&& trim_end(Str&& s);
+Str trim_end(Str&& s);
 template <typename Str, typename Filter>
-Str&& trim(Str&& s, Filter&& filter);
+Str trim(Str&& s, Filter&& filter);
 template <typename Str>
-Str&& trim(Str&& s);
+Str trim(Str&& s);
 bool iequals(std::string_view lhs, std::string_view rhs);
 bool istarts_with(std::string_view str, std::string_view prefix);
 std::string& trim_newline(std::string& s);
@@ -277,7 +277,7 @@ inline constexpr auto is_space = [](unsigned char c) { return std::isspace(c); }
 } // namespace multipass::utils::detail
 
 template <typename Str, typename Filter>
-Str&& multipass::utils::trim_begin(Str&& s, Filter&& filter)
+Str multipass::utils::trim_begin(Str&& s, Filter&& filter)
 {
     const auto it = std::find_if_not(s.begin(), s.end(), std::forward<Filter>(filter));
     s.erase(s.begin(), it);
@@ -285,13 +285,13 @@ Str&& multipass::utils::trim_begin(Str&& s, Filter&& filter)
 }
 
 template <typename Str>
-Str&& multipass::utils::trim_begin(Str&& s)
+Str multipass::utils::trim_begin(Str&& s)
 {
     return trim_begin(std::forward<Str>(s), detail::is_space);
 }
 
 template <typename Str, typename Filter>
-Str&& multipass::utils::trim_end(Str&& s, Filter&& filter)
+Str multipass::utils::trim_end(Str&& s, Filter&& filter)
 {
     auto rev_it = std::find_if_not(s.rbegin(), s.rend(), std::forward<Filter>(filter));
     s.erase(rev_it.base(), s.end());
@@ -299,20 +299,20 @@ Str&& multipass::utils::trim_end(Str&& s, Filter&& filter)
 }
 
 template <typename Str>
-Str&& multipass::utils::trim_end(Str&& s)
+Str multipass::utils::trim_end(Str&& s)
 {
     return trim_end(std::forward<Str>(s), detail::is_space);
 }
 
 template <typename Str, typename Filter>
-Str&& multipass::utils::trim(Str&& s, Filter&& filter)
+Str multipass::utils::trim(Str&& s, Filter&& filter)
 {
     auto&& ret = trim_end(std::forward<Str>(s), filter);
     return trim_begin(std::forward<decltype(ret)>(ret), std::forward<Filter>(filter));
 }
 
 template <typename Str>
-Str&& multipass::utils::trim(Str&& s)
+Str multipass::utils::trim(Str&& s)
 {
     return trim(std::forward<Str>(s), detail::is_space);
 }

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -325,6 +325,21 @@ TEST(Utils, toCmdArgumentsWithDoubleQuotesAreEscaped)
     EXPECT_THAT(output, ::testing::StrEq("they said \\\"please\\\""));
 }
 
+// clang-format off
+#define STATIC_ASSERT_STR_REF_OVERLOADS(func, ...)                                                                                    \
+    static_assert(std::is_same_v<decltype(func(std::declval<std::string&>(),       ##__VA_ARGS__)), std::string&>);        \
+    static_assert(std::is_same_v<decltype(func(std::declval<const std::string&>(), ##__VA_ARGS__)), const std::string&>);  \
+    static_assert(std::is_same_v<decltype(func(std::declval<std::string&&>(),      ##__VA_ARGS__)), std::string>);         \
+    static_assert(std::is_same_v<decltype(func(std::declval<std::string>(),        ##__VA_ARGS__)), std::string>)
+// clang-format on
+
+STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim_begin, std::declval<decltype(::isspace)&>());
+STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim_begin);
+STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim_end, std::declval<decltype(::isspace)&>());
+STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim_end);
+STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim, std::declval<decltype(::isspace)&>());
+STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim);
+
 struct TestTrimUtilities : public Test
 {
     std::string s{"\n \f \n \r \t   \vI'm a great\n\t string \n \f \n \r \t   \v"};

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -326,19 +326,26 @@ TEST(Utils, toCmdArgumentsWithDoubleQuotesAreEscaped)
 }
 
 // clang-format off
-#define STATIC_ASSERT_STR_REF_OVERLOADS(func, ...)                                                                                    \
-    static_assert(std::is_same_v<decltype(func(std::declval<std::string&>(),       ##__VA_ARGS__)), std::string&>);        \
-    static_assert(std::is_same_v<decltype(func(std::declval<const std::string&>(), ##__VA_ARGS__)), const std::string&>);  \
-    static_assert(std::is_same_v<decltype(func(std::declval<std::string&&>(),      ##__VA_ARGS__)), std::string>);         \
-    static_assert(std::is_same_v<decltype(func(std::declval<std::string>(),        ##__VA_ARGS__)), std::string>)
+template <typename Func, typename... ExtraArgs>
+concept expected_trim_traits =
+    std::same_as<std::invoke_result_t<Func, std::string&, ExtraArgs...>, std::string&> &&
+    std::same_as<std::invoke_result_t<Func, std::string&&, ExtraArgs...>, std::string> &&
+    std::same_as<std::invoke_result_t<Func, std::string, ExtraArgs...>, std::string> &&
+    !std::is_invocable_v<Func, const std::string&, ExtraArgs...>;
+
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0834r0.html
+#define LIFT(func) [](auto&&... a)                            \
+    noexcept(noexcept(func(std::forward<decltype(a)>(a)...))) \
+    -> decltype(func(std::forward<decltype(a)>(a)...))        \
+    { return func(std::forward<decltype(a)>(a)...); }
 // clang-format on
 
-STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim_begin, std::declval<decltype(::isspace)&>());
-STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim_begin);
-STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim_end, std::declval<decltype(::isspace)&>());
-STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim_end);
-STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim, std::declval<decltype(::isspace)&>());
-STATIC_ASSERT_STR_REF_OVERLOADS(mp::utils::trim);
+static_assert(expected_trim_traits<decltype(LIFT(mp::utils::trim)), decltype(::isspace)&>);
+static_assert(expected_trim_traits<decltype(LIFT(mp::utils::trim))>);
+static_assert(expected_trim_traits<decltype(LIFT(mp::utils::trim_begin)), decltype(::isspace)&>);
+static_assert(expected_trim_traits<decltype(LIFT(mp::utils::trim_begin))>);
+static_assert(expected_trim_traits<decltype(LIFT(mp::utils::trim_end)), decltype(::isspace)&>);
+static_assert(expected_trim_traits<decltype(LIFT(mp::utils::trim_end))>);
 
 struct TestTrimUtilities : public Test
 {
@@ -386,6 +393,12 @@ TEST(Utils, trimNewlineAssertionWorks)
     std::string s{"wrong"};
     // https://google.github.io/googletest/advanced.html#regular-expression-syntax
     ASSERT_DEBUG_DEATH(mp::utils::trim_newline(s), "\\wssert");
+}
+
+TEST_F(TestTrimUtilities, trimRvalue)
+{
+    auto result = mp::utils::trim_end(std::move(s));
+    EXPECT_THAT(result, ::testing::StrEq("\n \f \n \r \t   \vI'm a great\n\t string"));
 }
 
 TEST(Utils, escapeForShellActuallyEscapes)

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -401,6 +401,12 @@ TEST_F(TestTrimUtilities, trimRvalue)
     EXPECT_THAT(result, ::testing::StrEq("\n \f \n \r \t   \vI'm a great\n\t string"));
 }
 
+TEST_F(TestTrimUtilities, trimPrvalue)
+{
+    auto result = mp::utils::trim_end(std::string{s});
+    EXPECT_THAT(result, ::testing::StrEq("\n \f \n \r \t   \vI'm a great\n\t string"));
+}
+
 TEST(Utils, escapeForShellActuallyEscapes)
 {
     std::string s{"I've got \"quotes\""};


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
Make trim return Str instead of Str&& to avoid returning dangling rvalue references.

- Why is this change needed?
To make it harder to misuse the trim_* functions.

MULTI-2515