### PR TITLE
[qemu] Post vcpkg/qemu bugfixes

### DIFF
--- a/3rd-party/vcpkg-ports/qemu/portfile.cmake
+++ b/3rd-party/vcpkg-ports/qemu/portfile.cmake
@@ -54,6 +54,7 @@ set(QEMU_COMMON_OPTIONS
     "--disable-qed"
     "--disable-libiscsi"
     "--disable-vnc"
+    "--disable-png"
     "--disable-xen"
     "--disable-dmg"
     "--disable-replication"

--- a/packaging/gui-less/snap/snapcraft.yaml
+++ b/packaging/gui-less/snap/snapcraft.yaml
@@ -141,7 +141,6 @@ parts:
 
     stage-packages:
     - apparmor
-    - libpng16-16
     - libxml2
     - dnsmasq-base
     - dnsmasq-utils

--- a/packaging/gui-less/snap/snapcraft.yaml
+++ b/packaging/gui-less/snap/snapcraft.yaml
@@ -185,7 +185,6 @@ parts:
     - -usr/lib/*/libgtk-3-0t64/gtk-query-immodules-3.0
     - -usr/lib/*/libcolord.so*
     - -usr/lib/*/libcups.so*
-    - -usr/lib/*/libgiomm-2.4.so*
     - -usr/share/apport
     - -usr/share/bug
     - -usr/share/doc*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -204,7 +204,6 @@ parts:
     - -usr/lib/*/libgtk-3-0t64/gtk-query-immodules-3.0
     - -usr/lib/*/libcolord.so*
     - -usr/lib/*/libcups.so*
-    - -usr/lib/*/libgiomm-2.4.so*
     - -usr/share/apport
     - -usr/share/bug
     - -usr/share/doc*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -160,7 +160,6 @@ parts:
 
     stage-packages:
     - apparmor
-    - libpng16-16
     - libxml2
     - dnsmasq-base
     - dnsmasq-utils


### PR DESCRIPTION
A couple bugfixes following the move to manage the QEMU dependency via vcpkg.
1. QEMU failed to build on ppc64el/s390x architectures. The previous of `libpng` in the build environment caused a QEMU feature to be enabled which wasn't enabled before.
2. `libgiomm` seems to be required in order to run the GUI on Linux (no specific architecture). Adding it back in lets me launch the GUI.
3. Drive by fix: found an extra package; `libpng` that was associated with the old system tray UI. Removed as we don't use that implementation anymore.

Fixes #5093 

---

MULTI-2772