### PR TITLE
[hyperv-tests] Bump pause test wait timeout to 60s

### DIFF
--- a/tests/unit/hyperv_api/test_it_hyperv_hcs_api.cpp
+++ b/tests/unit/hyperv_api/test_it_hyperv_hcs_api.cpp
@@ -75,7 +75,7 @@ struct HyperVHCSAPI_IntegrationTests : public ::testing::Test
             ASSERT_TRUE(d_result);
             std::wprintf(L"%s\n\n", d_result.status_msg.c_str());
             handle.reset();
-            ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(15)))
+            ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(60)))
                 << "SystemExited callback not received within timeout";
         }
     }


### PR DESCRIPTION
# Description

To fix intermittent CI failures due to timeout: https://github.com/canonical/multipass/actions/runs/26763809758/job/78884577702?pr=4922

MULTI-2654