### PR TITLE
[github-actions] Split Windows/MacOS workflows

### DIFF
--- a/.github/workflows/dynamic-ci.yml
+++ b/.github/workflows/dynamic-ci.yml
@@ -121,7 +121,7 @@ jobs:
           needs.lint.result == 'failure' || needs.lint.result == 'cancelled' ||
           needs.linux.result == 'failure' || needs.linux.result == 'cancelled' ||
           needs.windows.result == 'failure' || needs.windows.result == 'cancelled' ||
-          needs.macos.result == 'failure' || needs.macos.result == 'cancelled' 
+          needs.macos.result == 'failure' || needs.macos.result == 'cancelled'
           }}
         run: exit 1
 

--- a/.github/workflows/dynamic-ci.yml
+++ b/.github/workflows/dynamic-ci.yml
@@ -45,7 +45,8 @@ jobs:
               - 'docs/**'
             code:
               - ".github/workflows/linux*"
-              - ".github/workflows/windows-macos.yml"
+              - ".github/workflows/macos.yml"
+              - ".github/workflows/windows.yml"
               - ".github/.codecov.yml"
               - "3rd-party/**"
               - "completions/**"
@@ -83,11 +84,18 @@ jobs:
     uses: "./.github/workflows/linux.yml"
     secrets: inherit
 
-  windows-macos:
-    name: Windows/macOS
+  macos:
+    name: macOS
     needs: filter
     if: needs.filter.outputs.code == 'true'
-    uses: "./.github/workflows/windows-macos.yml"
+    uses: "./.github/workflows/macos.yml"
+    secrets: inherit
+
+  windows:
+    name: Windows
+    needs: filter
+    if: needs.filter.outputs.code == 'true'
+    uses: "./.github/workflows/windows.yml"
     secrets: inherit
 
   hooks:
