### PR TITLE
[arch] Additional GitHub runners

### DIFF
--- a/.github/actions/read-snapcraft-yml-params/action.yml
+++ b/.github/actions/read-snapcraft-yml-params/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Install yq
       shell: bash
-      run: go install github.com/mikefarah/yq/v4@latest
+      run: sudo snap install yq
 
     - name: Extract CLANG_VERSION
       id: extract

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -66,17 +66,21 @@ jobs:
             const shortHash = str => crypto.createHash("sha256").update(str).digest("hex").slice(0, 12);
 
             if (SNAP_CHANNEL !== '<undefined>') {
-              matrix.include.push({
-                os: 'ubuntu-latest',
-                label: 'Snap',
-                'daemon-controller': 'snap',
-                'backend-driver': BACKEND_DRIVER,
-                'sudo-cmd': 'sudo',
-                'pkg-url': '',
-                'cmd-prologue': '',
-                'snap-channel': SNAP_CHANNEL,
-                'concurrency-key': shortHash(SNAP_CHANNEL)
-              });
+              for (const runner of [
+                'ubuntu-latest',
+                'self-hosted-linux-arm64-noble-edge']) {
+                matrix.include.push({
+                  os: runner,
+                  label: `Snap (${runner})`,
+                  'daemon-controller': 'snap',
+                  'backend-driver': BACKEND_DRIVER,
+                  'sudo-cmd': 'sudo',
+                  'pkg-url': '',
+                  'cmd-prologue': '',
+                  'snap-channel': SNAP_CHANNEL,
+                  'concurrency-key': shortHash(SNAP_CHANNEL + runner)
+                });
+              }
             }
 
             // macOS runs are disabled since GH macOS intel runners halt during execution

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -145,12 +145,6 @@ jobs:
         # Add CI=true environment variable to all parts' build-environment
         yq -i '.parts |= with_entries(.value.build-environment += [{"CI": "true"}])' snap/snapcraft.yaml
 
-    - name: Set up vcpkg
-      id: setup-vcpkg
-      uses: lukka/run-vcpkg@v11
-      with:
-        vcpkgDirectory: '${{ github.workspace }}/3rd-party/vcpkg'
-
     - name: Set up CCache
       id: setup-ccache
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -406,24 +406,27 @@ jobs:
 
     timeout-minutes: 15
     steps:
-    - name: Download the built snap
+    - name: Download the built snaps
       uses: actions/download-artifact@v8
       with:
-        name: ${{ needs.BuildAndTest.outputs.snap-file }}
+        pattern: '*.snap'
+        merge-multiple: true
 
     - name: Install Snapcraft and log in
       uses: samuelmeuli/action-snapcraft@v3
 
-    - name: Publish the snap
+    - name: Publish the snaps
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
       run: |
-        snapcraft upload *.snap --release ${{ needs.BuildAndTest.outputs.channel }}
+        for snap in *.snap; do
+          snapcraft upload "$snap" --release ${{ needs.BuildAndTest.outputs.channel }}
+        done
 
     - name: Delete unused artifacts from github
       uses: geekyeggo/delete-artifact@v6
       with:
-        name: ${{ needs.BuildAndTest.outputs.snap-file }}
+        name: '*.snap'
         failOnError: false
 
   Report-Workflow-Failure:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,15 +40,21 @@ jobs:
             "build-type": "Release",
             "cmake-preset": "ci-snap",
             "runs-on": "ubuntu-24.04-arm"
-          }, {
-            "build-type": "Release",
-            "cmake-preset": "ci-snap",
-            "runs-on": "self-hosted-linux-ppc64el-noble-edge"
-          }, {
-            "build-type": "Release",
-            "cmake-preset": "ci-snap",
-            "runs-on": "self-hosted-linux-s390x-noble-edge"
           });
