### PR TITLE
[GUI] Bring window to front on tray Quit even when only obscured, not minimized

### DIFF
--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -184,7 +184,9 @@ class _AppState extends ConsumerState<App> with WindowListener {
     }
 
     // checking the need to restore the window
-    if (!await windowManager.isVisible() || await windowManager.isMinimized()) {
+    if (!await windowManager.isVisible() ||
+        await windowManager.isMinimized() ||
+        !await windowManager.isFocused()) {
       windowManager.showAndRestore();
     }
 


### PR DESCRIPTION
## What this does

With "Ask about running instances" enabled, clicking tray Quit while the Multipass GUI window is obscured by another window (visible, not minimized, but not focused) never brought the confirmation dialog to front — so it looked like nothing happened.

`onWindowClose()` only called `windowManager.showAndRestore()` when the window was invisible or minimized, missing the "obscured but visible" case. This adds `!await windowManager.isFocused()` to that condition, so the window is restored/focused whenever it isn't already, not just when hidden or minimized.

## Testing

- `flutter analyze lib/main.dart`: same 5 pre-existing issues before and after (all pre-existing generated-protobuf-type issues, confirmed via `git stash`/`git stash pop`) — zero new issues introduced.
- Could not manually verify on macOS in this environment (no macOS device available); the fix relies on `window_manager`'s documented `isFocused()`/`show()` API and directly extends the existing, already-merged restore pattern from #4068/#4138.

Fixes #4210