### PR TITLE
[applevz] AZ support

### DIFF
--- a/feature-flags.cmake
+++ b/feature-flags.cmake
@@ -15,7 +15,7 @@
 include(src/cmake/feature-flag.cmake)
 
 # Multipass backend integrating with Apple Virtualization framework
-feature_flag(APPLEVZ_ENABLED "AppleVZ backend" APPLE)
+feature_flag(APPLEVZ_ENABLED "AppleVZ backend" "APPLE;AVAILABILITY_ZONES_ENABLED")
 
 # The new Windows backend based on Hyper-V Host Compute System / Host Compute Networking APIs
 feature_flag(HYPERV_HCS_ENABLED "Hyper-V HCS backend" WIN32)

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <applevz/cf_error.h>
+#include <multipass/availability_zone.h>
 #include <multipass/network_interface_info.h>
 #include <multipass/virtual_machine_description.h>
 
@@ -44,6 +45,7 @@ enum class AppleVMState
 };
 
 CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                multipass::AvailabilityZone& zone,
                                 VMHandle& out_handle);
 
 // Starting and stopping VM

--- a/src/platform/backends/applevz/applevz_bridge.h
+++ b/src/platform/backends/applevz/applevz_bridge.h
@@ -45,7 +45,7 @@ enum class AppleVMState
 };
 
 CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