+
+          if (context.eventName === 'schedule' &&
+              context.repo.owner === 'canonical' &&
+              context.repo.repo === 'multipass') {
+            matrix.include.push({
+              "build-type": "Release",
+              "cmake-preset": "ci-snap",
+              "runs-on": "self-hosted-linux-ppc64el-noble-edge"
+            }, {
+              "build-type": "Release",
+              "cmake-preset": "ci-snap",
+              "runs-on": "self-hosted-linux-s390x-noble-edge"
+            });
+          }
 
           if (context.eventName !== 'merge_group' &&
               context.eventName !== 'schedule' &&

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,12 +118,6 @@ jobs:
         fetch-depth: 0 # Need full history to derive version
         submodules: 'recursive'
 
-    - name: Exclude GUI from unsupported arches
-      if: ${{ matrix.runs-on == 'self-hosted-linux-ppc64el-noble-edge' || matrix.runs-on == 'self-hosted-linux-s390x-noble-edge' }}
-      run: |
-        cp packaging/gui-less/snap/snapcraft.yaml snap/snapcraft.yaml
-        yq -i '.parts.multipass.source = "."' snap/snapcraft.yaml
-
     - name: Determine build parameters
       id: build-params
       uses: ./.github/actions/build-params
@@ -131,16 +125,23 @@ jobs:
     - name: Read snapcraft.yml parameters
       uses: ./.github/actions/read-snapcraft-yml-params
 
+    - name: Install yq
+      run: |
+        sudo snap install yq
+
+    - name: Exclude GUI from unsupported arches
+      if: ${{ matrix.runs-on == 'self-hosted-linux-ppc64el-noble-edge' || matrix.runs-on == 'self-hosted-linux-s390x-noble-edge' }}
+      run: |
+        cp packaging/gui-less/snap/snapcraft.yaml snap/snapcraft.yaml
+        yq -i '.parts.multipass.source = "." | .parts.glue.source = "snap-wrappers" | del(.parts.glue."source-type", .parts.glue."source-subdir")' snap/snapcraft.yaml
+
     - name: Apply snapcraft-ci-override.yaml
       env:
         MULTIPASS_BUILD_LABEL:  ${{ steps.build-params.outputs.label }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CMAKE_PRESET: ${{ matrix.cmake-preset }}
         MP_ALLOW_OPTIONAL_FEATURES: ${{ github.event_name == 'schedule' && 'OFF' || 'ON' }}
-
       run: |
-        sudo snap install yq
-
         # Substitute the environment variables in the snapcraft-ci-override.yaml
         envsubst < snap/local/snapcraft-ci-override.yaml.in | yq eval 'del(.. | select(. == null or . == "")) | del(.. | select((tag == "!!map" or tag == "!!seq") and length == 0))' -P > snap/local/snapcraft-ci-override.yaml
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,27 +32,21 @@ jobs:
             "build-type": "Debug",
             "cmake-preset": "ci-snap-debug",
             "runs-on": "ubuntu-latest"
-          }, {
-            "build-type": "Release",
-            "cmake-preset": "ci-snap",
-            "runs-on": "ubuntu-latest"
-          }, {
-            "build-type": "Release",
-            "cmake-preset": "ci-snap",
-            "runs-on": "ubuntu-24.04-arm"
           });
 
+          let runners = ["ubuntu-latest", "ubuntu-24.04-arm"];
           if (context.eventName === 'schedule' &&
               context.repo.owner === 'canonical' &&
               context.repo.repo === 'multipass') {
+            runners.push("self-hosted-linux-ppc64el-noble-edge",
+                         "self-hosted-linux-s390x-noble-edge");
+          }
+
+          for (const runner of runners) {
             matrix.include.push({
               "build-type": "Release",
               "cmake-preset": "ci-snap",
-              "runs-on": "self-hosted-linux-ppc64el-noble-edge"
-            }, {
-              "build-type": "Release",
-              "cmake-preset": "ci-snap",
-              "runs-on": "self-hosted-linux-s390x-noble-edge"
+              "runs-on": runner
             });
           }
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -119,10 +119,6 @@ jobs:
     - name: Read snapcraft.yml parameters
       uses: ./.github/actions/read-snapcraft-yml-params
 
-    - name: Install yq
-      run: |
-        sudo snap install yq
-
     - name: Exclude GUI from unsupported arches
       if: ${{ matrix.runs-on == 'self-hosted-linux-ppc64el-noble-edge' || matrix.runs-on == 'self-hosted-linux-s390x-noble-edge' }}
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,6 +112,12 @@ jobs:
         fetch-depth: 0 # Need full history to derive version
         submodules: 'recursive'
 
+    - name: Exclude GUI from unsupported arches
+      if: ${{ matrix.runs-on == 'self-hosted-linux-ppc64el-noble-edge' || matrix.runs-on == 'self-hosted-linux-s390x-noble-edge' }}
+      run: |
+        cp packaging/gui-less/snap/snapcraft.yaml snap/snapcraft.yaml
+        yq -i '.parts.multipass.source = "."' snap/snapcraft.yaml
+
     - name: Determine build parameters
       id: build-params
       uses: ./.github/actions/build-params

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -133,7 +133,7 @@ jobs:
         MP_ALLOW_OPTIONAL_FEATURES: ${{ github.event_name == 'schedule' && 'OFF' || 'ON' }}
 
       run: |
