### PR TITLE
[cli-tests] Add missing import (vm_lifecycle)

### DIFF
--- a/tests/cli/cli_vm_lifecycle_test.py
+++ b/tests/cli/cli_vm_lifecycle_test.py
@@ -21,6 +21,7 @@
 import pytest
 
 from cli.multipass import multipass, state, launch, random_vm_name, get_boot_id
+from cli.config import cfg
 
 
 @pytest.mark.lifecycle


### PR DESCRIPTION
There's a missing import in the cli_vm_lifecycle_test.py, which makes one of the tests fail. This patch fixes that.