### PR TITLE
[image-host] Protect manifest with mutex

### DIFF
--- a/include/multipass/image_host/base_image_host.h
+++ b/include/multipass/image_host/base_image_host.h
@@ -33,25 +33,25 @@ class BaseVMImageHost : public VMImageHost
 public:
     BaseVMImageHost(URLDownloader* downloader);
 
-    std::optional<VMImageInfo> info_for(const Query& query) final;
-    std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) final;
-    VMImageInfo info_for_full_hash(const std::string& full_hash) final;
+    std::optional<VMImageInfo> info_for(const Query& query) const final;
+    std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) const final;
+    VMImageInfo info_for_full_hash(const std::string& full_hash) const final;
     std::vector<VMImageInfo> all_images_for(const std::string& remote_name,
-                                            const bool allow_unsupported) final;
-    void for_each_entry_do(const Action& action) final;
+                                            const bool allow_unsupported) const final;
+    void for_each_entry_do(const Action& action) const final;
     void update_manifests(const bool force_update);
 
 protected:
     void on_manifest_update_failure(const std::string& details);
     void on_manifest_empty(const std::string& details);
 
-    virtual std::optional<VMImageInfo> info_for_impl(const Query& query) = 0;
+    virtual std::optional<VMImageInfo> info_for_impl(const Query& query) const = 0;
     virtual std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(
-        const Query& query) = 0;
-    virtual VMImageInfo info_for_full_hash_impl(const std::string& full_hash) = 0;
+        const Query& query) const = 0;
+    virtual VMImageInfo info_for_full_hash_impl(const std::string& full_hash) const = 0;
     virtual std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
-                                                         const bool allow_unsupported) = 0;
-    virtual void for_each_entry_do_impl(const Action& action) = 0;
+                                                         const bool allow_unsupported) const = 0;
+    virtual void for_each_entry_do_impl(const Action& action) const = 0;
     virtual void clear() = 0;
     virtual void fetch_manifests(const bool force_update) = 0;
 

--- a/include/multipass/image_host/base_image_host.h
+++ b/include/multipass/image_host/base_image_host.h
@@ -23,6 +23,8 @@
 #include <QStringList>
 #include <QTimer>
 
+#include <shared_mutex>
+
 namespace multipass
 {
 
@@ -44,6 +46,7 @@ protected:
     virtual void clear() = 0;
     virtual void fetch_manifests(const bool force_update) = 0;
 
+    mutable std::shared_mutex manifest_mutex;
     URLDownloader* const url_downloader;
 };
 

--- a/include/multipass/image_host/base_image_host.h
+++ b/include/multipass/image_host/base_image_host.h
@@ -33,16 +33,25 @@ class BaseVMImageHost : public VMImageHost
 public:
     BaseVMImageHost(URLDownloader* downloader);
 
-    void for_each_entry_do(const Action& action) final;
+    std::optional<VMImageInfo> info_for(const Query& query) final;
+    std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) final;
     VMImageInfo info_for_full_hash(const std::string& full_hash) final;
+    std::vector<VMImageInfo> all_images_for(const std::string& remote_name,
+                                            const bool allow_unsupported) final;
+    void for_each_entry_do(const Action& action) final;
     void update_manifests(const bool force_update);
 
 protected:
     void on_manifest_update_failure(const std::string& details);
     void on_manifest_empty(const std::string& details);
 
-    virtual void for_each_entry_do_impl(const Action& action) = 0;
+    virtual std::optional<VMImageInfo> info_for_impl(const Query& query) = 0;
+    virtual std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(
+        const Query& query) = 0;
     virtual VMImageInfo info_for_full_hash_impl(const std::string& full_hash) = 0;
+    virtual std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
+                                                         const bool allow_unsupported) = 0;
+    virtual void for_each_entry_do_impl(const Action& action) = 0;
     virtual void clear() = 0;
     virtual void fetch_manifests(const bool force_update) = 0;
 

--- a/include/multipass/image_host/base_image_host.h
+++ b/include/multipass/image_host/base_image_host.h
@@ -37,9 +37,9 @@ public:
     std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) const final;
     VMImageInfo info_for_full_hash(const std::string& full_hash) const final;
     std::vector<VMImageInfo> all_images_for(const std::string& remote_name,
-                                            const bool allow_unsupported) const final;
+                                            bool allow_unsupported) const final;
     void for_each_entry_do(const Action& action) const final;
-    void update_manifests(const bool force_update);
+    void update_manifests(bool force_update);
 
 protected:
     void on_manifest_update_failure(const std::string& details);
@@ -50,10 +50,10 @@ protected:
         const Query& query) const = 0;
     virtual VMImageInfo info_for_full_hash_impl(const std::string& full_hash) const = 0;
     virtual std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
-                                                         const bool allow_unsupported) const = 0;
+                                                         bool allow_unsupported) const = 0;
     virtual void for_each_entry_do_impl(const Action& action) const = 0;
     virtual void clear() = 0;
-    virtual void fetch_manifests(const bool force_update) = 0;
+    virtual void fetch_manifests(bool force_update) = 0;
 
     mutable std::shared_mutex manifest_mutex;
     URLDownloader* const url_downloader;

--- a/include/multipass/image_host/custom_image_host.h
+++ b/include/multipass/image_host/custom_image_host.h
@@ -42,13 +42,13 @@ class CustomVMImageHost final : public BaseVMImageHost
 public:
     CustomVMImageHost(URLDownloader* downloader);
 
-    std::optional<VMImageInfo> info_for(const Query& query) override;
-    std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) override;
-    std::vector<VMImageInfo> all_images_for(const std::string& remote_name,
-                                            const bool allow_unsupported) override;
     std::vector<std::string> supported_remotes() override;
 
 private:
