### PR TITLE
feat: auto-suspend instances on macOS lid close

### DIFF
--- a/include/multipass/constants.h
+++ b/include/multipass/constants.h
@@ -40,8 +40,8 @@ constexpr auto default_memory_size = "1G";
 constexpr auto default_disk_size = "5G";
 constexpr auto default_cpu_cores = min_cpu_cores;
 constexpr auto default_timeout = std::chrono::seconds(300);
-constexpr auto image_resize_timeout =
-    std::chrono::duration_cast<std::chrono::milliseconds>(5min).count();
+constexpr auto image_resize_timeout = std::chrono::duration_cast<std::chrono::milliseconds>(5min)
+                                          .count();
 
 constexpr auto home_automount_dir = "Home";
 
@@ -66,6 +66,8 @@ constexpr auto bridged_interface_key = "local.bridged-network";
 constexpr auto mounts_key = "local.privileged-mounts";
 constexpr auto winterm_key = "client.apps.windows-terminal.profiles";
 constexpr auto mirror_key = "local.image.mirror"; // the mirror of simple streams
+constexpr auto auto_suspend_key = "local.auto-suspend-on-sleep";
+constexpr auto auto_resume_key = "local.auto-resume-on-wake";
 
 constexpr auto cloud_init_file_name = "cloud-init-config.iso";
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -136,8 +136,9 @@ auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider,
                                    const std::string& backend_version_string,
                                    const mp::CreateRequest* request)
 {
-    auto ssh_key_line =
-        fmt::format("ssh-rsa {} {}@localhost", key_provider.public_key_as_base64(), username);
+    auto ssh_key_line = fmt::format("ssh-rsa {} {}@localhost",
+                                    key_provider.public_key_as_base64(),
+                                    username);
     QString pollinate_alias = QString::fromStdString(request->image());
 
     if (pollinate_alias.isEmpty())
@@ -165,10 +166,11 @@ auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider,
     {
         config["packages"].push_back("pollinate");
 
-        auto pollinate_user_agent_string =
-            fmt::format("multipass/version/{} # written by Multipass\n", multipass::version_string);
-        pollinate_user_agent_string +=
-            fmt::format("multipass/driver/{} # written by Multipass\n", backend_version_string);
+        auto pollinate_user_agent_string = fmt::format(
+            "multipass/version/{} # written by Multipass\n",
+            multipass::version_string);
+        pollinate_user_agent_string += fmt::format("multipass/driver/{} # written by Multipass\n",
+                                                   backend_version_string);
         pollinate_user_agent_string += fmt::format("multipass/host/{} # written by Multipass\n",
                                                    multipass::platform::host_version());
         pollinate_user_agent_string += fmt::format("multipass/alias/{}{} # written by Multipass\n",
@@ -323,8 +325,9 @@ bool is_bridged_impl(const mp::VMSpecs& specs,
                      const std::vector<mp::NetworkInterfaceInfo>& host_nets,
                      const std::string& preferred_net)
 {
-    const auto& matching_bridge =
-        mpu::find_bridge_with(host_nets, preferred_net, MP_PLATFORM.bridge_nomenclature());
+    const auto& matching_bridge = mpu::find_bridge_with(host_nets,
+                                                        preferred_net,
+                                                        MP_PLATFORM.bridge_nomenclature());
     return std::any_of(specs.extra_interfaces.cbegin(),
                        specs.extra_interfaces.cend(),
                        [&preferred_net, &matching_bridge](const auto& network) -> bool {
@@ -443,8 +446,8 @@ auto validate_create_arguments(const mp::LaunchRequest* request, const mp::Daemo
     auto zone_name = request->zone();
     auto option_errors = mp::LaunchError{};
 
-    const auto opt_mem_size =
-        try_mem_size(mem_size_str.empty() ? mp::default_memory_size : mem_size_str);
+    const auto opt_mem_size = try_mem_size(mem_size_str.empty() ? mp::default_memory_size
+                                                                : mem_size_str);
 
     mp::MemorySize mem_size{};
     if (opt_mem_size && *opt_mem_size >= min_mem)
@@ -482,8 +485,10 @@ auto validate_create_arguments(const mp::LaunchRequest* request, const mp::Daemo
     }
 
     std::vector<std::string> nets_need_bridging;
-    auto extra_interfaces =
-        validate_extra_interfaces(request, *config->factory, nets_need_bridging, option_errors);
+    auto extra_interfaces = validate_extra_interfaces(request,
+                                                      *config->factory,
+                                                      nets_need_bridging,
+                                                      option_errors);
 
     struct CheckedArguments
     {
@@ -753,16 +758,19 @@ grpc::Status grpc_status_for_selection(const InstanceSelectionReport& selection,
     fmt::memory_buffer errors;
     auto status_code = grpc::StatusCode::OK;
 
-    if (auto code =
-            react_to_component(selection.operative_selection, reaction.operative_reaction, errors);
+    if (auto code = react_to_component(selection.operative_selection,
+                                       reaction.operative_reaction,
+                                       errors);
         code)
         status_code = code;
-    if (auto code =
-            react_to_component(selection.deleted_selection, reaction.deleted_reaction, errors);
+    if (auto code = react_to_component(selection.deleted_selection,
+                                       reaction.deleted_reaction,
+                                       errors);
         code)
         status_code = code;
-    if (auto code =
-            react_to_component(selection.missing_instances, reaction.missing_reaction, errors);
+    if (auto code = react_to_component(selection.missing_instances,
+                                       reaction.missing_reaction,
+                                       errors);
         code)
         status_code = code;
 
@@ -828,8 +836,10 @@ select_instances_and_react(InstanceTable& operative_instances,
                            InstanceGroup no_name_means,
                            const SelectionReaction& reaction)
 {
-    auto instance_selection =
-        select_instances(operative_instances, deleted_instances, names, no_name_means);
+    auto instance_selection = select_instances(operative_instances,
+                                               deleted_instances,
+                                               names,
+                                               no_name_means);
     return {instance_selection, grpc_status_for_selection(instance_selection, reaction)};
 }
 
@@ -1352,8 +1362,8 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
             continue;
         }
 
-        const auto instance_dir =
-            mp::utils::base_dir(MP_PLATFORM.path_to_qstr(vm_image.image_path));
+        const auto instance_dir = mp::utils::base_dir(
+            MP_PLATFORM.path_to_qstr(vm_image.image_path));
         const auto cloud_init_iso = instance_dir.filePath(cloud_init_file_name);
         mp::VirtualMachineDescription vm_desc{spec.num_cores,
                                               spec.mem_size,
@@ -1371,8 +1381,10 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
                                               {}};
 
         auto& instance_record = spec.deleted ? deleted_instances : operative_instances;
-        auto instance = instance_record[name] =
-            config->factory->create_virtual_machine(vm_desc, *config->ssh_key_provider, *this);
+        auto instance = instance_record[name] = config->factory->create_virtual_machine(
+            vm_desc,
+            *config->ssh_key_provider,
+            *this);
         instance->load_snapshots();
 
         // Add the new macs to the daemon's list only if we got this far
@@ -1751,12 +1763,12 @@ try
         return grpc_status_for(errors);
     };
 
-    auto [instance_selection, status] =
-        select_instances_and_react(operative_instances,
-                                   deleted_instances,
-                                   request->instance_snapshot_pairs(),
-                                   InstanceGroup::All,
-                                   require_existing_instances_reaction);
+    auto [instance_selection,
+          status] = select_instances_and_react(operative_instances,
+                                               deleted_instances,
+                                               request->instance_snapshot_pairs(),
+                                               InstanceGroup::All,
+                                               require_existing_instances_reaction);
 
     if (status.ok())
     {
@@ -1941,10 +1953,10 @@ try
     {
         const auto& name = path_entry.instance_name();
         auto q_target_path = QString::fromStdString(path_entry.target_path());
-        q_target_path =
-            q_target_path.isEmpty()
-                ? MP_UTILS.default_mount_target(QString::fromStdString(request->source_path()))
-                : MP_UTILS.normalize_mount_target(q_target_path);
+        q_target_path = q_target_path.isEmpty()
+                          ? MP_UTILS.default_mount_target(
+                                QString::fromStdString(request->source_path()))
+                          : MP_UTILS.normalize_mount_target(q_target_path);
         auto target_path = q_target_path.toStdString();
 
         auto it = operative_instances.find(name);
@@ -2024,12 +2036,12 @@ try
     recover_reaction.operative_reaction.message_template =
         "instance \"{}\" does not need to be recovered";
 
-    auto [instance_selection, status] =
-        select_instances_and_react(operative_instances,
-                                   deleted_instances,
-                                   request->instance_names().instance_name(),
-                                   InstanceGroup::Deleted,
-                                   recover_reaction);
+    auto [instance_selection,
+          status] = select_instances_and_react(operative_instances,
+                                               deleted_instances,
+                                               request->instance_names().instance_name(),
+                                               InstanceGroup::Deleted,
+                                               recover_reaction);
 
     if (status.ok())
     {
@@ -2058,12 +2070,12 @@ void mp::Daemon::ssh_info(const SSHInfoRequest* request,
                           DaemonRpcContext* context)
 try
 {
-    auto [instance_selection, status] =
-        select_instances_and_react(operative_instances,
-                                   deleted_instances,
-                                   request->instance_name(),
-                                   InstanceGroup::None,
-                                   require_operative_instances_reaction);
+    auto [instance_selection,
+          status] = select_instances_and_react(operative_instances,
+                                               deleted_instances,
+                                               request->instance_name(),
+                                               InstanceGroup::None,
+                                               require_operative_instances_reaction);
 
     if (status.ok())
     {
@@ -2097,12 +2109,12 @@ try
     const SelectionReaction custom_reaction{{grpc::StatusCode::OK},
                                             {grpc::StatusCode::ABORTED},
                                             {grpc::StatusCode::ABORTED}};
-    auto [instance_selection, status] =
-        select_instances_and_react(operative_instances,
-                                   deleted_instances,
-                                   request->instance_names().instance_name(),
-                                   InstanceGroup::Operative,
-                                   custom_reaction);
+    auto [instance_selection,
+          status] = select_instances_and_react(operative_instances,
+                                               deleted_instances,
+                                               request->instance_names().instance_name(),
+                                               InstanceGroup::Operative,
+                                               custom_reaction);
 
     if (!status.ok())
         return context->set_value({status.error_code(),
@@ -2124,10 +2136,10 @@ try
         {
         case VirtualMachine::State::unknown:
         {
-            auto error_string =
-                fmt::format("Instance '{0}' is already running, but in an unknown state.\n"
-                            "Try to stop it first.",
-                            name);
+            auto error_string = fmt::format(
+                "Instance '{0}' is already running, but in an unknown state.\n"
+                "Try to stop it first.",
+                name);
             mpl::log_message(mpl::Level::warning, category, error_string);
             start_errors.append(error_string);
             continue;
@@ -2183,12 +2195,12 @@ void mp::Daemon::stop(const StopRequest* request,
                       DaemonRpcContext* context)
 try
 {
-    auto [instance_selection, status] =
-        select_instances_and_react(operative_instances,
-                                   deleted_instances,
-                                   request->instance_names().instance_name(),
-                                   InstanceGroup::Operative,
-                                   require_operative_instances_reaction);
+    auto [instance_selection,
+          status] = select_instances_and_react(operative_instances,
+                                               deleted_instances,
+                                               request->instance_names().instance_name(),
+                                               InstanceGroup::Operative,
+                                               require_operative_instances_reaction);
 
     if (status.ok())
     {
@@ -2223,12 +2235,12 @@ void mp::Daemon::suspend(const SuspendRequest* request,
                          DaemonRpcContext* context)
 try
 {
-    auto [instance_selection, status] =
-        select_instances_and_react(operative_instances,
-                                   deleted_instances,
-                                   request->instance_names().instance_name(),
-                                   InstanceGroup::Operative,
-                                   require_operative_instances_reaction);
+    auto [instance_selection,
+          status] = select_instances_and_react(operative_instances,
+                                               deleted_instances,
+                                               request->instance_names().instance_name(),
+                                               InstanceGroup::Operative,
+                                               require_operative_instances_reaction);
 
     if (status.ok())
     {
@@ -2263,12 +2275,12 @@ try
     auto timeout = request->timeout() > 0 ? std::chrono::seconds(request->timeout())
                                           : mp::default_timeout;
 
-    auto [instance_selection, status] =
-        select_instances_and_react(operative_instances,
-                                   deleted_instances,
-                                   request->instance_names().instance_name(),
-                                   InstanceGroup::Operative,
-                                   require_operative_instances_reaction);
+    auto [instance_selection,
+          status] = select_instances_and_react(operative_instances,
+                                               deleted_instances,
+                                               request->instance_names().instance_name(),
+                                               InstanceGroup::Operative,
+                                               require_operative_instances_reaction);
 
     if (!status.ok())
     {
@@ -2310,12 +2322,12 @@ try
 {
     DeleteReply response;
 
-    auto [instance_selection, status] =
-        select_instances_and_react(operative_instances,
-                                   deleted_instances,
-                                   request->instance_snapshot_pairs(),
-                                   InstanceGroup::All,
-                                   require_existing_instances_reaction);
+    auto [instance_selection,
+          status] = select_instances_and_react(operative_instances,
+                                               deleted_instances,
+                                               request->instance_snapshot_pairs(),
+                                               InstanceGroup::All,
+                                               require_existing_instances_reaction);
 
     if (status.ok())
     {
@@ -2323,12 +2335,13 @@ try
         bool purge_snapshots = request->purge_snapshots();
         auto instances_dirty = false;
 
-        auto instance_snapshots_map =
-            map_snapshots_to_instances(request->instance_snapshot_pairs());
+        auto instance_snapshots_map = map_snapshots_to_instances(
+            request->instance_snapshot_pairs());
 
         // avoid deleting if any snapshot is missing or if we don't get confirmation
-        auto any_snapshot_args =
-            verify_snapshot_picks(instance_selection, instance_snapshots_map, purge);
+        auto any_snapshot_args = verify_snapshot_picks(instance_selection,
+                                                       instance_snapshots_map,
+                                                       purge);
         if (any_snapshot_args && !purge && !purge_snapshots)
         {
             DeleteReply confirm_action{};
@@ -2727,10 +2740,10 @@ try
                 reply_msg(server,
                           fmt::format("Taking snapshot before restoring {}", instance_name));
 
-                const auto snapshot =
-                    vm_ptr->take_snapshot(vm_specs,
-                                          "",
-                                          fmt::format("Before restoring {}", request->snapshot()));
+                const auto snapshot = vm_ptr->take_snapshot(
+                    vm_specs,
+                    "",
+                    fmt::format("Before restoring {}", request->snapshot()));
 
                 reply_msg(server,
                           fmt::format("Snapshot taken: {}.{}", instance_name, snapshot->get_name()),
@@ -2769,11 +2782,11 @@ void mp::Daemon::clone(const CloneRequest* request,
 try
 {
     const auto& source_name = request->source_name();
-    const auto [src_instance_trail, src_vm_status] =
-        find_instance_and_react(operative_instances,
-                                deleted_instances,
-                                source_name,
-                                require_operative_instances_reaction);
+    const auto [src_instance_trail,
+                src_vm_status] = find_instance_and_react(operative_instances,
+                                                         deleted_instances,
+                                                         source_name,
+                                                         require_operative_instances_reaction);
     if (src_vm_status.ok())
     {
         assert(src_instance_trail.index() == 0);
@@ -2805,20 +2818,21 @@ try
 
         config->vault->clone(source_name, destination_name);
 
-        const mp::VMImage dest_vm_image =
-            fetch_image_for(destination_name, *config->factory, *config->vault);
+        const mp::VMImage dest_vm_image = fetch_image_for(destination_name,
+                                                          *config->factory,
+                                                          *config->vault);
 
         // Specs need to be in place before the factory can create the VM
         // Notice that we are passing `this`, which can be used to retrieve further info
         vm_instance_specs.emplace(destination_name, dest_spec);
-        operative_instances[destination_name] =
-            config->factory->clone_bare_vm(src_spec,
-                                           dest_spec,
-                                           source_name,
-                                           destination_name,
-                                           dest_vm_image,
-                                           *config->ssh_key_provider,
-                                           *this);
+        operative_instances[destination_name] = config->factory->clone_bare_vm(
+            src_spec,
+            dest_spec,
+            source_name,
+            destination_name,
+            dest_vm_image,
+            *config->ssh_key_provider,
+            *this);
         ++src_spec.clone_count;
         // preparing instance is done
         preparing_instances.erase(destination_name);
@@ -2957,6 +2971,66 @@ void mp::Daemon::on_resume()
 
 void mp::Daemon::on_suspend()
 {
+}
+
+void mp::Daemon::suspend_all_instances()
+{
+    if (!MP_SETTINGS.get_as<bool>(mp::auto_suspend_key))
+        return;
+
+    mpl::log(mpl::Level::info, category, "Auto-suspending instances due to system sleep");
+
+    for (auto& [name, vm] : operative_instances)
+    {
+        auto state = vm->current_state();
+        if (state == VirtualMachine::State::running)
+        {
+            try
+            {
+                stop_mounts(name);
+                vm->suspend();
+                auto_suspended_instances.insert(name);
+                mpl::log(mpl::Level::info, name, "Auto-suspended instance");
+            }
+            catch (const std::exception& e)
+            {
+                mpl::log(mpl::Level::error,
+                         name,
+                         fmt::format("Failed to auto-suspend: {}", e.what()));
+            }
+        }
+    }
+}
+
+void mp::Daemon::resume_suspended_instances()
+{
+    if (!MP_SETTINGS.get_as<bool>(mp::auto_resume_key))
+        return;
+
+    mpl::log(mpl::Level::info, category, "Auto-resuming instances after system wake");
+
+    for (const auto& name : auto_suspended_instances)
+    {
+        try
+        {
+            auto it = operative_instances.find(name);
+            if (it != operative_instances.end())
+            {
+                auto& vm = it->second;
+                if (vm->current_state() == VirtualMachine::State::suspended)
+                {
+                    vm->start();
+                    mpl::log(mpl::Level::info, name, "Auto-resumed instance");
+                }
+            }
+        }
+        catch (const std::exception& e)
+        {
+            mpl::log(mpl::Level::error, name, fmt::format("Failed to auto-resume: {}", e.what()));
+        }
+    }
+
+    auto_suspended_instances.clear();
 }
 
 void mp::Daemon::on_restart(const std::string& name)
@@ -3112,10 +3186,10 @@ void mp::Daemon::create_vm(const CreateRequest* request,
                                  0,
                                  vm_desc.zone,
                              };
-                             operative_instances[name] =
-                                 config->factory->create_virtual_machine(vm_desc,
-                                                                         *config->ssh_key_provider,
-                                                                         *this);
+                             operative_instances[name] = config->factory->create_virtual_machine(
+                                 vm_desc,
+                                 *config->ssh_key_provider,
+                                 *this);
                              preparing_instances.erase(name);
 
                              persist_instances();
@@ -3266,9 +3340,9 @@ void mp::Daemon::create_vm(const CreateRequest* request,
             if (vm_desc.num_cores < std::stoi(mp::min_cpu_cores))
                 vm_desc.num_cores = std::stoi(mp::default_cpu_cores);
 
-            vm_desc.network_data_config =
-                mpu::make_cloud_init_network_config(vm_desc.default_mac_address,
-                                                    checked_args.extra_interfaces);
+            vm_desc.network_data_config = mpu::make_cloud_init_network_config(
+                vm_desc.default_mac_address,
+                checked_args.extra_interfaces);
 
             vm_desc.image = vm_image;
             config->factory->configure(vm_desc);
@@ -3810,11 +3884,11 @@ grpc::Status mp::Daemon::validate_dest_name(const std::string& name)
         return grpc::Status{grpc::INVALID_ARGUMENT, "Invalid destination instance name: " + name};
     }
 
-    const auto [dest_instance_trail, dest_vm_status] =
-        find_instance_and_react(operative_instances,
-                                deleted_instances,
-                                name,
-                                require_missing_instances_reaction);
+    const auto [dest_instance_trail,
+                dest_vm_status] = find_instance_and_react(operative_instances,
+                                                          deleted_instances,
+                                                          name,
+                                                          require_missing_instances_reaction);
     assert(dest_vm_status.ok() == (dest_instance_trail.index() == 2));
 
     if (!dest_vm_status.ok())
@@ -3872,8 +3946,8 @@ void mp::Daemon::add_bridged_interface(const std::string& instance_name)
     mp::VMSpecs& specs = vm_instance_specs.at(instance_name);
     mp::VirtualMachine::ShPtr instance = operative_instances.at(instance_name);
 
-    const auto& host_nets =
-        config->factory->networks(); // This will throw if not implemented on this backend.
+    const auto& host_nets = config->factory
+                                ->networks(); // This will throw if not implemented on this backend.
     const auto& preferred_net = get_bridged_interface_name();
     if (is_bridged_impl(specs, host_nets, preferred_net))
     {
@@ -3881,10 +3955,10 @@ void mp::Daemon::add_bridged_interface(const std::string& instance_name)
         return;
     }
 
-    if (const auto info =
-            std::find_if(host_nets.cbegin(),
-                         host_nets.cend(),
-                         [preferred_net](const auto& i) { return i.id == preferred_net; });
+    if (const auto info = std::find_if(
+            host_nets.cbegin(),
+            host_nets.cend(),
+            [preferred_net](const auto& i) { return i.id == preferred_net; });
         info == host_nets.cend())
     {
         throw std::runtime_error(
@@ -3911,8 +3985,8 @@ void mp::Daemon::add_bridged_interface(const std::string& instance_name)
 
     mpl::trace(category, "Prepare networking");
     config->factory->prepare_networking(specs.extra_interfaces);
-    new_if =
-        specs.extra_interfaces.back(); // prepare_networking can modify the id of the new interface.
+    new_if = specs.extra_interfaces
+                 .back(); // prepare_networking can modify the id of the new interface.
     mpl::trace(category, "Done preparation, new interface id is now \"{}\"", new_if.id);
 
     // Add the new interface to the VM.

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -53,6 +53,10 @@ public:
 
     void persist_instances();
 
+    // Auto-suspend/resume on system sleep/wake
+    void suspend_all_instances();
+    void resume_suspended_instances();
+
 protected:
     using InstanceTable = std::unordered_map<std::string, VirtualMachine::ShPtr>;
 
@@ -290,5 +294,6 @@ private:
     SettingsHandler* snapshot_mod_handler;
     std::unordered_map<std::string, std::unordered_map<std::string, MountHandler::UPtr>> mounts;
     std::unordered_set<std::string> user_authorized_bridges;
+    std::set<std::string> auto_suspended_instances; // Instances suspended by auto-suspend on sleep
 };
 } // namespace multipass

--- a/src/daemon/daemon_main.cpp
+++ b/src/daemon/daemon_main.cpp
@@ -31,6 +31,10 @@
 #include <multipass/utils.h>
 #include <multipass/version.h>
 
+#ifdef __APPLE__
+#include "shared/macos/sleep_wake_handler.h"
+#endif
+
 #include <multipass/format.h>
 
 #include <QCoreApplication>
@@ -97,6 +101,13 @@ int main_impl(int argc, char* argv[], mp::Signal& app_ready_signal)
                                                        // relevant settings handlers
 
     mp::Daemon daemon(std::move(config));
+
+#ifdef __APPLE__
+    // Initialize sleep/wake handler for macOS
+    auto sleep_wake_handler = std::make_unique<mp::platform::macos::SleepWakeHandler>();
+    sleep_wake_handler->set_suspend_callback([&daemon]() { daemon.suspend_all_instances(); });
+    sleep_wake_handler->set_resume_callback([&daemon]() { daemon.resume_suspended_instances(); });
+#endif
 
     QObject::connect(&app,
                      &QCoreApplication::aboutToQuit,

--- a/src/platform/backends/shared/macos/CMakeLists.txt
+++ b/src/platform/backends/shared/macos/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(shared_macos STATIC
   backend_utils.cpp
-  process_factory.cpp)
+  process_factory.cpp
+  sleep_wake_handler.mm)
 
 include_directories(shared_macos
   ..)
@@ -22,4 +23,6 @@ include_directories(shared_macos
 target_link_libraries(shared_macos
   fmt::fmt-header-only
   ssh_common
-  Qt6::Core)
+  Qt6::Core
+  "-framework AppKit"
+  "-framework Foundation")

--- a/src/platform/backends/shared/macos/sleep_wake_handler.h
+++ b/src/platform/backends/shared/macos/sleep_wake_handler.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+namespace multipass::platform::macos
+{
+/**
+ * @brief SleepWakeHandler handles macOS system sleep and wake notifications.
+ *
+ * This class subscribes to NSWorkspaceWillSleepNotification and
+ * NSWorkspaceDidWakeNotification to automatically suspend and resume
+ * Multipass instances when the system goes to sleep or wakes up.
+ */
+class SleepWakeHandler
+{
+public:
+    using SuspendCallback = std::function<void()>;
+    using ResumeCallback = std::function<void()>;
+
+    SleepWakeHandler();
+    ~SleepWakeHandler();
+
+    // Disable copy and move
+    SleepWakeHandler(const SleepWakeHandler&) = delete;
+    SleepWakeHandler& operator=(const SleepWakeHandler&) = delete;
+    SleepWakeHandler(SleepWakeHandler&&) = delete;
+    SleepWakeHandler& operator=(SleepWakeHandler&&) = delete;
+
+    /**
+     * @brief Set the callback to be invoked when system is about to sleep.
+     * @param callback The callback function to invoke.
+     */
+    void set_suspend_callback(SuspendCallback callback);
+
+    /**
+     * @brief Set the callback to be invoked when system wakes up.
+     * @param callback The callback function to invoke.
+     */
+    void set_resume_callback(ResumeCallback callback);
+
+    /**
+     * @brief Enable or disable the sleep/wake handler.
+     * @param enabled True to enable, false to disable.
+     */
+    void set_enabled(bool enabled);
+
+    /**
+     * @brief Check if the handler is enabled.
+     * @return True if enabled, false otherwise.
+     */
+    bool is_enabled() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl;
+};
+} // namespace multipass::platform::macos

--- a/src/platform/backends/shared/macos/sleep_wake_handler.mm
+++ b/src/platform/backends/shared/macos/sleep_wake_handler.mm
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "sleep_wake_handler.h"
+
+#include <multipass/logging/log.h>
+
+#include <AppKit/NSWorkspace.h>
+#include <Foundation/NSNotification.h>
+#include <Foundation/NSString.h>
+
+namespace mpl = multipass::logging;
+
+namespace
+{
+constexpr auto log_category = "sleep-wake-handler";
+} // namespace
+
+class multipass::platform::macos::SleepWakeHandler::Impl
+{
+public:
+    SuspendCallback suspend_callback;
+    ResumeCallback resume_callback;
+    bool enabled = true;
+    id sleep_observer = nil;
+    id wake_observer = nil;
+
+    Impl()
+    {
+        setup_notifications();
+    }
+
+    ~Impl()
+    {
+        remove_observers();
+    }
+
+    void setup_notifications()
+    {
+        auto* center = [NSWorkspace sharedWorkspace].notificationCenter;
+
+        // Register for sleep notification
+        sleep_observer = [center addObserverForName:NSWorkspaceWillSleepNotification
+                                              object:nil
+                                               queue:nil
+                                          usingBlock:^(NSNotification* _Nonnull note) {
+                                              handle_sleep_notification();
+                                          }];
+
+        // Register for wake notification
+        wake_observer = [center addObserverForName:NSWorkspaceDidWakeNotification
+                                            object:nil
+                                             queue:nil
+                                        usingBlock:^(NSNotification* _Nonnull note) {
+                                            handle_wake_notification();
+                                        }];
+
+        mpl::trace(log_category, "Sleep/wake notifications registered");
+    }
+
+    void remove_observers()
+    {
+        auto* center = [NSWorkspace sharedWorkspace].notificationCenter;
+        if (sleep_observer)
+        {
+            [center removeObserver:sleep_observer];
+            sleep_observer = nil;
+        }
+        if (wake_observer)
+        {
+            [center removeObserver:wake_observer];
+            wake_observer = nil;
+        }
+        mpl::trace(log_category, "Sleep/wake notifications removed");
+    }
+
+    void handle_sleep_notification()
+    {
+        if (!enabled)
+        {
+            mpl::debug(log_category, "Sleep notification ignored (handler disabled)");
+            return;
+        }
+
+        mpl::info(log_category, "System is about to sleep");
+
+        if (suspend_callback)
+        {
+            try
+            {
+                suspend_callback();
+            }
+            catch (const std::exception& e)
+            {
+                mpl::error(log_category, "Error in suspend callback: {}", e.what());
+            }
+        }
+    }
+
+    void handle_wake_notification()
+    {
+        if (!enabled)
+        {
+            mpl::debug(log_category, "Wake notification ignored (handler disabled)");
+            return;
+        }
+
+        mpl::info(log_category, "System woke up from sleep");
+
+        if (resume_callback)
+        {
+            try
+            {
+                resume_callback();
+            }
+            catch (const std::exception& e)
+            {
+                mpl::error(log_category, "Error in resume callback: {}", e.what());
+            }
+        }
+    }
+};
+
+multipass::platform::macos::SleepWakeHandler::SleepWakeHandler()
+    : impl{std::make_unique<Impl>()}
+{
+    mpl::debug(log_category, "SleepWakeHandler created");
+}
+
+multipass::platform::macos::SleepWakeHandler::~SleepWakeHandler()
+{
+    mpl::debug(log_category, "SleepWakeHandler destroyed");
+}
+
+void multipass::platform::macos::SleepWakeHandler::set_suspend_callback(SuspendCallback callback)
+{
+    impl->suspend_callback = std::move(callback);
+}
+
+void multipass::platform::macos::SleepWakeHandler::set_resume_callback(ResumeCallback callback)
+{
+    impl->resume_callback = std::move(callback);
+}
+
+void multipass::platform::macos::SleepWakeHandler::set_enabled(bool enabled)
+{
+    impl->enabled = enabled;
+    mpl::debug(log_category, "SleepWakeHandler {}", enabled ? "enabled" : "disabled");
+}
+
+bool multipass::platform::macos::SleepWakeHandler::is_enabled() const
+{
+    return impl->enabled;
+}

--- a/src/platform/platform_osx.cpp
+++ b/src/platform/platform_osx.cpp
@@ -22,6 +22,7 @@
 #include <multipass/format.h>
 #include <multipass/platform.h>
 #include <multipass/process/simple_process_spec.h>
+#include <multipass/settings/bool_setting_spec.h>
 #include <multipass/settings/settings.h>
 #include <multipass/standard_paths.h>
 #include <multipass/utils.h>
@@ -109,9 +110,9 @@ QStringList get_bridged_interfaces(const QString& if_name, const QString& ifconf
     // Search the substring of the full ifconfig output containing only the interface if_name.
     int start = ifconfig_output.indexOf(QRegularExpression{QStringLiteral("^%1:").arg(if_name),
                                                            QRegularExpression::MultilineOption});
-    int end =
-        ifconfig_output.indexOf(QRegularExpression("^\\w+:", QRegularExpression::MultilineOption),
-                                start + 1);
+    int end = ifconfig_output.indexOf(
+        QRegularExpression("^\\w+:", QRegularExpression::MultilineOption),
+        start + 1);
     auto ifconfig_entry = ifconfig_output.mid(start, end - start);
 
     // Search for the bridged interfaces in the resulting string ref.
@@ -200,8 +201,8 @@ mp::platform::Platform::get_network_interfaces_info() const
     mpl::trace(category, "Got the following output from networksetup:\n{}", nsetup_output);
 
     // split the output of networksetup in multiple entries (one per interface)
-    auto empty_line_regex =
-        QRegularExpression(QStringLiteral("^$"), QRegularExpression::MultilineOption);
+    auto empty_line_regex = QRegularExpression(QStringLiteral("^$"),
+                                               QRegularExpression::MultilineOption);
     auto nsetup_entries = nsetup_output.split(empty_line_regex, Qt::SkipEmptyParts);
 
     // Parse the output we got to obtain each interface's properties
@@ -382,8 +383,8 @@ QDir mp::platform::Platform::get_alias_scripts_folder() const
 {
     QDir aliases_folder;
 
-    QString location =
-        MP_STDPATHS.writableLocation(mp::StandardPaths::AppLocalDataLocation) + "/bin";
+    QString location = MP_STDPATHS.writableLocation(mp::StandardPaths::AppLocalDataLocation) +
+                       "/bin";
     aliases_folder = QDir{location};
 
     return aliases_folder;


### PR DESCRIPTION
## Summary

Fixes #5124

When closing the MacBook lid, Multipass instances continue running and cause the machine to heat up. This PR adds automatic suspend/resume functionality when the system goes to sleep/wakes up.

## Changes

### New Files
- `src/platform/backends/shared/macos/sleep_wake_handler.h` - Header for SleepWakeHandler class
- `src/platform/backends/shared/macos/sleep_wake_handler.mm` - Objective-C++ implementation that subscribes to NSWorkspace notifications

### Modified Files
- `include/multipass/constants.h` - Added `auto_suspend_key` and `auto_resume_key` setting keys
- `src/daemon/daemon.h` - Added `suspend_all_instances()`, `resume_suspended_instances()` methods and `auto_suspended_instances` member
- `src/daemon/daemon.cpp` - Implemented the auto-suspend/resume logic
- `src/daemon/daemon_main.cpp` - Initialize SleepWakeHandler on macOS
- `src/platform/platform_osx.cpp` - Register new settings
- `src/platform/backends/shared/macos/CMakeLists.txt` - Added new files to build

## New Settings

| Setting | Default | Description |
|---------|---------|-------------|
| `local.auto-suspend-on-sleep` | `true` | Automatically suspend all running instances when system goes to sleep |
| `local.auto-resume-on-wake` | `true` | Automatically resume instances that were auto-suspended when system wakes |

## How it works

1. **Sleep handler**: When macOS sends `NSWorkspaceWillSleepNotification`, the daemon suspends all running instances and records them in `auto_suspended_instances`

2. **Wake handler**: When macOS sends `NSWorkspaceDidWakeNotification`, the daemon resumes all instances in `auto_suspended_instances` and clears the set

## Testing

- [ ] Manual testing on macOS
- [ ] Verify suspend/resume cycle works correctly
- [ ] Verify settings can be toggled via `multipass set`

## Checklist

- [x] Code follows project conventions
- [x] Added appropriate logging
- [x] Settings are platform-specific (macOS only)