### PR TITLE
[vm-image-vault] Normalize image path before replace

### DIFF
--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -550,16 +550,24 @@ void mp::DefaultVMImageVault::clone(const std::string& source_instance_name,
                                  " already exists in the image records");
     }
 
+    if (source_instance_name == destination_instance_name)
+    {
+        throw std::runtime_error{
+            "Destination instance name could not be the same with the source."};
+    }
+
     auto& dest_vault_record = instance_image_records[destination_instance_name] =
         instance_image_records[source_instance_name];
 
     // string replacement is "instances/<src_name>"->"instances/<dest_name>" instead of
     // "<src_name>"->"<dest_name>", because the second one might match other substrings of the
     // metadata.
-    auto image_path = dest_vault_record.image.image_path.string();
+    // The path might have mixed slashes \\ / in Windows. Normalize it before replace.
+    auto image_path = dest_vault_record.image.image_path.generic_string();
     boost::replace_all(image_path,
                        "instances/" + source_instance_name,
                        "instances/" + destination_instance_name);
+    assert(image_path != dest_vault_record.image.image_path);
     dest_vault_record.image.image_path = image_path;
 
     persist_instance_records();

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -550,30 +550,28 @@ void mp::DefaultVMImageVault::clone(const std::string& source_instance_name,
                                  " already exists in the image records");
     }
 
-    if (source_instance_name == destination_instance_name)
-    {
-        throw std::runtime_error{
-            "Destination instance name could not be the same with the source."};
-    }
-
-    auto& dest_vault_record = instance_image_records[destination_instance_name] =
-        instance_image_records[source_instance_name];
+    const auto& source_vault_record = instance_image_records[source_instance_name];
 
     // string replacement is "instances/<src_name>"->"instances/<dest_name>" instead of
     // "<src_name>"->"<dest_name>", because the second one might match other substrings of the
     // metadata.
     // The path might have mixed slashes \\ / in Windows. Normalize it before replace.
-    auto image_path = dest_vault_record.image.image_path.generic_string();
+    auto image_path = source_vault_record.image.image_path.generic_string();
     boost::replace_all(image_path,
                        "instances/" + source_instance_name,
                        "instances/" + destination_instance_name);
 
-    if (image_path == dest_vault_record.image.image_path.generic_string())
+    if (image_path == source_vault_record.image.image_path.generic_string())
     {
-        throw std::runtime_error{"Path replace for cloned image failed."};
+        throw std::runtime_error{"Path replace for the cloned image failed!"};
     }
 
-    dest_vault_record.image.image_path = image_path;
+    // Update the instance_image_records after path replace succeeds.
+    instance_image_records[destination_instance_name] = [dst = source_vault_record,
+                                                         &image_path]() mutable {
+        dst.image.image_path = image_path;
+        return dst;
+    }();
 
     persist_instance_records();
 }

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -567,7 +567,12 @@ void mp::DefaultVMImageVault::clone(const std::string& source_instance_name,
     boost::replace_all(image_path,
                        "instances/" + source_instance_name,
                        "instances/" + destination_instance_name);
-    assert(image_path != dest_vault_record.image.image_path);
+
+    if (image_path == dest_vault_record.image.image_path.generic_string())
+    {
+        throw std::runtime_error{"Path replace for cloned image failed."};
+    }
+
     dest_vault_record.image.image_path = image_path;
 
     persist_instance_records();

--- a/src/daemon/default_vm_image_vault.cpp
+++ b/src/daemon/default_vm_image_vault.cpp
@@ -550,29 +550,22 @@ void mp::DefaultVMImageVault::clone(const std::string& source_instance_name,
                                  " already exists in the image records");
     }
 
-    const auto& source_vault_record = instance_image_records[source_instance_name];
+    auto dest_vault_record = instance_image_records[source_instance_name];
 
     // string replacement is "instances/<src_name>"->"instances/<dest_name>" instead of
     // "<src_name>"->"<dest_name>", because the second one might match other substrings of the
     // metadata.
     // The path might have mixed slashes \\ / in Windows. Normalize it before replace.
-    auto image_path = source_vault_record.image.image_path.generic_string();
-    boost::replace_all(image_path,
-                       "instances/" + source_instance_name,
-                       "instances/" + destination_instance_name);
+    auto image_path = dest_vault_record.image.image_path.generic_string();
+    dest_vault_record.image.image_path =
+        boost::replace_all_copy(image_path,
+                                "instances/" + source_instance_name,
+                                "instances/" + destination_instance_name);
 
-    if (image_path == source_vault_record.image.image_path.generic_string())
-    {
+    if (dest_vault_record.image.image_path.generic_string() == image_path)
         throw std::runtime_error{"Path replace for the cloned image failed!"};
-    }
 
-    // Update the instance_image_records after path replace succeeds.
-    instance_image_records[destination_instance_name] = [dst = source_vault_record,
-                                                         &image_path]() mutable {
-        dst.image.image_path = image_path;
-        return dst;
-    }();
-
+    instance_image_records[destination_instance_name] = dest_vault_record;
     persist_instance_records();
 }
 

--- a/tests/unit/test_image_vault.cpp
+++ b/tests/unit/test_image_vault.cpp
@@ -317,6 +317,27 @@ TEST_F(ImageVault, invalidFileURLThrows)
             StrEq(fmt::format("Invalid file URL `{}`; did you forget a slash?", invalid_url))));
 }
 
+TEST_F(ImageVault, imageCloneWithInvalidInstanceDirThrows)
+{
+    mp::DefaultVMImageVault vault{hosts,
+                                  &url_downloader,
+                                  cache_dir.path(),
+                                  data_dir.path(),
+                                  mp::days{0}};
+    vault.fetch_image(mp::FetchType::ImageOnly,
+                      default_query,
+                      stub_prepare,
+                      stub_monitor,
+                      std::nullopt,
+                      this->save_dir.path()); // no "/instances" in save dir
+
+    const std::string dest_name = instance_name + "clone";
+    MP_EXPECT_THROW_THAT(vault.clone(instance_name, dest_name),
+                         std::runtime_error,
+                         mpt::match_what(StrEq("Path replace for the cloned image failed!")));
+    EXPECT_FALSE(vault.has_record_for(dest_name));
+}
+
 TEST_F(ImageVault, nonexistentLocalFileImageThrows)
 {
     mp::DefaultVMImageVault vault{hosts,

--- a/tests/unit/test_image_vault.cpp
+++ b/tests/unit/test_image_vault.cpp
@@ -215,7 +215,7 @@ struct ImageVault : public testing::Test
     mpt::TempDir data_dir;
     mpt::TempDir save_dir;
     std::string instance_name{"valley-pied-piper"};
-    QString instance_dir = save_dir.filePath(QString::fromStdString(instance_name));
+    QString instance_dir = save_dir.filePath("instances/" + QString::fromStdString(instance_name));
     mp::Query default_query{instance_name, "xenial", false, "", mp::Query::Type::Alias};
 };
 } // namespace


### PR DESCRIPTION
The replace_all call assumes the path is single forward slashes, where Windows makes no such guarantees. Call generic_string() to grab a POSIX-like normalized path so it's always forward slashes.

MULTI-2563

