### PR TITLE
[macOS] Instance hostname resolution

### DIFF
--- a/include/multipass/base_dns_server.h
+++ b/include/multipass/base_dns_server.h
@@ -24,7 +24,7 @@
 
 namespace multipass
 {
-class DNSResolver
+class BaseDNSServer
 {
 public:
     // Maps instance name to its current IP address

--- a/include/multipass/dns_resolver.h
+++ b/include/multipass/dns_resolver.h
@@ -17,9 +17,17 @@
 
 #pragma once
 
+#include <multipass/ip_address.h>
+
+#include <functional>
+#include <optional>
+
 namespace multipass
 {
 class DNSResolver
 {
+public:
+    // Maps instance name to its current IP address
+    using Resolver = std::function<std::optional<IPAddress>(const std::string& hostname)>;
 };
 } // namespace multipass

--- a/include/multipass/dns_resolver.h
+++ b/include/multipass/dns_resolver.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+namespace multipass
+{
+class DNSResolver
+{
+};
+} // namespace multipass

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -19,8 +19,8 @@
 
 #include <multipass/alias_definition.h>
 #include <multipass/availability_zone_manager.h>
+#include <multipass/base_dns_server.h>
 #include <multipass/days.h>
-#include <multipass/dns_resolver.h>
 #include <multipass/logging/logger.h>
 #include <multipass/network_interface_info.h>
 #include <multipass/process/process.h>
@@ -101,7 +101,7 @@ logging::Logger::UPtr make_logger(logging::Level level);
 UpdatePrompt::UPtr make_update_prompt();
 std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& config);
 std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spec);
-std::unique_ptr<DNSResolver> make_dns_resolver(DNSResolver::Resolver resolver);
+std::unique_ptr<BaseDNSServer> make_dns_server(BaseDNSServer::Resolver resolver);
 
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 

--- a/include/multipass/platform.h
+++ b/include/multipass/platform.h
@@ -20,6 +20,7 @@
 #include <multipass/alias_definition.h>
 #include <multipass/availability_zone_manager.h>
 #include <multipass/days.h>
+#include <multipass/dns_resolver.h>
 #include <multipass/logging/logger.h>
 #include <multipass/network_interface_info.h>
 #include <multipass/process/process.h>
@@ -100,6 +101,8 @@ logging::Logger::UPtr make_logger(logging::Level level);
 UpdatePrompt::UPtr make_update_prompt();
 std::unique_ptr<Process> make_sshfs_server_process(const SSHFSServerConfig& config);
 std::unique_ptr<Process> make_process(std::unique_ptr<ProcessSpec>&& process_spec);
+std::unique_ptr<DNSResolver> make_dns_resolver(DNSResolver::Resolver resolver);
+
 int symlink_attr_from(const char* path, sftp_attributes_struct* attr);
 
 // Creates a function that will wait for signals or until the passed function returns false.

--- a/packaging/macos/postinstall-multipassd.sh.in
+++ b/packaging/macos/postinstall-multipassd.sh.in
@@ -17,6 +17,16 @@ chown -R root:wheel "${3}@CPACK_PACKAGING_INSTALL_PREFIX@"
 # Create log dir and ensure correct permissions
 mkdir -p "$3/Library/Logs/Multipass" -m 755
 
+# Install the DNS resolver for the *.multipass domain
+RESOLVER_DIR="$3/etc/resolver"
+RESOLVER_FILE="$RESOLVER_DIR/multipass"
+mkdir -p -m 755 "$RESOLVER_DIR"
+cat > "$RESOLVER_FILE" <<'EOF'
+nameserver 127.0.0.1
+port 5380
+EOF
+chmod 644 "$RESOLVER_FILE"
+
 # Install launch agent
 cp -v "$LAUNCH_AGENT_SRC" "$LAUNCH_AGENT_DEST"
 launchctl load -w "$LAUNCH_AGENT_DEST"

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -53,6 +53,9 @@ rm -fv "$LAUNCH_AGENT_DEST"
 rm -fv /usr/local/bin/multipass
 rm -rfv /Applications/Multipass.app
 
