### PR TITLE
[ci] Fix vcpkg environment variable issue in release branch

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -51,7 +51,10 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
       SNAPCRAFT_BUILD_INFO: 1
+      USERNAME: ${{ github.repository_owner }}
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
 
     timeout-minutes: 120
     steps:
@@ -139,7 +142,22 @@ jobs:
         fi
 
         if [ -n "${VCPKG_BINARY_SOURCES}" ]; then
-          sed -i "/build-environment:/a \    - VCPKG_BINARY_SOURCES: ${VCPKG_BINARY_SOURCES}" snap/snapcraft.yaml
+          sed -i '/build-environment:/ {
+          a\
+            - VCPKG_BINARY_SOURCES: '"${VCPKG_BINARY_SOURCES}"'\
+            - FEED_URL: '"${FEED_URL}"'\
+            - USERNAME: '"${USERNAME}"'\
+            - GITHUB_TOKEN: '"${{ secrets.GITHUB_TOKEN }}"'
+          }' snap/snapcraft.yaml
+          sed -i "/build-packages:/a \    - mono-complete" snap/snapcraft.yaml
+          sed -i '0,/override-build: |/ {
+            /override-build: |/ a\
+              curl -L -o /usr/local/bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe\
+              ln -sf /usr/local/bin/nuget.exe /usr/local/bin/nuget\
+              export PATH=$PATH:/usr/local/bin\
+              mono /usr/local/bin/nuget.exe sources add -name GitHubPackages -source "${FEED_URL}" -username "${USERNAME}" -password "${GITHUB_TOKEN}" -storePasswordInClearText\
+              mono /usr/local/bin/nuget.exe setapikey "${GITHUB_TOKEN}" -source "${FEED_URL}"
+          }' snap/snapcraft.yaml
         fi
 
         if [ -n "${GITHUB_ACTIONS}" ]; then

--- a/.github/workflows/windows-macos.yml
+++ b/.github/workflows/windows-macos.yml
@@ -14,7 +14,10 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
   S3_BUCKET: multipass-ci
+  USERNAME: ${{ github.repository_owner }}
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
 
 jobs:
   GetMatrix:
@@ -170,52 +173,48 @@ jobs:
       with:
         vcpkgDirectory: '${{ github.workspace }}/3rd-party/vcpkg'
 
+      # TODO: remove this when self-hosted runners are dropped
+    - name: Disable vcpkg binary cache on self-hosted runners
+      id: disable-cache
+      shell: bash
+      run: |
+        if [[ "${{ matrix['runs-on'] }}" == *multipass* ]]; then
+          echo "VCPKG_BINARY_SOURCES=" >> $GITHUB_ENV
+        fi
+
+    - name: Install nuget
+      if: ${{ contains(matrix.runs-on, 'macos-15') }}
+      run: |
+        brew install nuget mono
+
     - name: Configure NuGet Source
+      if: ${{ env.VCPKG_BINARY_SOURCES }} # TODO: remove this when self-hosted runners are dropped
       id: setup_nuget
       continue-on-error: true
       shell: 'bash'
       run: |
-        echo "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)"
         # https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages
-
-        # Retrieve vcpkg's nuget.
-        NUGET_PATH="$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)"
-        MONO_WRAPPER=""
-
-        if [[ "$RUNNER_OS" == "macOS" ]]; then
-            # Check if we actually need to call NuGet through mono.
-            # That would be the case if NuGet is the real PE32 executable
-            # instead of a shim.
-            if file "$NUGET_PATH" | grep -q "PE32"; then
-                MONO_WRAPPER="mono"
-            fi
-        fi
-
-        $MONO_WRAPPER "$NUGET_PATH" \
+        ${{ matrix.mono }} "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
           sources add \
           -source "${{ env.FEED_URL }}" \
           -storepasswordincleartext \
           -name "GitHubPackages" \
           -username "${{ env.USERNAME }}" \
           -password "${{ secrets.GITHUB_TOKEN }}"
-
-        $MONO_WRAPPER "$NUGET_PATH" \
+        ${{ matrix.mono }} "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n 1)" \
           setapikey "${{ secrets.GITHUB_TOKEN }}" \
           -source "${{ env.FEED_URL }}"
 
     - name: Overwrite Homebrew nuget shim with nuget DLL
       continue-on-error: true
-      if: ${{ steps.setup_nuget.outcome == 'success' && runner.os == 'macOS' }}
+      if: ${{ steps.setup_nuget.outcome == 'success' && runner.os == 'macOS' && matrix.arch == 'arm64' }}
       run: |
         # Locate the real NuGet.exe in Homebrew’s Cellar
         NUGET_EXE="$(brew --prefix nuget)/libexec/NuGet.exe"
-        if file "/opt/homebrew/bin/nuget" | grep -q "text"; then
-          # Remove the old shim and replace it with a symlink
-          echo "/opt/homebrew/bin/nuget is a shim, replacing it with $NUGET_EXE"
-          sudo rm -f /opt/homebrew/bin/nuget
-          sudo ln -s "$NUGET_EXE" /opt/homebrew/bin/nuget
-          sudo chmod +x /opt/homebrew/bin/nuget
-        fi
+        # Remove the old shim and replace it with a symlink
+        sudo rm -f /opt/homebrew/bin/nuget
+        sudo ln -s "$NUGET_EXE" /opt/homebrew/bin/nuget
+        sudo chmod +x /opt/homebrew/bin/nuget
 
     - name: Set up CCache
       if: ${{ runner.os == 'macOS' }}


### PR DESCRIPTION


# Description

<!-- Please include a summary of the changes and the motivation behind them. -->
- What does this PR do?
- Why is this change needed?
As it can be seen in an earlier run of this PR: https://github.com/canonical/multipass/actions/runs/25173093888/job/73797802282?pr=4859
With no meaningful changes to the CI or code, the build is stopped when the vcpkg from gha does not have access to 2 environment variables. The cherry-picked PR restores the necessary changes to the CI to be able to continue.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, if relevant -->
<img width="1501" height="447" alt="image" src="https://github.com/user-attachments/assets/8983b971-0f66-4b49-a7fc-7174bca2651c" />
