### PR TITLE
[build] Update cmake reqs

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -45,6 +45,9 @@ jobs:
           python3-pip
         sudo --preserve-env apt-get build-dep --yes ./
 
+    - name: Install cmake
+      uses: lukka/get-cmake@v4.3.3
+
     - name: Configure
       run: |
         cmake -B${{ env.BUILD_DIR }} \

--- a/BUILD.macOS.md
+++ b/BUILD.macOS.md
@@ -35,8 +35,8 @@ You may need to update your version of Ruby first. You can do so with RVM <https
 
 ### Cmake
 
-Building a Multipass package requires cmake 3.9 or greater. The most convenient
-means to obtain cmake is with Homebrew <https://brew.sh/>.
+Building a Multipass package requires cmake. The most convenient means to obtain cmake is with Homebrew
+<https://brew.sh/>.
 
     brew install cmake
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.29)
 cmake_policy(SET CMP0079 NEW) # Allow target_link_libraries() in subdirs
 
 include(feature-flags.cmake)

--- a/packaging/gui-less/generate-snapcraft.py
+++ b/packaging/gui-less/generate-snapcraft.py
@@ -39,12 +39,16 @@ def generate(input_path: Path, output_path: Path) -> None:
     data["platforms"]["s390x"] = None
     data["platforms"]["ppc64el"] = None
 
-    # The cmake snap on ppc64el/s390x is deprecated; use apt cmake instead
+    # The cmake snap on ppc64el/s390x is deprecated and apt packages are not up to date;
+    # use precompiled binaries from pip instead
+    # https://discourse.cmake.org/t/announcement-dropping-architectures-from-the-cmake-snap/8116
     multipass_part = data["parts"]["multipass"]
     multipass_part["build-snaps"] = [s for s in multipass_part.get("build-snaps", []) if s != "cmake"]
-    build_packages = multipass_part["build-packages"]
-    if "cmake" not in build_packages:
-        build_packages.append("cmake")
+    override_pull = str(multipass_part["override-pull"])
+    lines = override_pull.splitlines(keepends=True)
+    lines.insert(1, "python3 -m pip install --break-system-packages cmake\n")
+    override_pull = "".join(lines)
+    multipass_part["override-pull"] = LiteralScalarString(override_pull)
 
     # Remove the GUI app
     del data["apps"]["gui"]

--- a/packaging/gui-less/snap/snapcraft.yaml
+++ b/packaging/gui-less/snap/snapcraft.yaml
@@ -129,7 +129,6 @@ parts:
     - libltdl-dev # vcpkg-systemd: libxcrypt requires libltdl-dev from the system package manager
     - autoconf-archive # vcpkg-systemd: libxcrypt requires autoconf-archive
     - python3-pip
-    - cmake
     stage-packages:
     - apparmor
     - libpng16-16
@@ -195,6 +194,7 @@ parts:
     source-type: git
     override-pull: |
       set -e
+      python3 -m pip install --break-system-packages cmake
 
       rustup default stable
 


### PR DESCRIPTION
Push up cmake requirements so we can compile [double-conversion](https://github.com/google/double-conversion/blob/248996f5006537c5b5eada09e649625185e6c112/CMakeLists.txt#L4).

Currently causing build failures on [ppc64le](https://launchpadlibrarian.net/864332796/buildlog_snap_ubuntu_noble_ppc64el_multipass-gui-less-edge_BUILDING.txt.gz) and [s390x](https://launchpadlibrarian.net/864336092/buildlog_snap_ubuntu_noble_s390x_multipass-gui-less-edge_BUILDING.txt.gz) in launchpad.

Also, causing failures in [TICS](https://github.com/canonical/multipass/actions/runs/27084145749/job/79935220282#step:5:1448), and subsequently [fixed](https://github.com/canonical/multipass/actions/runs/27277725404/job/80563378444) when running on this branch.

---

MULTI-2631