### PR TITLE
[gui] Flutter unit tests: CMake/CI integration and example test suite

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -232,7 +232,7 @@ jobs:
     - name: Run unit tests
       id: test
       if: ${{ matrix.build-type == 'Debug' }}
-      timeout-minutes: 2
+      timeout-minutes: 5
       run: |
         instance_name=$(/snap/bin/lxc --project snapcraft --format=csv --columns=n list | grep multipass)
         trap '

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -278,7 +278,7 @@ jobs:
     - name: Measure coverage
       id: measure-coverage
       if: ${{ matrix.build-type == 'Coverage' }}
-      timeout-minutes: 5
+      timeout-minutes: 10
       run: |
 
         trap 'echo "MULTIPASS_TESTS_EXIT_CODE=$?" >> $GITHUB_ENV' EXIT

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -33,7 +33,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo --preserve-env apt-get install --yes \
+          clang \
           clang-tidy \
+          lld \
+          llvm \
           devscripts \
           equivs \
           flake8 \

--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -90,6 +90,12 @@ jobs:
               --gcov-ignore-parse-errors \
               --merge-mode-functions=separate
 
+    - name: Process Dart coverage
+      run: |
+        sed 's|lib/|'"$GITHUB_WORKSPACE"'/src/client/gui/lib/|g' \
+            src/client/gui/coverage/lcov.info \
+            > ${{ env.COVERAGE_DIR }}/dart.info
+
     - name: Detach TICS QServer to prevent "project already connected" issue
       env:
         TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,17 +339,6 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
       set(LCOV_IGNORE_ERRORS --ignore-errors mismatch --ignore-errors negative)
     endif()
 
-    if(MULTIPASS_ENABLE_FLUTTER_GUI)
-      set(FLUTTER_COVERAGE_COMMANDS
-        COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/src/client/gui
-                ${FLUTTER_EXECUTABLE} test --coverage
-        COMMAND ${LCOV}
-          --add-tracefile coverage.cleaned
-          --add-tracefile ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
-          --output-file coverage.cleaned
-      )
-    endif()
-
     add_custom_target(covreport
       DEPENDS multipass_cpp_tests multipass_integration_tests rust_coverage_tarpaulin
       WORKING_DIRECTORY ${CMAKE_BUILD_DIR}
@@ -365,9 +354,13 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
         ${CMAKE_BINARY_DIR}'/*'
         --output-file coverage.cleaned
       COMMAND ${CMAKE_COMMAND} -E remove coverage.info
-      COMMAND ${CMAKE_COMMAND} -E remove coverage.info
-      COMMAND ${LCOV} -a coverage.cleaned -a lcov.info -o total_coverage.info
-      ${FLUTTER_COVERAGE_COMMANDS}
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/src/client/gui
+              ${FLUTTER_EXECUTABLE} test --coverage
+      COMMAND ${LCOV}
+        --add-tracefile coverage.cleaned
+        --add-tracefile lcov.info
+        --add-tracefile ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
+        --output-file total_coverage.info
       COMMAND ${GENHTML} --source-directory ${CMAKE_SOURCE_DIR}/src/client/gui -o coverage total_coverage.info
     )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,10 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
       set(GENHTML_SOURCE_ARGS --source-directory ${CMAKE_SOURCE_DIR}/src/client/gui)
     else()
       set(FLUTTER_COVERAGE_COMMANDS
-        COMMAND ${CMAKE_COMMAND} -E copy coverage.cleaned total_coverage.info
+        COMMAND ${LCOV}
+          --add-tracefile coverage.cleaned
+          --add-tracefile lcov.info
+          --output-file total_coverage.info
       )
       set(GENHTML_SOURCE_ARGS)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,14 @@ add_subdirectory(src)
 if(MULTIPASS_ENABLE_TESTS)
   enable_testing()
   add_subdirectory(tests/unit)
+
+  if(MULTIPASS_ENABLE_FLUTTER_GUI)
+    add_test(
+      NAME multipass_gui_tests
+      COMMAND ${FLUTTER_EXECUTABLE} test --no-pub
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/client/gui
+    )
+  endif()
 endif()
 
 #Added later to be compatible with enable_testing() above

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,13 +355,22 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
         ${CMAKE_BINARY_DIR}'/*'
         --output-file coverage.cleaned
       COMMAND ${CMAKE_COMMAND} -E remove coverage.info
+
+      # Merge Flutter test coverage with C++ coverage
       COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/src/client/gui
               ${FLUTTER_EXECUTABLE} test --coverage
+      COMMAND ${LCOV}
+        --remove ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
+        --ignore-errors unused
+        '*/lib/generated/*'
+        '*/lib/l10n/*'
+        --output-file ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
       COMMAND ${LCOV}
         --add-tracefile coverage.cleaned
         --add-tracefile lcov.info
         --add-tracefile ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
         --output-file total_coverage.info