+# DNS resolver entry
+rm -fv "/etc/resolver/multipass"
+
 rm -rfv "/Library/Application Support/com.canonical.multipass"
 rm -rfv "/var/root/Library/Caches/multipassd"
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1508,6 +1508,9 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
 
 mp::Daemon::~Daemon()
 {
+    // Stop and join the DNS server first, before any member it might read is destroyed.
+    dns_server.reset();
+
     mp::top_catch_all(category, [this] {
         MP_SETTINGS.unregister_handler(instance_mod_handler);
         MP_SETTINGS.unregister_handler(snapshot_mod_handler);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1502,7 +1502,7 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
                 Qt::BlockingQueuedConnection);
             return ip;
         };
-        dns_resolver = mp::platform::make_dns_resolver(std::move(resolver));
+        dns_server = mp::platform::make_dns_server(std::move(resolver));
     });
 }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1485,6 +1485,25 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
         }
     });
     source_images_maintenance_task.start(config->image_refresh_timer);
+
+    mp::top_catch_all(category, [this] {
+        auto resolver = [this](const std::string& name) -> std::optional<mp::IPAddress> {
+            std::optional<mp::IPAddress> ip;
+            QMetaObject::invokeMethod(
+                this,
+                [this, &name, &ip] {
+                    if (auto it = operative_instances.find(name); it != operative_instances.end())
+                    {
+                        auto& vm = *it->second;
+                        if (MP_UTILS.is_running(vm.current_state()))
+                            ip = vm.management_ipv4();
+                    }
+                },
+                Qt::BlockingQueuedConnection);
+            return ip;
+        };
+        dns_resolver = mp::platform::make_dns_resolver(std::move(resolver));
+    });
 }
 
 mp::Daemon::~Daemon()

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -42,6 +42,7 @@ namespace multipass
 {
 struct DaemonConfig;
 class SettingsHandler;
+class DNSResolver;
 
 class Daemon : public QObject, public multipass::VMStatusMonitor
 {
@@ -287,5 +288,6 @@ private:
     SettingsHandler* snapshot_mod_handler;
     std::unordered_map<std::string, std::unordered_map<std::string, MountHandler::UPtr>> mounts;
     std::unordered_set<std::string> user_authorized_bridges;
+    std::unique_ptr<DNSResolver> dns_resolver;
 };
 } // namespace multipass

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -42,7 +42,7 @@ namespace multipass
 {
 struct DaemonConfig;
 class SettingsHandler;
-class DNSResolver;
+class BaseDNSServer;
 
 class Daemon : public QObject, public multipass::VMStatusMonitor
 {
@@ -288,6 +288,6 @@ private:
     SettingsHandler* snapshot_mod_handler;
     std::unordered_map<std::string, std::unordered_map<std::string, MountHandler::UPtr>> mounts;
     std::unordered_set<std::string> user_authorized_bridges;
-    std::unique_ptr<DNSResolver> dns_resolver;
+    std::unique_ptr<BaseDNSServer> dns_server;
 };
 } // namespace multipass

