### PR TITLE
[tics] TICs maintenance

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -45,6 +45,9 @@ jobs:
           python3-pip
         sudo --preserve-env apt-get build-dep --yes ./
 
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
     - name: Install cmake
       uses: lukka/get-cmake@v4.3.3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,7 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
     endif()
 
     add_custom_target(covreport
-      DEPENDS multipass_cpp_tests rust_coverage_tarpaulin
+      DEPENDS multipass_cpp_tests multipass_integration_tests rust_coverage_tarpaulin
       WORKING_DIRECTORY ${CMAKE_BUILD_DIR}
       COMMAND ${LCOV} --directory . --zerocounters
       COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target test

--- a/rxx/CMakeLists.txt
+++ b/rxx/CMakeLists.txt
@@ -147,16 +147,23 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
       COMMAND ${CARGO_CMD} install cargo-tarpaulin
     )
   endif()
+
+    # Isolate tarpaulin's target dir so its internal `cargo clean` doesn't wipe
+    # build/rxx/debug while cargo_build compiles into it
+    set(TARPAULIN_TARGET_DIR "${RUST_BUILD_DIR}-coverage")
+
     #Engine is for non-x86_64 processors. Can only use if return codes from test are always 0 + no fork or similar syscalls
     add_custom_target(rust_coverage_tarpaulin
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND ${CARGO_CMD} tarpaulin
+        --target-dir ${TARPAULIN_TARGET_DIR}
         --out Lcov
         --output-dir ${CMAKE_BINARY_DIR}
         --exclude-files '../*'
         --engine llvm
         --workspace
         ${TESTING_EXCLUDE_CRATES_ARG}
+      DEPENDS cargo_build
       COMMENT "Running Rust coverage with Tarpaulin"
     )
 endif()


### PR DESCRIPTION
Addressed build failures in TICS:
- Missing Rust toolchain
- Missing dependency on `multipass_integration_tests` in covreport
- Rust build race condition

---

MULTI-2671