### PR TITLE
[gui] Prevent multiple dialogs from being drawn

### DIFF
--- a/src/client/gui/lib/main.dart
+++ b/src/client/gui/lib/main.dart
@@ -76,6 +76,8 @@ class App extends ConsumerStatefulWidget {
 }
 
 class _AppState extends ConsumerState<App> with WindowListener {
+  var beforeQuitDialogShowing = false;
+
   @override
   Widget build(BuildContext context) {
     final currentKey = ref.watch(sidebarKeyProvider);
@@ -208,6 +210,9 @@ class _AppState extends ConsumerState<App> with WindowListener {
     }
 
     if (closeJob == 'ask') {
+      if (beforeQuitDialogShowing) return;
+      beforeQuitDialogShowing = true;
+
       // Get running instances count
       final vmInfos = ref.read(vmInfosProvider);
       final runningCount = vmInfos
@@ -233,7 +238,7 @@ class _AppState extends ConsumerState<App> with WindowListener {
             windowManager.destroy();
           },
         ),
-      );
+      ).whenComplete(() => beforeQuitDialogShowing = false);
     } else {
       stopAllInstances();
     }


### PR DESCRIPTION
This PR adds a boolean to the `BeforeQuitDialog` so that it does not get redrawn if the user clicks "Quit" from the tray menu multiple times.