+    std::optional<VMImageInfo> info_for_impl(const Query& query) override;
+    std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(const Query& query) override;
+    std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
+                                                 const bool allow_unsupported) override;
     void for_each_entry_do_impl(const Action& action) override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
     void fetch_manifests(const bool force_update) override;

--- a/include/multipass/image_host/custom_image_host.h
+++ b/include/multipass/image_host/custom_image_host.h
@@ -42,18 +42,19 @@ class CustomVMImageHost final : public BaseVMImageHost
 public:
     CustomVMImageHost(URLDownloader* downloader);
 
-    std::vector<std::string> supported_remotes() override;
+    std::vector<std::string> supported_remotes() const override;
 
 private:
-    std::optional<VMImageInfo> info_for_impl(const Query& query) override;
-    std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(const Query& query) override;
+    std::optional<VMImageInfo> info_for_impl(const Query& query) const override;
+    std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(
+        const Query& query) const override;
     std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
-                                                 const bool allow_unsupported) override;
-    void for_each_entry_do_impl(const Action& action) override;
-    VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
+                                                 const bool allow_unsupported) const override;
+    void for_each_entry_do_impl(const Action& action) const override;
+    VMImageInfo info_for_full_hash_impl(const std::string& full_hash) const override;
     void fetch_manifests(const bool force_update) override;
     void clear() override;
-    CustomManifest* manifest_from(const std::string& remote_name);
+    const CustomManifest* manifest_from(const std::string& remote_name) const;
 
     const QString arch;
     std::pair<std::string, std::unique_ptr<CustomManifest>> manifest;

--- a/include/multipass/image_host/custom_image_host.h
+++ b/include/multipass/image_host/custom_image_host.h
@@ -54,7 +54,7 @@ private:
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) const override;
     void fetch_manifests(const bool force_update) override;
     void clear() override;
-    const CustomManifest* manifest_from(const std::string& remote_name) const;
+    const CustomManifest& manifest_from(const std::string& remote_name) const;
 
     const QString arch;
     std::pair<std::string, std::unique_ptr<CustomManifest>> manifest;

--- a/include/multipass/image_host/custom_image_host.h
+++ b/include/multipass/image_host/custom_image_host.h
@@ -49,10 +49,10 @@ private:
     std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(
         const Query& query) const override;
     std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
-                                                 const bool allow_unsupported) const override;
+                                                 bool allow_unsupported) const override;
     void for_each_entry_do_impl(const Action& action) const override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) const override;
-    void fetch_manifests(const bool force_update) override;
+    void fetch_manifests(bool force_update) override;
     void clear() override;
     const CustomManifest& manifest_from(const std::string& remote_name) const;
 

--- a/include/multipass/image_host/ubuntu_image_host.h
+++ b/include/multipass/image_host/ubuntu_image_host.h
@@ -38,18 +38,19 @@ public:
     UbuntuVMImageHost(std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes,
                       URLDownloader* downloader);
 
-    std::vector<std::string> supported_remotes() override;
+    std::vector<std::string> supported_remotes() const override;
 
 private:
-    std::optional<VMImageInfo> info_for_impl(const Query& query) override;
-    std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(const Query& query) override;
+    std::optional<VMImageInfo> info_for_impl(const Query& query) const override;
+    std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(
+        const Query& query) const override;
     std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
-                                                 const bool allow_unsupported) override;
-    void for_each_entry_do_impl(const Action& action) override;
-    VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
+                                                 const bool allow_unsupported) const override;
+    void for_each_entry_do_impl(const Action& action) const override;
+    VMImageInfo info_for_full_hash_impl(const std::string& full_hash) const override;
     void fetch_manifests(const bool force_update) override;
     void clear() override;
-    SimpleStreamsManifest* manifest_from(const std::string& remote);
+    const SimpleStreamsManifest* manifest_from(const std::string& remote) const;
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;
 
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> manifests;

--- a/include/multipass/image_host/ubuntu_image_host.h
+++ b/include/multipass/image_host/ubuntu_image_host.h
@@ -38,13 +38,13 @@ public:
     UbuntuVMImageHost(std::vector<std::pair<std::string, UbuntuVMImageRemote>> remotes,
                       URLDownloader* downloader);
 
-    std::optional<VMImageInfo> info_for(const Query& query) override;
-    std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) override;
-    std::vector<VMImageInfo> all_images_for(const std::string& remote_name,
-                                            const bool allow_unsupported) override;
     std::vector<std::string> supported_remotes() override;
 
 private:
+    std::optional<VMImageInfo> info_for_impl(const Query& query) override;
+    std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(const Query& query) override;
+    std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
+                                                 const bool allow_unsupported) override;
     void for_each_entry_do_impl(const Action& action) override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) override;
     void fetch_manifests(const bool force_update) override;

--- a/include/multipass/image_host/ubuntu_image_host.h
+++ b/include/multipass/image_host/ubuntu_image_host.h
@@ -50,7 +50,7 @@ private:
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) const override;
     void fetch_manifests(const bool force_update) override;
     void clear() override;
-    const SimpleStreamsManifest* manifest_from(const std::string& remote) const;
+    const SimpleStreamsManifest& manifest_from(const std::string& remote) const;
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;
 
     std::vector<std::pair<std::string, std::unique_ptr<SimpleStreamsManifest>>> manifests;

--- a/include/multipass/image_host/ubuntu_image_host.h
+++ b/include/multipass/image_host/ubuntu_image_host.h
@@ -45,10 +45,10 @@ private:
     std::vector<std::pair<std::string, VMImageInfo>> all_info_for_impl(
         const Query& query) const override;
     std::vector<VMImageInfo> all_images_for_impl(const std::string& remote_name,
-                                                 const bool allow_unsupported) const override;
+                                                 bool allow_unsupported) const override;
     void for_each_entry_do_impl(const Action& action) const override;
     VMImageInfo info_for_full_hash_impl(const std::string& full_hash) const override;
