### PR TITLE
[lxd] Add image release to log message

### DIFF
--- a/src/platform/backends/lxd/lxd_vm_image_vault.cpp
+++ b/src/platform/backends/lxd/lxd_vm_image_vault.cpp
@@ -433,7 +433,8 @@ void mp::LXDVMImageVault::prune_expired_images()
         if (!last_used.has_value())
         {
             mpl::warn(category,
-                      "Source image `{}` does not have `last_used_at` property, skipping it!");
+                      "Source image `{}` does not have `last_used_at` property, skipping it!",
+                      image_info["properties"].toObject()["release"].toString());
             continue;
         }
 


### PR DESCRIPTION
A small fix to LXD logging to ensure the skipped image is named in the log.