### PR TITLE
[applevz] Short circuit state check when zone unavailable

### DIFF
--- a/src/platform/backends/applevz/applevz_bridge.mm
+++ b/src/platform/backends/applevz/applevz_bridge.mm
@@ -295,6 +295,9 @@ CFError resume_with_completion_handler(const VMHandle& vm_handle)
 
 AppleVMState get_state(const VMHandle& vm_handle)
 {
+    if (!vm_handle)
+        return AppleVMState::stopped;
+
     VZVirtualMachine* vm = (__bridge VZVirtualMachine*)vm_handle->vm.get();
     return AppleVMState(query_on_vm_queue(vm_handle, [&]() { return [vm state]; }));
 }

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -248,9 +248,17 @@ void AppleVZVirtualMachine::suspend()
 
 VirtualMachine::State AppleVZVirtualMachine::current_state()
 {
-    // Get state from AppleVZ, translate it to our state enum, and notify the monitor
+    if (state == State::unavailable)
+    {
+        mpl::debug(log_category, "current_state() -> VM `{}` zone is unavailable", vm_name);
+        assert(!vm_handle);
+        return state;
+    }
+
     if (!vm_handle)
         return State::stopped;
+
+    // Get state from AppleVZ, translate it to our state enum, and notify the monitor
     set_state(MP_APPLEVZ.get_state(vm_handle));
     return state;
 }

--- a/src/platform/backends/applevz/applevz_virtual_machine.cpp
+++ b/src/platform/backends/applevz/applevz_virtual_machine.cpp
@@ -248,16 +248,6 @@ void AppleVZVirtualMachine::suspend()
 
 VirtualMachine::State AppleVZVirtualMachine::current_state()
 {
-    if (state == State::unavailable)
-    {
-        mpl::debug(log_category, "current_state() -> VM `{}` zone is unavailable", vm_name);
-        assert(!vm_handle);
-        return state;
-    }
-
-    if (!vm_handle)
-        return State::stopped;
-
     // Get state from AppleVZ, translate it to our state enum, and notify the monitor
     set_state(MP_APPLEVZ.get_state(vm_handle));
     return state;
@@ -314,6 +304,12 @@ void AppleVZVirtualMachine::resize_disk_impl(const MemorySize& new_size)
 void AppleVZVirtualMachine::set_state(applevz::AppleVMState vm_state)
 {
     mpl::debug(log_category, "set_state() -> VM `{}` VZ state `{}`", vm_name, vm_state);
+
+    if (state == State::unavailable)
+    {
+        mpl::debug(log_category, "set_state() -> Zone for VM `{}` is unavailable", vm_name);
+        return;
+    }
 
     const auto prev_state = state;
     switch (vm_state)

--- a/tests/unit/applevz/test_applevz_virtual_machine.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine.cpp
@@ -299,4 +299,20 @@ TEST_F(AppleVZVirtualMachine_UnitTests, suspendThrowsNotImplemented)
 
     EXPECT_THROW(uut->suspend(), mp::NotImplementedOnThisBackendException);
 }
+
+TEST_F(AppleVZVirtualMachine_UnitTests, currentStateReportsUnavailableWhenZoneUnavailable)
+{
+    auto uut = construct_vm(applevz::AppleVMState::running);
+
+    EXPECT_CALL(mock_applevz, get_state(_))
+        .WillOnce(Return(applevz::AppleVMState::running))
+        .WillRepeatedly(Return(applevz::AppleVMState::stopped));
+
+    EXPECT_CALL(mock_applevz, can_stop(_)).WillOnce(Return(true));
+    EXPECT_CALL(mock_applevz, stop_vm(_, true)).WillOnce(Return(applevz::CFError{}));
+
+    uut->set_available(false);
+
+    EXPECT_EQ(uut->current_state(), VirtualMachine::State::unavailable);
+}
 }; // namespace multipass::test

--- a/tests/unit/applevz/test_applevz_virtual_machine.cpp
+++ b/tests/unit/applevz/test_applevz_virtual_machine.cpp
@@ -256,7 +256,9 @@ TEST_F(AppleVZVirtualMachine_UnitTests, shutdownForcedStopError)
 {
     auto uut = construct_vm(applevz::AppleVMState::running);
 
-    EXPECT_CALL(mock_applevz, get_state(_)).WillOnce(Return(applevz::AppleVMState::running));
+    EXPECT_CALL(mock_applevz, get_state(_))
+        .WillOnce(Return(applevz::AppleVMState::running))
+        .WillRepeatedly(Return(applevz::AppleVMState::stopped));
 
     EXPECT_CALL(mock_applevz, can_stop(_)).WillOnce(Return(true));
     EXPECT_CALL(mock_applevz, stop_vm(_, true))


### PR DESCRIPTION
This PR makes `current_state` short circuit when the zone is disabled. This prevents the daemon from reporting VMs in a disabled zones from reporting a `Stopped` state in the terminal output.

Fixes #5088 

---

MULTI-2791