### PR TITLE
[bugfix] AZ state transitions

### DIFF
--- a/include/multipass/availability_zone.h
+++ b/include/multipass/availability_zone.h
@@ -37,7 +37,7 @@ public:
     [[nodiscard]] virtual const std::string& get_name() const = 0;
     [[nodiscard]] virtual const Subnet& get_subnet() const = 0;
     [[nodiscard]] virtual bool is_available() const = 0;
-    virtual void set_available(bool new_available) = 0;
+    virtual std::vector<std::string> set_available(bool new_available) = 0;
     virtual void add_vm(VirtualMachine& vm) = 0;
     virtual void remove_vm(VirtualMachine& vm) = 0;
 };

--- a/include/multipass/base_availability_zone.h
+++ b/include/multipass/base_availability_zone.h
@@ -39,7 +39,7 @@ public:
     const std::string& get_name() const override;
     const Subnet& get_subnet() const override;
     bool is_available() const override;
-    void set_available(bool new_available) override;
+    std::vector<std::string> set_available(bool new_available) override;
     void add_vm(VirtualMachine& vm) override;
     void remove_vm(VirtualMachine& vm) override;
 

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -78,7 +78,7 @@ public:
     virtual void start() = 0;
     virtual void shutdown(ShutdownPolicy shutdown_policy = ShutdownPolicy::Powerdown) = 0;
     virtual void suspend() = 0;
