### PR TITLE
[cmake] Update CMake requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.28)
 cmake_policy(SET CMP0079 NEW) # Allow target_link_libraries() in subdirs
 
 include(feature-flags.cmake)


### PR DESCRIPTION
Update CMake requirements in Multipass for compiling `out_ptr`:

https://github.com/soasis/out_ptr/blob/02a577edfcf25e2519e380a95c16743b7e5878a1/CMakeLists.txt#L17

This is causing build failures in Launchpad:

https://launchpadlibrarian.net/860749277/buildlog_snap_ubuntu_noble_s390x_multipass-gui-less-edge_BUILDING.txt.gz