### PR TITLE
Fix duplicate newline in CLI failure output when details end with new…

### DIFF
--- a/src/client/common/client_common.cpp
+++ b/src/client/common/client_common.cpp
@@ -81,6 +81,7 @@ grpc::SslCredentialsOptions get_ssl_credentials_opts_from(const mp::CertProvider
 
     return opts;
 }
+
 } // namespace
 
 mp::ReturnCode mp::cmd::standard_failure_handler_for(const std::string& command,
@@ -88,11 +89,14 @@ mp::ReturnCode mp::cmd::standard_failure_handler_for(const std::string& command,
                                                      const grpc::Status& status,
                                                      const std::string& error_details)
 {
+    const auto trimmed =
+        std::string_view(error_details).substr(0, error_details.find_last_not_of("\r\n") + 1);
+
     fmt::print(cerr,
                "{} failed: {}\n{}",
                command,
                status.error_message(),
-               !error_details.empty() ? fmt::format("{}\n", error_details) : "");
+               trimmed.empty() ? "" : fmt::format("{}\n", trimmed));
 
     return return_code_for(status.error_code());
 }

--- a/tests/unit/test_client_common.cpp
+++ b/tests/unit/test_client_common.cpp
@@ -32,6 +32,8 @@
 #include <multipass/cli/client_common.h>
 #include <multipass/utils.h>
 
+#include <grpcpp/support/status.h>
+
 namespace mp = multipass;
 namespace mpt = multipass::test;
 
@@ -128,4 +130,19 @@ TEST(TestClientHandleUserPassword, defaultHasNoPassword)
     EXPECT_CALL(*client, Write(Property(&mp::MountRequest::password, IsEmpty()), _)).Times(1);
 
     mp::cmd::handle_password(client.get(), &term);
+}
+
+TEST(StandardFailureHandlerFormatting, singleTrailingNewlineWhenDetailsAlreadyEndWithNewline)
+{
+    std::stringstream cerr_stream;
+    grpc::Status status{grpc::StatusCode::ABORTED, "instance(s) missing", ""};
+
+    mp::cmd::standard_failure_handler_for("start",
+                                          cerr_stream,
+                                          status,
+                                          "Instance 'asdf' does not exist.\r\n\r\n\r");
+
+    EXPECT_EQ(cerr_stream.str(),
+              "start failed: instance(s) missing\n"
+              "Instance 'asdf' does not exist.\n");
 }


### PR DESCRIPTION
## Description

This PR normalizes how `standard_failure_handler_for` prints `error_details` so the CLI does not emit an extra blank line before the shell prompt when callers already end each detail line with a newline.

**What does this PR do?** Trims trailing `\r` and `\n` characters from `error_details`, then appends a single final newline when formatting stderr output.

**Why is this change needed?** `standard_failure_handler_for` previously used `fmt::format("{}\n", error_details)`. Commands such as `start` whose `error_details` already end in `\n` (e.g. `absent_error_fmt`) produced `\n\n` after the last visible line, so users saw one extra blank line compared to failures with no detail block (e.g. duplicate instance name on launch). This matches the behavior described in #2147 and the maintainer note that the issue was improved but not fully fixed.

## Related Issue

Closes #2147

## Testing

**Unit test:** Added `StandardFailureHandlerFormatting.singleTrailingNewlineWhenDetailsAlreadyEndWithNewline` in `tests/unit/test_client_common.cpp`, asserting that `error_details` ending with `\n` still results in exactly one trailing newline.

**Manual testing steps:**

1. Build the Multipass client from this branch (per project build instructions).
2. Run a command that triggers `standard_failure_handler_for` with multi-line details, e.g. `multipass start <nonexistent>` — expect no extra blank line before the shell prompt compared to a single-line failure such as a duplicate `launch --name`.
3. Optionally compare stderr capture or terminal scrollback before/after to confirm only one newline terminates the message block.

**Screenshots:** N/A — stderr text layout only, no UI change.

## Checklist

- [x] My code follows the [contributing guidelines](https://github.com/canonical/multipass/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Canonical CLA](https://canonical.com/legal/contributors)
- [x] I have added unit tests or no new ones were appropriate
- [ ] I have added integration tests or no new ones were appropriate
- [ ] I have updated documentation or no changes were appropriate
- [x] I have tested the changes locally or no specific testing was appropriate
