### PR TITLE
[az] Persist was_running across daemon restarts

### DIFF
--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -136,6 +136,11 @@ public:
     std::condition_variable state_wait;
     std::mutex state_mutex;
 
+    // Whether the VM was running when its zone was last disabled; used to decide whether to
+    // start it back up when the zone becomes available again. Public (like `state`) so it can be
+    // persisted and restored by the daemon across restarts.
+    bool was_running = false;
+
 protected:
     explicit VirtualMachine(State state = State::off) : state{state}
     {

--- a/include/multipass/vm_specs.h
+++ b/include/multipass/vm_specs.h
@@ -46,6 +46,7 @@ struct VMSpecs
     int clone_count =
         0; // tracks the number of cloned vm from this source vm (regardless of deletes)
     std::string zone;
+    bool was_running = false; // whether the VM was running when its zone was last disabled
 
     friend inline bool operator==(const VMSpecs& a, const VMSpecs& b) = default;
 };

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1426,6 +1426,16 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
             break;
             }
         }
+        else if (spec.state == e_state::unavailable)
+        {
+            // Backends decide the VM's initial in-memory state from local heuristics (e.g. QEMU
+            // looks for a suspend snapshot on disk) and know nothing about availability zones, so
+            // a VM whose zone was disabled always comes back as `off`/`suspended` here. Restore
+            // the persisted `unavailable` state and whether it was running, so that a later
+            // enable-zones still knows to start it back up.
+            operative_instances[name]->state = spec.state;
+            operative_instances[name]->was_running = spec.was_running;
+        }
     }
 
     for (const auto& bad_spec : invalid_specs)
@@ -2991,6 +3001,12 @@ void mp::Daemon::on_restart(const std::string& name)
 void mp::Daemon::persist_state_for(const std::string& name, const VirtualMachine::State& state)
 {
     vm_instance_specs[name].state = state;
+
+    // Capture whether the VM was running when it was last marked unavailable, so that
+    // enable-zones can correctly restart it even after a daemon restart in between.
+    if (const auto it = operative_instances.find(name); it != operative_instances.end())
+        vm_instance_specs[name].was_running = it->second->was_running;
+
     persist_instances();
 }
 

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -209,7 +209,6 @@ private:
     std::shared_ptr<Snapshot> head_snapshot = nullptr;
     int snapshot_count = 0; // tracks the number of snapshots ever taken (regardless of deletes)
     mutable std::recursive_mutex snapshot_mutex;
-    bool was_running{false};
 };
 
 } // namespace multipass

--- a/src/utils/vm_specs.cpp
+++ b/src/utils/vm_specs.cpp
@@ -45,6 +45,7 @@ void mp::tag_invoke(const boost::json::value_from_tag&,
         {"mounts", boost::json::value_from(specs.mounts, MapAsJsonArray{"target_path"})},
         {"clone_count", specs.clone_count},
         {"zone", specs.zone},
+        {"was_running", specs.was_running},
     };
 }
 
@@ -83,5 +84,6 @@ mp::VMSpecs mp::tag_invoke(const boost::json::value_to_tag<mp::VMSpecs>&,
         metadata,
         lookup_or<int>(json, "clone_count", 0),
         lookup_or<std::string>(json, "zone", az_manager.get_default_zone_name()),
+        lookup_or<bool>(json, "was_running", false),
     };
 }

--- a/tests/unit/daemon_test_fixture.cpp
+++ b/tests/unit/daemon_test_fixture.cpp
@@ -540,10 +540,12 @@ std::string mpt::DaemonTestFixture::fake_json_contents(const fake_vm_properties&
     contents += QString::fromStdString(fmt::format("\n        ],\n"
                                                    "        \"num_cores\": 1,\n"
                                                    "        \"ssh_username\": \"ubuntu\",\n"
-                                                   "        \"state\": {}\n"
+                                                   "        \"state\": {},\n"
+                                                   "        \"was_running\": {}\n"
                                                    "    }}\n"
                                                    "}}",
-                                                   fmt::underlying(vm_properties.state)));
+                                                   fmt::underlying(vm_properties.state),
+                                                   vm_properties.was_running));
 
     return contents.toStdString();
 }

--- a/tests/unit/daemon_test_fixture.h
+++ b/tests/unit/daemon_test_fixture.h
@@ -50,6 +50,7 @@ struct fake_vm_properties
     std::unordered_map<std::string, mp::VMMount> mounts{};
     bool deleted = false;
     VirtualMachine::State state = VirtualMachine::State::starting;
+    bool was_running = false;
 };
 
 struct DaemonTestFixture : public ::Test