--- a/src/platform/backends/shared/macos/CMakeLists.txt
+++ b/src/platform/backends/shared/macos/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_library(shared_macos STATIC
   backend_utils.cpp
+  dns_server.cpp
   process_factory.cpp)
 
 include_directories(shared_macos

--- a/src/platform/backends/shared/macos/dns_server.cpp
+++ b/src/platform/backends/shared/macos/dns_server.cpp
@@ -20,7 +20,9 @@
 #include <multipass/format.h>
 #include <multipass/logging/log.h>
 
+#include <fcntl.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
 
 namespace mp = multipass;
@@ -184,7 +186,7 @@ mp::MacDNSServer::MacDNSServer(const std::string& domain, std::uint16_t port, Re
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 
-    if (bind(socket_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr) > 0))
+    if (bind(socket_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
     {
         const auto err = std::strerror(errno);
         close(socket_fd);
@@ -192,6 +194,26 @@ mp::MacDNSServer::MacDNSServer(const std::string& domain, std::uint16_t port, Re
         throw std::runtime_error{
             fmt::format("failed to bind socket on 127.0.0.1:{}: {}", port, err)};
     }
+
+    // macOS does not interrupt a blocked recvfrom()/poll() via shutdown() on an unconnected
+    // datagram socket, so `stop_pipe_write` is used to signal the `run` loop to terminate from the
+    // destructor.
+    int pipe_fds[2];
+    if (pipe(pipe_fds) < 0)
+    {
+        const auto err = std::strerror(errno);
+        close(socket_fd);
+        socket_fd = -1;
+        throw std::runtime_error(fmt::format("failed to create DNS stop pipe: {}", err));
+    }
+
+    stop_pipe_read = pipe_fds[0];
+    stop_pipe_write = pipe_fds[1];
+
+    // Stop child processes from inheriting the pipe fds
+    if (fcntl(stop_pipe_read, F_SETFD, FD_CLOEXEC) < 0 ||
+        fcntl(stop_pipe_write, F_SETFD, FD_CLOEXEC) < 0)
+        mpl::warn(category, "failed to set FD_CLOEXEC on DNS self pipe: {}", std::strerror(errno));
 
     listener = std::jthread{[this](std::stop_token stop_token) { run(std::move(stop_token)); }};
 
@@ -202,9 +224,19 @@ mp::MacDNSServer::~MacDNSServer()
 {
     listener.request_stop();
 
+    if (stop_pipe_write >= 0)
+    {
+        const char wake = 'x';
+        write(stop_pipe_write, &wake, 1); // Unblock poll()
+    }
+
     if (listener.joinable())
         listener.join();
 
+    if (stop_pipe_write >= 0)
+        close(stop_pipe_write);
+    if (stop_pipe_read >= 0)
+        close(stop_pipe_read);
     if (socket_fd >= 0)
         close(socket_fd);
 }
@@ -216,6 +248,22 @@ void mp::MacDNSServer::run(std::stop_token stop_token) noexcept
     // UDP socket communication loop
     while (!stop_token.stop_requested())
     {
+        pollfd fds[2]{{.fd = socket_fd, .events = POLLIN},
+                      {.fd = stop_pipe_read, .events = POLLIN}};
+
+        // Wait for DNS socket or self-pipe
+        if (const auto ready = poll(fds, 2, -1); ready < 0)
+        {
+            if (errno != EINTR)
+                mpl::debug(category, "poll failed: {}", std::strerror(errno));
+            continue;
+        }
+
+        if (fds[1].revents & POLLIN) // Shutdown requested via self-pipe
+            break;
+        if (!(fds[0].revents & POLLIN))
+            continue;
+
         sockaddr_in client{};
         socklen_t client_len = sizeof(client);
         const auto msg_len = recvfrom(socket_fd,

--- a/src/platform/backends/shared/macos/dns_server.cpp
+++ b/src/platform/backends/shared/macos/dns_server.cpp
@@ -17,15 +17,53 @@
 
 #include "dns_server.h"
 
+#include <multipass/format.h>
+#include <multipass/logging/log.h>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
 namespace mp = multipass;
+namespace mpl = multipass::logging;
+
+namespace
+{
+constexpr auto category = "dns";
+}
 
 mp::MacDNSServer::MacDNSServer(const std::string& domain, std::uint16_t port, Resolver resolver)
     : domain{domain}, resolver{std::move(resolver)}
 {
+    socket_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (socket_fd < 0)
+        throw std::runtime_error{
+            fmt::format("failed to create DNS server socket: {}", std::strerror(errno))};
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    if (bind(socket_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr) > 0))
+    {
+        const auto err = std::strerror(errno);
+        close(socket_fd);
+        socket_fd = -1;
+        throw std::runtime_error{
+            fmt::format("failed to bind socket on 127.0.0.1:{}: {}", port, err)};
+    }
+
+    listener = std::jthread{[this](std::stop_token stop_token) { run(std::move(stop_token)); }};
+
+    mpl::info(category, "DNS resolver listening on 127.0.0.1:{} for *.{}", port, domain);
 }
 
 mp::MacDNSServer::~MacDNSServer()
 {
+    listener.request_stop();
+
+    if (socket_fd >= 0)
+        close(socket_fd);
 }
 
 void mp::MacDNSServer::run(std::stop_token stop_token) noexcept

--- a/src/platform/backends/shared/macos/dns_server.cpp
+++ b/src/platform/backends/shared/macos/dns_server.cpp
@@ -176,6 +176,27 @@ void mp::MacDNSServer::run(std::stop_token stop_token) noexcept
             continue;
         }
 
+        std::optional<mp::IPAddress> ip;
+        if (query->qclass == qclass_in && query->qtype == qtype_a)
+        {
+            // Strip the trailing ".<domain>" to resolve the instance name.
+            const std::string suffix = "." + domain;
+            if (query->qname.size() > suffix.size() && query->qname.ends_with(suffix))
+            {
+                const auto instance_name =
+                    query->qname.substr(0, query->qname.size() - suffix.size());
+                try
+                {
+                    ip = resolver(instance_name);
+                }
+                catch (const std::exception& e)
+                    mpl::warn(category,
+                              "Unexpected error occured resolving an IP address for \"{}\": {}",
+                              instance_name,
+                              e.what());
+            }
+        }
+
         const auto resp = build_response();
 
         sendto(socket_fd,

--- a/src/platform/backends/shared/macos/dns_server.cpp
+++ b/src/platform/backends/shared/macos/dns_server.cpp
@@ -30,10 +30,78 @@ namespace
 {
 constexpr auto category = "dns";
 
+constexpr std::uint16_t qclass_in = 1;
 constexpr std::size_t max_udp_msg = 512; // As per RFC 1035
+constexpr std::size_t dns_header_len = 12;
+constexpr std::uint16_t qr_mask = 0x8000; // Header bit mask
 
-void parse_msg(const unsigned char* msg, std::size_t len)
+// Decoded DNS query message as described in RFC 1035
+// Only the required header and the question are parsed
+struct Query
 {
+    std::uint16_t id;
+    std::uint16_t flags;
+    std::string qname;
+    std::uint16_t qtype;
+    std::uint16_t qclass;
+    std::size_t question_end;
+};
+
+std::uint16_t read_u16(std::span<const unsigned char> p)
+{
+    return static_cast<std::uint16_t>((p[0] << 8) | p[1]);
+}
+
+std::optional<Query> parse_msg(std::spane<const unsigned char> msg)
+{
+    const auto len = msg.size();
+    if (len < dns_header_len) // Invalid length for DNS header
+        return std::nullopt;
+
+    Query q{};
+    q.id = read_u16(msg);        // first byte
+    q.flags = read_u16(msg.subspan(2)); // next 2 bytes
+    const auto qdcount = read_u16(msg.subspan(4));
+
+    // msg type is query (0) and verify only one question
+    // https://www.ietf.org/archive/id/draft-bellis-dnsop-qdcount-is-one-00.html#name-updates-to-rfc-1035
+    if ((q.flags & qr_mask != 0) || qdcount != 1)
+        return std::nullopt;
+
+    // Parse the labels in the message
+    std::size_t pos = dns_header_len;
+    std::string name;
+    while (true)
+    {
+        if (pos >= len) // Invalid label length
+            return std::nullopt;
+
+        const unsigned char label_len = msg[pos++];
+        if (label_len == 0) // 0 means we found the root label
+            break;
+        if ((label_len & 0xc0) !=
+            0) // reject if compression pointer or reserved bits; signified by the top 2 bits
+            return std::nullopt;
+        if (pos + label_len > len) // Data does not equal label length
+            return std::nullopt;
+
+        if (!name.empty())
+            name.push_back('.');
+        std::ranges::transform(msg.subspan(pos, label_len),
+                               std::back_inserter(name),
+                               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        pos += label_len;
+    }
+
+    if (pos + 4 > len) // Invalid number of bytes left after root label
+        return std::nullopt;
+
+    q.qname = std::move(name);
+    q.qtype = read_u16(msg.subspan(pos));
+    q.qclass = read_u16(msg.subspan(pos + 2));
+    q.question_end = pos + 4;
+
+    return q;
 }
 
 std::vector<unsigned char> build_response()
@@ -100,7 +168,13 @@ void mp::MacDNSServer::run(std::stop_token stop_token) noexcept
             continue;
         }
 
-        parse_msg(buffer.data(), static_cast<std::size_t>(msg_len));
+        const auto datagram = std::span{buffer}.first(static_cast<std::size_t>(received));
+        const auto query = parse_msg(buffer.data(), static_cast<std::size_t>(msg_len));
+        if (!query)
+        {
+            mpl::debug(category, "Failed to parse message");
+            continue;
+        }
 
         const auto resp = build_response();
 

--- a/src/platform/backends/shared/macos/dns_server.cpp
+++ b/src/platform/backends/shared/macos/dns_server.cpp
@@ -30,10 +30,17 @@ namespace
 {
 constexpr auto category = "dns";
 
+// RFC 1035 constants
+constexpr std::uint16_t qtype_a = 1;
 constexpr std::uint16_t qclass_in = 1;
-constexpr std::size_t max_udp_msg = 512; // As per RFC 1035
+constexpr std::size_t max_udp_msg = 512;
 constexpr std::size_t dns_header_len = 12;
-constexpr std::uint16_t qr_mask = 0x8000; // Header bit mask
+constexpr std::uint32_t answer_ttl = 0; // Do not let client cache IPs
+
+// Header flags/masks
+constexpr std::uint16_t qr_mask = 0x8000;            // Header bit mask
+constexpr std::uint16_t authoritative_flag = 0x0400; // AA = 1
+constexpr std::uint16_t rcode_nxdomain = 0x0003;     // RCODE = 3
 
 // Decoded DNS query message as described in RFC 1035
 // Only the required header and the question are parsed
@@ -52,7 +59,25 @@ std::uint16_t read_u16(std::span<const unsigned char> p)
     return static_cast<std::uint16_t>((p[0] << 8) | p[1]);
 }
 
-std::optional<Query> parse_msg(std::spane<const unsigned char> msg)
+void append_u16(std::vector<unsigned char>& out, std::uint16_t val)
+{
+    out.push_back(static_cast<unsigned char>(val >> 8));
+    out.push_back(static_cast<unsigned char>(val & 0xff));
+}
+
+void append_u32(std::vector<unsigned char>& out, std::uint32_t val)
+{
+    out.push_back(static_cast<unsigned char>((val >> 24) & 0xff));
+    out.push_back(static_cast<unsigned char>((val >> 16) & 0xff));
+    out.push_back(static_cast<unsigned char>((val >> 8) & 0xff));
+    out.push_back(static_cast<unsigned char>(val & 0xff));
+}
+
+// Parses a raw DNS message into a Query object
+//
+// We put extra care into verifying the message form because this comes from a UDP socket that is
+// connectionless and spoofable
+std::optional<Query> parse_msg(std::span<const unsigned char> msg)
 {
     const auto len = msg.size();
     if (len < dns_header_len) // Invalid length for DNS header
@@ -65,7 +90,7 @@ std::optional<Query> parse_msg(std::spane<const unsigned char> msg)
 
     // msg type is query (0) and verify only one question
     // https://www.ietf.org/archive/id/draft-bellis-dnsop-qdcount-is-one-00.html#name-updates-to-rfc-1035
-    if ((q.flags & qr_mask != 0) || qdcount != 1)
+    if ((q.flags & qr_mask) != 0 || qdcount != 1)
         return std::nullopt;
 
     // Parse the labels in the message
@@ -104,9 +129,45 @@ std::optional<Query> parse_msg(std::spane<const unsigned char> msg)
     return q;
 }
 
-std::vector<unsigned char> build_response()
+// Build a DNS response message for the given parsed query
+//
+// The response always echoes back the original question section verbatim so the client can match
+// the reply to its question
+std::vector<unsigned char> build_response(std::span<const unsigned char> query,
+                                          const Query& q,
+                                          const std::optional<mp::IPAddress>& ip)
 {
-    return {};
+    std::vector<unsigned char> retval;
+    retval.reserve(q.question_end + 16); // Answer record is 16 bytes long
+
+    const bool resolved = ip.has_value();
+    std::uint16_t flags = qr_mask | authoritative_flag | (q.flags & 0x0100); // preserve RD
+    if (!resolved)
+        flags |= rcode_nxdomain;
+
+    append_u16(retval, q.id);
+    append_u16(retval, flags);
+    append_u16(retval, 1);                // QDCOUNT
+    append_u16(retval, resolved ? 1 : 0); // ANCOUNT
+    append_u16(retval, 0);                // NSCOUNT
+    append_u16(retval, 0);                // ARCOUNT
+
+    // Echo the question section verbatim
+    retval.insert(retval.end(), query.begin() + dns_header_len, query.begin() + q.question_end);
+
+    if (resolved)
+    {
+        append_u16(retval, 0xc00c);     // NAME: internal pointer to the question name at offset 12
+        append_u16(retval, qtype_a);    // TYPE: A
+        append_u16(retval, qclass_in);  // CLASS: IN
+        append_u32(retval, answer_ttl); // TTL
+        append_u16(retval, 4);          // RDLENGTH
+
+        // insert IP address octets
+        retval.insert(retval.end(), ip->octets.begin(), ip->octets.end());
+    }
+
+    return retval;
 }
 }
 
@@ -141,6 +202,9 @@ mp::MacDNSServer::~MacDNSServer()
 {
     listener.request_stop();
 
+    if (listener.joinable())
+        listener.join();
+
     if (socket_fd >= 0)
         close(socket_fd);
 }
@@ -168,8 +232,8 @@ void mp::MacDNSServer::run(std::stop_token stop_token) noexcept
             continue;
         }
 
-        const auto datagram = std::span{buffer}.first(static_cast<std::size_t>(received));
-        const auto query = parse_msg(buffer.data(), static_cast<std::size_t>(msg_len));
+        const auto datagram = std::span{buffer}.first(static_cast<std::size_t>(msg_len));
+        const auto query = parse_msg(datagram);
         if (!query)
         {
             mpl::debug(category, "Failed to parse message");
@@ -190,14 +254,16 @@ void mp::MacDNSServer::run(std::stop_token stop_token) noexcept
                     ip = resolver(instance_name);
                 }
                 catch (const std::exception& e)
+                {
                     mpl::warn(category,
                               "Unexpected error occured resolving an IP address for \"{}\": {}",
                               instance_name,
                               e.what());
+                }
             }
         }
 
-        const auto resp = build_response();
+        const auto resp = build_response(datagram, *query, ip);
 
         sendto(socket_fd,
                resp.data(),

--- a/src/platform/backends/shared/macos/dns_server.cpp
+++ b/src/platform/backends/shared/macos/dns_server.cpp
@@ -86,7 +86,7 @@ std::optional<Query> parse_msg(std::span<const unsigned char> msg)
         return std::nullopt;
 
     Query q{};
-    q.id = read_u16(msg);        // first byte
+    q.id = read_u16(msg);               // first byte
     q.flags = read_u16(msg.subspan(2)); // next 2 bytes
     const auto qdcount = read_u16(msg.subspan(4));
 
@@ -171,7 +171,7 @@ std::vector<unsigned char> build_response(std::span<const unsigned char> query,
 
     return retval;
 }
-}
+} // namespace
 
 mp::MacDNSServer::MacDNSServer(const std::string& domain, std::uint16_t port, Resolver resolver)
     : domain{domain}, resolver{std::move(resolver)}

--- a/src/platform/backends/shared/macos/dns_server.cpp
+++ b/src/platform/backends/shared/macos/dns_server.cpp
@@ -29,6 +29,17 @@ namespace mpl = multipass::logging;
 namespace
 {
 constexpr auto category = "dns";
+
+constexpr std::size_t max_udp_msg = 512; // As per RFC 1035
+
+void parse_msg(const unsigned char* msg, std::size_t len)
+{
+}
+
+std::vector<unsigned char> build_response()
+{
+    return {};
+}
 }
 
 mp::MacDNSServer::MacDNSServer(const std::string& domain, std::uint16_t port, Resolver resolver)
@@ -68,4 +79,36 @@ mp::MacDNSServer::~MacDNSServer()
 
 void mp::MacDNSServer::run(std::stop_token stop_token) noexcept
 {
+    std::array<unsigned char, max_udp_msg> buffer{};
+
+    // UDP socket communication loop
+    while (!stop_token.stop_requested())
+    {
+        sockaddr_in client{};
+        socklen_t client_len = sizeof(client);
+        const auto msg_len = recvfrom(socket_fd,
+                                      buffer.data(),
+                                      buffer.size(),
+                                      0,
+                                      reinterpret_cast<sockaddr*>(&client),
+                                      &client_len);
+
+        if (msg_len <= 0)
+        {
+            if (msg_len < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+                mpl::debug(category, "recvfrom failed: {}", std::strerror(errno));
+            continue;
+        }
+
+        parse_msg(buffer.data(), static_cast<std::size_t>(msg_len));
+
+        const auto resp = build_response();
+
+        sendto(socket_fd,
+               resp.data(),
+               resp.size(),
+               0,
+               reinterpret_cast<sockaddr*>(&client),
+               client_len);
+    }
 }

--- a/src/platform/backends/shared/macos/dns_server.cpp
+++ b/src/platform/backends/shared/macos/dns_server.cpp
@@ -15,21 +15,19 @@
  *
  */
 
-#pragma once
+#include "dns_server.h"
 
-#include <multipass/ip_address.h>
+namespace mp = multipass;
 
-#include <functional>
-#include <optional>
-
-namespace multipass
+mp::MacDNSServer::MacDNSServer(const std::string& domain, std::uint16_t port, Resolver resolver)
+    : domain{domain}, resolver{std::move(resolver)}
 {
-class BaseDNSServer
-{
-public:
-    // Maps instance name to its current IP address
-    using Resolver = std::function<std::optional<IPAddress>(const std::string& hostname)>;
+}
 
-    virtual ~BaseDNSServer() = default;
-};
-} // namespace multipass
+mp::MacDNSServer::~MacDNSServer()
+{
+}
+
+void mp::MacDNSServer::run(std::stop_token stop_token) noexcept
+{
+}

--- a/src/platform/backends/shared/macos/dns_server.h
+++ b/src/platform/backends/shared/macos/dns_server.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <multipass/disabled_copy_move.h>
 #include <multipass/base_dns_server.h>
+#include <multipass/disabled_copy_move.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/platform/backends/shared/macos/dns_server.h
+++ b/src/platform/backends/shared/macos/dns_server.h
@@ -36,12 +36,12 @@ class MacDNSServer : public BaseDNSServer, private DisabledCopyMove
 {
 public:
     MacDNSServer(const std::string& domain, std::uint16_t port, Resolver resolver);
+    ~MacDNSServer() override;
 
 private:
     void run(std::stop_token stop_token) noexcept;
 
     const std::string domain;
-    const std::uint16_t port;
     const Resolver resolver;
     int socket_fd{-1};
     std::jthread listener;

--- a/src/platform/backends/shared/macos/dns_server.h
+++ b/src/platform/backends/shared/macos/dns_server.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <multipass/disabled_copy_move.h>
+#include <multipass/base_dns_server.h>
+
+#include <cstdint>
+#include <optional>
+#include <stop_token>
+#include <string>
+#include <thread>
+
+namespace multipass
+{
+// A minimal authoritative DNS responder for a single custom domain (e.g. "multipass"),
+// answering A-record queries for "<name>.<domain>" on a loopback UDP port. Intended to be
+// paired with an `/etc/resolver/<domain>` file so the macOS system resolver forwards
+// matching queries here.
+class MacDNSServer : public BaseDNSServer, private DisabledCopyMove
+{
+public:
+    MacDNSServer(const std::string& domain, std::uint16_t port, Resolver resolver);
+
+private:
+    void run(std::stop_token stop_token) noexcept;
+
+    const std::string domain;
+    const std::uint16_t port;
+    const Resolver resolver;
+    int socket_fd{-1};
+    std::jthread listener;
+};
+} // namespace multipass

--- a/src/platform/backends/shared/macos/dns_server.h
+++ b/src/platform/backends/shared/macos/dns_server.h
@@ -45,5 +45,9 @@ private:
     const Resolver resolver;
     int socket_fd{-1};
     std::jthread listener;
+
+    // Self-pipe
+    int stop_pipe_read{-1};
+    int stop_pipe_write{-1};
 };
 } // namespace multipass

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -476,7 +476,7 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
     return std::make_unique<DisabledUpdatePrompt>();
 }
 
