### PR TITLE
[macOS/az] Override subnet isolation

### DIFF
--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -78,6 +78,9 @@ void AppleVZVirtualMachineFactory::hypervisor_health_check()
     {
         throw std::runtime_error("Virtualization is not supported on this system.");
     }
+
+    // Re-assert cross-zone routing in case macOS reloaded its pf anchors
+    enable_zone_routing(az_manager);
 }
 
 void AppleVZVirtualMachineFactory::remove_resources_for_impl(const std::string& name)

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -19,8 +19,21 @@
 #include <applevz/applevz_virtual_machine.h>
 #include <applevz/applevz_virtual_machine_factory.h>
 #include <multipass/utils/qemu_img_utils.h>
+#include <shared/macos/backend_utils.h>
 
 namespace mp = multipass;
+
+namespace
+{
+void enable_zone_routing(mp::AvailabilityZoneManager& az_manager)
+{
+    std::vector<mp::Subnet> subnets;
+    for (const auto& zone : az_manager.get_zones())
+        subnets.push_back(zone.get().get_subnet());
+
+    mp::backend::enable_cross_zone_routing(subnets);
+}
+} // namespace
 
 namespace multipass::applevz
 {
@@ -30,6 +43,7 @@ AppleVZVirtualMachineFactory::AppleVZVirtualMachineFactory(const Path& data_dir,
           MP_UTILS.derive_instances_dir(data_dir, get_backend_directory_name(), instances_subdir),
           az_manager)
 {
+    enable_zone_routing(az_manager);
 }
 
 VirtualMachine::UPtr AppleVZVirtualMachineFactory::create_virtual_machine(

--- a/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine_factory.cpp
@@ -23,18 +23,6 @@
 
 namespace mp = multipass;
 
-namespace
-{
-void enable_zone_routing(mp::AvailabilityZoneManager& az_manager)
-{
-    std::vector<mp::Subnet> subnets;
-    for (const auto& zone : az_manager.get_zones())
-        subnets.push_back(zone.get().get_subnet());
-
-    mp::backend::enable_cross_zone_routing(subnets);
-}
-} // namespace
-
 namespace multipass::applevz
 {
 AppleVZVirtualMachineFactory::AppleVZVirtualMachineFactory(const Path& data_dir,
@@ -43,7 +31,7 @@ AppleVZVirtualMachineFactory::AppleVZVirtualMachineFactory(const Path& data_dir,
           MP_UTILS.derive_instances_dir(data_dir, get_backend_directory_name(), instances_subdir),
           az_manager)
 {
-    enable_zone_routing(az_manager);
+    mp::backend::enable_cross_zone_routing(az_manager);
 }
 
 VirtualMachine::UPtr AppleVZVirtualMachineFactory::create_virtual_machine(
@@ -80,7 +68,7 @@ void AppleVZVirtualMachineFactory::hypervisor_health_check()
     }
 
     // Re-assert cross-zone routing in case macOS reloaded its pf anchors
-    enable_zone_routing(az_manager);
+    mp::backend::enable_cross_zone_routing(az_manager);
 }
 
 void AppleVZVirtualMachineFactory::remove_resources_for_impl(const std::string& name)

--- a/src/platform/backends/qemu/macos/qemu_platform_macos.cpp
+++ b/src/platform/backends/qemu/macos/qemu_platform_macos.cpp
@@ -42,23 +42,13 @@ auto get_common_args(const QString& host_arch)
 
     return qemu_args;
 }
-
-void enable_zone_routing(const std::unordered_map<std::string, mp::Subnet>& bridges)
-{
-    std::vector<mp::Subnet> subnets;
-    subnets.reserve(bridges.size());
-    for (const auto& [_, subnet] : bridges)
-        subnets.push_back(subnet);
-
-    mp::backend::enable_cross_zone_routing(subnets);
-}
 } // namespace
 
 mp::QemuPlatformMacOS::QemuPlatformMacOS(const AvailabilityZoneManager& az_manager)
     : common_args{get_common_args(host_arch)}, az_manager{az_manager}
 
 {
-    enable_zone_routing(bridges);
+    mp::backend::enable_cross_zone_routing(az_manager);
 }
 
 std::optional<mp::IPAddress> mp::QemuPlatformMacOS::get_ip_for(const std::string& hw_addr)
@@ -75,7 +65,7 @@ void mp::QemuPlatformMacOS::platform_health_check()
     // TODO: Add appropriate health checks to ensure the QEMU backend will work as expected
 
     // Re-assert cross-zone routing in case macOS reloaded its pf anchors
-    enable_zone_routing(bridges);
+    mp::backend::enable_cross_zone_routing(az_manager);
 }
 
 QStringList mp::QemuPlatformMacOS::vmstate_platform_args()

