### PR TITLE
[utils] Only seed generator once per thread

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -273,10 +273,9 @@ std::vector<std::string> mp::utils::split(const std::string& string, const std::
 
 std::string mp::utils::generate_mac_address()
 {
-    std::default_random_engine gen;
-    std::uniform_int_distribution<int> dist{0, 255};
+    thread_local std::mt19937 gen{std::random_device{}()};
+    thread_local std::uniform_int_distribution<int> dist{0, 255};
 
-    gen.seed(std::chrono::system_clock::now().time_since_epoch().count());
     std::array<int, 3> octets{{dist(gen), dist(gen), dist(gen)}};
     return fmt::format("52:54:00:{:02x}:{:02x}:{:02x}", octets[0], octets[1], octets[2]);
 }


### PR DESCRIPTION
This PR changes the way random generator is seeded for generating MAC addresses. This avoiding issues where generating multiple MAC addresses in quick succession can lack uniqueness. This has caused issues in CI when running unit tests.

https://github.com/canonical/multipass/actions/runs/23876122460/job/69619347352#step:24:5533

Stress testing the unit test in CI and linking a debugger reveals the underlying issue:
```
% lldb -- ./bin/multipass_tests --gtest_filter=Daemon/LaunchWithBridges.createsNetworkCloudInitIso\* --gtest_repeat=-1 --gtest_break_on_failure
...
(lldb) p e.what()
(const char *) 0x0000600002eed018 "Failed to generate an unique mac address after 5 attempts. Number of mac addresses in use: 2"
```

Fixes #4796 