### PR TITLE
[packaging] Remove old GUI app before installing

### DIFF
--- a/packaging/cpack.cmake
+++ b/packaging/cpack.cmake
@@ -109,6 +109,8 @@ if(APPLE)
                  "${CMAKE_BINARY_DIR}/postinstall-multipassd.sh" @ONLY)
   configure_file("${CMAKE_SOURCE_DIR}/packaging/macos/postinstall-multipass.sh.in"
                  "${CMAKE_BINARY_DIR}/postinstall-multipass.sh" @ONLY)
+  configure_file("${CMAKE_SOURCE_DIR}/packaging/macos/preinstall-multipass-gui.sh.in"
+                 "${CMAKE_BINARY_DIR}/preinstall-multipass-gui.sh" @ONLY)
   configure_file("${CMAKE_SOURCE_DIR}/packaging/macos/postinstall-multipass-gui.sh.in"
                  "${CMAKE_BINARY_DIR}/postinstall-multipass-gui.sh" @ONLY)
 
@@ -121,6 +123,7 @@ if(APPLE)
   set(CPACK_PREFLIGHT_MULTIPASSD_SCRIPT  "${CMAKE_BINARY_DIR}/preinstall-multipassd.sh")
   set(CPACK_POSTFLIGHT_MULTIPASSD_SCRIPT "${CMAKE_BINARY_DIR}/postinstall-multipassd.sh")
   set(CPACK_POSTFLIGHT_MULTIPASS_SCRIPT  "${CMAKE_BINARY_DIR}/postinstall-multipass.sh")
+  set(CPACK_PREFLIGHT_MULTIPASS_GUI_SCRIPT  "${CMAKE_BINARY_DIR}/preinstall-multipass-gui.sh")
   set(CPACK_POSTFLIGHT_MULTIPASS_GUI_SCRIPT  "${CMAKE_BINARY_DIR}/postinstall-multipass-gui.sh")
 
   # Cleans up the installed package

--- a/packaging/macos/preinstall-multipass-gui.sh.in
+++ b/packaging/macos/preinstall-multipass-gui.sh.in
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Remove any previously installed GUI bundle before the new payload lands.
+
+rm -rfv "${3}@CPACK_PACKAGING_INSTALL_PREFIX@/bin/Multipass.app"
+rm -rfv "${3}/Applications/Multipass.app"
+
+exit 0


### PR DESCRIPTION
This PR adds a preinstall script that makes sure the old GUI app is gone before installing the new one. Some systems (this causes issue on macOS) don't want to remove the old symlink when the app version isn't strictly increasing. This can cause issues when trying to install CI packages.

### Testing steps:

Install a package from a PR that has a higher PR number (results in a higher version number) from this PR. Install a package from another PR that has a lower number. Open spotlight and try to launch the GUI. You should get an error from the system:

> You can’t open the application “Multipass” because it may be damaged or incomplete.

Install a package from a PR that has a higher PR number (results in a higher version number) from this PR. Install the package from this PR. Open spotlight and GUI launches as expected.