-                                multipass::AvailabilityZone& zone,
+                                const multipass::AvailabilityZone& zone,
                                 VMHandle& out_handle);
 
 // Starting and stopping VM

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -105,7 +105,7 @@ auto query_on_vm_queue(const multipass::applevz::VMHandle& vm_handle, Callable c
 namespace multipass::applevz
 {
 CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
-                                multipass::AvailabilityZone& zone,
+                                const multipass::AvailabilityZone& zone,
                                 VMHandle& out_handle)
 {
     @autoreleasepool

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -178,13 +178,12 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
         config.entropyDevices = @[ entropy ];
 
         // Network devices
-        // Primary NAT interface
         NSMutableArray<VZNetworkDeviceConfiguration*>* networkDevices = [NSMutableArray array];
 
         VZVirtioNetworkDeviceConfiguration* netDevice =
             [[VZVirtioNetworkDeviceConfiguration alloc] init];
-        VZNATNetworkDeviceAttachment* natAttachment = [[VZNATNetworkDeviceAttachment alloc] init];
-        netDevice.attachment = natAttachment;
+        VmnetBridge zone_bridge{zone};
+        netDevice.attachment = zone_bridge.attachment;
 
         VZMACAddress* mac =
             [[VZMACAddress alloc] initWithString:nsstring_from_stdstring(desc.default_mac_address)];
@@ -225,6 +224,7 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
 
         out_handle = std::make_shared<VirtualMachineHandle>();
         out_handle->relays = std::move(relays);
+        out_handle->relays.push_back(std::move(zone_bridge.relay));
         out_handle->id = vmIDCounter.fetch_add(1, std::memory_order_relaxed);
 
         // Create dispatch queue

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -195,7 +195,7 @@ CFError init_with_configuration(const multipass::VirtualMachineDescription& desc
         std::vector<VmnetRelayHandle> relays;
         for (const auto& extra : desc.extra_interfaces)
         {
-            VmnetBridge bridge = create_vmnet_bridge(extra.id);
+            VmnetBridge bridge{extra.id};
 
             VZVirtioNetworkDeviceConfiguration* bridgedDevice =
                 [[VZVirtioNetworkDeviceConfiguration alloc] init];

--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -105,6 +105,7 @@ auto query_on_vm_queue(const multipass::applevz::VMHandle& vm_handle, Callable c
 namespace multipass::applevz
 {
 CFError init_with_configuration(const multipass::VirtualMachineDescription& desc,
+                                multipass::AvailabilityZone& zone,
                                 VMHandle& out_handle)
 {
     @autoreleasepool

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -367,7 +367,7 @@ void AppleVZVirtualMachine::initialize_vm_handle()
     mpl::trace(log_category, "initialize_vm_handle() -> Creating VM handle for '{}'", vm_name);
 
     vm_handle.reset();
-    if (const auto& error = MP_APPLEVZ.create_vm(desc, vm_handle); error)
+    if (const auto& error = MP_APPLEVZ.create_vm(desc, zone, vm_handle); error)
     {
         throw std::runtime_error(
             fmt::format("Failed to create VM handle for '{}': {}", vm_name, error));

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -82,7 +82,7 @@ std::string AppleVZVirtualMachineFactory::create_bridge_with(const NetworkInterf
 
 VirtualMachine::UPtr AppleVZVirtualMachineFactory::clone_vm_impl(
     const std::string& /*source_vm_name*/,
-    const multipass::VMSpecs& /*src_vm_specs*/,
+    const mp::VMSpecs& /*src_vm_specs*/,
     const VirtualMachineDescription& desc,
     VMStatusMonitor& monitor,
     const SSHKeyProvider& key_provider)

--- a/src/platform/backends/applevz/applevz_vmnet.h
+++ b/src/platform/backends/applevz/applevz_vmnet.h
@@ -19,6 +19,8 @@
 
 #include <Virtualization/Virtualization.h>
 
+#include <multipass/availability_zone.h>
+
 #include <memory>
 
 namespace multipass::applevz
@@ -29,10 +31,11 @@ using VmnetRelayHandle = std::shared_ptr<void>;
 
 struct VmnetBridge
 {
+    explicit VmnetBridge(const std::string& physical_iface);
+    explicit VmnetBridge(multipass::AvailabilityZone& zone);
+
     VZFileHandleNetworkDeviceAttachment* attachment;
     VmnetRelayHandle relay;
 };
-
-VmnetBridge create_vmnet_bridge(const std::string& physical_iface);
 
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_vmnet.h
+++ b/src/platform/backends/applevz/applevz_vmnet.h
@@ -32,7 +32,7 @@ using VmnetRelayHandle = std::shared_ptr<void>;
 struct VmnetBridge
 {
     explicit VmnetBridge(const std::string& physical_iface);
-    explicit VmnetBridge(multipass::AvailabilityZone& zone);
+    explicit VmnetBridge(const multipass::AvailabilityZone& zone);
 
     VZFileHandleNetworkDeviceAttachment* attachment;
     VmnetRelayHandle relay;

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -192,7 +192,7 @@ void start_vmnet_interface(VmnetRelay& relay, const multipass::Subnet& subnet)
 
     xpc_object_t opts = xpc_dictionary_create(nullptr, nullptr, 0);
     xpc_dictionary_set_uint64(opts, vmnet_operation_mode_key, VMNET_SHARED_MODE);
-    const auto start_addr = (subnet.min_address()).as_string();
+    const auto start_addr = subnet.min_address().as_string();
     const auto end_addr = subnet.max_address().as_string();
     const auto mask = subnet.subnet_mask().as_string();
     xpc_dictionary_set_string(opts, vmnet_start_address_key, start_addr.c_str());

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -32,6 +32,7 @@
 
 #include <applevz/applevz_utils.h>
 #include <applevz/applevz_vmnet.h>
+#include <multipass/availability_zone.h>
 #include <multipass/logging/log.h>
 
 #include <fmt/format.h>
@@ -39,6 +40,7 @@
 #include <array>
 #include <chrono>
 #include <thread>
+#include <vector>
 
 #include <errno.h>
 #include <vmnet/vmnet.h>
@@ -144,41 +146,60 @@ struct VmnetRelay
     VmnetRelay& operator=(const VmnetRelay&) = delete;
 };
 
+void start_interface(VmnetRelay& relay, xpc_object_t opts, std::string_view description)
+{
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    __block vmnet_return_t vmnet_status = VMNET_FAILURE;
+
+    relay.iface =
+        vmnet_start_interface(opts, relay.queue, ^(vmnet_return_t status, xpc_object_t params) {
+          vmnet_status = status;
+          if (status == VMNET_SUCCESS)
+              relay.max_packet_bytes =
+                  (uint32_t)xpc_dictionary_get_uint64(params, vmnet_max_packet_size_key);
+          dispatch_semaphore_signal(sema);
+        });
+
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    if (vmnet_status != VMNET_SUCCESS || !relay.iface)
+        throw std::runtime_error(fmt::format("vmnet_start_interface() failed (status {}) for '{}'",
+                                             static_cast<int>(vmnet_status),
+                                             description));
+
+    mpl::debug(category, "vmnet interface started for '{}'", description);
+}
+
 void start_vmnet_interface(VmnetRelay& relay, const std::string& physical_iface)
 {
     relay.queue = dispatch_queue_create(
         fmt::format("com.canonical.multipassd.vmnet.{}", physical_iface).c_str(),
         DISPATCH_QUEUE_SERIAL);
 
-    xpc_object_t iface_opts = xpc_dictionary_create(nullptr, nullptr, 0);
-    xpc_dictionary_set_uint64(iface_opts, vmnet_operation_mode_key, VMNET_BRIDGED_MODE);
-    xpc_dictionary_set_string(iface_opts, vmnet_shared_interface_name_key, physical_iface.c_str());
+    xpc_object_t opts = xpc_dictionary_create(nullptr, nullptr, 0);
+    // Bridged mode requires root
+    xpc_dictionary_set_uint64(opts, vmnet_operation_mode_key, VMNET_BRIDGED_MODE);
+    xpc_dictionary_set_string(opts, vmnet_shared_interface_name_key, physical_iface.c_str());
 
-    dispatch_semaphore_t vmnet_sema = dispatch_semaphore_create(0);
-    __block vmnet_return_t vmnet_status = VMNET_FAILURE;
+    start_interface(relay, opts, physical_iface);
+}
 
-    // Starting the vmnet interface requires root on macOS 15 and older
-    relay.iface = vmnet_start_interface(
-        iface_opts,
-        relay.queue,
-        ^(vmnet_return_t status, xpc_object_t params) {
-          vmnet_status = status;
-          if (status == VMNET_SUCCESS)
-              relay.max_packet_bytes =
-                  (uint32_t)xpc_dictionary_get_uint64(params, vmnet_max_packet_size_key);
-          dispatch_semaphore_signal(vmnet_sema);
-        });
+void start_vmnet_interface(VmnetRelay& relay, const multipass::Subnet& subnet)
+{
+    relay.queue = dispatch_queue_create(
+        fmt::format("com.canonical.multipassd.vmnet.zone.{}", subnet.to_cidr()).c_str(),
+        DISPATCH_QUEUE_SERIAL);
 
-    dispatch_semaphore_wait(vmnet_sema, DISPATCH_TIME_FOREVER);
+    xpc_object_t opts = xpc_dictionary_create(nullptr, nullptr, 0);
+    xpc_dictionary_set_uint64(opts, vmnet_operation_mode_key, VMNET_SHARED_MODE);
+    const auto start_addr = (subnet.min_address() + 1).as_string();
+    const auto end_addr = subnet.max_address().as_string();
+    const auto mask = subnet.subnet_mask().as_string();
+    xpc_dictionary_set_string(opts, vmnet_start_address_key, start_addr.c_str());
+    xpc_dictionary_set_string(opts, vmnet_end_address_key, end_addr.c_str());
+    xpc_dictionary_set_string(opts, vmnet_subnet_mask_key, mask.c_str());
 
-    if (vmnet_status != VMNET_SUCCESS || !relay.iface)
-    {
-        throw std::runtime_error(fmt::format("vmnet_start_interface() failed (status {}) for '{}'",
-                                             static_cast<int>(vmnet_status),
-                                             physical_iface));
-    }
-
-    mpl::debug(category, "vmnet bridged interface started on '{}'", physical_iface);
+    start_interface(relay, opts, subnet.to_cidr());
 }
 
 // Forward one batch of packets from the socket to the vmnet interface.
@@ -345,15 +366,9 @@ std::array<int, 2> create_socket_pair()
 
     return fds;
 }
-} // namespace
-
-namespace multipass::applevz
+std::pair<VZFileHandleNetworkDeviceAttachment*, multipass::applevz::VmnetRelayHandle> connect_relay(
+    std::unique_ptr<VmnetRelay> relay)
 {
-VmnetBridge create_vmnet_bridge(const std::string& physical_iface)
-{
-    auto relay = std::make_unique<VmnetRelay>();
-    start_vmnet_interface(*relay, physical_iface);
-
     auto [vz_fd, relay_fd] = create_socket_pair();
 
     relay->fd = relay_fd;
@@ -364,9 +379,24 @@ VmnetBridge create_vmnet_bridge(const std::string& physical_iface)
 
     NSFileHandle* vz_handle = [[NSFileHandle alloc] initWithFileDescriptor:vz_fd
                                                             closeOnDealloc:YES];
-    VZFileHandleNetworkDeviceAttachment* attachment =
-        [[VZFileHandleNetworkDeviceAttachment alloc] initWithFileHandle:vz_handle];
+    auto* attachment = [[VZFileHandleNetworkDeviceAttachment alloc] initWithFileHandle:vz_handle];
+    return {attachment, std::move(relay)};
+}
+} // namespace
 
-    return VmnetBridge{attachment, std::move(relay)};
+namespace multipass::applevz
+{
+VmnetBridge::VmnetBridge(const std::string& physical_iface)
+{
+    auto relay = std::make_unique<VmnetRelay>();
+    start_vmnet_interface(*relay, physical_iface);
+    std::tie(this->attachment, this->relay) = connect_relay(std::move(relay));
+}
+
+VmnetBridge::VmnetBridge(multipass::AvailabilityZone& zone)
+{
+    auto relay = std::make_unique<VmnetRelay>();
+    start_vmnet_interface(*relay, zone.get_subnet());
+    std::tie(this->attachment, this->relay) = connect_relay(std::move(relay));
 }
 } // namespace multipass::applevz

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -393,7 +393,7 @@ VmnetBridge::VmnetBridge(const std::string& physical_iface)
     std::tie(this->attachment, this->relay) = connect_relay(std::move(relay));
 }
 
-VmnetBridge::VmnetBridge(multipass::AvailabilityZone& zone)
+VmnetBridge::VmnetBridge(const multipass::AvailabilityZone& zone)
 {
     auto relay = std::make_unique<VmnetRelay>();
     start_vmnet_interface(*relay, zone.get_subnet());

--- a/src/platform/backends/applevz/applevz_vmnet.mm
+++ b/src/platform/backends/applevz/applevz_vmnet.mm
@@ -192,7 +192,7 @@ void start_vmnet_interface(VmnetRelay& relay, const multipass::Subnet& subnet)
 
     xpc_object_t opts = xpc_dictionary_create(nullptr, nullptr, 0);
     xpc_dictionary_set_uint64(opts, vmnet_operation_mode_key, VMNET_SHARED_MODE);
-    const auto start_addr = (subnet.min_address() + 1).as_string();
+    const auto start_addr = (subnet.min_address()).as_string();
     const auto end_addr = subnet.max_address().as_string();
     const auto mask = subnet.subnet_mask().as_string();
     xpc_dictionary_set_string(opts, vmnet_start_address_key, start_addr.c_str());

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -21,7 +21,7 @@
 namespace multipass::applevz
 {
 CFError AppleVZ::create_vm(const VirtualMachineDescription& desc,
-                           multipass::AvailabilityZone& zone,
+                           const multipass::AvailabilityZone& zone,
                            VMHandle& out_handle) const
 {
     return init_with_configuration(desc, zone, out_handle);

--- a/src/platform/backends/applevz/applevz_wrapper.cpp
+++ b/src/platform/backends/applevz/applevz_wrapper.cpp
@@ -20,9 +20,11 @@
 
 namespace multipass::applevz
 {
-CFError AppleVZ::create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const
+CFError AppleVZ::create_vm(const VirtualMachineDescription& desc,
+                           multipass::AvailabilityZone& zone,
+                           VMHandle& out_handle) const
 {
-    return init_with_configuration(desc, out_handle);
+    return init_with_configuration(desc, zone, out_handle);
 }
 
 CFError AppleVZ::start_vm(const VMHandle& vm_handle) const

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -31,7 +31,9 @@ class AppleVZ : public Singleton<AppleVZ>
 public:
     using Singleton<AppleVZ>::Singleton;
 
-    virtual CFError create_vm(const VirtualMachineDescription& desc, VMHandle& out_handle) const;
+    virtual CFError create_vm(const VirtualMachineDescription& desc,
+                              multipass::AvailabilityZone& zone,
+                              VMHandle& out_handle) const;
 
     // Starting and stopping VM
     virtual CFError start_vm(const VMHandle& vm_handle) const;

--- a/src/platform/backends/applevz/applevz_wrapper.h
+++ b/src/platform/backends/applevz/applevz_wrapper.h
@@ -32,7 +32,7 @@ public:
     using Singleton<AppleVZ>::Singleton;
 
     virtual CFError create_vm(const VirtualMachineDescription& desc,
-                              multipass::AvailabilityZone& zone,
+                              const multipass::AvailabilityZone& zone,
                               VMHandle& out_handle) const;
 
     // Starting and stopping VM

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -33,7 +33,7 @@ public:
     MOCK_METHOD(applevz::CFError,
                 create_vm,
                 (const multipass::VirtualMachineDescription& desc,
-                 multipass::AvailabilityZone& zone,
+                 const multipass::AvailabilityZone& zone,
                  multipass::applevz::VMHandle& out_handle),
                 (const, override));
     MOCK_METHOD(applevz::CFError,

--- a/tests/unit/applevz/mock_applevz_wrapper.h
+++ b/tests/unit/applevz/mock_applevz_wrapper.h
@@ -21,6 +21,7 @@
 #include "tests/unit/mock_singleton_helpers.h"
 
 #include <applevz/applevz_wrapper.h>
+#include <multipass/availability_zone.h>
 #include <multipass/network_interface_info.h>
 
 namespace multipass::test
@@ -32,6 +33,7 @@ public:
     MOCK_METHOD(applevz::CFError,
                 create_vm,
                 (const multipass::VirtualMachineDescription& desc,
+                 multipass::AvailabilityZone& zone,
                  multipass::applevz::VMHandle& out_handle),
                 (const, override));
     MOCK_METHOD(applevz::CFError,

--- a/tests/unit/applevz/test_applevz_virtual_machine.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine.cpp
@@ -81,8 +81,8 @@ struct AppleVZVirtualMachine_UnitTests : public testing::Test
 
     auto construct_vm(applevz::AppleVMState initial_state = applevz::AppleVMState::stopped)
     {
-        EXPECT_CALL(mock_applevz, create_vm(_, _))
-            .WillOnce(DoAll(SetArgReferee<1>(mock_handle), Return(applevz::CFError{})));
+        EXPECT_CALL(mock_applevz, create_vm(_, _, _))
+            .WillOnce(DoAll(SetArgReferee<2>(mock_handle), Return(applevz::CFError{})));
 
         EXPECT_CALL(mock_applevz, get_state(_)).WillRepeatedly(Return(initial_state));
         EXPECT_CALL(mock_monitor, persist_state_for(desc.vm_name, _)).Times(AnyNumber());

--- a/tests/unit/applevz/test_applevz_virtual_machine_factory.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine_factory.cpp
@@ -172,12 +172,13 @@ TEST_F(AppleVZVirtualMachineFactory_UnitTests, createVirtualMachine)
 {
     mp::VirtualMachineDescription desc;
     desc.vm_name = "test-vm";
+    desc.zone = "zone1";
 
     EXPECT_CALL(mock_applevz_utils, convert_to_supported_format(_, _))
         .WillRepeatedly(ReturnArg<0>());
 
-    EXPECT_CALL(mock_applevz, create_vm(_, _))
-        .WillOnce(DoAll(SetArgReferee<1>(mock_handle), Return(mp::applevz::CFError{})));
+    EXPECT_CALL(mock_applevz, create_vm(_, _, _))
+        .WillOnce(DoAll(SetArgReferee<2>(mock_handle), Return(mp::applevz::CFError{})));
 
     EXPECT_CALL(mock_applevz, get_state(_))
         .WillRepeatedly(Return(mp::applevz::AppleVMState::stopped));
@@ -213,16 +214,21 @@ TEST_F(AppleVZVirtualMachineFactory_UnitTests, cloneCopiesRelevantFiles)
         std::ofstream(src_vm_dir / file);
     }
 
-    EXPECT_CALL(mock_applevz, create_vm(_, _))
-        .WillOnce(DoAll(SetArgReferee<1>(mock_handle), Return(mp::applevz::CFError{})));
+    EXPECT_CALL(mock_applevz, create_vm(_, _, _))
+        .WillOnce(DoAll(SetArgReferee<2>(mock_handle), Return(mp::applevz::CFError{})));
     EXPECT_CALL(mock_applevz, get_state(_))
         .WillRepeatedly(Return(mp::applevz::AppleVMState::stopped));
     EXPECT_CALL(mock_applevz_utils, convert_to_supported_format(_, _))
         .WillRepeatedly(ReturnArg<0>());
     EXPECT_CALL(mock_applevz_utils, resize_image(_, _)).WillRepeatedly(Return());
 
-    EXPECT_TRUE(
-        uut->clone_bare_vm({}, {}, src_vm_name, dest_vm_name, {}, stub_key_provider, stub_monitor));
+    EXPECT_TRUE(uut->clone_bare_vm({},
+                                   {.zone = "zone1"},
+                                   src_vm_name,
+                                   dest_vm_name,
+                                   {},
+                                   stub_key_provider,
+                                   stub_monitor));
 
     std::unordered_set<std::string> actual_files;
     for (const auto& file : fs::directory_iterator(dest_vm_dir))


### PR DESCRIPTION
This PR adds AZ support for the `applevz` backend in Multipass powered by Vmnet and the Apple Virtualization framework. An 'AZ' is not much different from a network bridge so there isn't much new stuff here. The most interesting bits are found in `void start_vmnet_interface(VmnetRelay& relay, const multipass::Subnet& subnet)` of `applevz_vmnet.mm` with the rest of the diff being scaffolding, code cleanup, and restructuring.

One other thing. Rather than deal with the added complexity of having the `applevz` feature work with and without the `avability_zones` feature, I've decided to make the former feature depend on the latter. `applevz` is an unreleased feature that either be released alongside AZs or after so I don't see any reason to go to the trouble of supporting both scenarios as well as the subsequent migration of VMs from a non-AZs environment to an AZ-enabled one.

## Performance testing

#### Server setup

```bash
# Host
iperf3 -s -D --logfile /tmp/iperf3-host.log

# foo VM
multipass exec foo -- sudo systemd-run --unit=iperf3-server /usr/bin/iperf3 -s

# bar VM
multipass exec bar -- sudo systemd-run --unit=iperf3-server /usr/bin/iperf3 -s
```

---

### Latency — VM -> host (ping, 20 packets, interval 0.2 s)

```bash
multipass exec foo -- ping -c 20 -i 0.2 192.168.252.1
```

| Metric (lower is better) | applevz | qemu |
|--------------------------|--------------|-----------|
| min (ms) | 0.16 | 0.16 |
| avg (ms) | 0.55 | 1.04 |
| max (ms) | 0.92 | 3.47 |

### Latency — host -> VM (ping, 20 packets, interval 0.2 s)

```bash
ping -c 20 -i 0.2 $FOO_IP
```

| Metric (lower is better) | applevz | qemu |
|--------------------------|--------------|-----------|
| min (ms) | 0.43 | 0.46 |
| avg (ms) | 0.88 | 0.75 |
| max (ms) | 1.71 | 1.95 |

### Latency — VM -> VM (ping, 20 packets, interval 0.2 s)

```bash
multipass exec foo -- ping -c 20 -i 0.2 $BAR_IP
```

| Metric (lower is better) | applevz | qemu |
|--------------------------|--------------|-----------|
| min (ms) | 0.33 | 0.35 |
| avg (ms) | 1.06 | 1.68 |
| max (ms) | 2.34 | 4.00 |

---

### TCP Throughput — VM -> host (4 parallel streams, 10 s)

```bash
# server: host (see setup above)
multipass exec foo -- iperf3 -c 192.168.252.1 -P 4 -t 10
```

| Metric | applevz | qemu |
|--------|--------------|-----------|
| sender (Gbits/s) (higher is better) | 8.63 | 3.33 |
| receiver (Gbits/s) (higher is better) | 8.62 | 3.32 |

### TCP Throughput — host -> VM (4 parallel streams, 10 s)

```bash
# server: foo VM (see setup above)
iperf3 -c $FOO_IP -P 4 -t 10
```

| Metric | applevz | qemu |
|--------|--------------|-----------|
| sender (Gbits/s) (higher is better) | 7.23 | 5.18 |
| receiver (Gbits/s) (higher is better) | 7.22 | 5.17 |
| retransmits (lower is better) | 1,381 | ~44,000 |

### TCP Throughput — VM -> VM (4 parallel streams, 10 s)

```bash
# server: bar VM (see setup above)
multipass exec foo -- iperf3 -c $BAR_IP -P 4 -t 10
```

| Metric | applevz | qemu |
|--------|--------------|-----------|
| sender (Gbits/s) (higher is better) | 7.62 | 3.16 |
| receiver (Gbits/s) (higher is better) | 7.61 | 3.16 |
| retransmits (lower is better) | 1,106 | ~11,700 |

---

MULTI-2262