### PR TITLE
[main] Add GOOGLE_PROTOBUF_VERIFY_VERSION to main

### DIFF
--- a/src/client/cli/main.cpp
+++ b/src/client/cli/main.cpp
@@ -49,5 +49,9 @@ int main_impl(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
+    // Verify that the version of the library that we linked against is
+    // compatible with the version of the headers we compiled against.
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
     return mp::top_catch_all("client", /* fallback_return = */ EXIT_FAILURE, main_impl, argc, argv);
 }

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -121,6 +121,10 @@ int main_impl(int argc, char* argv[], mp::Signal& app_ready_signal)
 
 int main(int argc, char* argv[])
 {
+    // Verify that the version of the library that we linked against is
+    // compatible with the version of the headers we compiled against.
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
     mp::Signal app_ready_signal{};
     //
     // Register the signal handler as the first thing so the signal handler won't miss

--- a/src/daemon/daemon_main_win.cpp
+++ b/src/daemon/daemon_main_win.cpp
@@ -199,6 +199,10 @@ catch (...)
 int main(int argc, char* argv[])
 try
 {
+    // Verify that the version of the library that we linked against is
+    // compatible with the version of the headers we compiled against.
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
     service_argv.assign(argv, argv + argc);
 
     auto logger = mp::platform::make_logger(mpl::Level::info);

--- a/tests/unit/main.cpp
+++ b/tests/unit/main.cpp
@@ -26,6 +26,10 @@ namespace mp = multipass;
 // also define main... DAMN THEM!
 int main(int argc, char* argv[])
 {
+    // Verify that the version of the library that we linked against is
+    // compatible with the version of the headers we compiled against.
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
     QCoreApplication app(argc, argv);
     QCoreApplication::setApplicationName("multipass_tests");
 


### PR DESCRIPTION
This macro verifies the linked protobuf lib version against headers.

# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
Add GOOGLE_PROTOBUF_VERIFY_VERSION macro call to daemon (unix, win), cli, and unit test main functions.
- Why is this change needed?
To ensure that the linked protobuf header and library versions match.

MULTI-2514