-std::unique_ptr<mp::DNSResolver> mp::platform::make_dns_resolver(mp::DNSResolver::Resolver)
+std::unique_ptr<mp::BaseDNSServer> mp::platform::make_dns_server(mp::BaseDNSServer::Resolver)
 {
     return nullptr;
 }

--- a/src/platform/platform_linux.cpp
+++ b/src/platform/platform_linux.cpp
@@ -476,6 +476,11 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
     return std::make_unique<DisabledUpdatePrompt>();
 }
 
+std::unique_ptr<mp::DNSResolver> mp::platform::make_dns_resolver(mp::DNSResolver::Resolver)
+{
+    return nullptr;
+}
+
 mp::logging::Logger::UPtr mp::platform::make_logger(mp::logging::Level level)
 {
 #if MULTIPASS_JOURNALD_ENABLED

--- a/src/platform/platform_osx.cpp
+++ b/src/platform/platform_osx.cpp
@@ -369,7 +369,8 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
 std::unique_ptr<mp::BaseDNSServer> mp::platform::make_dns_server(
     mp::BaseDNSServer::Resolver resolver)
 {
-    return nullptr;
+    constexpr std::uint16_t hostname_port = 5380;
+    return std::make_unique<mp::MacDNSServer>("multipass", hostname_port, std::move(resolver));
 }
 
 bool mp::platform::Platform::link(const char* target, const char* link) const

--- a/src/platform/platform_osx.cpp
+++ b/src/platform/platform_osx.cpp
@@ -365,6 +365,11 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
     return std::make_unique<DefaultUpdatePrompt>();
 }
 
