### PR TITLE
[github] Update template to use GitHub field

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,8 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement, needs triage
+labels: needs triage
+type: feature
 assignees: ''
 
 ---


### PR DESCRIPTION
This PR updates the feature request GitHub issue template to use the built-in GitHub `type` [field](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/managing-issue-types-in-an-organization) and not the defunct `enhancement` label.