### PR TITLE
[gui] Avoid divide by 0 error caused by overflow

### DIFF
--- a/src/client/gui/lib/catalogue/catalogue.dart
+++ b/src/client/gui/lib/catalogue/catalogue.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:basics/basics.dart';
 import 'package:collection/collection.dart';
@@ -226,7 +227,7 @@ class CatalogueScreen extends ConsumerWidget {
             builder: (_, constraints) {
               const minCardWidth = 285;
               const spacing = 32.0;
-              final nCards = constraints.maxWidth ~/ minCardWidth;
+              final nCards = max(1, constraints.maxWidth ~/ minCardWidth);
               final whiteSpace = spacing * (nCards - 1);
               final cardWidth = (constraints.maxWidth - whiteSpace) / nCards;
               final cards = _groupAndCreateCards(images, cardWidth);


### PR DESCRIPTION
This PR changes how the number of columns of image cards is computed so that it's never 0. Having 0 columns causes a divide by 0 and the GUI goes into an infinite loop taking 100% CPU power and freezing the window. This bug can be replicated on `edge` by setting the GUI to its minimum wide.

---

MULTI-2758