### PR TITLE
[bugfix] Disable Valgrind compilation on s390x

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,13 +34,10 @@ jobs:
             "runs-on": "ubuntu-latest"
           });
 
-          let runners = ["ubuntu-latest", "ubuntu-24.04-arm"];
-          if (context.eventName === 'schedule' &&
-              context.repo.owner === 'canonical' &&
-              context.repo.repo === 'multipass') {
-            runners.push("self-hosted-linux-ppc64el-noble-edge",
-                         "self-hosted-linux-s390x-noble-edge");
-          }
+          let runners = ["ubuntu-latest",
+                         "ubuntu-24.04-arm",
+                         "self-hosted-linux-ppc64el-noble-edge",
+                         "self-hosted-linux-s390x-noble-edge"];
 
           for (const runner of runners) {
             matrix.include.push({

--- a/3rd-party/vcpkg-triplets/s390x-linux-release.cmake
+++ b/3rd-party/vcpkg-triplets/s390x-linux-release.cmake
@@ -10,5 +10,7 @@ set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CROSSCOMPILING:BOOL=OFF")
 
 # Disable Valgrind which glib pulls in and compiles. Valgrind will not compile on s390x
 # with newer versions of clang.
-set(VCPKG_C_FLAGS "-DNVALGRIND")
-set(VCPKG_CXX_FLAGS "-DNVALGRIND")
+if(PORT STREQUAL "glib")
+    set(VCPKG_C_FLAGS "-DNVALGRIND")
+    set(VCPKG_CXX_FLAGS "-DNVALGRIND")
+endif()

--- a/3rd-party/vcpkg-triplets/s390x-linux-release.cmake
+++ b/3rd-party/vcpkg-triplets/s390x-linux-release.cmake
@@ -7,3 +7,8 @@ set(VCPKG_BUILD_TYPE release)
 # Workaround for dbus and qtbase: when vcpkg sets VCPKG_CMAKE_SYSTEM_NAME, CMake may treat
 # native s390x builds as cross-compiling.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CROSSCOMPILING:BOOL=OFF")
+
+# Disable Valgrind which glib pulls in and compiles. Valgrind will not compile on s390x
+# with newer versions of clang.
+set(VCPKG_C_FLAGS "-DNVALGRIND")
+set(VCPKG_CXX_FLAGS "-DNVALGRIND")

--- a/3rd-party/vcpkg-triplets/s390x-linux-release.cmake
+++ b/3rd-party/vcpkg-triplets/s390x-linux-release.cmake
@@ -7,3 +7,8 @@ set(VCPKG_BUILD_TYPE release)
 # Workaround for dbus and qtbase: when vcpkg sets VCPKG_CMAKE_SYSTEM_NAME, CMake may treat
 # native s390x builds as cross-compiling.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CROSSCOMPILING:BOOL=OFF")
+
+# Valgrind does not compile without errors with newer version of clang. Valgrind is compiled
+# as a transitive dependency of glib and QEMU. Note that this will disable Valgrind whenever
+# its linked by meson.
+list(APPEND VCPKG_MESON_CONFIGURE_OPTIONS "-Dvalgrind=disabled")


### PR DESCRIPTION
This PR disables the compilation of Valgrind on s390x. Valgrind is getting pulled in as a transitive dependency of glib and QEMU now that QEMU is being managed through vcpkg. Valgrind will not compile with newer versions of clang and its strictly enforcement of compiler warnings.

A successful compilation on an s390x runner can be found [here](https://github.com/canonical/multipass/actions/runs/32302539839/job/96228218459).

Closes #5154 

MULTI-2820