### PR TITLE
[tests] Generalize custom image matchers

### DIFF
--- a/tests/cli/cli_find_test.py
+++ b/tests/cli/cli_find_test.py
@@ -129,60 +129,34 @@ class TestFind:
             # Pull the keys present in expected and do a comparison
             assert {k: image[k] for k in expected_image} == expected_image
 
-    @pytest.mark.parametrize(
-        "param",
-        [
-            {"name": "debian", "expected_release": "Trixie"},
-        ],
-    )
-    def test_query_image_debian(self, param):
+    def test_query_image_debian(self):
         skip_if_feature_not_supported("debian_images")
 
-        with multipass(
-            "find",
-            param["name"],
-            "--format=json",
-            *(["--show-unsupported"] if param.get("unsupported") else []),
-        ).json() as output:
+        with multipass("find", "debian", "--format=json").json() as output:
             assert output
-            images = output["images"]
-            image = images[param["name"]]
+            image = output["images"]["debian"]
 
             expected_image = {
                 "aliases": [],
                 "os": "Debian",
-                "release": param["expected_release"],
                 "remote": "",
             }
 
-            # Pull the keys present in expected and do a comparison
             assert {k: image[k] for k in expected_image} == expected_image
+            assert image["release"]
 
-    @pytest.mark.parametrize(
-        "param",
-        [
-            {"name": "fedora", "expected_release": "43"},
-        ],
-    )
-    def test_query_image_fedora(self, param):
+    def test_query_image_fedora(self):
         skip_if_feature_not_supported("fedora_images")
 
-        with multipass(
-            "find",
-            param["name"],
-            "--format=json",
-            *(["--show-unsupported"] if param.get("unsupported") else []),
-        ).json() as output:
+        with multipass("find", "fedora", "--format=json").json() as output:
             assert output
-            images = output["images"]
-            image = images[param["name"]]
+            image = output["images"]["fedora"]
 
             expected_image = {
                 "aliases": [],
                 "os": "Fedora",
-                "release": param["expected_release"],
                 "remote": "",
             }
 
-            # Pull the keys present in expected and do a comparison
             assert {k: image[k] for k in expected_image} == expected_image
+            assert image["release"]

--- a/tests/cli/cli_launch_test.py
+++ b/tests/cli/cli_launch_test.py
@@ -95,13 +95,13 @@ class TestLaunch:
         assert not vm_exists(instance)
 
     @pytest.mark.parametrize(
-        "instance, param",
+        "instance",
         [
-            ({"image": "debian", "autopurge": False}, {"expected_release": "Trixie"}),
+            {"image": "debian", "autopurge": False},
         ],
-        indirect=["instance"],
+        indirect=True,
     )
-    def test_launch_debian(self, instance, param, feat_snapshot):
+    def test_launch_debian(self, instance, feat_snapshot):
         """Try to launch a Debian VM with default specs.
         Then, validate the basics."""
 
@@ -111,7 +111,7 @@ class TestLaunch:
             instance,
             {
                 "state": "Running",
-                "release": f"Debian {param["expected_release"]}",
+                "release": lambda r: r.startswith("Debian "),
                 "ipv4": is_valid_ipv4_addr,
             },
         )
@@ -122,7 +122,7 @@ class TestLaunch:
                 "cpu_count": "2",
                 "state": "Running",
                 "mounts": {},
-                "image_release": param["expected_release"],
+                "image_release": lambda r: bool(r),
                 "ipv4": is_valid_ipv4_addr,
             },
         )
@@ -149,13 +149,13 @@ class TestLaunch:
         assert not vm_exists(instance)
 
     @pytest.mark.parametrize(
-        "instance, param",
+        "instance",
         [
-            ({"image": "fedora", "autopurge": False}, {"expected_release": "43"}),
+            {"image": "fedora", "autopurge": False},
         ],
-        indirect=["instance"],
+        indirect=True,
     )
-    def test_launch_fedora(self, instance, param, feat_snapshot):
+    def test_launch_fedora(self, instance, feat_snapshot):
         """Try to launch a Fedora VM with default specs.
         Then, validate the basics."""
 
@@ -165,7 +165,7 @@ class TestLaunch:
             instance,
             {
                 "state": "Running",
-                "release": f"Fedora {param["expected_release"]}",
+                "release": lambda r: r.startswith("Fedora "),
                 "ipv4": is_valid_ipv4_addr,
             },
         )
@@ -176,7 +176,7 @@ class TestLaunch:
                 "cpu_count": "2",
                 "state": "Running",
                 "mounts": {},
-                "image_release": param["expected_release"],
+                "image_release": lambda r: bool(r),
                 "ipv4": is_valid_ipv4_addr,
             },
         )

--- a/tests/cli/multipass/validate.py
+++ b/tests/cli/multipass/validate.py
@@ -33,7 +33,7 @@ def validate_output(*args, properties, jq_filter=None):
             # to treat it as a predicate and call it. We'd call it for each
             # element if the matching key's value is a collection.
             if callable(v):
-                if isinstance(instance[k], Sequence):
+                if isinstance(instance[k], Sequence) and not isinstance(instance[k], str):
                     for item in instance[k]:
                         assert v(item)
                 else:


### PR DESCRIPTION
Generalize the matching of 3rd-party images in the CLI tests so as not to depend on a certain release.

Another option was to parse `data/distributions/distribution-info.json`, but I wanted to avoid depending on files outside the cli test directory in case someone is doing a sparse checkout or if the CLI tests eventually move to a separate repository. We could also do a GET request on `https://raw.githubusercontent.com/canonical/multipass/refs/heads/main/data/distributions/distribution-info.json`, but that seemed a bit overkill.