### PR TITLE
[windows] Gate default driver behind HYPERV_HCS_ENABLED

### DIFF
--- a/src/platform/platform_win.cpp
+++ b/src/platform/platform_win.cpp
@@ -871,7 +871,11 @@ std::string mp::platform::default_server_address()
 
 QString mp::platform::Platform::default_driver() const
 {
+#if defined(HYPERV_HCS_ENABLED)
     return QStringLiteral("hyperv_api");
+#else
+    return QStringLiteral("hyperv");
+#endif
 }
 
 QString mp::platform::Platform::default_privileged_mounts() const


### PR DESCRIPTION
## Summary
- `Platform::default_driver()` in `platform_win.cpp` unconditionally returned `"hyperv_api"`, but `is_backend_supported()` and `vm_backend()` only accept `"hyperv_api"` when `HYPERV_HCS_ENABLED` is compiled in.
- On "noff" builds (feature flags disabled, e.g. the scheduled `windows.yml` workflow), this mismatch caused `CustomSettingSpec`'s eager validation of the default `local.driver` setting to throw during `register_global_settings_handlers()`, crashing the daemon immediately after the Windows service had already reported `SERVICE_RUNNING` to the SCM.
- This produced exactly the symptoms in the issue: the Windows Event Log shows "service is running", but the Services panel shows the service not running, and the MSI installer's `StartServices` step times out after ~5 minutes with error 1920.
- Fix: gate `default_driver()`'s return value behind `HYPERV_HCS_ENABLED`, falling back to `"hyperv"` (always supported) when the flag is off — consistent with how `is_backend_supported()` and `vm_backend()` already treat this driver.

Note: I don't have a Windows machine to reproduce/verify this end-to-end, so this is based on tracing the code path (`daemon_main_win.cpp` → `daemon_main()` → `register_global_settings_handlers()` → `CustomSettingSpec` eager interpreter call → `Platform::is_backend_supported()`) plus CI logs referenced in the issue. Would appreciate a CI/Windows run to confirm the noff MSI installs cleanly with this change.

## Test plan
- [ ] Existing unit test `PlatformWin.testDefaultDriver` in `tests/unit/windows/test_platform_win.cpp` already accepts `"hyperv"`, `"hyperv_api"`, or `"virtualbox"` as valid outcomes, so it should continue to pass unchanged.
- [ ] Verify a noff MSI package (built from the scheduled `windows.yml` workflow) installs successfully and the Multipass service reaches a stable `Running` state.
- [ ] Verify `multipass get local.driver` returns `hyperv` on a fresh noff install, and `hyperv_api` on a ff-enabled install.

Fixes #5142