### PR TITLE
[daemon] Reject more vCPUs than the host has

### DIFF
--- a/src/client/cli/cmd/launch.cpp
+++ b/src/client/cli/cmd/launch.cpp
@@ -589,6 +589,13 @@ mp::ReturnCodeVariant cmd::Launch::request_launch(const ArgParser* parser)
                 error_details =
                     fmt::format("Invalid memory size value supplied: {}.", request.mem_size());
             }
+            else if (error == LaunchError::INVALID_NUM_CORES)
+            {
+                error_details = fmt::format(
+                    "Invalid number of CPUs requested: {}. It must not exceed the number "
+                    "available on the host.",
+                    request.num_cores());
+            }
             else if (error == LaunchError::INVALID_HOSTNAME)
             {
                 error_details =

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -468,6 +468,19 @@ auto validate_create_arguments(const mp::LaunchRequest* request, const mp::Daemo
         }
     }
 
+    // CPUs are the one launch resource with no host-side upper bound: unlike memory and
+    // disk (checked above / when reserving space), an over-provisioned core count is
+    // accepted and then wedges the instance at boot -- it times out, leaving the daemon
+    // reporting "IP not available" until the user runs `delete --purge`. Reject a request
+    // for more vCPUs than the host reports up front instead. See issue #5061.
+    // (A stricter "leave one core for the host" policy would be `>= host_cpus`; `>` is
+    // used here so a VM may still use every core.) The `host_cpus > 0` guard skips the
+    // check when the host core count can't be determined (get_cpus() returns -1), so a
+    // failed probe never rejects an otherwise valid request.
+    if (const auto num_cores = request->num_cores(), host_cpus = MP_PLATFORM.get_cpus();
+        num_cores > 0 && host_cpus > 0 && num_cores > host_cpus)
+        option_errors.add_error_codes(mp::LaunchError::INVALID_NUM_CORES);
+
     if (!instance_name.empty() && !mp::utils::valid_hostname(instance_name))
         option_errors.add_error_codes(mp::LaunchError::INVALID_HOSTNAME);
 

--- a/src/daemon/instance_settings_handler.cpp
+++ b/src/daemon/instance_settings_handler.cpp
@@ -20,6 +20,7 @@
 #include <multipass/cli/prompters.h>
 #include <multipass/constants.h>
 #include <multipass/exceptions/invalid_memory_size_exception.h>
+#include <multipass/platform.h>
 #include <multipass/settings/bool_setting_spec.h>
 
 #include <QRegularExpression>
@@ -131,14 +132,29 @@ void update_cpus(const QString& key,
                  mp::VMSpecs& spec)
 {
     bool converted_ok = false;
-    if (auto cpus = val.toInt(&converted_ok); !converted_ok || cpus < std::stoi(mp::min_cpu_cores))
+    const auto cpus = val.toInt(&converted_ok);
+    if (!converted_ok || cpus < std::stoi(mp::min_cpu_cores))
         throw mp::InvalidSettingException{
             key,
             val,
             QString("Need a positive integer (in decimal format) of minimum %1")
                 .arg(mp::min_cpu_cores)};
-    else if (cpus != spec.num_cores) // NOOP if equal
+
+    if (cpus != spec.num_cores) // NOOP if equal
     {
+        // Reject more vCPUs than the host has -- an over-provisioned count wedges the
+        // instance (see #5061). Mirrors the launch-time check in daemon.cpp. Only an
+        // actual change is validated: re-setting the current value stays a no-op even
+        // if it already exceeds the host (e.g. the spec was moved to a smaller host),
+        // and a `host_cpus > 0` guard skips the check when get_cpus() can't probe (-1).
+        if (const auto host_cpus = MP_PLATFORM.get_cpus(); host_cpus > 0 && cpus > host_cpus)
+            throw mp::InvalidSettingException{
+                key,
+                val,
+                QString("Number of CPUs (%1) must not exceed the %2 available on the host")
+                    .arg(cpus)
+                    .arg(host_cpus)};
+
         instance.update_cpus(cpus);
         spec.num_cores = cpus;
     }

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -88,6 +88,7 @@ message LaunchError {
         INVALID_NETWORK = 4;
         INVALID_ZONE = 5;
         ZONE_UNAVAILABLE = 6;
+        INVALID_NUM_CORES = 7;
     }
     repeated ErrorCodes error_codes = 1;
 }

--- a/tests/unit/mock_platform.h
+++ b/tests/unit/mock_platform.h
@@ -33,6 +33,15 @@ public:
         EXPECT_CALL(*this, set_server_socket_restrictions)
             .Times(testing::AnyNumber())
             .WillRepeatedly(testing::Return());
