### PR TITLE
[arch] ppc64el maintenance

### DIFF
--- a/packaging/gui-less/generate-snapcraft.py
+++ b/packaging/gui-less/generate-snapcraft.py
@@ -43,7 +43,8 @@ def generate(input_path: Path, output_path: Path) -> None:
     multipass_part = data["parts"]["multipass"]
     multipass_part["build-snaps"] = [s for s in multipass_part.get("build-snaps", []) if s != "cmake"]
     build_packages = multipass_part["build-packages"]
-    build_packages.append("cmake")
+    if "cmake" not in build_packages:
+        build_packages.append("cmake")
 
     # Remove the GUI app
     del data["apps"]["gui"]

--- a/packaging/gui-less/generate-snapcraft.py
+++ b/packaging/gui-less/generate-snapcraft.py
@@ -39,14 +39,20 @@ def generate(input_path: Path, output_path: Path) -> None:
     data["platforms"]["s390x"] = None
     data["platforms"]["ppc64el"] = None
 
+    # The cmake snap on ppc64el/s390x is deprecated; use apt cmake instead
+    multipass_part = data["parts"]["multipass"]
+    multipass_part["build-snaps"] = [s for s in multipass_part.get("build-snaps", []) if s != "cmake"]
+    build_packages = multipass_part["build-packages"]
+    build_packages.append("cmake")
+
     # Remove the GUI app
     del data["apps"]["gui"]
 
     # Change multipass part to use remote git source
-    data["parts"]["multipass"]["source"] = MULTIPASS_SOURCE
+    multipass_part["source"] = MULTIPASS_SOURCE
 
     # Use a CMake preset to turn off the GUI