-    void fetch_manifests(const bool force_update) override;
+    void fetch_manifests(bool force_update) override;
     void clear() override;
     const SimpleStreamsManifest& manifest_from(const std::string& remote) const;
     const VMImageInfo* match_alias(const QString& key, const SimpleStreamsManifest& manifest) const;

--- a/include/multipass/image_host/vm_image_host.h
+++ b/include/multipass/image_host/vm_image_host.h
@@ -36,13 +36,14 @@ public:
     using Action = std::function<void(const std::string&, const VMImageInfo&)>;
 
     virtual ~VMImageHost() = default;
-    virtual std::optional<VMImageInfo> info_for(const Query& query) = 0;
-    virtual std::vector<std::pair<std::string, VMImageInfo>> all_info_for(const Query& query) = 0;
-    virtual VMImageInfo info_for_full_hash(const std::string& full_hash) = 0;
+    virtual std::optional<VMImageInfo> info_for(const Query& query) const = 0;
+    virtual std::vector<std::pair<std::string, VMImageInfo>> all_info_for(
+        const Query& query) const = 0;
+    virtual VMImageInfo info_for_full_hash(const std::string& full_hash) const = 0;
     virtual std::vector<VMImageInfo> all_images_for(const std::string& remote_name,
-                                                    const bool allow_unsupported) = 0;
-    virtual void for_each_entry_do(const Action& action) = 0;
-    virtual std::vector<std::string> supported_remotes() = 0;
+                                                    const bool allow_unsupported) const = 0;
+    virtual void for_each_entry_do(const Action& action) const = 0;
+    virtual std::vector<std::string> supported_remotes() const = 0;
     virtual void update_manifests(const bool force_update) = 0;
 
 protected:

--- a/include/multipass/image_host/vm_image_host.h
+++ b/include/multipass/image_host/vm_image_host.h
@@ -41,10 +41,10 @@ public:
         const Query& query) const = 0;
     virtual VMImageInfo info_for_full_hash(const std::string& full_hash) const = 0;
     virtual std::vector<VMImageInfo> all_images_for(const std::string& remote_name,
-                                                    const bool allow_unsupported) const = 0;
+                                                    bool allow_unsupported) const = 0;
     virtual void for_each_entry_do(const Action& action) const = 0;
     virtual std::vector<std::string> supported_remotes() const = 0;
-    virtual void update_manifests(const bool force_update) = 0;
+    virtual void update_manifests(bool force_update) = 0;
 
 protected:
     VMImageHost() = default;

--- a/src/image_host/base_image_host.cpp
+++ b/src/image_host/base_image_host.cpp
@@ -32,16 +32,36 @@ mp::BaseVMImageHost::BaseVMImageHost(URLDownloader* downloader) : url_downloader
 {
 }
 
-void mp::BaseVMImageHost::for_each_entry_do(const Action& action)
+auto mp::BaseVMImageHost::info_for(const Query& query) -> std::optional<VMImageInfo>
 {
     std::shared_lock lock{manifest_mutex};
-    for_each_entry_do_impl(action);
+    return info_for_impl(query);
+}
+
+auto mp::BaseVMImageHost::all_info_for(const Query& query)
+    -> std::vector<std::pair<std::string, VMImageInfo>>
+{
+    std::shared_lock lock{manifest_mutex};
+    return all_info_for_impl(query);
 }
 
 auto mp::BaseVMImageHost::info_for_full_hash(const std::string& full_hash) -> VMImageInfo
 {
     std::shared_lock lock{manifest_mutex};
     return info_for_full_hash_impl(full_hash);
+}
+
+auto mp::BaseVMImageHost::all_images_for(const std::string& remote_name,
+                                         const bool allow_unsupported) -> std::vector<VMImageInfo>
+{
+    std::shared_lock lock{manifest_mutex};
+    return all_images_for_impl(remote_name, allow_unsupported);
+}
+
+void mp::BaseVMImageHost::for_each_entry_do(const Action& action)
+{
+    std::shared_lock lock{manifest_mutex};
+    for_each_entry_do_impl(action);
 }
 
 void mp::BaseVMImageHost::update_manifests(const bool force_update)

--- a/src/image_host/base_image_host.cpp
+++ b/src/image_host/base_image_host.cpp
@@ -32,33 +32,34 @@ mp::BaseVMImageHost::BaseVMImageHost(URLDownloader* downloader) : url_downloader
 {
 }
 
-auto mp::BaseVMImageHost::info_for(const Query& query) -> std::optional<VMImageInfo>
+auto mp::BaseVMImageHost::info_for(const Query& query) const -> std::optional<VMImageInfo>
 {
     std::shared_lock lock{manifest_mutex};
     return info_for_impl(query);
 }
 
-auto mp::BaseVMImageHost::all_info_for(const Query& query)
+auto mp::BaseVMImageHost::all_info_for(const Query& query) const
     -> std::vector<std::pair<std::string, VMImageInfo>>
 {
     std::shared_lock lock{manifest_mutex};
     return all_info_for_impl(query);
 }
 
-auto mp::BaseVMImageHost::info_for_full_hash(const std::string& full_hash) -> VMImageInfo
+auto mp::BaseVMImageHost::info_for_full_hash(const std::string& full_hash) const -> VMImageInfo
 {
     std::shared_lock lock{manifest_mutex};
     return info_for_full_hash_impl(full_hash);
 }
 
 auto mp::BaseVMImageHost::all_images_for(const std::string& remote_name,
-                                         const bool allow_unsupported) -> std::vector<VMImageInfo>
+                                         const bool allow_unsupported) const
+    -> std::vector<VMImageInfo>
 {
     std::shared_lock lock{manifest_mutex};
     return all_images_for_impl(remote_name, allow_unsupported);
 }
 
