### PR TITLE
Bugfix/Ensure libssh is initialized

### DIFF
--- a/include/multipass/ssh/libssh_scope_guard.h
+++ b/include/multipass/ssh/libssh_scope_guard.h
@@ -13,8 +13,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
- *
  */
 
 #pragma once

--- a/include/multipass/ssh/libssh_scope_guard.h
+++ b/include/multipass/ssh/libssh_scope_guard.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alberto Aguirre <alberto.aguirre@canonical.com>
+ *
+ */
+
+#pragma once
+
+namespace multipass
+{
+struct LibsshScopeGuard
+{
+    LibsshScopeGuard();
+    ~LibsshScopeGuard();
+};
+} // namespace multipass

--- a/src/client/cli/main.cpp
+++ b/src/client/cli/main.cpp
@@ -20,6 +20,7 @@
 #include <multipass/cli/client_common.h>
 #include <multipass/console.h>
 #include <multipass/constants.h>
+#include <multipass/ssh/libssh_scope_guard.h>
 #include <multipass/top_catch_all.h>
 
 #include <QCoreApplication>
@@ -52,6 +53,8 @@ int main(int argc, char* argv[])
     // Verify that the version of the library that we linked against is
     // compatible with the version of the headers we compiled against.
     GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+    multipass::LibsshScopeGuard libssh_guard;
 
     return mp::top_catch_all("client", /* fallback_return = */ EXIT_FAILURE, main_impl, argc, argv);
 }

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -26,6 +26,7 @@
 #include <multipass/logging/log.h>
 #include <multipass/platform_unix.h>
 #include <multipass/signal.h>
+#include <multipass/ssh/libssh_scope_guard.h>
 #include <multipass/top_catch_all.h>
 #include <multipass/utils.h>
 #include <multipass/version.h>
@@ -124,6 +125,8 @@ int main(int argc, char* argv[])
     // Verify that the version of the library that we linked against is
     // compatible with the version of the headers we compiled against.
     GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+    multipass::LibsshScopeGuard libssh_guard;
 
     mp::Signal app_ready_signal{};
     //

--- a/src/daemon/daemon_main_win.cpp
+++ b/src/daemon/daemon_main_win.cpp
@@ -19,6 +19,7 @@
 #include "daemon.h"
 #include "daemon_config.h"
 #include "daemon_init_settings.h"
+#include <multipass/ssh/libssh_scope_guard.h>
 
 #include <multipass/cli/client_common.h>
 #include <multipass/client_cert_store.h>
@@ -26,6 +27,7 @@
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 #include <multipass/platform.h>
+#include <multipass/ssh/libssh_scope_guard.h>
 #include <multipass/ssl_cert_provider.h>
 #include <multipass/standard_paths.h>
 #include <multipass/utils.h>
@@ -202,6 +204,8 @@ try
     // Verify that the version of the library that we linked against is
     // compatible with the version of the headers we compiled against.
     GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+    multipass::LibsshScopeGuard libssh_guard;
 
     service_argv.assign(argv, argv + argc);
 

--- a/src/daemon/daemon_main_win.cpp
+++ b/src/daemon/daemon_main_win.cpp
@@ -19,7 +19,6 @@
 #include "daemon.h"
 #include "daemon_config.h"
 #include "daemon_init_settings.h"
-#include <multipass/ssh/libssh_scope_guard.h>
 
 #include <multipass/cli/client_common.h>
 #include <multipass/client_cert_store.h>

--- a/src/ssh/CMakeLists.txt
+++ b/src/ssh/CMakeLists.txt
@@ -18,7 +18,8 @@ function(add_ssh_target TARGET_NAME)
     openssh_key_provider.cpp
     ssh_client_key_provider.cpp
     ssh_process.cpp
-    ssh_session.cpp)
+    ssh_session.cpp
+    libssh_scope_guard.cpp)
 
   target_link_libraries(${TARGET_NAME}
     fmt::fmt-header-only

--- a/src/ssh/libssh_scope_guard.cpp
+++ b/src/ssh/libssh_scope_guard.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <multipass/ssh/libssh_scope_guard.h>
+
+#include "libssh/libssh.h"
+
+namespace mp = multipass;
+
+mp::LibsshScopeGuard::LibsshScopeGuard()
+{
+    ssh_init();
+}
+
+mp::LibsshScopeGuard::~LibsshScopeGuard()
+{
+    ssh_finalize();
+}


### PR DESCRIPTION
After migrating libssh to vcpkg, it started linking statically against the binary. With dynamic linkage, the DllMain function was [already calling ssh_init()](https://github.com/canonical/libssh/blob/f23d1454e50d0dbb314edd9bf4227ab72303484b/src/init.c#L257) so everything was working as intended. This is no longer the case since DllMain is not being invoked in static linkage. Linux and macOS are still fine since there's the [libssh_constructor](https://github.com/canonical/libssh/blob/f23d1454e50d0dbb314edd9bf4227ab72303484b/src/init.c#L59) func marked with `__attribute__((constructor))`, which works with gcc/clang but not with MSVC.

This PR ensures that the library is initialized before first use for both the daemon and the CLI.
    

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
Ensures libssh is initialized.
- Why is this change needed?
Fix broken SSH in Windows.

MULTI-2535