### PR TITLE
[cmake] Fix dependency ordering in feature flags

### DIFF
--- a/feature-flags.cmake
+++ b/feature-flags.cmake
@@ -14,13 +14,13 @@
 
 include(src/cmake/feature-flag.cmake)
 
+feature_flag(AVAILABILITY_ZONES_ENABLED "Availability zone support")
+if(AVAILABILITY_ZONES_ENABLED)
+  add_compile_definitions(AVAILABILITY_ZONES_FEATURE)
+endif()
+
 # Multipass backend integrating with Apple Virtualization framework
 feature_flag(APPLEVZ_ENABLED "AppleVZ backend" "APPLE;AVAILABILITY_ZONES_ENABLED")
 
 # The new Windows backend based on Hyper-V Host Compute System / Host Compute Networking APIs
 feature_flag(HYPERV_HCS_ENABLED "Hyper-V HCS backend" WIN32)
-
-feature_flag(AVAILABILITY_ZONES_ENABLED "Availability zone support")
-if(AVAILABILITY_ZONES_ENABLED)
-  add_compile_definitions(AVAILABILITY_ZONES_FEATURE)
-endif()


### PR DESCRIPTION
Reorder the declaration of feature flags so that applevz, which depends on AZs, is enabled.