+
       COMMAND ${GENHTML} --source-directory ${CMAKE_SOURCE_DIR}/src/client/gui -o coverage total_coverage.info
     )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,7 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
 
     add_custom_target(covreport
       DEPENDS multipass_cpp_tests multipass_integration_tests rust_coverage_tarpaulin
+        $<$<BOOL:${MULTIPASS_ENABLE_FLUTTER_GUI}>:multipass_gui>
       WORKING_DIRECTORY ${CMAKE_BUILD_DIR}
       COMMAND ${LCOV} --directory . --zerocounters
       COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,17 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
       set(LCOV_IGNORE_ERRORS --ignore-errors mismatch --ignore-errors negative)
     endif()
 
+    if(MULTIPASS_ENABLE_FLUTTER_GUI)
+      set(FLUTTER_COVERAGE_COMMANDS
+        COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/src/client/gui
+                ${FLUTTER_EXECUTABLE} test --coverage
+        COMMAND ${LCOV}
+          --add-tracefile coverage.cleaned
+          --add-tracefile ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
+          --output-file coverage.cleaned
+      )
+    endif()
+
     add_custom_target(covreport
       DEPENDS multipass_cpp_tests multipass_integration_tests rust_coverage_tarpaulin
       WORKING_DIRECTORY ${CMAKE_BUILD_DIR}
@@ -356,7 +367,8 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
       COMMAND ${CMAKE_COMMAND} -E remove coverage.info
       COMMAND ${CMAKE_COMMAND} -E remove coverage.info
       COMMAND ${LCOV} -a coverage.cleaned -a lcov.info -o total_coverage.info
-      COMMAND ${GENHTML} -o coverage total_coverage.info
+      ${FLUTTER_COVERAGE_COMMANDS}
+      COMMAND ${GENHTML} --source-directory ${CMAKE_SOURCE_DIR}/src/client/gui -o coverage total_coverage.info
     )
   endif()
 endif()
@@ -378,7 +390,7 @@ if(MULTIPASS_ENABLE_TESTS)
   if(MULTIPASS_ENABLE_FLUTTER_GUI)
     add_test(
       NAME multipass_gui_tests
-      COMMAND ${FLUTTER_EXECUTABLE} test --no-pub
+      COMMAND ${FLUTTER_EXECUTABLE} test
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/client/gui
     )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,30 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
       set(LCOV_IGNORE_ERRORS --ignore-errors mismatch --ignore-errors negative)
     endif()
 
+    if(MULTIPASS_ENABLE_FLUTTER_GUI)
+      set(FLUTTER_COVERAGE_COMMANDS
+        COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/src/client/gui
+                ${FLUTTER_EXECUTABLE} test --coverage
+        COMMAND ${LCOV}
+          --remove ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
+          --ignore-errors unused
+          '*/lib/generated/*'
+          '*/lib/l10n/*'
+          --output-file ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
+        COMMAND ${LCOV}
+          --add-tracefile coverage.cleaned
+          --add-tracefile lcov.info
+          --add-tracefile ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
+          --output-file total_coverage.info
+      )
+      set(GENHTML_SOURCE_ARGS --source-directory ${CMAKE_SOURCE_DIR}/src/client/gui)
+    else()
+      set(FLUTTER_COVERAGE_COMMANDS
+        COMMAND ${CMAKE_COMMAND} -E copy coverage.cleaned total_coverage.info
+      )
+      set(GENHTML_SOURCE_ARGS)
+    endif()
+
     add_custom_target(covreport
       DEPENDS multipass_cpp_tests multipass_integration_tests rust_coverage_tarpaulin
         $<$<BOOL:${MULTIPASS_ENABLE_FLUTTER_GUI}>:multipass_gui>
@@ -355,23 +379,9 @@ if(CMAKE_BUILD_TYPE_LOWER MATCHES "coverage")
         ${CMAKE_BINARY_DIR}'/*'
         --output-file coverage.cleaned
       COMMAND ${CMAKE_COMMAND} -E remove coverage.info
-
-      # Merge Flutter test coverage with C++ coverage
-      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_SOURCE_DIR}/src/client/gui
-              ${FLUTTER_EXECUTABLE} test --coverage
-      COMMAND ${LCOV}
-        --remove ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
-        --ignore-errors unused
-        '*/lib/generated/*'
-        '*/lib/l10n/*'
-        --output-file ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
-      COMMAND ${LCOV}
-        --add-tracefile coverage.cleaned
-        --add-tracefile lcov.info
-        --add-tracefile ${CMAKE_SOURCE_DIR}/src/client/gui/coverage/lcov.info
-        --output-file total_coverage.info
-
-      COMMAND ${GENHTML} --source-directory ${CMAKE_SOURCE_DIR}/src/client/gui -o coverage total_coverage.info
+      # Merge Flutter test coverage with C++ coverage (when enabled)
+      ${FLUTTER_COVERAGE_COMMANDS}
+      COMMAND ${GENHTML} ${GENHTML_SOURCE_ARGS} -o coverage total_coverage.info
     )
   endif()
 endif()