-        go install github.com/mikefarah/yq/v4@latest
+        sudo snap install yq
 
         # Substitute the environment variables in the snapcraft-ci-override.yaml
         envsubst < snap/local/snapcraft-ci-override.yaml.in | yq eval 'del(.. | select(. == null or . == "")) | del(.. | select((tag == "!!map" or tag == "!!seq") and length == 0))' -P > snap/local/snapcraft-ci-override.yaml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,10 +30,24 @@ jobs:
 
           matrix.include.push({
             "build-type": "Debug",
-            "cmake-preset": "ci-snap-debug"
+            "cmake-preset": "ci-snap-debug",
+            "runs-on": "ubuntu-latest"
           }, {
             "build-type": "Release",
-            "cmake-preset": "ci-snap"
+            "cmake-preset": "ci-snap",
+            "runs-on": "ubuntu-latest"
+          }, {
+            "build-type": "Release",
+            "cmake-preset": "ci-snap",
+            "runs-on": "ubuntu-24.04-arm"
+          }, {
+            "build-type": "Release",
+            "cmake-preset": "ci-snap",
+            "runs-on": "self-hosted-linux-ppc64el-noble-edge"
+          }, {
+            "build-type": "Release",
+            "cmake-preset": "ci-snap",
+            "runs-on": "self-hosted-linux-s390x-noble-edge"
           });
 
           if (context.eventName !== 'merge_group' &&
@@ -43,7 +57,8 @@ jobs:
               context.repo.repo === 'multipass') {
             matrix.include.push({
               "build-type": "Coverage",
-              "cmake-preset": "ci-snap-coverage"
+              "cmake-preset": "ci-snap-coverage",
+              "runs-on": "ubuntu-latest"
             });
           }
 
@@ -67,7 +82,7 @@ jobs:
       matrix: ${{ fromJSON(needs.GetMatrix.outputs.matrix) }}
       fail-fast: ${{ github.event_name == 'merge_group' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
 
     env:
       FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
@@ -145,9 +160,9 @@ jobs:
     - name: CCache
       uses: actions/cache@v5
       with:
-        key: ccache-${{ runner.os }}-${{ matrix.build-type }}-${{ steps.setup-ccache.outputs.cache-key }}
+        key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build-type }}-${{ steps.setup-ccache.outputs.cache-key }}
         restore-keys: |
-          ccache-${{ runner.os }}-${{ matrix.build-type }}-
+          ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build-type }}-
         path: ~/.ccache
 
     - name: Set up coverage
@@ -428,6 +443,7 @@ jobs:
           Scheduled [Linux](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow exited before completing.
         MATTERMOST_USERNAME: ${{ github.triggering_actor }}
         MATTERMOST_ICON_URL: https://www.flaticon.com/free-icon/github-logo_25231
+
   Dispatch-CLI-Tests-Workflow:
     permissions:
       contents: read

--- a/packaging/gui-less/snap/snapcraft.yaml
+++ b/packaging/gui-less/snap/snapcraft.yaml
@@ -323,7 +323,7 @@ parts:
     stage-packages:
     - ipxe-qemu
     - on amd64: [ovmf]
-    - on arm64: [qemu-efi]
+    - on arm64: [qemu-efi-aarch64]
     organize:
       usr/share/ovmf/*: qemu/
       usr/lib/ipxe/qemu/*: qemu/

--- a/snap/local/snapcraft-ci-override.yaml.in
+++ b/snap/local/snapcraft-ci-override.yaml.in
@@ -3,6 +3,14 @@ parts:
     plugin: nil
     override-pull: |
       # Based on https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/configure-apt-sources.sh
+      # Mirrors only serve amd64/i386; skip on other architectures
+      # http://azure.archive.ubuntu.com/ubuntu/dists/noble/
+      arch="$(dpkg --print-architecture)"
+      if [ "$arch" != "amd64" ] && [ "$arch" != "i386" ]; then
+        echo "Skipping mirror injection (not amd64/i386)"
+        exit 0
+      fi
+
       echo "Injecting custom APT mirror priorities..."
 
       cat <<EOF > /etc/apt/apt-mirrors.txt

--- a/snap/local/snapcraft-ci-override.yaml.in
+++ b/snap/local/snapcraft-ci-override.yaml.in
@@ -12,9 +12,9 @@ parts:
       EOF
 
       cat <<EOF > /etc/apt/sources.list
-      deb mirror+file:/etc/apt/apt-mirrors.txt jammy main restricted universe multiverse
-      deb mirror+file:/etc/apt/apt-mirrors.txt jammy-updates main restricted universe multiverse
-      deb mirror+file:/etc/apt/apt-mirrors.txt jammy-security main restricted universe multiverse
+      deb mirror+file:/etc/apt/apt-mirrors.txt noble main restricted universe multiverse
+      deb mirror+file:/etc/apt/apt-mirrors.txt noble-updates main restricted universe multiverse
+      deb mirror+file:/etc/apt/apt-mirrors.txt noble-security main restricted universe multiverse
       EOF
 
       apt-get update

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -339,7 +339,7 @@ parts:
     stage-packages:
     - ipxe-qemu
     - on amd64: [ovmf]
-    - on arm64: [qemu-efi]
+    - on arm64: [qemu-efi-aarch64]
     organize:
       usr/share/ovmf/*: qemu/
       usr/lib/ipxe/qemu/*: qemu/


### PR DESCRIPTION
This PR adds CI matrix workflows for ARM, ppc64el, and s390x runners.

Canonical self-hosted runners are used for ppc64el/s390x. They can be tardy in picking up jobs, so for the time being, they have been scheduled to run with the nightly builds. Several other modifications were made to accommodate having multipass snaps built in different architectures. ppc64el/s390x also do not support nested virtualization so they have not been added to the CLI test workflow.

---

MULTI-2632