### PR TITLE
[qemu] Disable GTK/SDL display backends

### DIFF
--- a/packaging/gui-less/snap/snapcraft.yaml
+++ b/packaging/gui-less/snap/snapcraft.yaml
@@ -268,6 +268,9 @@ parts:
     - --disable-libvduse
     - --disable-vduse-blk-export
     - --disable-dbus-display
+    - --disable-gtk
+    - --disable-sdl
+    - --disable-sdl-image
     - --firmwarepath=/snap/multipass/current/qemu/
     - --prefix=/usr
     - --libdir=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -284,6 +284,9 @@ parts:
     - --disable-libvduse
     - --disable-vduse-blk-export
     - --disable-dbus-display
+    - --disable-gtk
+    - --disable-sdl
+    - --disable-sdl-image
     - --firmwarepath=/snap/multipass/current/qemu/
     - --prefix=/usr
     - --libdir=/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR


### PR DESCRIPTION
Disable the GTK/SDL display backends in QEMU. These display rely on X11 dependencies that are not present in the Multipass snap, causing VM launch failures. See below:

```
[2026-06-16T13:06:47.914] [error] [qemu factory] Qemu fail: 'Process returned exit code: 127' with outputs:

/snap/multipass/17453/usr/bin/qemu-system-x86_64: error while loading shared libraries: libX11.so.6: cannot open shared object file: No such file or directory

launch failed: Internal error: qemu-system-x86_64 failed getting vmstate (Process returned exit code: 127) with output:
/snap/multipass/17453/usr/bin/qemu-system-x86_64: error while loading shared libraries: libX11.so.6: cannot open shared object file: No such file or directory
```