### PR TITLE
[url-downloader] Force HTTP/1 for QNetworkRequest

### DIFF
--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -104,6 +104,7 @@ QByteArray download(QNetworkAccessManager* manager,
     request.setRawHeader("Connection", "Keep-Alive");
     request.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, cache_load_control);
+    request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
     request.setHeader(QNetworkRequest::UserAgentHeader,
                       QString::fromStdString(fmt::format("Multipass/{} ({}; {})",
                                                          multipass::version_string,
@@ -184,6 +185,7 @@ auto get_header(QNetworkAccessManager* manager,
 
     const QUrl adjusted_url = make_http_url_https(url);
     QNetworkRequest request{adjusted_url};
+    request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
 
     NetworkReplyUPtr reply{manager->head(request)};
 


### PR DESCRIPTION
To see if QT's happy eyeball impl. would work for HTTP/1.

Closes: #3662

