### PR TITLE
[tests-cli] Add AZ cross-zone connectivity test

### DIFF
--- a/tests/cli/cli_az_test.py
+++ b/tests/cli/cli_az_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Canonical, Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Multipass command line tests for availability zones."""
+
+import pytest
+
+from cli.multipass import exec, info, launch, skip_if_feature_not_supported
+
+
+@pytest.mark.az
+@pytest.mark.usefixtures("multipassd")
+class TestAvailabilityZones:
+    """CLI availability-zone tests."""
+
+    def test_instances_in_different_zones_can_communicate(self):
+        """Check that instances can communicate across zone subnets."""
+
+        skip_if_feature_not_supported("az")
+
+        with (
+            launch({"zone": "zone1"}) as zone1_instance,
+            launch({"zone": "zone2"}) as zone2_instance,
+        ):
+            zone1_ip = info(zone1_instance)[zone1_instance]["ipv4"][0]
+            zone2_ip = info(zone2_instance)[zone2_instance]["ipv4"][0]
+
+            assert exec(zone1_instance, "ping", "-c", "3", "-W", "2", zone2_ip)
+            assert exec(zone2_instance, "ping", "-c", "3", "-W", "2", zone1_ip)

--- a/tests/cli/multipass/feature_versions.py
+++ b/tests/cli/multipass/feature_versions.py
@@ -30,6 +30,7 @@ def _feature_version(name):
         "debian_images": {"min": ver.parse("1.17")},
         "fedora_images": {"min": ver.parse("1.17")},
         "wait_ready": {"min": ver.parse("1.17")},
+        "az": {"min": ver.parse("1.17")},
     }
     assert name in feats, f"No such feature: {name}"
     return feats[name]

--- a/tests/cli/multipass/launch.py
+++ b/tests/cli/multipass/launch.py
@@ -57,7 +57,7 @@ def launch(cfg_override=None):
 
     assert not vm_exists(vm_cfg["name"])
 
-    with multipass(
+    launch_args = [
         "launch",
         "--cpus",
         vm_cfg["cpus"],
@@ -69,7 +69,13 @@ def launch(cfg_override=None):
         vm_cfg["name"],
         "--timeout",
         getattr(cfg.timeouts, "launch", 300),
-        vm_cfg["image"],
+    ]
+    if "zone" in vm_cfg:
+        launch_args.extend(["--zone", vm_cfg["zone"]])
+    launch_args.append(vm_cfg["image"])
+
+    with multipass(
+        *launch_args,
         retry=vm_cfg["retry"],
     ) as launch_r:
         # The launch does not have a dedicated exit code for the "already exists".

--- a/tests/cli/pyproject.toml
+++ b/tests/cli/pyproject.toml
@@ -43,4 +43,5 @@ markers = [
     "version: Version tests",
     "find: Find tests",
     "exec: Exec tests",
+    "az: Availability zone tests",
 ]


### PR DESCRIPTION
Follow-up PR for #5169 to add a CLI test exercising cross-zone connectivity.

MULTI-2899