### PR TITLE
[cmake] Remove applevz feature flag

### DIFF
--- a/feature-flags.cmake
+++ b/feature-flags.cmake
@@ -14,8 +14,5 @@
 
 include(src/cmake/feature-flag.cmake)
 
-# Multipass backend integrating with Apple Virtualization framework
-feature_flag(APPLEVZ_ENABLED "AppleVZ backend" APPLE)
-
 # The new Windows backend based on Hyper-V Host Compute System / Host Compute Networking APIs
 feature_flag(HYPERV_HCS_ENABLED "Hyper-V HCS backend" WIN32)

--- a/src/cmake/populate-supported-backends-list.cmake
+++ b/src/cmake/populate-supported-backends-list.cmake
@@ -19,7 +19,7 @@ if(UNIX)
         list(APPEND MULTIPASS_BACKENDS virtualbox)
     endif()
 
-    if(APPLEVZ_ENABLED)
+    if(APPLE)
         list(APPEND MULTIPASS_BACKENDS applevz)
     endif()
 elseif(WIN32)


### PR DESCRIPTION
Removing the `applevz` feature flag now that the AZ feature flag is gone.