-void mp::BaseVMImageHost::for_each_entry_do(const Action& action)
+void mp::BaseVMImageHost::for_each_entry_do(const Action& action) const
 {
     std::shared_lock lock{manifest_mutex};
     for_each_entry_do_impl(action);

--- a/src/image_host/base_image_host.cpp
+++ b/src/image_host/base_image_host.cpp
@@ -67,7 +67,7 @@ void mp::BaseVMImageHost::for_each_entry_do(const Action& action) const
 
 void mp::BaseVMImageHost::update_manifests(const bool force_update)
 {
-    std::unique_lock lock{manifest_mutex};
+    std::lock_guard lock{manifest_mutex};
     clear();
     fetch_manifests(force_update);
 }

--- a/src/image_host/base_image_host.cpp
+++ b/src/image_host/base_image_host.cpp
@@ -34,16 +34,19 @@ mp::BaseVMImageHost::BaseVMImageHost(URLDownloader* downloader) : url_downloader
 
 void mp::BaseVMImageHost::for_each_entry_do(const Action& action)
 {
+    std::shared_lock lock{manifest_mutex};
     for_each_entry_do_impl(action);
 }
 
 auto mp::BaseVMImageHost::info_for_full_hash(const std::string& full_hash) -> VMImageInfo
 {
+    std::shared_lock lock{manifest_mutex};
     return info_for_full_hash_impl(full_hash);
 }
 
 void mp::BaseVMImageHost::update_manifests(const bool force_update)
 {
+    std::unique_lock lock{manifest_mutex};
     clear();
     fetch_manifests(force_update);
 }

--- a/src/image_host/base_image_host.cpp
+++ b/src/image_host/base_image_host.cpp
@@ -52,8 +52,7 @@ auto mp::BaseVMImageHost::info_for_full_hash(const std::string& full_hash) const
 }
 
 auto mp::BaseVMImageHost::all_images_for(const std::string& remote_name,
-                                         const bool allow_unsupported) const
-    -> std::vector<VMImageInfo>
+                                         bool allow_unsupported) const -> std::vector<VMImageInfo>
 {
     std::shared_lock lock{manifest_mutex};
     return all_images_for_impl(remote_name, allow_unsupported);
@@ -65,7 +64,7 @@ void mp::BaseVMImageHost::for_each_entry_do(const Action& action) const
     for_each_entry_do_impl(action);
 }
 