@@ -100,7 +108,7 @@ jobs:
     name: Finalize
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [docs, lint, linux, windows-macos, hooks]
+    needs: [docs, lint, linux, windows, macos, hooks]
     steps:
       - name: Docs failure check
         if: ${{
@@ -112,7 +120,8 @@ jobs:
         if: ${{
           needs.lint.result == 'failure' || needs.lint.result == 'cancelled' ||
           needs.linux.result == 'failure' || needs.linux.result == 'cancelled' ||
-          needs.windows-macos.result == 'failure' || needs.windows-macos.result == 'cancelled'
+          needs.windows.result == 'failure' || needs.windows.result == 'cancelled' ||
+          needs.macos.result == 'failure' || needs.macos.result == 'cancelled' 
           }}
         run: exit 1
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: WindowsMacOS
+name: MacOS
 
 on:
   workflow_call:
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: windows-macos-${{ github.workflow }}-${{ github.event.number && format('pr{0}', github.event.number) || github.run_id }}
+  group: macos-${{ github.workflow }}-${{ github.event.number && format('pr{0}', github.event.number) || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -38,13 +38,6 @@ jobs:
         script: |
           const matrix = { include: [] };
 
-          // Windows targets
-          matrix.include.push({
-              "name": "Windows Server 2025",
-              "runs-on": "windows-2025"
-          });
-
-          // macOS targets
           matrix.include.push({
             "name": "macOS Latest (Apple Silicon)",
             "runs-on": "macos-latest"
@@ -75,7 +68,6 @@ jobs:
       mac-arm-package-artifact-name: ${{ steps.publish-data.outputs.macos-latest-package-artifact-name }}
       mac-x86-package-file-name: ${{ steps.publish-data.outputs.macos-15-intel-package-file-name }}
       mac-arm-package-file-name: ${{ steps.publish-data.outputs.macos-latest-package-file-name }}
-      windows-pkg-url: ${{ steps.publish-data.outputs.windows-2025-s3-url }}
 
     name: Build and Test (${{ matrix.name }})
     runs-on: ${{ matrix.runs-on }}
@@ -101,20 +93,11 @@ jobs:
       with:
         xcode-version: '16.2'
 
-    - name: Enable symlinks
-      if: ${{ runner.os == 'Windows' }}
-      run: git config --local core.symlinks true
-
-    - name: Disable auto CRLF on Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: git config --local core.autocrlf false
-
     - name: Determine build parameters
       id: build-params
       uses: ./.github/actions/build-params
 
     - name: Set preferred tar
-      if: ${{ runner.os == 'macOS' }}
       id: preferred-tar
       run: |
         # Prepend gnu-tar's (future) location to the path, to prioritize it over system tar
@@ -123,13 +106,11 @@ jobs:
 
       # TODO: find a friendlier approach for installing pip packages on GitHub runners
     - name: Force pip to allow break-system-packages via pip.conf
-      if: ${{ runner.os == 'macOS' }}
       run: |
         mkdir -p ~/.pip
         echo -e "[install]\nbreak-system-packages = true" > ~/.pip/pip.conf
 
     - name: Install dependencies from brew
-      if: ${{ runner.os == 'macOS' }}
       run: |
         # Avoid reinstalling cmake
         brew list cmake > /dev/null || brew install cmake
@@ -158,21 +139,8 @@ jobs:
         brew link --overwrite nuget
 
     - name: Install dependencies from pip
-      if: ${{ runner.os == 'macOS' }}
       run: |
         python3 -m pip install --user --upgrade distlib
-
-    - name: Install specific QEMU from Choco
-      if: ${{ runner.os == 'Windows' }}
-      uses: crazy-max/ghaction-chocolatey@v4
-      with:
-        args: install --yes qemu --version=2023.4.24
-
-    - name: Install other packages from Choco
-      if: ${{ runner.os == 'Windows' }}
-      uses: crazy-max/ghaction-chocolatey@v4
-      with:
-        args: install --yes wget unzip
 
     - name: Set up vcpkg
       id: setup-vcpkg
@@ -192,13 +160,12 @@ jobs:
         NUGET_PATH="$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)"
         MONO_WRAPPER=""
 
-        if [[ "$RUNNER_OS" == "macOS" ]]; then
-            # Check if we actually need to call NuGet through mono.
-            # That would be the case if NuGet is the real PE32 executable
-            # instead of a shim.
-            if file "$NUGET_PATH" | grep -q "PE32"; then
-                MONO_WRAPPER="mono"
-            fi
+
+        # Check if we actually need to call NuGet through mono.
+        # That would be the case if NuGet is the real PE32 executable
+        # instead of a shim.
+        if file "$NUGET_PATH" | grep -q "PE32"; then
+            MONO_WRAPPER="mono"
         fi
 
         $MONO_WRAPPER "$NUGET_PATH" \
@@ -248,20 +215,6 @@ jobs:
       with:
         version: "v0.12.0"
 
-    - name: Install Windows ADK
-      if: ${{ runner.os == 'Windows' }}
-      uses: crazy-max/ghaction-chocolatey@v4
-      with:
-        args: install --yes windows-adk-deploy
-
-    - name: Install cmake
-      if: ${{ runner.os == 'Windows' }}
-      uses: lukka/get-cmake@v4.3.0
-
-    - name: Set up MSVC
-      if: ${{ runner.os == 'Windows' }}
-      uses: ilammy/msvc-dev-cmd@v1
-
     - name: Configure
       run: >
         cmake
@@ -270,7 +223,6 @@ jobs:
         -GNinja
         -DMULTIPASS_UPSTREAM=origin
         -DMULTIPASS_BUILD_LABEL=${{ steps.build-params.outputs.label }}
-        ${{ runner.os == 'Windows' && '-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe' || '' }}
         ${{ github.event_name == 'schedule' && '-DMP_ALLOW_OPTIONAL_FEATURES=OFF' || '' }}
         ${{ github.workspace }}
 
@@ -287,20 +239,12 @@ jobs:
       working-directory: ${{ env.BUILD_DIR }}
       run: >
         cmake --build . --target package
-
-        echo "name=$( ${{ runner.os != 'Windows' && 'basename *.pkg' ||
-        '( Get-ChildItem .\packages\en-US\multipass-*.msi ).Name' }} ) " >>
-        ${{ runner.os != 'Windows' && '$GITHUB_OUTPUT' || '$env:GITHUB_OUTPUT' }}
-
-        echo "path=$( ${{ runner.os != 'Windows' && 'greadlink -f *.pkg' ||
-        '( Get-ChildItem .\packages\en-US\multipass-*.msi ).FullName' }} )" >>
-        ${{ runner.os != 'Windows' && '$GITHUB_OUTPUT' || '$env:GITHUB_OUTPUT' }}
+        echo "name=$( basename *.pkg )" >> $GITHUB_OUTPUT
+        echo "path=$( greadlink -f *.pkg )" >> $GITHUB_OUTPUT
 
     - name: Get package logs
       if: ${{ failure() && steps.cmake-package.outcome == 'failure' }}
