### PR TITLE
[platform-win] Initialize pSD to nullptr

### DIFF
--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -975,7 +975,7 @@ auto new_ACL(LPSTR path)
     auto deleter = [](ACL* acl) noexcept { return LocalFree(HLOCAL(acl)); };
     auto newACL = std::unique_ptr<ACL, decltype(deleter)>{NULL, deleter};
 
-    PSECURITY_DESCRIPTOR pSD;
+    PSECURITY_DESCRIPTOR pSD{nullptr};
     auto pSD_guard = sg::make_scope_guard([&pSD]() noexcept { LocalFree((HLOCAL)(pSD)); });
 
     PACL pOldDACL = nullptr;


### PR DESCRIPTION
pSD is being auto-released by the scope guard but it's not guaranteed to be initialized, and it's not null-initialized either meaning LocalFree would be called with a garbage value.

This patch fixes that.