-    data["parts"]["multipass"]["build-environment"].append(
+    multipass_part["build-environment"].append(
         {"CMAKE_PRESET": "snap-gui-less"}
     )
 

--- a/packaging/gui-less/snap/snapcraft.yaml
+++ b/packaging/gui-less/snap/snapcraft.yaml
@@ -94,7 +94,6 @@ parts:
     after: [qt-ssl-plugin]
     plugin: cmake
     build-snaps:
-    - cmake
     - rustup
     build-environment:
     - PATH: /snap/bin:$PATH
@@ -130,6 +129,7 @@ parts:
     - libltdl-dev # vcpkg-systemd: libxcrypt requires libltdl-dev from the system package manager
     - autoconf-archive # vcpkg-systemd: libxcrypt requires autoconf-archive
     - python3-pip
+    - cmake
     stage-packages:
     - apparmor
     - libpng16-16

--- a/src/platform/backends/qemu/linux/qemu_platform_linux.cpp
+++ b/src/platform/backends/qemu/linux/qemu_platform_linux.cpp
@@ -241,16 +241,10 @@ QStringList mp::QemuPlatformLinux::vm_platform_args(const VirtualMachineDescript
 #endif
     }
 
-    opts << "--enable-kvm";
-
-    // Pass host CPU flags to VM
-#if defined Q_PROCESSOR_POWER
-    opts << "-cpu"
-         << "POWER9";
-#else
-    opts << "-cpu"
+    opts << "--enable-kvm"
+         // Pass host CPU flags to VM
+         << "-cpu"
          << "host";
-#endif
     // clang-format on
 
     // Set up the network related args

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -538,8 +538,14 @@ void mp::QemuVirtualMachine::initialize_vm_process()
     QObject::connect(vm_process.get(), &Process::ready_read_standard_output, [this]() {
         auto qmp_output = vm_process->read_all_standard_output();
         mpl::debug(vm_name, "QMP: {}", qmp_output);
-        auto qmp_object =
-            boost::json::parse(qmp_output.split('\n').first().toStdString()).as_object();
+        // Skip non-JSON output.
+        const auto lines = qmp_output.split('\n');
+        const auto json_line = std::find_if(lines.cbegin(), lines.cend(), [](const QString& line) {
+            return line.startsWith('{');
+        });
+        if (json_line == lines.cend())
+            return;
+        auto qmp_object = boost::json::parse(json_line->toStdString()).as_object();
 
         if (auto event = qmp_object.if_contains("event"))
         {

--- a/tests/unit/qemu/test_qemu_backend.cpp
+++ b/tests/unit/qemu/test_qemu_backend.cpp
@@ -306,6 +306,85 @@ TEST_F(QemuBackend, QMPErrorGetsLogged)
     machine->state = mp::VirtualMachine::State::running; // Necessary to properly shutdown
 }
 
+TEST_F(QemuBackend, QMPHandlerIgnoresNonJsonLines)
+{
+    EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_, _)).WillOnce([this](auto...) {
+        return std::move(mock_qemu_platform);
+    });
+
+    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+    mp::QemuVirtualMachineFactory backend{data_dir.path(), az_manager};
+
+    process_factory->register_callback([](mpt::MockProcess* process) {
+        if (process->program().startsWith("qemu-system-"))
+        {
+            EXPECT_CALL(*process, write(_)).WillRepeatedly([process](const QByteArray& data) {
+                auto json = boost::json::parse(std::string_view(data));
+                auto execute = value_to<std::string>(json.at("execute"));
+
+                if (execute == "qmp_capabilities")
+                {
+                    EXPECT_CALL(*process, read_all_standard_output())
+                        .WillRepeatedly(Return("Can't open directory /proc/device-tree/cpus/\n"
+                                               "Can't open directory /proc/device-tree/cpus/\n"));
+                    emit process->ready_read_standard_output();
+                }
+
+                return data.size();
+            });
+        }
+    });
+
+    auto machine = backend.create_virtual_machine(default_description, key_provider, mock_monitor);
+
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _));
+    EXPECT_CALL(mock_monitor, on_resume());
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+
+    machine->start();
+    machine->state = mp::VirtualMachine::State::running;
+}
+
+TEST_F(QemuBackend, QMPHandlerProcessesInterleavedJson)
+{
+    EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_, _)).WillOnce([this](auto...) {
+        return std::move(mock_qemu_platform);
+    });
+
+    NiceMock<mpt::MockVMStatusMonitor> mock_monitor;
+    mp::QemuVirtualMachineFactory backend{data_dir.path(), az_manager};
+
+    process_factory->register_callback([](mpt::MockProcess* process) {
+        if (process->program().startsWith("qemu-system-"))
+        {
+            EXPECT_CALL(*process, write(_)).WillRepeatedly([process](const QByteArray& data) {
+                auto json = boost::json::parse(std::string_view(data));
+                auto execute = value_to<std::string>(json.at("execute"));
+
+                if (execute == "qmp_capabilities")
+                {
+                    EXPECT_CALL(*process, read_all_standard_output())
+                        .WillRepeatedly(Return("Can't open directory /proc/device-tree/cpus/\n"
+                                               "{\"error\": {\"desc\": \"some error\"}}\n"
+                                               "Can't open directory /proc/device-tree/cpus/\n"));
+                    emit process->ready_read_standard_output();
+                }
+
+                return data.size();
+            });
+        }
+    });
+
+    auto machine = backend.create_virtual_machine(default_description, key_provider, mock_monitor);
+
+    EXPECT_CALL(mock_monitor, persist_state_for(_, _));
+    EXPECT_CALL(mock_monitor, on_resume());
+    logger_scope.mock_logger->screen_logs(mpl::Level::error);
+    logger_scope.mock_logger->expect_log(mpl::Level::error, "QMP error: some error");
+    machine->start();
+    machine->state = mp::VirtualMachine::State::running;
+}
+
 TEST_F(QemuBackend, throwsWhenShutdownWhileStarting)
 {
     mpt::MockProcess* vmproc = nullptr;


### PR DESCRIPTION
A couple fixes for Multipass on ppc64 and s390x:

1. Install cmake from apt as the snap package is no longer being updated. https://forum.snapcraft.io/t/announcement-dropping-architectures-from-the-cmake-snap/35137
2. Edit qemu system arg to use host cpu instead of hardcoded `POWER9`
3. Filter out non-JSON output from QMP. This was an issue as a ppc64 machine was logging:
```
May 21 19:38:48 baltar-kernel multipassd[119399]: QMP: Can't open directory /proc/device-tree/cpus/
                                                  Can't open directory /proc/device-tree/cpus/
                                                  Can't open directory /proc/device-tree/cpus/
                                                  {"QMP": {"version": {"qemu": {"micro": 3, "minor": 0, "major": 10}, "package": ""}, "capabilities": ["oob"]}}
```

---

MULTI-2631