### PR TITLE
[cli] Hint at troubleshooting docs on timeout

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -594,6 +594,13 @@ mp::ReturnCodeVariant cmd::Launch::request_launch(const ArgParser* parser)
             }
         }
 
+        if (error_details.empty() && status.error_message().find("timed out") != std::string::npos)
+        {
+            error_details =
+                "For troubleshooting, see "
+                "https://documentation.ubuntu.com/multipass/stable/how-to-guides/troubleshoot/";
+        }
+
         return standard_failure_handler_for(name(), cerr, status, error_details);
     };
 


### PR DESCRIPTION
## Summary

When `multipass launch` times out waiting for an instance to become ready (e.g. due to a firewall blocking DHCP, or network misconfiguration), the error message provides no guidance on what to try next.

This adds a link to the troubleshooting documentation when the launch failure indicates a timeout, giving users a starting point to diagnose the issue.

**Before:**
```
launch failed: The following errors occurred:
test-vm: timed out waiting for response
```

**After:**
```
launch failed: The following errors occurred:
test-vm: timed out waiting for response
For troubleshooting, see https://documentation.ubuntu.com/multipass/stable/how-to-guides/troubleshoot/
```

Based on reviewer feedback from #4500:
- Does not mention any specific cause (multiple causes are possible)
- Points to the general troubleshooting page rather than a specific sub-page
- Uses a single string construction

## Test plan

- [x] Verify that launch timeouts now include the troubleshooting link in the error output
- [x] Verify that non-timeout launch failures (invalid disk size, invalid hostname, etc.) are unaffected
- [x] Verify that the `INVALID_NETWORK` error still shows its own troubleshooting link

Closes #533