### PR TITLE
Bugfix/cli tests win fix event loop freeze

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -175,7 +175,7 @@ def pytest_addoption(parser):
             ("restart", 240),
             ("delete", 90),
             ("exec", 90),
-            ("start", 90),
+            ("start", 180),
             ("umount", 45),
         ],
         help="Per-command timeout override; may be given multiple times. "

--- a/tests/cli/controller/winsvc_multipassd_controller.py
+++ b/tests/cli/controller/winsvc_multipassd_controller.py
@@ -39,7 +39,7 @@ from cli.utilities import (
     StdoutAsyncSubprocess,
     SilentAsyncSubprocess,
     sudo,
-    run_detached_thread
+    run_detached_thread,
 )
 from cli.config import cfg
 from .controller_exceptions import ControllerPrerequisiteError
@@ -147,22 +147,34 @@ class WindowsServiceMultipassdController:
                 except Exception as ex:
                     msg = f"<unformatted event>: {ex}"
 
-                # Hand off to asyncio loop
-                loop.call_soon_threadsafe(
-                    q.put_nowait, msg.replace("\r\n", "\n"))
+                # Hand off to asyncio loop. In-flight callbacks can outlive the
+                # async generator teardown, so re-check `closing` and guard the
+                # scheduling in case the loop is already closing.
+                if closing.is_set():
+                    return
+                with suppress(RuntimeError):
+                    loop.call_soon_threadsafe(
+                        q.put_nowait, msg.replace("\r\n", "\n"))
 
         signal_event = None  # you can pass a Windows event for shutdown if you want
         flags = win32evtlog.EvtSubscribeToFutureEvents
         channel = "Application"
         query = "*[System[Provider[@Name='Multipass']]]"
 
-        sub = win32evtlog.EvtSubscribe(
-            ChannelPath=channel,
-            SignalEvent=signal_event,
-            Query=query,
-            Callback=callback,
-            Flags=flags
-        )
+        try:
+            sub = win32evtlog.EvtSubscribe(
+                ChannelPath=channel,
+                SignalEvent=signal_event,
+                Query=query,
+                Callback=callback,
+                Flags=flags
+            )
+        except Exception:
+            # Avoid leaking the publisher metadata handle if the subscription
+            # creation fails (e.g., permissions/invalid query).
+            with suppress(Exception):
+                pubmeta.Close()
+            raise
 
         def close_eventlog_handles():
             # EvtClose() can block while Windows/pywin32 waits for in-flight callbacks.

--- a/tests/cli/controller/winsvc_multipassd_controller.py
+++ b/tests/cli/controller/winsvc_multipassd_controller.py
@@ -31,12 +31,15 @@ import asyncio
 import re
 import sys
 import subprocess
+import threading
+from contextlib import suppress
 from typing import AsyncIterator, Optional
 
 from cli.utilities import (
     StdoutAsyncSubprocess,
     SilentAsyncSubprocess,
-    sudo
+    sudo,
+    run_detached_thread
 )
 from cli.config import cfg
 from .controller_exceptions import ControllerPrerequisiteError
@@ -124,12 +127,16 @@ class WindowsServiceMultipassdController:
 
         loop = asyncio.get_running_loop()
         q: asyncio.Queue[str] = asyncio.Queue()
+        closing = threading.Event()
 
         pubmeta = win32evtlog.EvtOpenPublisherMetadata(
             "Multipass",          # provider name
         )
 
         def callback(action, _, handle):
+            if closing.is_set():
+                return
+
             # action is one of the EVT_SUBSCRIBE_NOTIFY_* values.
             # We only care about new events.
             if action == win32evtlog.EvtSubscribeActionDeliver:
@@ -157,12 +164,25 @@ class WindowsServiceMultipassdController:
             Flags=flags
         )
 
+        def close_eventlog_handles():
+            # EvtClose() can block while Windows/pywin32 waits for in-flight callbacks.
+            # Keep that native wait off the asyncio loop thread. The thread is daemonized
+            # so a stuck EvtClose() cannot keep pytest alive.
+            with suppress(Exception):
+                sub.Close()
+
+            # Close publisher metadata only after the subscription close returns,
+            # because callbacks may still use it while EvtClose() drains.
+            with suppress(Exception):
+                pubmeta.Close()
+
         try:
             while True:
                 msg = await q.get()
                 yield msg
         finally:
-            sub.Close()
+            closing.set()
+            run_detached_thread("close-multipass-eventlog-subscription", close_eventlog_handles)
 
     async def is_active(self) -> bool:
         return await self._get_state() == "RUNNING"

--- a/tests/cli/utilities/__init__.py
+++ b/tests/cli/utilities/__init__.py
@@ -25,6 +25,7 @@ from .threadutils import (
     SilentAsyncSubprocess,
     StdoutAsyncSubprocess,
     wait_for_future,
+    run_detached_thread
 )
 from .functional import retry, wrap_call_if
 from .privutils import run_in_new_interpreter, run_in_new_interpreter_async, get_sudo_tool, sudo

--- a/tests/cli/utilities/threadutils.py
+++ b/tests/cli/utilities/threadutils.py
@@ -20,7 +20,7 @@ import threading
 import asyncio
 import time
 from concurrent.futures import Future
-from typing import Callable
+from typing import Callable, Any
 from contextlib import suppress
 
 
@@ -260,3 +260,17 @@ def wait_for_future(fut, timeout: float = 60, poll_interval: float = 0.5):
         raise TimeoutError(f"Operation timed out after {timeout} seconds")
 
     return fut.result()
+
+def run_detached_thread(name: str, target: Callable[[], Any]) -> threading.Thread:
+    """Run a synchronous callable on a detached daemon thread.
+
+    Intended for best-effort cleanup of blocking native calls where waiting for
+    completion would risk hanging pytest teardown.
+    """
+    thread = threading.Thread(
+        target=target,
+        name=name,
+        daemon=True,
+    )
+    thread.start()
+    return thread


### PR DESCRIPTION
Win: Avoid blocking the event loop on close
    
EvtClose can wait for in-flight callbacks, stalling pytest daemon teardown. Close the subscription on a detached daemon thread so pytest daemon teardown is not stalled if it blocks.