### PR TITLE
[vault] Don't prune image dirs being downloaded

### DIFF
--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -311,7 +311,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
                               prepare,
                               monitor));
 
-                in_progress_image_fetches[id] = future;
+                in_progress_image_fetches[id] = {image_dir, future};
             }
         }
         else
@@ -363,7 +363,7 @@ mp::VMImage mp::DefaultVMImageVault::fetch_image(const FetchType& fetch_type,
                               prepare,
                               monitor));
 
-                in_progress_image_fetches[id] = future;
+                in_progress_image_fetches[id] = {image_dir, future};
             }
         }
 
@@ -426,7 +426,12 @@ void mp::DefaultVMImageVault::prune_expired_images()
                          [&entry](const std::pair<std::string, VaultRecord>& record) {
                              return MP_PLATFORM.path_to_qstr(record.second.image.image_path)
                                  .contains(entry.absoluteFilePath());
-                         }) == prepared_image_records.cend())
+                         }) == prepared_image_records.cend() &&
+            !std::any_of(in_progress_image_fetches.cbegin(),
+                         in_progress_image_fetches.cend(),
+                         [&entry](const auto& fetch) {
+                             return fetch.second.first == entry.absoluteFilePath();
+                         }))
         {
             mpl::info(category,
                       "Source image {} is no longer valid. Removing it from the cache.",
@@ -662,7 +667,7 @@ std::optional<QFuture<mp::VMImage>> mp::DefaultVMImageVault::get_image_future(co
     auto it = in_progress_image_fetches.find(id);
     if (it != in_progress_image_fetches.end())
     {
-        return it->second;
+        return it->second.second;
     }
 
     return std::nullopt;

--- a/src/daemon/default_vm_image_vault.h
+++ b/src/daemon/default_vm_image_vault.h
@@ -98,7 +98,7 @@ private:
 
     std::unordered_map<std::string, VaultRecord> prepared_image_records;
     std::unordered_map<std::string, VaultRecord> instance_image_records;
-    std::unordered_map<std::string, QFuture<VMImage>> in_progress_image_fetches;
+    std::unordered_map<std::string, std::pair<QString, QFuture<VMImage>>> in_progress_image_fetches;
 };
 
 void tag_invoke(const boost::json::value_from_tag&,

--- a/tests/unit/test_image_vault.cpp
+++ b/tests/unit/test_image_vault.cpp
@@ -44,6 +44,8 @@
 #include <QThread>
 #include <QUrl>
 
+#include <future>
+
 namespace mp = multipass;
 namespace mpl = multipass::logging;
 namespace mpt = multipass::test;
@@ -126,6 +128,32 @@ struct RunningURLDownloader : public mp::URLDownloader
     {
         return {};
     }
+};
+
+struct BlockingURLDownloader : public mp::URLDownloader
+{
+    BlockingURLDownloader() : mp::URLDownloader{std::chrono::seconds(10)}
+    {
+    }
+
+    void download_to(const QUrl&,
+                     const QString& file_name,
+                     int64_t,
+                     const int,
+                     const mp::ProgressMonitor&) override
+    {
+        started.set_value();
+        proceed.get_future().wait();
+        mpt::make_file_with_content(file_name, "");
+    }
+
+    QByteArray download(const QUrl&) override
+    {
+        return {};
+    }
+
+    std::promise<void> started;
+    std::promise<void> proceed;
 };
 
 struct ImageVault : public testing::Test
@@ -709,6 +737,41 @@ TEST_F(ImageVault, imageExistsNotExpired)
     vault.prune_expired_images();
 
     EXPECT_TRUE(QFileInfo::exists(file_name));
+}
+
+TEST_F(ImageVault, inProgressDownloadDirectoryNotPrunedDuringFetch)
+{
+    BlockingURLDownloader blocking_downloader;
+    mp::DefaultVMImageVault vault{hosts,
+                                  &blocking_downloader,
+                                  cache_dir.path(),
+                                  data_dir.path(),
+                                  mp::days{0}};
+
+    auto fetch_future = std::async(std::launch::async, [&] {
+        vault.fetch_image(mp::FetchType::ImageOnly,
+                          default_query,
+                          stub_prepare,
+                          stub_monitor,
+                          std::nullopt,
+                          instance_dir);
+    });
+
+    // Wait for download to start
+    blocking_downloader.started.get_future().wait();
+
+    QDir images_dir{MP_UTILS.make_dir(cache_dir.path(), "vault/images")};
+    const auto entries = images_dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot);
+    ASSERT_EQ(entries.size(), 1);
+    const auto image_dir_path = entries.first().absoluteFilePath();
+
+    vault.prune_expired_images();
+
+    EXPECT_TRUE(QFileInfo::exists(image_dir_path));
+
+    // Release the downloader
+    blocking_downloader.proceed.set_value();
+    fetch_future.wait();
 }
 
 TEST_F(ImageVault, invalidImageDirIsRemoved)


### PR DESCRIPTION
Stop the image vault from deleting images while they are being downloaded.

Fixes #4804 

---

MULTI-2532