-    virtual void set_available(bool available) = 0;
+    virtual bool set_available(bool available) = 0;
     virtual State current_state() = 0;
     virtual int ssh_port() = 0;
     virtual std::string ssh_hostname() = 0;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2916,19 +2916,34 @@ void mp::Daemon::zones_state(const ZonesStateRequest* request,
 try // clang-format on
 {
     auto& az_manager = *config->az_manager;
+
+    std::vector<std::string> transitioned;
+    auto apply_to = [&](const std::string& zone_name) {
+        auto names = az_manager.get_zone(zone_name).set_available(request->available());
+        transitioned.insert(transitioned.end(),
+                            std::make_move_iterator(names.begin()),
+                            std::make_move_iterator(names.end()));
+    };
+
     if (request->zones().empty())
     {
         for (auto&& zone : az_manager.get_zones())
         {
-            az_manager.get_zone(zone.get().get_name()).set_available(request->available());
+            apply_to(zone.get().get_name());
         }
     }
     else
     {
         for (const auto& zone_name : request->zones())
         {
-            az_manager.get_zone(zone_name).set_available(request->available());
+            apply_to(zone_name);
         }
+    }
+
+    for (const auto& name : transitioned)
+    {
+        if (request->available())
+            on_restart(name);
     }
 
     context->set_value(grpc::Status{});

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2974,7 +2974,7 @@ void mp::Daemon::on_suspend()
 void mp::Daemon::on_restart(const std::string& name)
 {
     stop_mounts(name);
-    auto future_watcher = create_future_watcher([this, &name]() {
+    auto future_watcher = create_future_watcher([this, name]() {
         try
         {
             auto virtual_machine = operative_instances.at(name);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2944,6 +2944,8 @@ try // clang-format on
     {
         if (request->available())
             on_restart(name);
+        else
+            stop_mounts(name);
     }
 
     context->set_value(grpc::Status{});

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2917,12 +2917,13 @@ try // clang-format on
 {
     auto& az_manager = *config->az_manager;
 
-    std::vector<std::string> transitioned;
-    auto apply_to = [&](const std::string& zone_name) {
-        auto names = az_manager.get_zone(zone_name).set_available(request->available());
-        transitioned.insert(transitioned.end(),
-                            std::make_move_iterator(names.begin()),
-                            std::make_move_iterator(names.end()));
+    std::vector<std::string> restart_mounts;
+    auto apply_to = [&restart_mounts, &az_manager, available = request->available()](
+                        const std::string& zone_name) {
+        auto names = az_manager.get_zone(zone_name).set_available(available);
+        restart_mounts.insert(restart_mounts.end(),
+                              std::make_move_iterator(names.begin()),
+                              std::make_move_iterator(names.end()));
     };
 
     if (request->zones().empty())
@@ -2940,10 +2941,10 @@ try // clang-format on
         }
     }
 
-    for (const auto& name : transitioned)
+    for (const auto& name : restart_mounts)
     {
         if (request->available())
-            on_restart(name);
+            start_mounts(name);
         else
             stop_mounts(name);
     }
@@ -2971,9 +2972,8 @@ void mp::Daemon::on_suspend()
 {
 }
 
-void mp::Daemon::on_restart(const std::string& name)
+void mp::Daemon::start_mounts(const std::string& name)
 {
-    stop_mounts(name);
     auto future_watcher = create_future_watcher([this, name]() {
         try
         {
@@ -2998,6 +2998,12 @@ void mp::Daemon::on_restart(const std::string& name)
                           nullptr,
                           std::string(),
                           std::string()));
+}
+
+void mp::Daemon::on_restart(const std::string& name)
+{
+    stop_mounts(name);
+    start_mounts(name);
 }
 
 void mp::Daemon::persist_state_for(const std::string& name, const VirtualMachine::State& state)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -196,6 +196,7 @@ private:
     grpc::Status get_ssh_info_for_vm(VirtualMachine& vm, SSHInfoReply& response);
 
     void init_mounts(const std::string& name);
+    void start_mounts(const std::string& name);
     void stop_mounts(const std::string& name);
 
     // This returns whether any specs were updated (and need persisting)

--- a/src/platform/backends/shared/base_availability_zone.cpp
+++ b/src/platform/backends/shared/base_availability_zone.cpp
@@ -62,13 +62,13 @@ bool BaseAvailabilityZone::is_available() const
     return m.available;
 }
 
-void BaseAvailabilityZone::set_available(const bool new_available)
+std::vector<std::string> BaseAvailabilityZone::set_available(const bool new_available)
 {
 
     mpl::debug(name, "making AZ {}available", new_available ? "" : "un");
     const std::unique_lock lock{mutex};
     if (m.available == new_available)
-        return;
+        return {};
 
     m.available = new_available;
     auto save_file_guard = sg::make_scope_guard([this]() noexcept {
@@ -84,8 +84,12 @@ void BaseAvailabilityZone::set_available(const bool new_available)
 
     try
     {
+        std::vector<std::string> transitioned;
         for (auto& vm : vms)
-            vm.get().set_available(new_available);
+            if (vm.get().set_available(new_available))
+                transitioned.push_back(vm.get().get_name());
+
+        return transitioned;
     }
     catch (...)
     {

--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -207,31 +207,28 @@ void mp::BaseVirtualMachine::check_state_for_shutdown(ShutdownPolicy shutdown_po
     }
 }
 
-void mp::BaseVirtualMachine::set_available(bool available)
+bool mp::BaseVirtualMachine::set_available(bool available)
 {
     // Ignore idempotent calls
     if (available == (state != State::unavailable))
-        return;
+        return false;
 
     if (available)
     {
         state = State::off;
         handle_state_update();
-        if (was_running)
-        {
-            start();
+        if (!was_running)
+            return false;
 
-            // normally the daemon sets the state to running...
-            state = State::running;
-            handle_state_update();
-        }
-        return;
+        start();
+        return true;
     }
 
     was_running = state == State::running || state == State::starting || state == State::restarting;
     shutdown(ShutdownPolicy::Poweroff);
     state = State::unavailable;
     handle_state_update();
+    return true;
 }
 
 std::string mp::BaseVirtualMachine::ssh_exec(const std::string& cmd, bool whisper)

--- a/src/platform/backends/shared/base_virtual_machine.h
+++ b/src/platform/backends/shared/base_virtual_machine.h
@@ -57,7 +57,7 @@ public:
                                                  bool whisper = false) override;
     [[nodiscard]] std::unique_ptr<SSHSession> new_ssh_session() override;
 
-    void set_available(bool available) override;
+    bool set_available(bool available) override;
 
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
     void wait_for_cloud_init(std::chrono::milliseconds timeout) override;

--- a/tests/unit/mock_availability_zone.h
+++ b/tests/unit/mock_availability_zone.h
@@ -33,7 +33,7 @@ struct MockAvailabilityZone : public mp::AvailabilityZone
     MOCK_METHOD(const std::string&, get_name, (), (const, override));
     MOCK_METHOD(const Subnet&, get_subnet, (), (const, override));
     MOCK_METHOD(bool, is_available, (), (const, override));
-    MOCK_METHOD(void, set_available, (bool), (override));
+    MOCK_METHOD(std::vector<std::string>, set_available, (bool), (override));
     MOCK_METHOD(void, add_vm, (mp::VirtualMachine&), (override));
     MOCK_METHOD(void, remove_vm, (mp::VirtualMachine&), (override));
 };

--- a/tests/unit/mock_virtual_machine.h
+++ b/tests/unit/mock_virtual_machine.h
@@ -79,7 +79,7 @@ struct MockVirtualMachineT : public T
     MOCK_METHOD(void, start, (), (override));
     MOCK_METHOD(void, shutdown, (VirtualMachine::ShutdownPolicy), (override));
     MOCK_METHOD(void, suspend, (), (override));
-    MOCK_METHOD(void, set_available, (bool), (override));
+    MOCK_METHOD(bool, set_available, (bool), (override));
     MOCK_METHOD(VirtualMachine::State, current_state, (), (override));
     MOCK_METHOD(int, ssh_port, (), (override));
     MOCK_METHOD(std::string, ssh_hostname, (), (override));

--- a/tests/unit/stub_availability_zone.h
+++ b/tests/unit/stub_availability_zone.h
@@ -47,8 +47,9 @@ public:
         return true;
     }
 
-    void set_available(bool) override
+    std::vector<std::string> set_available(bool) override
     {
+        return {};
     }
 
     void add_vm(VirtualMachine&) override

--- a/tests/unit/stub_virtual_machine.h
+++ b/tests/unit/stub_virtual_machine.h
@@ -59,8 +59,9 @@ struct StubVirtualMachine final : public VirtualMachine
     {
     }
 
-    void set_available(bool) override
+    bool set_available(bool) override
     {
+        return false;
     }
 
     State current_state() override

--- a/tests/unit/test_base_availability_zone.cpp
+++ b/tests/unit/test_base_availability_zone.cpp
@@ -128,8 +128,8 @@ TEST_F(BaseAvailabilityZoneTest, AvailabilityStateManagement)
     NiceMock<mpt::MockVirtualMachine> mock_vm2;
 
     // Both VMs should be notified when state changes
-    EXPECT_CALL(mock_vm1, set_available(false));
-    EXPECT_CALL(mock_vm2, set_available(false));
+    EXPECT_CALL(mock_vm1, set_available(false)).WillOnce(Return(true));
+    EXPECT_CALL(mock_vm2, set_available(false)).WillOnce(Return(false));
 
     mp::BaseAvailabilityZone zone{az_name, az_dir, subnet_alloc};
 
@@ -137,8 +137,8 @@ TEST_F(BaseAvailabilityZoneTest, AvailabilityStateManagement)
     zone.add_vm(mock_vm2);
 
     // Setting to current state (true) shouldn't trigger VM updates
-    zone.set_available(true);
+    EXPECT_THAT(zone.set_available(true), IsEmpty());
 
-    // Setting to new state should notify all VMs
-    zone.set_available(false);
+    // Setting to new state should notify all VMs, reporting only those that transitioned
+    EXPECT_THAT(zone.set_available(false), ElementsAre(mock_vm1.get_name()));
 }

--- a/tests/unit/test_base_availability_zone.cpp
+++ b/tests/unit/test_base_availability_zone.cpp
@@ -139,6 +139,6 @@ TEST_F(BaseAvailabilityZoneTest, AvailabilityStateManagement)
     // Setting to current state (true) shouldn't trigger VM updates
     EXPECT_THAT(zone.set_available(true), IsEmpty());
 
-    // Setting to new state should notify all VMs, reporting only those that transitioned
+    // Setting to new state should notify all VMs, reporting only those that need mounts restarted
     EXPECT_THAT(zone.set_available(false), ElementsAre(mock_vm1.get_name()));
 }

--- a/tests/unit/test_base_virtual_machine.cpp
+++ b/tests/unit/test_base_virtual_machine.cpp
@@ -161,7 +161,7 @@ struct StubBaseVirtualMachine : public mp::BaseVirtualMachine
 
     void start() override
     {
-        state = St::running;
+        state = St::starting;
     }
 
     void shutdown(ShutdownPolicy = ShutdownPolicy::Powerdown) override
@@ -1576,28 +1576,36 @@ TEST_F(BaseVM, setUnavailableShutsdownRunning)
     vm.set_available(false);
 }
 
-TEST_F(BaseVM, setAvailableRestartsRunning)
+TEST_F(BaseVM, setUnavailableIsIdempotent)
 {
     StubBaseVirtualMachine base_vm(zone, St::running);
 
-    base_vm.set_available(false);
+    EXPECT_TRUE(base_vm.set_available(false));
     ASSERT_EQ(base_vm.current_state(), St::unavailable);
 
-    base_vm.set_available(false);
+    EXPECT_FALSE(base_vm.set_available(false));
+    EXPECT_EQ(base_vm.current_state(), St::unavailable);
+}
+
+TEST_F(BaseVM, setAvailableRestartsRunningAndLeavesResultingStateToStart)
+{
+    StubBaseVirtualMachine base_vm(zone, St::running);
+
+    ASSERT_TRUE(base_vm.set_available(false));
     ASSERT_EQ(base_vm.current_state(), St::unavailable);
 
-    base_vm.set_available(true);
-    EXPECT_EQ(base_vm.current_state(), St::running);
+    EXPECT_TRUE(base_vm.set_available(true));
+    EXPECT_EQ(base_vm.current_state(), St::starting);
 }
 
 TEST_F(BaseVM, setAvailableKeepsOffOff)
 {
     StubBaseVirtualMachine base_vm(zone, St::off);
 
-    base_vm.set_available(false);
+    EXPECT_TRUE(base_vm.set_available(false));
     ASSERT_EQ(base_vm.current_state(), St::unavailable);
 
-    base_vm.set_available(true);
+    EXPECT_FALSE(base_vm.set_available(true));
     EXPECT_EQ(base_vm.current_state(), St::off);
 }
 


### PR DESCRIPTION
This PR fixes several issues with AZs that were caused by state transition being done by the AZ manager and then not being reflected in the daemon.

The fix proposed here is to have the AZ manager return a list of VMs that are being returned to their original `running` state after the AZ has been re-enabled. The daemon can then track these VMs and update their state as SSH comes up.

So, on top of the linked GitHub issue, this PR also fixes several others issues with AZ state transitions.

1. SSHFS mounts were not being stopped when a VM was forced off due to an AZ being disabled. This resulted in orphaned SSHFS processes. We now explicitly stop the mounts.
2. SSHFS mounts were not being restarted for VMs that are in an AZ that was enabled. Having the daemon track the starting VMs now also automatically starts the mounts.

In conclusion, this is another difficulty born out of the monolithic daemon and not having VM objects be responsible for their own resources, namely VM mounts. Due to the time sensitive nature of releasing AZs, the presented diff is favoured over a larger refactor.

Fixes #5089 

---

MULTI-2790