-void mp::BaseVMImageHost::update_manifests(const bool force_update)
+void mp::BaseVMImageHost::update_manifests(bool force_update)
 {
     std::lock_guard lock{manifest_mutex};
     clear();

--- a/src/image_host/custom_image_host.cpp
+++ b/src/image_host/custom_image_host.cpp
@@ -123,11 +123,11 @@ mp::CustomVMImageHost::CustomVMImageHost(URLDownloader* downloader)
 
 std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for_impl(const Query& query) const
 {
-    auto custom_manifest = manifest_from(query.remote_name);
+    const auto& custom_manifest = manifest_from(query.remote_name);
 
-    auto it = custom_manifest->image_records.find(query.release);
+    auto it = custom_manifest.image_records.find(query.release);
 
-    if (it == custom_manifest->image_records.end())
+    if (it == custom_manifest.image_records.end())
         return std::nullopt;
 
     return *it->second;
@@ -148,10 +148,7 @@ std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for_impl(
     const std::string& remote_name,
     const bool allow_unsupported) const
 {
-    if (auto custom_manifest = manifest_from(remote_name))
-        return custom_manifest->products;
-
-    return {};
+    return manifest_from(remote_name).products;
 }
 
 std::vector<std::string> mp::CustomVMImageHost::supported_remotes() const
@@ -199,12 +196,11 @@ void mp::CustomVMImageHost::clear()
     manifest = std::pair<std::string, std::unique_ptr<CustomManifest>>{};
 }
 
-const mp::CustomManifest* mp::CustomVMImageHost::manifest_from(
-    const std::string& remote_name) const
+const mp::CustomManifest& mp::CustomVMImageHost::manifest_from(const std::string& remote_name) const
 {
-    if (remote_name != manifest.first)
+    if (remote_name != manifest.first || !manifest.second)
         throw std::runtime_error(
             fmt::format("Remote \"{}\" is unknown or unreachable.", remote_name));
 
-    return manifest.second.get();
+    return *manifest.second;
 }

--- a/src/image_host/custom_image_host.cpp
+++ b/src/image_host/custom_image_host.cpp
@@ -121,9 +121,8 @@ mp::CustomVMImageHost::CustomVMImageHost(URLDownloader* downloader)
 {
 }
 
-std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for(const Query& query)
+std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for_impl(const Query& query)
 {
-    std::shared_lock lock{manifest_mutex};
     auto custom_manifest = manifest_from(query.remote_name);
 
     auto it = custom_manifest->image_records.find(query.release);
@@ -134,22 +133,21 @@ std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for(const Query& quer
     return *it->second;
 }
 
-std::vector<std::pair<std::string, mp::VMImageInfo>> mp::CustomVMImageHost::all_info_for(
+std::vector<std::pair<std::string, mp::VMImageInfo>> mp::CustomVMImageHost::all_info_for_impl(
     const Query& query)
 {
-    std::shared_lock lock{manifest_mutex};
     std::vector<std::pair<std::string, mp::VMImageInfo>> images;
 
-    if (auto image = info_for(query))
+    if (auto image = info_for_impl(query))
         images.emplace_back(query.remote_name, std::move(*image));
 
     return images;
 }
 
-std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for(const std::string& remote_name,
-                                                                   const bool allow_unsupported)
+std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for_impl(
+    const std::string& remote_name,
+    const bool allow_unsupported)
 {
-    std::shared_lock lock{manifest_mutex};
     if (auto custom_manifest = manifest_from(remote_name))
         return custom_manifest->products;
 

--- a/src/image_host/custom_image_host.cpp
+++ b/src/image_host/custom_image_host.cpp
@@ -121,7 +121,7 @@ mp::CustomVMImageHost::CustomVMImageHost(URLDownloader* downloader)
 {
 }
 
-std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for_impl(const Query& query)
+std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for_impl(const Query& query) const
 {
     auto custom_manifest = manifest_from(query.remote_name);
 
@@ -134,7 +134,7 @@ std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for_impl(const Query&
 }
 
 std::vector<std::pair<std::string, mp::VMImageInfo>> mp::CustomVMImageHost::all_info_for_impl(
-    const Query& query)
+    const Query& query) const
 {
     std::vector<std::pair<std::string, mp::VMImageInfo>> images;
 
@@ -146,7 +146,7 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::CustomVMImageHost::all_
 
 std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for_impl(
     const std::string& remote_name,
-    const bool allow_unsupported)
+    const bool allow_unsupported) const
 {
     if (auto custom_manifest = manifest_from(remote_name))
         return custom_manifest->products;
@@ -154,12 +154,12 @@ std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for_impl(
     return {};
 }
 
-std::vector<std::string> mp::CustomVMImageHost::supported_remotes()
+std::vector<std::string> mp::CustomVMImageHost::supported_remotes() const
 {
     return {remote};
 }
 
-void mp::CustomVMImageHost::for_each_entry_do_impl(const Action& action)
+void mp::CustomVMImageHost::for_each_entry_do_impl(const Action& action) const
 {
     for (const auto& info : manifest.second->products)
     {
@@ -167,7 +167,7 @@ void mp::CustomVMImageHost::for_each_entry_do_impl(const Action& action)
     }
 }
 
-mp::VMImageInfo mp::CustomVMImageHost::info_for_full_hash_impl(const std::string& full_hash)
+mp::VMImageInfo mp::CustomVMImageHost::info_for_full_hash_impl(const std::string& full_hash) const
 {
     for (const auto& product : manifest.second->products)
     {
@@ -199,7 +199,8 @@ void mp::CustomVMImageHost::clear()
     manifest = std::pair<std::string, std::unique_ptr<CustomManifest>>{};
 }
 
-mp::CustomManifest* mp::CustomVMImageHost::manifest_from(const std::string& remote_name)
+const mp::CustomManifest* mp::CustomVMImageHost::manifest_from(
+    const std::string& remote_name) const
 {
     if (remote_name != manifest.first)
         throw std::runtime_error(

--- a/src/image_host/custom_image_host.cpp
+++ b/src/image_host/custom_image_host.cpp
@@ -123,6 +123,7 @@ mp::CustomVMImageHost::CustomVMImageHost(URLDownloader* downloader)
 
 std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for(const Query& query)
 {
+    std::shared_lock lock{manifest_mutex};
     auto custom_manifest = manifest_from(query.remote_name);
 
     auto it = custom_manifest->image_records.find(query.release);
@@ -136,6 +137,7 @@ std::optional<mp::VMImageInfo> mp::CustomVMImageHost::info_for(const Query& quer
 std::vector<std::pair<std::string, mp::VMImageInfo>> mp::CustomVMImageHost::all_info_for(
     const Query& query)
 {
+    std::shared_lock lock{manifest_mutex};
     std::vector<std::pair<std::string, mp::VMImageInfo>> images;
 
     if (auto image = info_for(query))
@@ -147,6 +149,7 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::CustomVMImageHost::all_
 std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for(const std::string& remote_name,
                                                                    const bool allow_unsupported)
 {
+    std::shared_lock lock{manifest_mutex};
     if (auto custom_manifest = manifest_from(remote_name))
         return custom_manifest->products;
 

--- a/src/image_host/custom_image_host.cpp
+++ b/src/image_host/custom_image_host.cpp
@@ -64,7 +64,7 @@ auto map_aliases_to_vm_info(const std::vector<mp::VMImageInfo>& images)
 
 std::vector<mp::VMImageInfo> fetch_image_info(const QString& arch,
                                               mp::URLDownloader* url_downloader,
-                                              const bool force_update = false)
+                                              bool force_update = false)
 {
     mpl::log(mpl::Level::debug, category, "Fetching images from {}", get_manifest_url());
 
@@ -146,7 +146,7 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::CustomVMImageHost::all_
 
 std::vector<mp::VMImageInfo> mp::CustomVMImageHost::all_images_for_impl(
     const std::string& remote_name,
-    const bool allow_unsupported) const
+    bool allow_unsupported) const
 {
     return manifest_from(remote_name).products;
 }
@@ -177,7 +177,7 @@ mp::VMImageInfo mp::CustomVMImageHost::info_for_full_hash_impl(const std::string
     throw mp::ImageNotFoundException(full_hash);
 }
 
-void mp::CustomVMImageHost::fetch_manifests(const bool force_update)
+void mp::CustomVMImageHost::fetch_manifests(bool force_update)
 {
     try
     {

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -89,6 +89,7 @@ std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& quer
 std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for(
     const Query& query)
 {
+    std::shared_lock lock{manifest_mutex};
     auto key = key_from(query.release);
 
     std::vector<std::string> remotes_to_search;
@@ -153,6 +154,7 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
 std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::string& remote_name,
                                                                    const bool allow_unsupported)
 {
+    std::shared_lock lock{manifest_mutex};
     std::vector<mp::VMImageInfo> images;
     auto manifest = manifest_from(remote_name);
 

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -106,9 +106,9 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_
 
     for (const auto& remote_name : remotes_to_search)
     {
-        auto* manifest = manifest_from(remote_name);
+        const auto& manifest = manifest_from(remote_name);
 
-        if (const auto* info = match_alias(key, *manifest); info)
+        if (const auto* info = match_alias(key, manifest); info)
         {
             if (!info->supported && !query.allow_unsupported)
                 throw mp::UnsupportedImageException(query.release);
@@ -119,7 +119,7 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_
         {
             std::unordered_set<std::string> found_hashes;
 
-            for (const auto& entry : manifest->products)
+            for (const auto& entry : manifest.products)
             {
                 if (entry.id.startsWith(key) && (entry.supported || query.allow_unsupported) &&
                     found_hashes.find(entry.id.toStdString()) == found_hashes.end())
@@ -155,9 +155,9 @@ std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
     const bool allow_unsupported) const
 {
     std::vector<mp::VMImageInfo> images;
-    auto manifest = manifest_from(remote_name);
+    const auto& manifest = manifest_from(remote_name);
 
-    for (const auto& entry : manifest->products)
+    for (const auto& entry : manifest.products)
     {
         if (entry.supported || allow_unsupported)
         {
@@ -254,7 +254,7 @@ void mp::UbuntuVMImageHost::clear()
     manifests.clear();
 }
 
-const mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(
+const mp::SimpleStreamsManifest& mp::UbuntuVMImageHost::manifest_from(
     const std::string& remote) const
 {
     const auto it = std::find_if(
@@ -269,7 +269,7 @@ const mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(
                                              "mirror is enabled, please confirm it is valid.",
                                              remote));
 
-    return it->second.get();
+    return *it->second;
 }
 
 const mp::VMImageInfo* mp::UbuntuVMImageHost::match_alias(

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -68,7 +68,7 @@ mp::UbuntuVMImageHost::UbuntuVMImageHost(
 {
 }
 
-std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for_impl(const Query& query)
+std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for_impl(const Query& query) const
 {
     auto images = all_info_for_impl(query);
 
@@ -87,7 +87,7 @@ std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for_impl(const Query&
 }
 
 std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for_impl(
-    const Query& query)
+    const Query& query) const
 {
     auto key = key_from(query.release);
 
@@ -134,7 +134,7 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_
     return images;
 }
 
-mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string& full_hash)
+mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string& full_hash) const
 {
     for (const auto& manifest : manifests)
     {
@@ -152,7 +152,7 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
 
 std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
     const std::string& remote_name,
-    const bool allow_unsupported)
+    const bool allow_unsupported) const
 {
     std::vector<mp::VMImageInfo> images;
     auto manifest = manifest_from(remote_name);
@@ -172,7 +172,7 @@ std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
     return images;
 }
 
-void mp::UbuntuVMImageHost::for_each_entry_do_impl(const Action& action)
+void mp::UbuntuVMImageHost::for_each_entry_do_impl(const Action& action) const
 {
     for (const auto& [remote_name, manifest] : manifests)
     {
@@ -183,7 +183,7 @@ void mp::UbuntuVMImageHost::for_each_entry_do_impl(const Action& action)
     }
 }
 
-std::vector<std::string> mp::UbuntuVMImageHost::supported_remotes()
+std::vector<std::string> mp::UbuntuVMImageHost::supported_remotes() const
 {
     std::vector<std::string> supported_remotes;
 
@@ -254,7 +254,8 @@ void mp::UbuntuVMImageHost::clear()
     manifests.clear();
 }
 
-mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(const std::string& remote)
+const mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(
+    const std::string& remote) const
 {
     const auto it = std::find_if(
         manifests.cbegin(),

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -68,9 +68,9 @@ mp::UbuntuVMImageHost::UbuntuVMImageHost(
 {
 }
 
-std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& query)
+std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for_impl(const Query& query)
 {
-    auto images = all_info_for(query);
+    auto images = all_info_for_impl(query);
 
     if (images.size() == 0)
         return std::nullopt;
@@ -86,10 +86,9 @@ std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& quer
     return images.front().second;
 }
 
-std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for(
+std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for_impl(
     const Query& query)
 {
-    std::shared_lock lock{manifest_mutex};
     auto key = key_from(query.release);
 
     std::vector<std::string> remotes_to_search;
@@ -151,10 +150,10 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
     throw mp::ImageNotFoundException(full_hash);
 }
 
-std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::string& remote_name,
-                                                                   const bool allow_unsupported)
+std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
+    const std::string& remote_name,
+    const bool allow_unsupported)
 {
-    std::shared_lock lock{manifest_mutex};
     std::vector<mp::VMImageInfo> images;
     auto manifest = manifest_from(remote_name);
 

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -66,9 +66,9 @@ mp::UbuntuVMImageHost::UbuntuVMImageHost(
 {
 }
 
-std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& query)
+std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for_impl(const Query& query)
 {
-    auto images = all_info_for(query);
+    auto images = all_info_for_impl(query);
 
     if (images.size() == 0)
         return std::nullopt;
@@ -84,10 +84,9 @@ std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& quer
     return images.front().second;
 }
 
-std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for(
+std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for_impl(
     const Query& query)
 {
-    std::shared_lock lock{manifest_mutex};
     auto key = key_from(query.release);
 
     std::vector<std::string> remotes_to_search;
@@ -149,10 +148,10 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
     throw mp::ImageNotFoundException(full_hash);
 }
 
-std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::string& remote_name,
-                                                                   const bool allow_unsupported)
+std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
+    const std::string& remote_name,
+    const bool allow_unsupported)
 {
-    std::shared_lock lock{manifest_mutex};
     std::vector<mp::VMImageInfo> images;
     auto manifest = manifest_from(remote_name);
 

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -41,7 +41,7 @@ constexpr auto index_path = "streams/v1/index.json";
 
 auto download_manifest(const QString& host_url,
                        mp::URLDownloader* url_downloader,
-                       const bool force_update)
+                       bool force_update)
 {
     auto json_index = url_downloader->download({host_url + index_path}, force_update);
     auto index = mp::SimpleStreamsIndex::fromJson(json_index);
@@ -150,7 +150,7 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
 
 std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
     const std::string& remote_name,
-    const bool allow_unsupported) const
+    bool allow_unsupported) const
 {
     std::vector<mp::VMImageInfo> images;
     const auto& manifest = manifest_from(remote_name);
@@ -193,7 +193,7 @@ std::vector<std::string> mp::UbuntuVMImageHost::supported_remotes() const
     return supported_remotes;
 }
 
-void mp::UbuntuVMImageHost::fetch_manifests(const bool force_update)
+void mp::UbuntuVMImageHost::fetch_manifests(bool force_update)
 {
     auto fetch_one_remote =
         [this, force_update](const std::pair<std::string, UbuntuVMImageRemote>& remote_pair)

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -104,9 +104,9 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_
 
     for (const auto& remote_name : remotes_to_search)
     {
-        auto* manifest = manifest_from(remote_name);
+        const auto& manifest = manifest_from(remote_name);
 
-        if (const auto* info = match_alias(key, *manifest); info)
+        if (const auto* info = match_alias(key, manifest); info)
         {
             if (!info->supported && !query.allow_unsupported)
                 throw mp::UnsupportedImageException(query.release);
@@ -117,7 +117,7 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_
         {
             std::unordered_set<std::string> found_hashes;
 
-            for (const auto& entry : manifest->products)
+            for (const auto& entry : manifest.products)
             {
                 if (entry.id.startsWith(key) && (entry.supported || query.allow_unsupported) &&
                     found_hashes.find(entry.id.toStdString()) == found_hashes.end())
@@ -153,9 +153,9 @@ std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
     const bool allow_unsupported) const
 {
     std::vector<mp::VMImageInfo> images;
-    auto manifest = manifest_from(remote_name);
+    const auto& manifest = manifest_from(remote_name);
 
-    for (const auto& entry : manifest->products)
+    for (const auto& entry : manifest.products)
     {
         if (entry.supported || allow_unsupported)
         {
@@ -252,7 +252,7 @@ void mp::UbuntuVMImageHost::clear()
     manifests.clear();
 }
 
-const mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(
+const mp::SimpleStreamsManifest& mp::UbuntuVMImageHost::manifest_from(
     const std::string& remote) const
 {
     const auto it = std::find_if(
@@ -267,7 +267,7 @@ const mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(
                                              "mirror is enabled, please confirm it is valid.",
                                              remote));
 
-    return it->second.get();
+    return *it->second;
 }
 
 const mp::VMImageInfo* mp::UbuntuVMImageHost::match_alias(

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -87,6 +87,7 @@ std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for(const Query& quer
 std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for(
     const Query& query)
 {
+    std::shared_lock lock{manifest_mutex};
     auto key = key_from(query.release);
 
     std::vector<std::string> remotes_to_search;
@@ -151,6 +152,7 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
 std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for(const std::string& remote_name,
                                                                    const bool allow_unsupported)
 {
+    std::shared_lock lock{manifest_mutex};
     std::vector<mp::VMImageInfo> images;
     auto manifest = manifest_from(remote_name);
 

--- a/src/image_host/ubuntu_image_host.cpp
+++ b/src/image_host/ubuntu_image_host.cpp
@@ -66,7 +66,7 @@ mp::UbuntuVMImageHost::UbuntuVMImageHost(
 {
 }
 
-std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for_impl(const Query& query)
+std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for_impl(const Query& query) const
 {
     auto images = all_info_for_impl(query);
 
@@ -85,7 +85,7 @@ std::optional<mp::VMImageInfo> mp::UbuntuVMImageHost::info_for_impl(const Query&
 }
 
 std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_info_for_impl(
-    const Query& query)
+    const Query& query) const
 {
     auto key = key_from(query.release);
 
@@ -132,7 +132,7 @@ std::vector<std::pair<std::string, mp::VMImageInfo>> mp::UbuntuVMImageHost::all_
     return images;
 }
 
-mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string& full_hash)
+mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string& full_hash) const
 {
     for (const auto& manifest : manifests)
     {
@@ -150,7 +150,7 @@ mp::VMImageInfo mp::UbuntuVMImageHost::info_for_full_hash_impl(const std::string
 
 std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
     const std::string& remote_name,
-    const bool allow_unsupported)
+    const bool allow_unsupported) const
 {
     std::vector<mp::VMImageInfo> images;
     auto manifest = manifest_from(remote_name);
@@ -170,7 +170,7 @@ std::vector<mp::VMImageInfo> mp::UbuntuVMImageHost::all_images_for_impl(
     return images;
 }
 
-void mp::UbuntuVMImageHost::for_each_entry_do_impl(const Action& action)
+void mp::UbuntuVMImageHost::for_each_entry_do_impl(const Action& action) const
 {
     for (const auto& [remote_name, manifest] : manifests)
     {
@@ -181,7 +181,7 @@ void mp::UbuntuVMImageHost::for_each_entry_do_impl(const Action& action)
     }
 }
 
-std::vector<std::string> mp::UbuntuVMImageHost::supported_remotes()
+std::vector<std::string> mp::UbuntuVMImageHost::supported_remotes() const
 {
     std::vector<std::string> supported_remotes;
 
@@ -252,7 +252,8 @@ void mp::UbuntuVMImageHost::clear()
     manifests.clear();
 }
 
-mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(const std::string& remote)
+const mp::SimpleStreamsManifest* mp::UbuntuVMImageHost::manifest_from(
+    const std::string& remote) const
 {
     const auto it = std::find_if(
         manifests.cbegin(),

--- a/tests/unit/mock_image_host.h
+++ b/tests/unit/mock_image_host.h
@@ -87,18 +87,18 @@ public:
         ON_CALL(*this, supported_remotes()).WillByDefault(Return(remote));
     };
 
-    MOCK_METHOD(std::optional<VMImageInfo>, info_for, (const Query&), (override));
+    MOCK_METHOD(std::optional<VMImageInfo>, info_for, (const Query&), (const, override));
     MOCK_METHOD((std::vector<std::pair<std::string, VMImageInfo>>),
                 all_info_for,
                 (const Query&),
-                (override));
-    MOCK_METHOD(VMImageInfo, info_for_full_hash, (const std::string&), (override));
+                (const, override));
+    MOCK_METHOD(VMImageInfo, info_for_full_hash, (const std::string&), (const, override));
     MOCK_METHOD(std::vector<VMImageInfo>,
                 all_images_for,
                 (const std::string&, const bool),
-                (override));
-    MOCK_METHOD(void, for_each_entry_do, (const Action&), (override));
-    MOCK_METHOD(std::vector<std::string>, supported_remotes, (), (override));
+                (const, override));
+    MOCK_METHOD(void, for_each_entry_do, (const Action&), (const, override));
+    MOCK_METHOD(std::vector<std::string>, supported_remotes, (), (const, override));
     MOCK_METHOD(void, update_manifests, (bool), (override));
 
     TempFile image;

--- a/tests/unit/mock_image_host.h
+++ b/tests/unit/mock_image_host.h
@@ -95,7 +95,7 @@ public:
     MOCK_METHOD(VMImageInfo, info_for_full_hash, (const std::string&), (const, override));
     MOCK_METHOD(std::vector<VMImageInfo>,
                 all_images_for,
-                (const std::string&, const bool),
+                (const std::string&, bool),
                 (const, override));
     MOCK_METHOD(void, for_each_entry_do, (const Action&), (const, override));
     MOCK_METHOD(std::vector<std::string>, supported_remotes, (), (const, override));

--- a/tests/unit/stub_image_host.h
+++ b/tests/unit/stub_image_host.h
@@ -25,34 +25,34 @@ namespace test
 {
 struct StubVMImageHost final : public multipass::VMImageHost
 {
-    std::optional<multipass::VMImageInfo> info_for(const multipass::Query& query) override
+    std::optional<multipass::VMImageInfo> info_for(const multipass::Query& query) const override
     {
         return std::optional<multipass::VMImageInfo>{
             VMImageInfo{{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1, {}}};
     };
 
     std::vector<std::pair<std::string, multipass::VMImageInfo>> all_info_for(
-        const multipass::Query& query) override
+        const multipass::Query& query) const override
     {
         return {};
     };
 
-    multipass::VMImageInfo info_for_full_hash(const std::string& full_hash) override
+    multipass::VMImageInfo info_for_full_hash(const std::string& full_hash) const override
     {
         return {{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, -1, {}};
     };
 
     std::vector<multipass::VMImageInfo> all_images_for(const std::string& remote_name,
-                                                       const bool allow_unsupported) override
+                                                       const bool allow_unsupported) const override
     {
         return {};
     };
 
-    void for_each_entry_do(const Action&) override
+    void for_each_entry_do(const Action&) const override
     {
     }
 
-    std::vector<std::string> supported_remotes() override
+    std::vector<std::string> supported_remotes() const override
     {
         return {};
     }

--- a/tests/unit/stub_image_host.h
+++ b/tests/unit/stub_image_host.h
@@ -43,7 +43,7 @@ struct StubVMImageHost final : public multipass::VMImageHost
     };
 
     std::vector<multipass::VMImageInfo> all_images_for(const std::string& remote_name,
-                                                       const bool allow_unsupported) const override
+                                                       bool allow_unsupported) const override
     {
         return {};
     };
@@ -57,7 +57,7 @@ struct StubVMImageHost final : public multipass::VMImageHost
         return {};
     }
 
-    void update_manifests(const bool force_update) override
+    void update_manifests(bool force_update) override
     {
     }
 };


### PR DESCRIPTION
Thread-safe image vault?

This issue has been plaguing me for awhile. See #4613 for a bit of my detective work, but this is what I've found to be happening:

1. There are two separate timers that hit the image hosts; the 6 hr timer of `source_images_maintenance_task` and the 15 min timer of `update_manifests_all_task`
2. You put your PC to sleep long enough for timers to expire
3. You wake your machine up. The `update_manifests_all_task` clears the manifest and repopulates it. Concurrently, the `source_images_maintenance_task` tries to update the images in the vault and queries the image host for info on the images. The first task invalidates the data structure causing the second task to reference freed memory.
4. The daemon crashes and immediately restarts. The orphaned QEMU process still holds a lock on the backing disk image. The restarted daemon tries to create another QEMU process, but fails to get a lock on the disk image.
5. At this point I'm not sure exactly what is happening, but the daemon gets into a bad state where it is busy waiting for something causing >400% CPU usage.

This PR solves the issue by adding a mutex to the `BaseVMImageHost` to protect the state of the manifest(s). Reader methods use a `shared_lock` while the writer method, `update_manifests()`, uses a `unique_lock`.

In order to keep the manipulation of the mutex to a single file, the specific implementations of the subclass image hosts are called via the Template Method pattern.

Fixes #4613 

---

MULTI-2533