### PR TITLE
Add user agent strings to network requests

### DIFF
--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -70,6 +70,16 @@ auto make_network_manager(const mp::Path& cache_dir_path)
     return out;
 }
 
+QString multipass_user_agent()
+{
+    static const auto user_agent = QString::fromStdString(
+        fmt::format("Multipass/{} ({}; {})",
+                    multipass::version_string,
+                    mp::platform::host_version(),
+                    QSysInfo::currentCpuArchitecture()));
+    return user_agent;
+}
+
 void wait_for_reply(QNetworkReply* reply, QTimer& download_timeout)
 {
     QEventLoop event_loop;
@@ -104,11 +114,7 @@ QByteArray download(QNetworkAccessManager* manager,
     request.setRawHeader("Connection", "Keep-Alive");
     request.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, cache_load_control);
-    request.setHeader(QNetworkRequest::UserAgentHeader,
-                      QString::fromStdString(fmt::format("Multipass/{} ({}; {})",
-                                                         multipass::version_string,
-                                                         mp::platform::host_version(),
-                                                         QSysInfo::currentCpuArchitecture())));
+    request.setHeader(QNetworkRequest::UserAgentHeader, multipass_user_agent());
 
     NetworkReplyUPtr reply{manager->get(request)};
 
@@ -184,6 +190,7 @@ auto get_header(QNetworkAccessManager* manager,
 
     const QUrl adjusted_url = make_http_url_https(url);
     QNetworkRequest request{adjusted_url};
+    request.setHeader(QNetworkRequest::UserAgentHeader, multipass_user_agent());
 
     NetworkReplyUPtr reply{manager->head(request)};
 

--- a/tools/distro-scraper/pyproject.toml
+++ b/tools/distro-scraper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "distro-scraper"
-version = "0.1.0"
+version = "0.1.1"
 description = "Cloud distribution image scraper for Multipass"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tools/distro-scraper/pyproject.toml
+++ b/tools/distro-scraper/pyproject.toml
@@ -7,7 +7,7 @@ name = "distro-scraper"
 version = "0.1.0"
 description = "Cloud distribution image scraper for Multipass"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.9.0",
     "beautifulsoup4>=4.12.0",

--- a/tools/distro-scraper/pyproject.toml
+++ b/tools/distro-scraper/pyproject.toml
@@ -7,7 +7,7 @@ name = "distro-scraper"
 version = "0.1.0"
 description = "Cloud distribution image scraper for Multipass"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 dependencies = [
     "aiohttp>=3.9.0",
     "beautifulsoup4>=4.12.0",

--- a/tools/distro-scraper/scraper/base.py
+++ b/tools/distro-scraper/scraper/base.py
@@ -1,20 +1,23 @@
 import logging
 import aiohttp
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from importlib.metadata import version
 
 
 DEFAULT_TIMEOUT = 10
 _VERSION = version("distro-scraper")
-USER_AGENT = f"multipass-distro-scraper/{_VERSION} (+https://github.com/canonical/multipass)"
+USER_AGENT = (
+    f"multipass-distro-scraper/{_VERSION} (+https://github.com/canonical/multipass)"
+)
 
 
-def make_session(**kwargs) -> aiohttp.ClientSession:
+def make_session(*, headers: Mapping[str, str] = {}, **kwargs) -> aiohttp.ClientSession:
     """
     Create an aiohttp.ClientSession that identifies itself with the Multipass
     distro-scraper User-Agent.
     """
-    headers = {"User-Agent": USER_AGENT, **kwargs.pop("headers", {})}
+    headers = {"User-Agent": USER_AGENT, **headers}
     return aiohttp.ClientSession(headers=headers, **kwargs)
 
 

--- a/tools/distro-scraper/scraper/base.py
+++ b/tools/distro-scraper/scraper/base.py
@@ -1,15 +1,14 @@
 import logging
+import tomllib
 import aiohttp
 from abc import ABC, abstractmethod
-from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 
 DEFAULT_TIMEOUT = 10
 
-try:
-    _VERSION = version("distro-scraper")
-except PackageNotFoundError:
-    _VERSION = "0.0.0"
+with (Path(__file__).resolve().parent.parent / "pyproject.toml").open("rb") as _f:
+    _VERSION = tomllib.load(_f)["project"]["version"]
 
 USER_AGENT = f"multipass-distro-scraper/{_VERSION} (+https://github.com/canonical/multipass)"
 

--- a/tools/distro-scraper/scraper/base.py
+++ b/tools/distro-scraper/scraper/base.py
@@ -1,15 +1,11 @@
 import logging
-import tomllib
 import aiohttp
 from abc import ABC, abstractmethod
-from pathlib import Path
+from importlib.metadata import version
 
 
 DEFAULT_TIMEOUT = 10
-
-with (Path(__file__).resolve().parent.parent / "pyproject.toml").open("rb") as _f:
-    _VERSION = tomllib.load(_f)["project"]["version"]
-
+_VERSION = version("distro-scraper")
 USER_AGENT = f"multipass-distro-scraper/{_VERSION} (+https://github.com/canonical/multipass)"
 
 

--- a/tools/distro-scraper/scraper/base.py
+++ b/tools/distro-scraper/scraper/base.py
@@ -1,9 +1,26 @@
 import logging
 import aiohttp
 from abc import ABC, abstractmethod
+from importlib.metadata import PackageNotFoundError, version
 
 
 DEFAULT_TIMEOUT = 10
+
+try:
+    _VERSION = version("distro-scraper")
+except PackageNotFoundError:
+    _VERSION = "0.0.0"
+
+USER_AGENT = f"multipass-distro-scraper/{_VERSION} (+https://github.com/canonical/multipass)"
+
+
+def make_session(**kwargs) -> aiohttp.ClientSession:
+    """
+    Create an aiohttp.ClientSession that identifies itself with the Multipass
+    distro-scraper User-Agent.
+    """
+    headers = {"User-Agent": USER_AGENT, **kwargs.pop("headers", {})}
+    return aiohttp.ClientSession(headers=headers, **kwargs)
 
 
 class BaseScraper(ABC):

--- a/tools/distro-scraper/scraper/scrapers/debian.py
+++ b/tools/distro-scraper/scraper/scrapers/debian.py
@@ -2,7 +2,7 @@ import base64
 import aiohttp
 import asyncio
 from email.parser import Parser
-from ..base import BaseScraper
+from ..base import BaseScraper, make_session
 from ..models import SUPPORTED_ARCHITECTURES
 
 RELEASE_FILE_URL = "https://deb.debian.org/debian/dists/stable/Release"
@@ -159,7 +159,7 @@ class DebianScraper(BaseScraper):
         """
         Fetch Debian Cloud images and return normalized metadata.
         """
-        async with aiohttp.ClientSession() as session:
+        async with make_session() as session:
             release_text = await self._fetch_text(session, RELEASE_FILE_URL)
 
             raw_version, codename = self._parse_release_file(release_text)

--- a/tools/distro-scraper/scraper/scrapers/fedora.py
+++ b/tools/distro-scraper/scraper/scrapers/fedora.py
@@ -4,7 +4,7 @@ import asyncio
 from urllib.parse import urljoin
 from bs4 import BeautifulSoup
 from dateutil import parser
-from ..base import BaseScraper, DEFAULT_TIMEOUT
+from ..base import BaseScraper, DEFAULT_TIMEOUT, make_session
 from ..models import SUPPORTED_ARCHITECTURES
 
 
@@ -130,7 +130,7 @@ class FedoraScraper(BaseScraper):
         """
         Fetch Fedora Cloud Base Generic images for all supported architectures.
         """
-        async with aiohttp.ClientSession() as session:
+        async with make_session() as session:
             version = await self._fetch_latest_version(session)
 
             results = await asyncio.gather(


### PR DESCRIPTION
This PR adds a user agent string to the distro scraper so that we are a bit more friendly when scrapping other organization's data. Also, tweak the url downloader so that the user agent string is used for making HEAD requests as well.