+        // get_cpus() gained a mock override (see #5061). Default it to an effectively
+        // unlimited host so tests that don't care about the CPU ceiling are unaffected
+        // and host-independent; tests exercising the ceiling override this with EXPECT_CALL.
+        // The value must exceed the largest cpu count any existing test sets (some reuse a
+        // generic numeric value of 134217728 across all numeric properties).
+        // NOTE: get_cpus() is also called by the daemon_info RPC (daemon.cpp); no test
+        // currently exercises DaemonInfoRequest, but any future one will see this default
+        // rather than a real count -- override it there with EXPECT_CALL if it matters.
+        ON_CALL(*this, get_cpus()).WillByDefault(testing::Return(2'000'000'000));
     };
 
     MOCK_METHOD((std::map < std::string, NetworkInterfaceInfo) >,
@@ -60,6 +69,7 @@ public:
                 (const std::string&, const bool),
                 (const, override));
     MOCK_METHOD(QString, multipass_storage_location, (), (const, override));
+    MOCK_METHOD(int, get_cpus, (), (const, override));
     MOCK_METHOD(SettingSpec::Set, extra_daemon_settings, (), (const, override));
     MOCK_METHOD(SettingSpec::Set, extra_client_settings, (), (const, override));
     MOCK_METHOD(QString, daemon_config_home, (), (const, override));

--- a/tests/unit/test_daemon.cpp
+++ b/tests/unit/test_daemon.cpp
@@ -1376,6 +1376,48 @@ TEST_F(Daemon, refusesLaunchWithInvalidNetworkInterface)
     EXPECT_THAT(err_stream.str(), HasSubstr("Invalid network options."));
 }
 
+TEST_F(Daemon, refusesLaunchWithMoreCPUsThanAvailableOnHost)
+{
+    mp::Daemon daemon{config_builder.build()};
+
+    // Pretend the host has only 4 logical CPUs. A request for more must be refused up
+    // front: an over-provisioned CPU count launches a VM that never gets an IP and wedges
+    // the daemon until `delete --purge` (see #5061). Memory and disk are already bounded
+    // against the host; CPUs were the one launch resource with no such ceiling.
+    EXPECT_CALL(mock_platform, get_cpus()).WillRepeatedly(Return(4));
+
+    std::stringstream err_stream;
+    send_command({"launch", "--cpus", "8"}, trash_stream, err_stream);
+    EXPECT_THAT(err_stream.str(), HasSubstr("Invalid number of CPUs"));
+}
+
+TEST_F(Daemon, launchesWithExactlyHostCPUCount)
+{
+    [[maybe_unused]] auto mock_factory = use_a_mock_vm_factory();
+    mp::Daemon daemon{config_builder.build()};
+
+    // The ceiling is `> host`, not `>= host`: a VM may still claim every core.
+    EXPECT_CALL(mock_platform, get_cpus()).WillRepeatedly(Return(4));
+
+    std::stringstream err_stream;
+    send_command({"launch", "--cpus", "4"}, trash_stream, err_stream);
+    EXPECT_THAT(err_stream.str(), Not(HasSubstr("Invalid number of CPUs")));
+}
+
+TEST_F(Daemon, launchAcceptsCPUsWhenHostCountUnavailable)
+{
+    [[maybe_unused]] auto mock_factory = use_a_mock_vm_factory();
+    mp::Daemon daemon{config_builder.build()};
+
+    // get_cpus() returns -1 when the host core count can't be probed. The ceiling must
+    // skip that case rather than reject every positive request (see #5061 review).
+    EXPECT_CALL(mock_platform, get_cpus()).WillRepeatedly(Return(-1));
+
+    std::stringstream err_stream;
+    send_command({"launch", "--cpus", "8"}, trash_stream, err_stream);
+    EXPECT_THAT(err_stream.str(), Not(HasSubstr("Invalid number of CPUs")));
+}
+
 TEST_F(Daemon, refusesLaunchBecauseBridgingIsNotImplemented)
 {
     // Use the stub factory, which throws when networks() is called.

--- a/tests/unit/test_instance_settings_handler.cpp
+++ b/tests/unit/test_instance_settings_handler.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "common.h"
+#include "mock_platform.h"
 #include "mock_virtual_machine.h"
 
 #include <multipass/constants.h>
@@ -144,6 +145,13 @@ struct TestInstanceSettingsHandler : public Test
     inline static constexpr std::array numeric_properties{"cpus", "disk", "memory"};
     inline static constexpr std::array boolean_properties{"bridged"};
     inline static constexpr std::array properties{"cpus", "disk", "memory", "bridged"};
+
+    // Setting `cpus` now rejects counts above the host's (see #5061); update_cpus reads
+    // MP_PLATFORM.get_cpus(). Inject the platform mock so those reads are deterministic.
+    // Its ctor defaults get_cpus() to an effectively unlimited host, so the existing
+    // cpu-setting tests are unaffected; the ceiling test below overrides it.
+    mpt::MockPlatform::GuardedMock mock_platform_injection{mpt::MockPlatform::inject<NiceMock>()};
+    mpt::MockPlatform& mock_platform = *mock_platform_injection.first;
 };
 
 QString make_key(const QString& instance_name, const QString& property)
