### PR TITLE
[gha-win-mac] Gate CLI test dispatch on pkg url

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -414,6 +414,7 @@ jobs:
 
   DispatchCLITestsWorkflow:
     name: "Dispatch CLI Tests (macOS)"
+    if: needs.CombineAndPublishMacOSPackage.outputs.macos-pkg-url != ''
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -253,6 +253,7 @@ jobs:
   # of time.
   # DispatchCLITestsWorkflow:
   #   name: "Dispatch CLI Tests (Windows)"
+  #   if: needs.BuildAndTest.outputs.windows-pkg-url != ''
   #   permissions:
   #     contents: read
   #     actions: read


### PR DESCRIPTION
# Description

Add a condition to the CLI test dispatch jobs that verifies the package URL is set.
