### PR TITLE
[debian] Add `lld` as dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,7 @@
 Source: multipass
 Build-Depends: build-essential,
                llvm,
+               lld,
                clang,
                clang-tools,
                cmake,


### PR DESCRIPTION
A silver lining from my main dev machine being broken is that I had a chance to build Multipass from a fresh Ubuntu install. I found one small issue, which is that our Debian control file was missing the `lld` package, which Dart needs for linking. Here's a simple one-liner fix so that new contributors have an easier time building for the first time.