-      run: >
-        ${{ format('cat {0}/_CPack_Packages/{1}', env.BUILD_DIR,
-        runner.os == 'Windows' && 'win64/External/WiXOutput.log' || 'Darwin/productbuild/InstallOutput.log') }}
+      run: cat ${{ env.BUILD_DIR }}/_CPack_Packages/Darwin/productbuild/InstallOutput.log
 
     - name: Upload package
       uses: actions/upload-artifact@v7
@@ -366,7 +310,6 @@ jobs:
 
       # TODO: find a friendlier approach for installing pip packages on GitHub runners
     - name: Force pip to allow break-system-packages via pip.conf
-      if: ${{ runner.os == 'macOS' }}
       run: |
         mkdir -p ~/.pip
         echo -e "[install]\nbreak-system-packages = true" > ~/.pip/pip.conf
@@ -436,13 +379,10 @@ jobs:
       actions: read
       checks:  write
     secrets: inherit
-    needs:
-      - BuildAndTest
-      - CombineAndPublishMacOSPackage
+    needs: [BuildAndTest, CombineAndPublishMacOSPackage]
     uses: ./.github/workflows/cli-tests.yml
     with:
       macos-pkg-url: ${{ needs.CombineAndPublishMacOSPackage.outputs.macos-pkg-url }}
-      windows-pkg-url: ${{ needs.BuildAndTest.outputs.windows-pkg-url }}
 
   DeleteSeparateMacPackages:
     if: ${{ !cancelled() && success() && needs.CombineAndPublishMacOSPackage.result == 'success' }}
@@ -474,6 +414,6 @@ jobs:
         MATTERMOST_CHANNEL: multipass
         TEXT: |
           :red_circle: @mp