--- a/src/platform/backends/qemu/macos/qemu_platform_macos.cpp
+++ b/src/platform/backends/qemu/macos/qemu_platform_macos.cpp
@@ -42,12 +42,23 @@ auto get_common_args(const QString& host_arch)
 
     return qemu_args;
 }
+
+void enable_zone_routing(const std::unordered_map<std::string, mp::Subnet>& bridges)
+{
+    std::vector<mp::Subnet> subnets;
+    subnets.reserve(bridges.size());
+    for (const auto& [_, subnet] : bridges)
+        subnets.push_back(subnet);
+
+    mp::backend::enable_cross_zone_routing(subnets);
+}
 } // namespace
 
 mp::QemuPlatformMacOS::QemuPlatformMacOS(const AvailabilityZoneManager& az_manager)
     : common_args{get_common_args(host_arch)}, az_manager{az_manager}
 
 {
+    enable_zone_routing(bridges);
 }
 
 std::optional<mp::IPAddress> mp::QemuPlatformMacOS::get_ip_for(const std::string& hw_addr)

--- a/src/platform/backends/qemu/macos/qemu_platform_macos.cpp
+++ b/src/platform/backends/qemu/macos/qemu_platform_macos.cpp
@@ -73,6 +73,9 @@ void mp::QemuPlatformMacOS::remove_resources_for(const std::string& name)
 void mp::QemuPlatformMacOS::platform_health_check()
 {
     // TODO: Add appropriate health checks to ensure the QEMU backend will work as expected
+
+    // Re-assert cross-zone routing in case macOS reloaded its pf anchors
+    enable_zone_routing(bridges);
 }
 
 QStringList mp::QemuPlatformMacOS::vmstate_platform_args()

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -30,6 +30,7 @@ namespace mp = multipass;
 namespace
 {
 constexpr auto category = "backend-utils";
+constexpr auto pf_anchor = "com.apple/multipass";
 
 void set_ip_forward()
 {
@@ -120,4 +121,42 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
     }
 
     return std::nullopt;
+}
+
+void mp::backend::enable_cross_zone_routing(const std::vector<mp::Subnet>& zone_subnets)
+{
+    set_ip_forward();
+
+    std::vector<std::string> cidrs;
+    cidrs.reserve(zone_subnets.size());
+    for (const auto& subnet : zone_subnets)
+        cidrs.push_back(subnet.canonical().to_cidr());
+
+    if (cidrs.size() < 2)
+        return;
+
+    // macOS automatically enforces isolation between subnets via a pf "block drop quick"
+    // rule. Override the rule by adding a "pass quick" rule in an earlier-evaluated anchor.
+    std::string rules;
+    for (const auto& src : cidrs)
+        for (const auto& dst : cidrs)
+            if (src != dst)
+                rules += fmt::format("pass quick inet from {} to {} flags any keep state\n",
+                                     src,
+                                     dst);
+
+    const auto pfctl = mp::platform::make_process(
+        mp::simple_process_spec("pfctl", {"-a", pf_anchor, "-f", "-"}));
+    pfctl->start();
+    if (!pfctl->wait_for_started())
+    {
+        mpl::warn(category, "Failed to run pfctl");
+        return;
+    }
+
+    pfctl->write(QByteArray::fromStdString(rules));
+    pfctl->close_write_channel();
+
+    if (!pfctl->wait_for_finished() || !pfctl->process_state().completed_successfully())
+        mpl::warn(category, "Failed to install pf rules for cross-zone routing");
 }

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -31,6 +31,12 @@ namespace
 {
 constexpr auto category = "backend-utils";
 
+void set_ip_forward()
+{
+    if (!MP_UTILS.run_cmd_for_status("sysctl", {"-w", "net.inet.ip.forwarding=1"}))
+        mpl::warn(category, "Failed to enable IP forwarding");
+}
+
 QString simplify_mac_address(const QString& input_mac_address)
 {
     // Trim the (first) leading 0 of each segment of the a MAC address.

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -123,27 +123,23 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
     return std::nullopt;
 }
 
-void mp::backend::enable_cross_zone_routing(const std::vector<mp::Subnet>& zone_subnets)
+void mp::backend::enable_cross_zone_routing(const AvailabilityZoneManager& az_manager)
 {
     set_ip_forward();
 
-    std::vector<std::string> cidrs;
-    cidrs.reserve(zone_subnets.size());
-    for (const auto& subnet : zone_subnets)
-        cidrs.push_back(subnet.canonical().to_cidr());
-
-    if (cidrs.size() < 2)
+    const auto zones = az_manager.get_zones();
+    if (zones.size() < 2)
         return;
 
     // macOS automatically enforces isolation between subnets via a pf "block drop quick"
     // rule. Override the rule by adding a "pass quick" rule in an earlier-evaluated anchor.
     std::string rules;
-    for (const auto& src : cidrs)
-        for (const auto& dst : cidrs)
-            if (src != dst)
+    for (const auto& src : zones)
+        for (const auto& dst : zones)
+            if (&src.get() != &dst.get())
                 rules += fmt::format("pass quick inet from {} to {} flags any keep state\n",
-                                     src,
-                                     dst);
+                                     src.get().get_subnet().canonical().to_cidr(),
+                                     dst.get().get_subnet().canonical().to_cidr());
 
     const auto pfctl = mp::platform::make_process(
         mp::simple_process_spec("pfctl", {"-a", pf_anchor, "-f", "-"}));

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -136,7 +136,7 @@ void mp::backend::enable_cross_zone_routing(const AvailabilityZoneManager& az_ma
     std::string rules;
     for (const auto& src : zones)
         for (const auto& dst : zones)
-            if (&src.get() != &dst.get())
+            if (src.get().get_subnet() != dst.get().get_subnet())
                 rules += fmt::format("pass quick inet from {} to {} flags any keep state\n",
                                      src.get().get_subnet().canonical().to_cidr(),
                                      dst.get().get_subnet().canonical().to_cidr());

--- a/src/platform/backends/shared/macos/backend_utils.cpp
+++ b/src/platform/backends/shared/macos/backend_utils.cpp
@@ -125,11 +125,11 @@ std::optional<mp::IPAddress> mp::backend::get_neighbour_ip(const std::string& ma
 
 void mp::backend::enable_cross_zone_routing(const AvailabilityZoneManager& az_manager)
 {
-    set_ip_forward();
-
     const auto zones = az_manager.get_zones();
     if (zones.size() < 2)
         return;
+
+    set_ip_forward();
 
     // macOS automatically enforces isolation between subnets via a pf "block drop quick"
     // rule. Override the rule by adding a "pass quick" rule in an earlier-evaluated anchor.
@@ -154,5 +154,8 @@ void mp::backend::enable_cross_zone_routing(const AvailabilityZoneManager& az_ma
     pfctl->close_write_channel();
 
     if (!pfctl->wait_for_finished() || !pfctl->process_state().completed_successfully())
-        mpl::warn(category, "Failed to install pf rules for cross-zone routing");
+        mpl::warn(category,
+                  "Failed to install pf rules for cross-zone routing: {}\n{}",
+                  pfctl->process_state().failure_message(),
+                  pfctl->read_all_standard_error());
 }

--- a/src/platform/backends/shared/macos/backend_utils.h
+++ b/src/platform/backends/shared/macos/backend_utils.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
+#include <multipass/availability_zone_manager.h>
 #include <multipass/ip_address.h>
-#include <multipass/subnet.h>
 
 #include <optional>
 #include <string>
@@ -27,5 +27,5 @@
 namespace multipass::backend
 {
 std::optional<IPAddress> get_neighbour_ip(const std::string& mac_address);
-void enable_cross_zone_routing(const std::vector<Subnet>& zone_subnets);
+void enable_cross_zone_routing(const AvailabilityZoneManager& az_manager);
 } // namespace multipass::backend

--- a/src/platform/backends/shared/macos/backend_utils.h
+++ b/src/platform/backends/shared/macos/backend_utils.h
@@ -22,7 +22,6 @@
 
 #include <optional>
 #include <string>
-#include <vector>
 
 namespace multipass::backend
 {

--- a/src/platform/backends/shared/macos/backend_utils.h
+++ b/src/platform/backends/shared/macos/backend_utils.h
@@ -18,11 +18,14 @@
 #pragma once
 
 #include <multipass/ip_address.h>
+#include <multipass/subnet.h>
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace multipass::backend
 {
 std::optional<IPAddress> get_neighbour_ip(const std::string& mac_address);
+void enable_cross_zone_routing(const std::vector<Subnet>& zone_subnets);
 } // namespace multipass::backend

--- a/tests/unit/macos/test_backend_utils.cpp
+++ b/tests/unit/macos/test_backend_utils.cpp
@@ -15,9 +15,9 @@
  *
  */
 
-#include "tests/unit/mock_availability_zone_manager.h"
 #include "tests/unit/mock_process_factory.h"
 #include "tests/unit/mock_utils.h"
+#include "tests/unit/stub_availability_zone_manager.h"
 
 #include <src/platform/backends/shared/macos/backend_utils.h>
 
@@ -123,18 +123,12 @@ TEST(EnableCrossZoneRouting, singleZoneDoesNotTouchForwardingOrPf)
     const auto mock_process_factory = mpt::MockProcessFactory::Inject();
     auto [mock_utils, utils_guard] = mpt::MockUtils::inject();
 
-    const mp::Subnet subnet{"192.168.64.0/24"};
-    NiceMock<mpt::MockAvailabilityZone> zone;
-    ON_CALL(zone, get_subnet()).WillByDefault(ReturnRef(subnet));
-
-    NiceMock<mpt::MockAvailabilityZoneManager> mock_manager;
-    const std::vector<std::reference_wrapper<const mp::AvailabilityZone>> zones{zone};
-    EXPECT_CALL(mock_manager, get_zones()).WillRepeatedly(Return(zones));
+    const mpt::StubAvailabilityZoneManager az_manager;
 
     // Neither IP forwarding nor pf rules should be touched with fewer than two zones.
     EXPECT_CALL(*mock_utils, run_cmd_for_status(_, _, _)).Times(0);
 
-    mp::backend::enable_cross_zone_routing(mock_manager);
+    mp::backend::enable_cross_zone_routing(az_manager);
 
     EXPECT_TRUE(mock_process_factory->process_list().empty());
 }
@@ -144,20 +138,10 @@ TEST(EnableCrossZoneRouting, multipleZonesEnablesForwardingAndInstallsPfRules)
     const auto mock_process_factory = mpt::MockProcessFactory::Inject();
     auto [mock_utils, utils_guard] = mpt::MockUtils::inject();
 
-    const mp::Subnet subnet_a{"192.168.64.0/24"};
-    const mp::Subnet subnet_b{"192.168.65.0/24"};
-    const mp::Subnet subnet_c{"192.168.66.0/24"};
-
-    NiceMock<mpt::MockAvailabilityZone> zone_a, zone_b, zone_c;
-    ON_CALL(zone_a, get_subnet()).WillByDefault(ReturnRef(subnet_a));
-    ON_CALL(zone_b, get_subnet()).WillByDefault(ReturnRef(subnet_b));
-    ON_CALL(zone_c, get_subnet()).WillByDefault(ReturnRef(subnet_c));
-
-    NiceMock<mpt::MockAvailabilityZoneManager> mock_manager;
-    const std::vector<std::reference_wrapper<const mp::AvailabilityZone>> zones{zone_a,
-                                                                                zone_b,
-                                                                                zone_c};
-    EXPECT_CALL(mock_manager, get_zones()).WillRepeatedly(Return(zones));
+    const auto zones = {mp::Subnet{"192.168.64.0/24"},
+                        mp::Subnet{"192.168.65.0/24"},
+                        mp::Subnet{"192.168.66.0/24"}};
+    const mpt::StubAvailabilityZoneManager az_manager{zones};
 
     EXPECT_CALL(
         *mock_utils,
@@ -177,14 +161,14 @@ TEST(EnableCrossZoneRouting, multipleZonesEnablesForwardingAndInstallsPfRules)
         }
     });
 
-    mp::backend::enable_cross_zone_routing(mock_manager);
+    mp::backend::enable_cross_zone_routing(az_manager);
 
     // N zones produce a "pass" rule for each of the N * (N - 1) ordered, distinct subnet pairs.
     EXPECT_THAT(QString::fromStdString(captured_rules).split('\n', Qt::SkipEmptyParts),
                 SizeIs(zones.size() * (zones.size() - 1)));
-    for (const auto& src : mock_manager.get_zones())
+    for (const auto& src : az_manager.get_zones())
     {
-        for (const auto& dst : mock_manager.get_zones())
+        for (const auto& dst : az_manager.get_zones())
         {
             if (&src.get() != &dst.get())
             {

--- a/tests/unit/macos/test_backend_utils.cpp
+++ b/tests/unit/macos/test_backend_utils.cpp
@@ -15,10 +15,13 @@
  *
  */
 
+#include "tests/unit/mock_availability_zone_manager.h"
 #include "tests/unit/mock_process_factory.h"
 #include "tests/unit/mock_utils.h"
 
 #include <src/platform/backends/shared/macos/backend_utils.h>
+
+#include <multipass/subnet.h>
 
 namespace mp = multipass;
 namespace mpt = multipass::test;
@@ -114,3 +117,91 @@ TEST_P(GetNeighbourIPInvalidInputsTests, inValidInputCases)
 INSTANTIATE_TEST_SUITE_P(GetNeighbourIPTestsInstantiation,
                          GetNeighbourIPInvalidInputsTests,
                          Values("11:11:11:11:11:11", "ee:ee:ee:ee:ee:ee"));
+
+TEST(EnableCrossZoneRouting, singleZoneDoesNotTouchForwardingOrPf)
+{
+    const auto mock_process_factory = mpt::MockProcessFactory::Inject();
+    auto [mock_utils, utils_guard] = mpt::MockUtils::inject();
+
+    const mp::Subnet subnet{"192.168.64.0/24"};
+    NiceMock<mpt::MockAvailabilityZone> zone;
+    ON_CALL(zone, get_subnet()).WillByDefault(ReturnRef(subnet));
+
+    NiceMock<mpt::MockAvailabilityZoneManager> mock_manager;
+    const std::vector<std::reference_wrapper<const mp::AvailabilityZone>> zones{zone};
+    EXPECT_CALL(mock_manager, get_zones()).WillRepeatedly(Return(zones));
+
+    // Neither IP forwarding nor pf rules should be touched with fewer than two zones.
+    EXPECT_CALL(*mock_utils, run_cmd_for_status(_, _, _)).Times(0);
+
+    mp::backend::enable_cross_zone_routing(mock_manager);
+
+    EXPECT_TRUE(mock_process_factory->process_list().empty());
+}
+
+TEST(EnableCrossZoneRouting, multipleZonesEnablesForwardingAndInstallsPfRules)
+{
+    const auto mock_process_factory = mpt::MockProcessFactory::Inject();
+    auto [mock_utils, utils_guard] = mpt::MockUtils::inject();
+
+    const mp::Subnet subnet_a{"192.168.64.0/24"};
+    const mp::Subnet subnet_b{"192.168.65.0/24"};
+    const mp::Subnet subnet_c{"192.168.66.0/24"};
+
+    NiceMock<mpt::MockAvailabilityZone> zone_a, zone_b, zone_c;
+    ON_CALL(zone_a, get_subnet()).WillByDefault(ReturnRef(subnet_a));
+    ON_CALL(zone_b, get_subnet()).WillByDefault(ReturnRef(subnet_b));
+    ON_CALL(zone_c, get_subnet()).WillByDefault(ReturnRef(subnet_c));
+
+    NiceMock<mpt::MockAvailabilityZoneManager> mock_manager;
+    const std::vector<std::reference_wrapper<const mp::AvailabilityZone>> zones{zone_a,
+                                                                                zone_b,
+                                                                                zone_c};
+    EXPECT_CALL(mock_manager, get_zones()).WillRepeatedly(Return(zones));
+
+    EXPECT_CALL(
+        *mock_utils,
+        run_cmd_for_status(QString("sysctl"), Contains(QString("net.inet.ip.forwarding=1")), _))
+        .WillOnce(Return(true));
+
+    std::string captured_rules;
+    mock_process_factory->register_callback([&captured_rules](mpt::MockProcess* process) {
+        if (process->program() == "pfctl")
+        {
+            EXPECT_THAT(process->arguments(), Contains(QString("-f")));
+            EXPECT_CALL(*process, write(_)).WillOnce([&captured_rules](const QByteArray& data) {
+                captured_rules = data.toStdString();
+                return data.size();
+            });
+            EXPECT_CALL(*process, wait_for_finished(_)).WillRepeatedly(Return(true));
+        }
+    });
+
+    mp::backend::enable_cross_zone_routing(mock_manager);
+
+    // N zones produce a "pass" rule for each of the N * (N - 1) ordered, distinct subnet pairs.
+    EXPECT_THAT(QString::fromStdString(captured_rules).split('\n', Qt::SkipEmptyParts),
+                SizeIs(zones.size() * (zones.size() - 1)));
+    for (const auto& src : mock_manager.get_zones())
+    {
+        for (const auto& dst : mock_manager.get_zones())
+        {
+            if (&src.get() != &dst.get())
+            {
+                EXPECT_THAT(captured_rules,
+                            HasSubstr(fmt::format("pass quick inet from {} to {} flags any keep "
+                                                  "state",
+                                                  src.get().get_subnet().canonical().to_cidr(),
+                                                  dst.get().get_subnet().canonical().to_cidr())));
+            }
+            else
+            {
+                EXPECT_THAT(
+                    captured_rules,
+                    Not(HasSubstr(fmt::format("from {} to {}",
+                                              src.get().get_subnet().canonical().to_cidr(),
+                                              dst.get().get_subnet().canonical().to_cidr()))));
+            }
+        }
+    }
+}

--- a/tests/unit/macos/test_backend_utils.cpp
+++ b/tests/unit/macos/test_backend_utils.cpp
@@ -163,29 +163,14 @@ TEST(EnableCrossZoneRouting, multipleZonesEnablesForwardingAndInstallsPfRules)
 
     mp::backend::enable_cross_zone_routing(az_manager);
 
-    // N zones produce a "pass" rule for each of the N * (N - 1) ordered, distinct subnet pairs.
-    EXPECT_THAT(QString::fromStdString(captured_rules).split('\n', Qt::SkipEmptyParts),
-                SizeIs(zones.size() * (zones.size() - 1)));
-    for (const auto& src : az_manager.get_zones())
-    {
-        for (const auto& dst : az_manager.get_zones())
-        {
-            if (&src.get() != &dst.get())
-            {
-                EXPECT_THAT(captured_rules,
-                            HasSubstr(fmt::format("pass quick inet from {} to {} flags any keep "
-                                                  "state",
-                                                  src.get().get_subnet().canonical().to_cidr(),
-                                                  dst.get().get_subnet().canonical().to_cidr())));
-            }
-            else
-            {
-                EXPECT_THAT(
-                    captured_rules,
-                    Not(HasSubstr(fmt::format("from {} to {}",
-                                              src.get().get_subnet().canonical().to_cidr(),
-                                              dst.get().get_subnet().canonical().to_cidr()))));
-            }
-        }
-    }
+    EXPECT_EQ(captured_rules,
+              fmt::format(("pass quick inet from {0} to {1} flags any keep state\n"
+                           "pass quick inet from {0} to {2} flags any keep state\n"
+                           "pass quick inet from {1} to {0} flags any keep state\n"
+                           "pass quick inet from {1} to {2} flags any keep state\n"
+                           "pass quick inet from {2} to {0} flags any keep state\n"
+                           "pass quick inet from {2} to {1} flags any keep state\n"),
+                          "192.168.64.0/24",
+                          "192.168.65.0/24",
+                          "192.168.66.0/24"));
 }


### PR DESCRIPTION
When using vmnet-shared subnets on macOS, the OS will automatically install pf anchors in `com.apple.internet-sharing/network_isolation` with `block drop quick` between distinct subnets resulting in VMs in different zones not being able to communicate with each other. This PR adds a couple system commands to one, ensure that IP forwarding is enabled (it was already enabled on my machine, buts we set it just to make sure), and two, add additional pf anchors that get evaluated before the ones that are auto generated by the OS.

There are some disadvantages to this approach:
1. Using `pfctl` requires elevated privileges
2. PF rules are a system resource that can be modified by other services or even the OS. For that reason, we reassert the added pf anchors on various VM operations.

The alternative approach that I explored is to create a single shared `vmnet`-shared interface plus a userspace network fabric. One in-process L2 switch per AZ and an in-process L3 router that forwards between zones and out the uplink. This would be simpler to integrate with `applevz`, but more difficult with QEMU. Because of the complexity of this approach and the fact that this is blocking the AZ feature, the first approach was preferred. In the future, when we look at removing QEMU from use on macOS and reduce the privileges of the daemon process, this or a similar solution can be explores more.

---

MULTI-2761