### PR TITLE
fix(qemu): drop native mounts with missing host source before VM start

### DIFF
--- a/src/platform/backends/qemu/qemu_mount_handler.cpp
+++ b/src/platform/backends/qemu/qemu_mount_handler.cpp
@@ -113,6 +113,10 @@ catch (const std::exception& e)
 
 void QemuMountHandler::activate_impl(ServerVariant, std::chrono::milliseconds)
 {
+    if (!MP_FILEOPS.exists(source))
+        throw std::runtime_error(
+            fmt::format("Mount source path \"{}\" no longer exists on the host", source));
+
     auto session = vm->new_ssh_session();
 
     // Split the path in existing and missing parts

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -518,6 +518,22 @@ void mp::QemuVirtualMachine::wait_until_ssh_up(std::chrono::milliseconds timeout
 
 void mp::QemuVirtualMachine::initialize_vm_process()
 {
+    for (auto it = mount_args.begin(); it != mount_args.end();)
+    {
+        const auto& source = it->second.first;
+        if (MP_FILEOPS.exists(source))
+        {
+            ++it;
+        }
+        else
+        {
+            mpl::warn(vm_name,
+                      "Removing mount with source \"{}\" as it no longer exists on the host",
+                      source);
+            it = mount_args.erase(it);
+        }
+    }
+
     vm_process = make_qemu_process(
         desc,
         ((state == State::suspended) ? std::make_optional(monitor->retrieve_metadata_for(vm_name))

--- a/tests/unit/qemu/test_qemu_backend.cpp
+++ b/tests/unit/qemu/test_qemu_backend.cpp
@@ -254,6 +254,42 @@ TEST_F(QemuBackend, machineStartShutdownSendsMonitoringEvents)
     machine->shutdown();
 }
 
+TEST_F(QemuBackend, startRemovesMountsWithMissingSource)
+{
+    EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_, _)).WillOnce([this](auto&&...) {
+        return std::move(mock_qemu_platform);
+    });
+
+    mp::QemuVirtualMachineFactory backend{data_dir.path(), az_manager};
+    process_factory->register_callback(handle_qemu_system);
+
+    auto machine = backend.create_virtual_machine(default_description, key_provider, stub_monitor);
+    auto* qemu_machine = static_cast<mp::QemuVirtualMachine*>(machine.get());
+
+    mpt::TempDir existing_dir;
+    const std::string existing_source = existing_dir.path().toStdString();
+    const std::string missing_source = existing_source + "/definitely-missing";
+
+    auto& mount_args = qemu_machine->modifiable_mount_args();
+    mount_args["existing-tag"] = {existing_source, {"-virtfs", "dummy-existing-arg"}};
+    mount_args["missing-tag"] = {missing_source, {"-virtfs", "dummy-missing-arg"}};
+
+    logger_scope.mock_logger->screen_logs(mpl::Level::warning);
+    logger_scope.mock_logger->expect_log(
+        mpl::Level::warning,
+        fmt::format("Removing mount with source \"{}\" as it no longer exists on the host",
+                    missing_source));
+
+    machine->start();
+    machine->state = mp::VirtualMachine::State::running;
+
+    EXPECT_EQ(mount_args.size(), 1);
+    EXPECT_NE(mount_args.find("existing-tag"), mount_args.end());
+    EXPECT_EQ(mount_args.find("missing-tag"), mount_args.end());
+
+    machine->shutdown();
+}
+
 TEST_F(QemuBackend, machineStartSuspendSendsMonitoringEvent)
 {
     EXPECT_CALL(*mock_qemu_platform_factory, make_qemu_platform(_, _)).WillOnce([this](auto&&...) {

--- a/tests/unit/qemu/test_qemu_mount_handler.cpp
+++ b/tests/unit/qemu/test_qemu_mount_handler.cpp
@@ -111,6 +111,7 @@ struct QemuMountHandlerTest : public ::Test
             .WillOnce(
                 Return(mp::fs::file_status{mp::fs::file_type::directory, mp::fs::perms::all}));
         EXPECT_CALL(vm, modifiable_mount_args).WillOnce(ReturnRef(mount_args));
+        ON_CALL(mock_file_ops, exists(A<const mp::fs::path&>())).WillByDefault(Return(true));
     }
 
     template <bool Success>
@@ -317,6 +318,19 @@ TEST_F(QemuMountHandlerTest, targetDirectoryMissing)
 
     mp::QemuMountHandler handler{&vm, &key_provider, default_target, mount};
     EXPECT_NO_THROW(handler.activate(&server));
+}
+
+TEST_F(QemuMountHandlerTest, activateThrowsWhenSourceNoLongerExists)
+{
+    mp::QemuMountHandler handler{&vm, &key_provider, default_target, mount};
+
+    EXPECT_CALL(mock_file_ops, exists(A<const mp::fs::path&>())).WillOnce(Return(false));
+    EXPECT_CALL(vm, new_ssh_session()).Times(0);
+
+    MP_EXPECT_THROW_THAT(
+        handler.activate(&server),
+        std::runtime_error,
+        mpt::match_what(HasSubstr("no longer exists on the host")));
 }
 
 INSTANTIATE_TEST_SUITE_P(QemuMountHandlerFailCommand,


### PR DESCRIPTION
## Description

Fixes an issue where a Multipass instance fails to start entirely if a previously-configured native mount's host source directory has since become unavailable (e.g. deleted, or on removable/network storage that's no longer connected).

### Root cause

`QemuMountHandler`'s constructor validates that a mount's source directory exists — but only once, when the handler is first constructed. `QemuVirtualMachine::mount_args` is persisted as JSON metadata and reloaded on every `QemuVirtualMachine` construction, so a stale entry can survive across VM stop/start cycles and even full daemon restarts without ever being re-validated.

`QemuVirtualMachine::initialize_vm_process()` passes `mount_args` directly into the QEMU process spec with no re-check, so a mount whose source has vanished still gets included as a `-virtfs` argument on every subsequent start — causing the QEMU process itself to fail at launch, rather than the VM simply starting without that one mount.

### Fix

`initialize_vm_process()` now filters `mount_args` immediately before building the QEMU process spec, dropping any entry whose source no longer exists on disk and logging a warning for each removal. The VM then starts normally, minus the invalid mount, instead of failing to boot.

As a side effect, on a normal (non-suspended) start, the filtered `mount_args` is what gets persisted back via `update_metadata_for`, so the stale entry is also cleaned from the daemon's saved metadata after one successful start — not just skipped for a single boot.

## Related Issue(s)

Closes #4957

## Testing

- Added `QemuBackend.startRemovesMountsWithMissingSource` in `tests/unit/qemu/test_qemu_backend.cpp`, covering: a mount with a valid source is preserved and reaches the actual QEMU process arguments; a mount with a missing source is dropped with the expected warning logged; the VM starts successfully in both cases.
- Ran the full existing `QemuBackend` and `QemuMountHandler` test suites locally (59 tests) — all pass, no regressions.
- Built and tested on native Ubuntu 24.04 (WSL2).

## Known scope / limitations

- This checks `exists()` only, not full accessibility/directory-type, unlike the stricter check in the `MountHandler` base constructor. This covers the reported scenario (source deleted) but not, e.g., a source that still exists but became unreadable or was replaced by a file.
- On resume-from-suspend specifically, the filter still runs correctly (VM resumes fine), but that code path doesn't call `update_metadata_for`, so the metadata self-cleanup described above only applies to normal starts, not suspend/resume.

## Additional Notes

This is my first contribution to Multipass. Happy to adjust scope or approach based on feedback if there's a preferred pattern for this I've missed.