-          Scheduled [WindowsMacOS](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow exited before completing.
+          Scheduled [MacOS](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow exited before completing.
         MATTERMOST_USERNAME: ${{ github.triggering_actor }}
         MATTERMOST_ICON_URL: https://www.flaticon.com/free-icon/github-logo_25231

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -239,7 +239,9 @@ jobs:
       working-directory: ${{ env.BUILD_DIR }}
       run: >
         cmake --build . --target package
+
         echo "name=$( basename *.pkg )" >> $GITHUB_OUTPUT
+
         echo "path=$( greadlink -f *.pkg )" >> $GITHUB_OUTPUT
 
     - name: Get package logs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -243,7 +243,7 @@ jobs:
         path: ${{ env.SCCACHE_DIR }}
         key: "sccache-${{ matrix.runs-on }}-${{ steps.cache-key.outputs.cache-key }}"
 
-   DispatchCLITestsWorkflow:
+  DispatchCLITestsWorkflow:
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,274 @@
+name: Windows
+
+on:
+  workflow_call:
+  schedule:
+  # Daily at 00:34 UTC
+    - cron: 34 0 * * *
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-${{ github.workflow }}-${{ github.event.number && format('pr{0}', github.event.number) || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+  S3_BUCKET: multipass-ci
+  USERNAME: ${{ github.repository_owner }}
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
+
+jobs:
+  GetMatrix:
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+    - name: Determine build matrix
+      id: set-matrix
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const matrix = { include: [] };
+
+          matrix.include.push({
+              "name": "Windows Server 2025",
+              "runs-on": "windows-2025"
+          });
+
+          core.setOutput('matrix', JSON.stringify(matrix));
+
+  BuildAndTest:
+    needs: GetMatrix
+
+    permissions:
+      contents: read
+      packages: write
+
+    if: ${{ !cancelled() }}
+
+    strategy:
+      matrix: ${{ fromJSON(needs.GetMatrix.outputs.matrix) }}
+      fail-fast: ${{ github.event_name == 'merge_group' }}
+
+    outputs:
+      build-label: ${{ steps.build-params.outputs.label }}
+      windows-pkg-url: ${{ steps.publish-data.outputs.windows-2025-s3-url }}
+
+    name: Build and Test (${{ matrix.name }})
+    runs-on: ${{ matrix.runs-on }}
+
+    env:
+      BUILD_DIR: ${{ github.workspace }}/build
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
+      RUSTC_WRAPPER: "sccache"
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0 # Need full history to derive version
+        submodules: 'recursive'
+
+    - name: Enable symlinks
+      run: git config --local core.symlinks true
+
+    - name: Disable auto CRLF on Windows
+      run: git config --local core.autocrlf false
+
+    - name: Determine build parameters
+      id: build-params
+      uses: ./.github/actions/build-params
+
+    - name: Install specific QEMU from Choco
+      uses: crazy-max/ghaction-chocolatey@v4
+      with:
+        args: install --yes qemu --version=2023.4.24
+
+    - name: Install other packages from Choco
+      uses: crazy-max/ghaction-chocolatey@v4
+      with:
+        args: install --yes wget unzip
+
+    - name: Set up vcpkg
+      id: setup-vcpkg
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{ github.workspace }}/3rd-party/vcpkg'
+
+    - name: Configure NuGet Source
+      id: setup_nuget
+      continue-on-error: true
+      shell: 'bash'
+      run: |
+        echo "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)"
+        # https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages
+
+        # Retrieve vcpkg's nuget.
+        NUGET_PATH="$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)"
+        MONO_WRAPPER=""
+
+        $MONO_WRAPPER "$NUGET_PATH" \
+          sources add \
+          -source "${{ env.FEED_URL }}" \
+          -storepasswordincleartext \
+          -name "GitHubPackages" \
+          -username "${{ env.USERNAME }}" \
+          -password "${{ secrets.GITHUB_TOKEN }}"
+
+        $MONO_WRAPPER "$NUGET_PATH" \
+          setapikey "${{ secrets.GITHUB_TOKEN }}" \
+          -source "${{ env.FEED_URL }}"
+
+    - name: Determine cache key
+      id: cache-key
+      shell: bash
+      run: |
+        # Find common base between main and HEAD to use as cache key.
+        git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules origin main
+        echo "cache-key=$( git merge-base origin/main ${{ github.sha }} )" >> $GITHUB_OUTPUT
+
+    - name: Restore sccache
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: "sccache-${{ matrix.runs-on }}-${{ steps.cache-key.outputs.cache-key }}"
+        restore-keys: sccache-${{ matrix.runs-on }}
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
+      continue-on-error: true
+      with:
+        version: "v0.12.0"
+
+    - name: Install Windows ADK
+      uses: crazy-max/ghaction-chocolatey@v4
+      with:
+        args: install --yes windows-adk-deploy
+
+    - name: Install cmake
+      uses: lukka/get-cmake@v4.3.0
+
+    - name: Set up MSVC
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Configure
+      run: >
+        cmake
+        -B${{ env.BUILD_DIR }}
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -GNinja
+        -DMULTIPASS_UPSTREAM=origin
+        -DMULTIPASS_BUILD_LABEL=${{ steps.build-params.outputs.label }}
+        ${{ runner.os == 'Windows' && '-DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe' || '' }}
+        ${{ github.event_name == 'schedule' && '-DMP_ALLOW_OPTIONAL_FEATURES=OFF' || '' }}
+        ${{ github.workspace }}
+
+    - name: Build
+      run: cmake --build ${{ env.BUILD_DIR }}
+
+    - name: Test
+      working-directory: ${{ env.BUILD_DIR }}
+      run: |
+        bin/multipass_tests
+
+    - name: Package
+      id: cmake-package
+      working-directory: ${{ env.BUILD_DIR }}
+      run: >
+        cmake --build . --target package
+
+        echo "name=$( ( Get-ChildItem .\packages\en-US\multipass-*.msi ).Name )" >>
+        $env:GITHUB_OUTPUT
+
+        echo "path=$( ( Get-ChildItem .\packages\en-US\multipass-*.msi ).FullName )" >>
+        $env:GITHUB_OUTPUT
+
+    - name: Get package logs
+      if: ${{ failure() && steps.cmake-package.outcome == 'failure' }}
+      run: >
+        ${{ format('cat {0}/_CPack_Packages/{1}', env.BUILD_DIR,
+        runner.os == 'Windows' && 'win64/External/WiXOutput.log' || 'Darwin/productbuild/InstallOutput.log') }}
+
+    - name: Upload package
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ matrix.runs-on }}-${{ steps.cmake-package.outputs.name }}
+        path: ${{ steps.cmake-package.outputs.path }}
+        if-no-files-found: error
+        retention-days: 7
+
+    # Put the package on S3 for public consumption
+    - name: Publish package on S3
+      id: s3-upload
+      uses: canonical/actions/s3-upload@release
+      if: ${{ env.AWS_ACCESS_KEY_ID }}
+      with:
+        path: ${{ steps.cmake-package.outputs.path }}
+        bucket: ${{ env.S3_BUCKET }}
+        prefix: ${{ steps.build-params.outputs.label }}
+        public: true
+        storage-class: ONEZONE_IA
+      timeout-minutes: 5
+
+    # This shows up on this run's page
+    - name: Report public URL
+      run: |
+        echo "##[warning] Public URL: ${{ steps.s3-upload.outputs.url }}"
+
+    - name: Store publishing outputs
+      if: always()
+      id: publish-data
+      shell: bash
+      run: |
+        NAME="${{ steps.cmake-package.outputs.name }}"
+        ARTIFACT_NAME="${{ matrix.runs-on }}-package-artifact-name=${{ matrix.runs-on }}-${NAME}"
+        FILE_NAME="${{ matrix.runs-on }}-package-file-name=${NAME}"
+
+        echo "$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+        echo "$FILE_NAME" >> "$GITHUB_OUTPUT"
+
+        echo "${{ matrix.runs-on }}-s3-url=${{ steps.s3-upload.outputs.url }}" >> "$GITHUB_OUTPUT"
+
+    - name: Save sccache
+      uses: actions/cache/save@v5
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: "sccache-${{ matrix.runs-on }}-${{ steps.cache-key.outputs.cache-key }}"
+
+   DispatchCLITestsWorkflow:
+    permissions:
+      contents: read
+      actions: read
+      checks:  write
+    secrets: inherit
+    needs:
+      - BuildAndTest
+    uses: ./.github/workflows/cli-tests.yml
+    with:
+      windows-pkg-url: ${{ needs.BuildAndTest.outputs.windows-pkg-url }}
+
+  Report-Workflow-Failure:
+    needs: [BuildAndTest]
+    if: ${{ !cancelled() && !success() && github.event_name == 'schedule' }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Report workflow failure
+      uses: mattermost/action-mattermost-notify@master
+      with:
+        MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+        MATTERMOST_CHANNEL: multipass
+        TEXT: |
+          :red_circle: @mp
+          Scheduled [Windows](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow exited before completing.
+        MATTERMOST_USERNAME: ${{ github.triggering_actor }}
+        MATTERMOST_ICON_URL: https://www.flaticon.com/free-icon/github-logo_25231


### PR DESCRIPTION
The workflows are split for better organization, control, and clarity.

# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
Splits the Windows macOS workflow into macOS and Windows.
- Why is this change needed?
To remove the need for if this and that checks, and have more granular control over workflows

This PR splits the workflows. No additional code is being introduced.

MULTI-2534