--- a/src/client/gui/test/action_tile_test.dart
+++ b/src/client/gui/test/action_tile_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:multipass_gui/grpc_client.dart';
+import 'package:multipass_gui/l10n/app_localizations.dart';
+import 'package:multipass_gui/providers.dart';
+import 'package:multipass_gui/vm_action.dart';
+import 'package:multipass_gui/vm_details/vm_action_buttons.dart';
+
+void main() {
+  const vmName = 'test-vm';
+
+  Widget buildWidget({
+    required VmAction action,
+    required Status status,
+    VoidCallback? onTap,
+  }) {
+    return ProviderScope(
+      overrides: [
+        vmInfoProvider(vmName).overrideWithBuild(
+          (ref, notifier) => DetailedInfoItem(
+            instanceStatus: InstanceStatus(status: status),
+          ),
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ActionTile(vmName, action, onTap ?? () {}),
+        ),
+      ),
+    );
+  }
+
+  group('ActionTile', () {
+    void runEnabledTests(VmAction action, List<(Status, bool)> cases) {
+      for (final (status, enabled) in cases) {
+        testWidgets(
+            'is ${enabled ? 'enabled' : 'disabled'} when status is ${status.name}',
+            (tester) async {
+          await tester.pumpWidget(buildWidget(action: action, status: status));
+          await tester.pumpAndSettle();
+
+          final tile = tester.widget<ListTile>(find.byType(ListTile));
+          expect(tile.enabled, enabled);
+        });
+      }
+    }
+
+    const allStatuses = [
+      Status.UNKNOWN,
+      Status.RUNNING,
+      Status.STARTING,
+      Status.RESTARTING,
+      Status.STOPPED,
+      Status.DELETED,
+      Status.DELAYED_SHUTDOWN,
+      Status.SUSPENDING,
+      Status.SUSPENDED,
+    ];
+
+    group('VmAction.start', () {
+      runEnabledTests(VmAction.start, [
+        for (final s in allStatuses)
+          (s, s == Status.STOPPED || s == Status.SUSPENDED),
+      ]);
+    });
+
+    group('VmAction.stop', () {
+      runEnabledTests(VmAction.stop, [
+        for (final s in allStatuses) (s, s == Status.RUNNING),
+      ]);
+    });
+
+    group('VmAction.suspend', () {
+      runEnabledTests(VmAction.suspend, [
+        for (final s in allStatuses) (s, s == Status.RUNNING),
+      ]);
+    });
+
+    group('VmAction.delete', () {
+      runEnabledTests(VmAction.delete, [
+        for (final s in allStatuses)
+          (
+            s,
+            s == Status.STOPPED || s == Status.SUSPENDED || s == Status.RUNNING
+          ),
+      ]);
+    });
+
+    group('tap behaviour', () {
+      testWidgets('invokes callback when tapped while enabled',
+          (WidgetTester tester) async {
+        var tapped = false;
+
+        await tester.pumpWidget(buildWidget(
+          action: VmAction.stop,
+          status: Status.RUNNING,
+          onTap: () => tapped = true,
+        ));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(ListTile));
+        await tester.pumpAndSettle();
+
+        expect(tapped, isTrue);
+      });
+
+      testWidgets('displays action label as tile title',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildWidget(
+          action: VmAction.start,
+          status: Status.STOPPED,
+        ));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.descendant(
+            of: find.byType(ListTile),
+            matching: find.byType(Text),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('title text style is not null when enabled',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildWidget(
+          action: VmAction.start,
+          status: Status.STOPPED,
+        ));
+        await tester.pumpAndSettle();
+
+        final text = tester.widget<Text>(
+          find.descendant(
+            of: find.byType(ListTile),
+            matching: find.byType(Text),
+          ),
+        );
+        expect(text.style?.color, isNotNull);
+      });
+
+      testWidgets('title text style is null when disabled',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildWidget(
+          action: VmAction.start,
+          status: Status.RUNNING,
+        ));
+        await tester.pumpAndSettle();
+
+        final text = tester.widget<Text>(
+          find.descendant(
+            of: find.byType(ListTile),
+            matching: find.byType(Text),
+          ),
+        );
+        expect(text.style, isNull);
+      });
+    });
+  });
+}

--- a/src/client/gui/test/action_tile_test.dart
+++ b/src/client/gui/test/action_tile_test.dart
@@ -115,13 +115,17 @@ void main() {
         ));
         await tester.pumpAndSettle();
 
-        expect(
+        final context = tester.element(find.byType(ListTile));
+        final expectedLabel =
+            VmAction.start.label(AppLocalizations.of(context)!);
+
+        final text = tester.widget<Text>(
           find.descendant(
             of: find.byType(ListTile),
             matching: find.byType(Text),
           ),
-          findsOneWidget,
         );
+        expect(text.data, expectedLabel);
       });
 
       testWidgets('title text style is not null when enabled',


### PR DESCRIPTION
This PR introduces Flutter unit testing to the Multipass GUI. A single test suite is added to demonstrate the function of Flutter unit tests. Integration with CMake/covreport/CI/TICS is also added to establish the foundation of how future unit tests will be added and run.

An additional CMake target, `multipass_gui_tests`, is added. Unit tests can be run through the use of `ctest` or can be targeted directly by `cd`'ing to `src/client/gui` and executing `flutter test`. See the official Flutter documentation linked below for more information on using `flutter` directly. 


https://docs.flutter.dev/cookbook/testing/unit/introduction

---

MULTI-2521