--- a/tests/unit/test_daemon.cpp
+++ b/tests/unit/test_daemon.cpp
@@ -531,6 +531,40 @@ TEST_F(Daemon, callsOnRestartForAlreadyStartingVmsOnConstruction)
     mp::Daemon daemon{config_builder.build()};
 }
 
+TEST_F(Daemon, restoresUnavailableStateAndWasRunningOnConstruction)
+{
+    auto mock_factory = use_a_mock_vm_factory();
+    multipass::test::fake_vm_properties vm_props{};
+    vm_props.default_mac = "52:54:00:73:76:28";
+    vm_props.state = multipass::VirtualMachine::State::unavailable;
+    vm_props.was_running = true;
+    const auto [temp_dir, _] = plant_instance_json(fake_json_contents(vm_props));
+    config_builder.data_directory = temp_dir->path();
+    config_builder.vault = std::make_unique<NiceMock<mpt::MockVMImageVault>>();
+
+    // Backends know nothing about availability zones, so on construction they reset their
+    // in-memory state using their own heuristics (e.g. off, or suspended if a snapshot exists),
+    // ignoring the persisted `unavailable` state and losing was_running.
+    auto mock_vm = std::make_unique<NiceMock<mpt::MockVirtualMachine>>();
+    EXPECT_CALL(*mock_vm, get_name).WillRepeatedly(ReturnRef(vm_props.name));
+    EXPECT_CALL(*mock_vm, current_state).Times(0);
+    EXPECT_CALL(*mock_vm, start).Times(0);
+    EXPECT_CALL(*mock_vm, handle_state_update).Times(0);
+    EXPECT_CALL(*mock_vm, wait_until_ssh_up).Times(0);
+    mock_vm->state = mp::VirtualMachine::State::off;
+    mock_vm->was_running = false;
+
+    auto* mock_vm_ptr = mock_vm.get();
+    EXPECT_CALL(*mock_factory, create_virtual_machine).WillOnce(Return(std::move(mock_vm)));
+
+    mp::Daemon daemon{config_builder.build()};
+
+    // The daemon should have restored both fields from the persisted spec, so that a later
+    // enable-zones still knows this instance needs to be started back up.
+    EXPECT_EQ(mock_vm_ptr->state, mp::VirtualMachine::State::unavailable);
+    EXPECT_TRUE(mock_vm_ptr->was_running);
+}
+
 TEST_F(Daemon, updatesTheDeletedButNonStoppedVmState)
 {
     auto mock_factory = use_a_mock_vm_factory();


### PR DESCRIPTION
## Summary

`was_running` (whether a VM should be restarted when its zone is re-enabled) lived only as an in-memory flag on `BaseVirtualMachine`, never part of `VMSpecs`/the instance-db JSON. Separately, backend VM constructors decide their initial in-memory `state` from local heuristics (e.g. QEMU checks for a suspend snapshot on disk) with no awareness of zones at all, so a VM whose zone was disabled always came back as `off`/`suspended` on reconstruction instead of `unavailable`.

Together this is why `enable-zones` stops restarting instances if `multipassd` restarts while their zone is disabled — exactly the repro in #5087.

- Promote `was_running` to a public field on `VirtualMachine`, mirroring how `state` already works, so the daemon can read/write it directly without new virtual interfaces or backend-specific plumbing
- Add `was_running` to `VMSpecs` and its JSON (de)serialization (defaults to `false` for existing instance records, so old on-disk data stays loadable)
- `Daemon::persist_state_for` now also syncs the live `was_running` value into the persisted spec whenever a VM's state changes
- At daemon startup, when a persisted spec has `state == unavailable`, restore both `state` and `was_running` directly on the reconstructed VM (parallel to the existing "was running" reconciliation branch)

## Test plan

- [x] Added `Daemon.restoresUnavailableStateAndWasRunningOnConstruction` in `tests/unit/test_daemon.cpp`, which reproduces the reported scenario end-to-end: plants a persisted instance record with `state: unavailable, was_running: true`, constructs a fresh `Daemon` over it (simulating a restart), and asserts the reconstructed VM has both fields restored
- [x] Extended `fake_vm_properties`/`fake_json_contents` in the shared daemon test fixture with a `was_running` field to support the above
- [x] Traced every changed call site by hand for compile correctness (field visibility, `lookup_or<bool>` usage matching existing fields, other `VMSpecs{...}` aggregate-init call sites in `tests/unit/qemu/test_qemu_snapshot.cpp` — confirmed the new trailing field with a default member initializer doesn't break them under `-Werror -Wall -pedantic`)
- [ ] **Not compiled or run** — this environment doesn't have the Qt/gRPC/protobuf/Boost toolchain this project pulls via vcpkg, and building it from scratch here would take hours with no cached artifacts. Would appreciate a maintainer/CI build check before merge.

Fixes #5087