+std::unique_ptr<mp::DNSResolver> mp::platform::make_dns_resolver(mp::DNSResolver::Resolver resolver)
+{
+    return nullptr;
+}
+
 bool mp::platform::Platform::link(const char* target, const char* link) const
 {
     QFileInfo file_info{target};

--- a/src/platform/platform_osx.cpp
+++ b/src/platform/platform_osx.cpp
@@ -39,6 +39,7 @@
 #include "backends/applevz/applevz_virtual_machine_factory.h"
 #endif
 
+#include "shared/macos/dns_server.h"
 #include "shared/macos/process_factory.h"
 #include "shared/sshfs_server_process_spec.h"
 #include <daemon/default_vm_image_vault.h>
@@ -365,7 +366,8 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
     return std::make_unique<DefaultUpdatePrompt>();
 }
 
-std::unique_ptr<mp::DNSResolver> mp::platform::make_dns_resolver(mp::DNSResolver::Resolver resolver)
+std::unique_ptr<mp::BaseDNSServer> mp::platform::make_dns_server(
+    mp::BaseDNSServer::Resolver resolver)
 {
     return nullptr;
 }

--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -958,6 +958,11 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
     return std::make_unique<DefaultUpdatePrompt>();
 }
 
+std::unique_ptr<mp::DNSResolver> mp::platform::make_dns_resolver(mp::DNSResolver::Resolver)
+{
+    return nullptr;
+}
+
 int mp::platform::Platform::chown(const char* path, unsigned int uid, unsigned int gid) const
 {
     logging::trace(log_category,

--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -958,7 +958,7 @@ mp::UpdatePrompt::UPtr mp::platform::make_update_prompt()
     return std::make_unique<DefaultUpdatePrompt>();
 }
 
-std::unique_ptr<mp::DNSResolver> mp::platform::make_dns_resolver(mp::DNSResolver::Resolver)
+std::unique_ptr<mp::BaseDNSServer> mp::platform::make_dns_server(mp::BaseDNSServer::Resolver)
 {
     return nullptr;
 }


### PR DESCRIPTION
This PR implements a DNS resolver that allows the system's mDNSResponder to forward `.multipass` DNS requests to a thread being run by the Multipass daemon.

Requests come through a UDP socket and the requested hostname has its IP address queried by the Multipass daemon.

This is an MVP solution that provides most of the functionality of instance hostname resolution, but lacks a few potentially useful features such as IPv6 support and reverse lookups. If this direction was to be closen, some further development would be done along with proper unit testing.