@@ -404,6 +412,49 @@ TEST_F(TestInstanceSettingsHandler, setMaintainsInstanceCPUsUntouchedIfSameButSu
                                        QString::number(same_cpus),
                                        messages));
     EXPECT_EQ(actual_cpus, same_cpus);
+}
+
+TEST_F(TestInstanceSettingsHandler, setRefusesMoreCPUsThanAvailableOnHost)
+{
+    constexpr auto target_instance_name = "qwer";
+    constexpr auto host_cpus = 4;
+    constexpr auto too_many_cpus = 8;
+    constexpr auto original_cpus = 2;
+    specs[target_instance_name].num_cores = original_cpus;
+
+    // Over-provisioning vCPUs wedges the instance (see #5061); mirror the launch-time
+    // ceiling in daemon.cpp. The VM must never be resized when the request is rejected.
+    EXPECT_CALL(mock_platform, get_cpus()).WillRepeatedly(Return(host_cpus));
+    EXPECT_CALL(mock_vm(target_instance_name), update_cpus).Times(0);
+
+    [[maybe_unused]] mp::UserMessages messages{};
+    MP_EXPECT_THROW_THAT(make_handler().set(make_key(target_instance_name, "cpus"),
+                                            QString::number(too_many_cpus),
+                                            messages),
+                         mp::InvalidSettingException,
+                         mpt::match_what(AllOf(HasSubstr("CPUs"), HasSubstr("host"))));
+    EXPECT_EQ(specs[target_instance_name].num_cores, original_cpus); // spec left untouched
+}
+
+TEST_F(TestInstanceSettingsHandler, setToCurrentCPUsSucceedsEvenIfAboveHost)
+{
+    // Regression (see #5061 review): the host ceiling gates only an ACTUAL change.
+    // Re-setting the current value is a no-op and must not start throwing just because
+    // the stored count already exceeds the host (e.g. the spec outlived a move to a
+    // smaller host). Host reports fewer cores than the instance currently has.
+    constexpr auto target_instance_name = "zxcv";
+    constexpr auto host_cpus = 4;
+    constexpr auto current_cpus = 8; // already above the host
+    const auto& actual_cpus = specs[target_instance_name].num_cores = current_cpus;
+
+    EXPECT_CALL(mock_platform, get_cpus()).WillRepeatedly(Return(host_cpus));
+    EXPECT_CALL(mock_vm(target_instance_name), update_cpus).Times(0);
+
+    [[maybe_unused]] mp::UserMessages messages{};
+    EXPECT_NO_THROW(make_handler().set(make_key(target_instance_name, "cpus"),
+                                       QString::number(current_cpus),
+                                       messages));
+    EXPECT_EQ(actual_cpus, current_cpus);
 }
 
 TEST_F(TestInstanceSettingsHandler, setAllowsDecreaseInstanceCPUs)


### PR DESCRIPTION
### Problem

The daemon bounds a launch request's **memory** and **disk** against the host,
but there is no equivalent ceiling on the **CPU count**. Requesting more vCPUs
than the host has is accepted, and the resulting VM never gets an IP — it hangs
at boot and wedges the daemon, which then reports "IP not available" until the
instance is removed with `delete --purge`.

Reproducer (on an 8-core host):

```
multipass launch --cpus 12
```

The same over-provisioning is also reachable at runtime via
`multipass set local.<instance>.cpus=<n>` on a stopped instance.

### Fix

Reject a request for more vCPUs than the host reports, at both seams:

- **Launch** — `validate_create_arguments` now adds a new `INVALID_NUM_CORES`
  launch error when `num_cores > host`, and the client prints an actionable
  message.
- **`set cpus`** — `update_cpus` throws `InvalidSettingException` for the same
  condition.

Details:

- The bound is strict (`>`, not `>=`), so a VM may still claim every core.
- The `set cpus` check applies only to an **actual** change, so re-setting the
  current value stays a no-op even if that value already exceeds the host (e.g.
  a spec that outlived a move to a smaller host).
- Both seams skip the check when the host count cannot be determined
  (`get_cpus()` returning a non-positive value), so a failed probe never
  rejects an otherwise valid request.

### Testing

- New daemon tests: refuses a launch above the host count, allows exactly the
  host count, and still accepts a request when the host count is unavailable.
- New settings-handler tests: refuses `set cpus` above the host (leaving the
  spec untouched) and keeps a same-value set a no-op even when above the host.
- Full unit test suite passes.

Fixes #5061
