### PR TITLE
[applevz] Support applevz with CLI tests

### DIFF
--- a/tests/cli/README.md
+++ b/tests/cli/README.md
@@ -173,6 +173,18 @@ pytest tests/cli/ --daemon-backend=snapd --driver=lxd # Test the `lxd` backend o
 pytest tests/cli/ --daemon-backend=winsvc --driver=virtualbox # Test the `virtualbox` backend on Windows
 ```
 
+```bash
+pytest tests/cli/ --daemon-controller=launchd --driver=applevz # Test the `applevz` backend on macOS
+```
+
+Some backends do not support all Multipass features. The test suite automatically skips tests that require unsupported features for a given driver:
+
+| Feature       | Unsupported drivers       | Skipped marker  |
+| ------------- | ------------------------- | --------------- |
+| snapshots     | `lxd`, `applevz`          | `snapshot`      |
+| suspend/restore | `applevz`               | `suspend`       |
+| clone         | `lxd`                     | `clone`         |
+
 #### `--remove-all-instances` flag
 
 Additionally, there's a convenience flag called `--remove-all-instances`. The test executor would remove the instance storage directories (including backend-specific ones), like `vault/instances`, `qemu/vault/instances`, `virtualbox/vault/instances` while keeping the image cache and other things intact. This would allow reuse of a `MULTIPASS_STORAGE_DIR` without having adverse effects on future test runs due to persisted instances.

--- a/tests/cli/cli_clone_test.py
+++ b/tests/cli/cli_clone_test.py
@@ -55,6 +55,7 @@ class TestClone:
             assert not output
             assert "already exist" in output
 
+    @pytest.mark.snapshot
     def test_clone_instance_with_snapshot(self, instance):
         take_snapshot(instance, "snapshot1")
         with multipass("clone", f"{instance}") as output:

--- a/tests/cli/cli_vm_lifecycle_test.py
+++ b/tests/cli/cli_vm_lifecycle_test.py
@@ -58,6 +58,7 @@ class TestVmLifecycle:
         assert state(f"{instance}") == "Running"
         assert boot_id_before != get_boot_id(instance)
 
+    @pytest.mark.suspend
     def test_suspend_resume(self, instance):
         assert state(f"{instance}") == "Running"
         boot_id_before = get_boot_id(instance)
@@ -116,6 +117,7 @@ class TestVmLifecycle:
                     assert not output
                     assert "does not exist" in output
 
+    @pytest.mark.suspend
     def test_lifecycle_multiple(self):
         with (
             launch({"autopurge": False}) as name1,

--- a/tests/cli/cli_vm_lifecycle_test.py
+++ b/tests/cli/cli_vm_lifecycle_test.py
@@ -117,7 +117,6 @@ class TestVmLifecycle:
                     assert not output
                     assert "does not exist" in output
 
-    @pytest.mark.suspend
     def test_lifecycle_multiple(self):
         with (
             launch({"autopurge": False}) as name1,
@@ -129,8 +128,9 @@ class TestVmLifecycle:
             assert multipass("start", name1, name2)
             assert state(name1) == "Running" and state(name2) == "Running"
 
-            assert multipass("suspend", name1, name2)
-            assert state(name1) == "Suspended" and state(name2) == "Suspended"
+            if cfg.driver != "applevz":
+                assert multipass("suspend", name1, name2)
+                assert state(name1) == "Suspended" and state(name2) == "Suspended"
 
             assert multipass("start", name1, name2)
             assert state(name1) == "Running" and state(name2) == "Running"

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -309,11 +309,28 @@ def pytest_collection_modifyitems(config, items):
                     "Skipped -- LXD driver does not support the `snapshot` feature."
                 )
             )
+        if config.getoption("--driver") == "applevz":
+            item.add_marker(
+                pytest.mark.skip(
+                    "Skipped -- AppleVZ driver does not support the `snapshot` feature."
+                )
+            )
+
+    def maybe_skip_suspend_test(item):
+        if not item.get_closest_marker("suspend"):
+            return
+        if config.getoption("--driver") == "applevz":
+            item.add_marker(
+                pytest.mark.skip(
+                    "Skipped -- AppleVZ driver does not support suspend/restore."
+                )
+            )
 
     for item in items:
         maybe_skip_mount_test(item)
         maybe_skip_clone_test(item)
         maybe_skip_snapshot_test(item)
+        maybe_skip_suspend_test(item)
 
 
 def pytest_runtest_setup(item):

--- a/tests/cli/pyproject.toml
+++ b/tests/cli/pyproject.toml
@@ -26,6 +26,7 @@ known_first_party = ["cli_tests"]
 filterwarnings = ["ignore:.*multi-threaded.*forkpty.*:DeprecationWarning"]
 markers = [
     "snapshot: Snapshot tests.",
+    "suspend: VM suspension and restore.",
     "clone: Clone tests.",
     "slow: The tests that known to have a slow run time.",
     "lifecycle: Basic VM lifecycle tests.",


### PR DESCRIPTION
This PR adds some configuration to the CLI tests so that they can be run with the `applevz` backend driver in Multipass. Most notably, all `suspend` and `snapshot` tests are skipped. At this point in the git history several tests will fail, but are fixed by other AppleVZ PRs that are currently awaiting review. Yeah for TDD! 😄 

---

MULTI-2528