### PR TITLE
[dnsmasq] Get_ip_for: Skip IPs from unserved range

### DIFF
--- a/src/platform/backends/qemu/linux/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/linux/dnsmasq_server.cpp
@@ -36,6 +36,7 @@ namespace mpl = multipass::logging;
 namespace
 {
 constexpr auto immediate_wait = 100; // period to wait for immediate dnsmasq failures, in ms
+constexpr auto log_category = "dnsmasq";
 
 auto make_dnsmasq_process(const mp::Path& data_dir,
                           const mp::BridgeSubnetList& subnets,
@@ -85,17 +86,17 @@ mp::DNSMasqServer::~DNSMasqServer()
     {
         QObject::disconnect(finish_connection);
 
-        mpl::debug("dnsmasq", "terminating");
+        mpl::debug(log_category, "terminating");
         dnsmasq_cmd->terminate();
 
         if (!dnsmasq_cmd->wait_for_finished(terminate_timeout))
         {
-            mpl::info("dnsmasq", "failed to terminate nicely, killing");
+            mpl::info(log_category, "failed to terminate nicely, killing");
             dnsmasq_cmd->kill();
 
             if (!dnsmasq_cmd->wait_for_finished(kill_timeout))
             {
-                mpl::warn("dnsmasq", "failed to kill (timed out)");
+                mpl::warn(log_category, "failed to kill (timed out)");
             }
         }
     }
@@ -124,6 +125,8 @@ std::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const std::string& hw
                 // address; skip it so we resolve the current, reachable one instead.
                 if (ip_in_served_subnets(subnets, ip))
                     return ip;
+                // TODO: Also check if the lease is still valid
+                // TODO: Aggregate all leases for the MAC before filtering
             }
             catch (const std::exception&) // unparseable address -> skip this line
             {
@@ -138,7 +141,7 @@ void mp::DNSMasqServer::release_mac(const std::string& hw_addr, const QString& b
     auto ip = get_ip_for(hw_addr);
     if (!ip)
     {
-        mpl::warn("dnsmasq", "attempting to release non-existent addr: {}", hw_addr);
+        mpl::warn(log_category, "attempting to release non-existent addr: {}", hw_addr);
         return;
     }
 
@@ -146,7 +149,7 @@ void mp::DNSMasqServer::release_mac(const std::string& hw_addr, const QString& b
     QObject::connect(&dhcp_release,
                      &QProcess::errorOccurred,
                      [&ip, &hw_addr](QProcess::ProcessError error) {
-                         mpl::warn("dnsmasq",
+                         mpl::warn(log_category,
                                    "failed to release ip addr {} with mac {}: {}",
                                    ip.value().as_string(),
                                    hw_addr,
@@ -157,7 +160,7 @@ void mp::DNSMasqServer::release_mac(const std::string& hw_addr, const QString& b
         if (exit_code == 0 && exit_status == QProcess::NormalExit)
             return;
 
-        mpl::warn("dnsmasq",
+        mpl::warn(log_category,
                   "failed to release ip addr {} with mac {}, exit_code: {}",
                   ip.value().as_string(),
                   hw_addr,
@@ -180,7 +183,7 @@ void mp::DNSMasqServer::check_dnsmasq_running()
 {
     if (!dnsmasq_cmd->running())
     {
-        mpl::warn("dnsmasq", "Not running");
+        mpl::warn(log_category, "Not running");
         start_dnsmasq();
     }
 }
@@ -207,7 +210,7 @@ std::string dnsmasq_failure_msg(const mp::ProcessState& state)
 
 void mp::DNSMasqServer::start_dnsmasq()
 {
-    mpl::debug("dnsmasq", "Starting dnsmasq");
+    mpl::debug(log_category, "Starting dnsmasq");
 
     finish_connection =
         QObject::connect(dnsmasq_cmd.get(), &mp::Process::finished, [](const ProcessState& state) {

--- a/src/platform/backends/qemu/linux/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/linux/dnsmasq_server.cpp
@@ -26,6 +26,7 @@
 
 #include <QDir>
 
+#include <algorithm>
 #include <chrono>
 #include <fstream>
 
@@ -43,10 +44,19 @@ auto make_dnsmasq_process(const mp::Path& data_dir,
     auto process_spec = std::make_unique<mp::DNSMasqProcessSpec>(data_dir, subnets, conf_file_path);
     return MP_PROCFACTORY.create_process(std::move(process_spec));
 }
+
+bool ip_in_served_subnets(const mp::BridgeSubnetList& subnets, const mp::IPAddress& ip)
+{
+    return std::ranges::any_of(subnets, [&ip](const auto& bridge_subnet) {
+        return bridge_subnet.second.contains(ip);
+    });
+}
 } // namespace
 
 mp::DNSMasqServer::DNSMasqServer(const Path& data_dir, const BridgeSubnetList& subnets)
-    : data_dir{data_dir}, conf_file{QDir(data_dir).absoluteFilePath("dnsmasq-XXXXXX.conf")}
+    : data_dir{data_dir},
+      subnets{subnets},
+      conf_file{QDir(data_dir).absoluteFilePath("dnsmasq-XXXXXX.conf")}
 {
     if (!conf_file.open())
         throw std::runtime_error("unable to create temporary dnsmasq conf file");
@@ -105,7 +115,20 @@ std::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const std::string& hw
     {
         const auto fields = mp::utils::split(line, delimiter);
         if (fields.size() > 2 && fields[hw_addr_idx] == hw_addr)
-            return IPAddress{fields[ipv4_idx]};
+        {
+            try
+            {
+                const IPAddress ip{fields[ipv4_idx]};
+                // Ignore leases outside the subnets we currently serve. A version upgrade that
+                // changes the bridge layout can leave an old lease pointing at an unreachable
+                // address; skip it so we resolve the current, reachable one instead.
+                if (ip_in_served_subnets(subnets, ip))
+                    return ip;
+            }
+            catch (const std::exception&) // unparseable address -> skip this line
+            {
+            }
+        }
     }
     return std::nullopt;
 }

--- a/src/platform/backends/qemu/linux/dnsmasq_server.cpp
+++ b/src/platform/backends/qemu/linux/dnsmasq_server.cpp
@@ -128,8 +128,12 @@ std::optional<mp::IPAddress> mp::DNSMasqServer::get_ip_for(const std::string& hw
                 // TODO: Also check if the lease is still valid
                 // TODO: Aggregate all leases for the MAC before filtering
             }
-            catch (const std::exception&) // unparseable address -> skip this line
+            catch (const std::invalid_argument& ex) // unparseable address -> skip this line
             {
+                mpl::debug(log_category,
+                           "Could not parse `{}` as IPv4 address: {}, ignoring lease line",
+                           fields[ipv4_idx],
+                           ex.what());
             }
         }
     }

--- a/src/platform/backends/qemu/linux/dnsmasq_server.h
+++ b/src/platform/backends/qemu/linux/dnsmasq_server.h
@@ -54,6 +54,7 @@ private:
     void start_dnsmasq();
 
     const QString data_dir;
+    const BridgeSubnetList subnets;
     std::unique_ptr<Process> dnsmasq_cmd;
     QMetaObject::Connection finish_connection;
     QTemporaryFile conf_file;

--- a/tests/unit/qemu/linux/test_dnsmasq_server.cpp
+++ b/tests/unit/qemu/linux/test_dnsmasq_server.cpp
@@ -93,7 +93,7 @@ struct DNSMasqServer : public mpt::TestWithMockedBinPath
     const mp::Subnet error_subnet{
         "0.0.0.0/24"}; // This forces the mock dnsmasq process to exit with error
     const std::string hw_addr{"00:01:02:03:04:05"};
-    const mp::IPAddress expected_ip{"10.177.224.22"};
+    const mp::IPAddress expected_ip{"192.168.64.22"}; // within default_subnet (192.168.64.0/24)
 
     [[nodiscard]] static mp::BridgeSubnetList make_subnets(const QString& bridge,
                                                            const mp::Subnet& subnet)
@@ -139,6 +139,108 @@ TEST_F(DNSMasqServer, returnsNullIpWhenLeasesFileDoesNotExist)
     auto ip = dns.get_ip_for(hw_addr);
 
     EXPECT_FALSE(ip);
+}
+
+TEST_F(DNSMasqServer, getIpForSkipsStaleLeaseAndReturnsLiveOne)
+{
+    // Regression (MULTI-2701 follow-up): a version upgrade can change the served subnet, leaving a
+    // stale lease pointing at an unreachable old-subnet address ahead of the current one for a MAC.
+    // get_ip_for must skip the out-of-subnet lease and resolve the reachable address instead.
+    const mp::IPAddress live_ip{"192.168.64.60"}; // within default_subnet (192.168.64.0/24)
+    mpt::make_file_with_content(
+        QDir{data_dir.path()}.filePath("dnsmasq.leases"),
+        fmt::format("0 {} 10.130.128.252 old_name *\n0 {} {} upg-lifecycle *\n",
+                    hw_addr,
+                    hw_addr,
+                    live_ip.as_string()));
+
+    auto dns = make_default_dnsmasq_server();
+
+    auto ip = dns.get_ip_for(hw_addr);
+    ASSERT_TRUE(ip);
+    EXPECT_EQ(ip.value(), live_ip);
+}
+
+TEST_F(DNSMasqServer, getIpForReturnsNullWhenOnlyStaleLeaseExists)
+{
+    // The sole lease for this MAC is outside every served subnet, so there is no reachable address
+    // to hand back.
+    mpt::make_file_with_content(QDir{data_dir.path()}.filePath("dnsmasq.leases"),
+                                fmt::format("0 {} 10.130.128.252 old_name *\n", hw_addr));
+
+    auto dns = make_default_dnsmasq_server();
+
+    EXPECT_FALSE(dns.get_ip_for(hw_addr));
+}
+
+TEST_F(DNSMasqServer, getIpForResolvesLeasesAtSubnetBoundaries)
+{
+    // Legitimate leases at the first and last usable addresses of the served subnet must resolve -
+    // the subnet-membership check must not exclude its own boundaries.
+    const std::string other_hw{"00:aa:bb:cc:dd:ee"};
+    const mp::IPAddress first_ip{"192.168.64.1"};
+    const mp::IPAddress last_ip{"192.168.64.254"};
+    mpt::make_file_with_content(QDir{data_dir.path()}.filePath("dnsmasq.leases"),
+                                fmt::format("0 {} {} vm-low *\n0 {} {} vm-high *\n",
+                                            hw_addr,
+                                            first_ip.as_string(),
+                                            other_hw,
+                                            last_ip.as_string()));
+
+    auto dns = make_default_dnsmasq_server();
+
+    auto low = dns.get_ip_for(hw_addr);
+    ASSERT_TRUE(low);
+    EXPECT_EQ(low.value(), first_ip);
+
+    auto high = dns.get_ip_for(other_hw);
+    ASSERT_TRUE(high);
+    EXPECT_EQ(high.value(), last_ip);
+}
+
+TEST_F(DNSMasqServer, getIpForResolvesLeaseInAnyServedSubnet)
+{
+    // With several served subnets, a lease is legitimate if it belongs to *any* of them; the same
+    // lease is filtered out once that subnet is no longer served.
+    const mp::Subnet second_subnet{"192.168.65.0/24"};
+    const mp::IPAddress ip_in_second{"192.168.65.40"};
+    mpt::make_file_with_content(
+        QDir{data_dir.path()}.filePath("dnsmasq.leases"),
+        fmt::format("0 {} {} vm-second *\n", hw_addr, ip_in_second.as_string()));
+
+    mp::DNSMasqServer serving_both{
+        data_dir.path(),
+        {{dummy_bridge, default_subnet}, {QStringLiteral("second-bridge"), second_subnet}}};
+    auto resolved = serving_both.get_ip_for(hw_addr);
+    ASSERT_TRUE(resolved);
+    EXPECT_EQ(resolved.value(), ip_in_second);
+
+    auto dns_default = make_default_dnsmasq_server(); // no longer serves 192.168.65.0/24
+    EXPECT_FALSE(dns_default.get_ip_for(hw_addr));
+}
+
+TEST_F(DNSMasqServer, getIpForIgnoresNonIpv4AndMalformedLines)
+{
+    // A real leases file can start with a duid line and hold IPv6 entries or truncated/garbled
+    // lines. None of these should crash the lookup, and a valid in-subnet lease elsewhere in the
+    // file must still resolve. A matching MAC whose address field is unparseable is skipped, not
+    // fatal.
+    const mp::IPAddress live_ip{"192.168.64.70"};
+    mpt::make_file_with_content(QDir{data_dir.path()}.filePath("dnsmasq.leases"),
+                                fmt::format("duid 00:01:00:01:29:6c:5e:0e:52:54:00:12:34:56\n"
+                                            "1700000000 123456 fdaa::1234 vm-v6 00:01:00:01:29:6c\n"
+                                            "garbage\n"
+                                            "0 {} not-an-ip broken *\n"
+                                            "0 {} {} vm-live *\n",
+                                            hw_addr,
+                                            hw_addr,
+                                            live_ip.as_string()));
+
+    auto dns = make_default_dnsmasq_server();
+
+    auto ip = dns.get_ip_for(hw_addr);
+    ASSERT_TRUE(ip);
+    EXPECT_EQ(ip.value(), live_ip);
 }
 
 TEST_F(DNSMasqServer, releaseMacReleasesIp)

--- a/tests/unit/qemu/linux/test_dnsmasq_server.cpp
+++ b/tests/unit/qemu/linux/test_dnsmasq_server.cpp
@@ -141,7 +141,7 @@ TEST_F(DNSMasqServer, returnsNullIpWhenLeasesFileDoesNotExist)
     EXPECT_FALSE(ip);
 }
 
-TEST_F(DNSMasqServer, getIpForSkipsStaleLeaseAndReturnsLiveOne)
+TEST_F(DNSMasqServer, getIpForSkipsStaleSubnetLeaseAndReturnsLiveOne)
 {
     // Regression (MULTI-2701 follow-up): a version upgrade can change the served subnet, leaving a
     // stale lease pointing at an unreachable old-subnet address ahead of the current one for a MAC.


### PR DESCRIPTION
The previous implementation returned the first matching entry for the given MAC address, which could be from an old bridge that's been served before. This patch ensures that get_ip_for skips the lease entries that are not in the served subnets.