### PR TITLE
daemon: don't abort delete for all instances when one is missing

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2312,60 +2312,61 @@ try
                                    InstanceGroup::All,
                                    require_existing_instances_reaction);
 
-    if (status.ok())
+    // `status` may already carry an error at this point, if some of the requested instances
+    // don't exist. Still, go ahead and act on whichever instances were actually found below,
+    // instead of dropping the whole request - a missing instance shouldn't prevent deletion of
+    // the others that do exist.
+    const bool purge = request->purge();
+    bool purge_snapshots = request->purge_snapshots();
+    auto instances_dirty = false;
+
+    auto instance_snapshots_map = map_snapshots_to_instances(request->instance_snapshot_pairs());
+
+    // avoid deleting if any snapshot is missing or if we don't get confirmation
+    auto any_snapshot_args = verify_snapshot_picks(instance_selection,
+                                                   instance_snapshots_map,
+                                                   purge);
+    if (any_snapshot_args && !purge && !purge_snapshots)
     {
-        const bool purge = request->purge();
-        bool purge_snapshots = request->purge_snapshots();
-        auto instances_dirty = false;
+        DeleteReply confirm_action{};
+        confirm_action.set_confirm_snapshot_purging(true);
 
-        auto instance_snapshots_map =
-            map_snapshots_to_instances(request->instance_snapshot_pairs());
+        // TODO refactor with bridging and restore prompts
+        if (!server->Write(confirm_action))
+            throw std::runtime_error("Cannot request confirmation from client. Aborting...");
+        DeleteRequest client_response;
+        if (!server->Read(&client_response))
+            throw std::runtime_error("Cannot get confirmation from client. Aborting...");
 
-        // avoid deleting if any snapshot is missing or if we don't get confirmation
-        auto any_snapshot_args =
-            verify_snapshot_picks(instance_selection, instance_snapshots_map, purge);
-        if (any_snapshot_args && !purge && !purge_snapshots)
-        {
-            DeleteReply confirm_action{};
-            confirm_action.set_confirm_snapshot_purging(true);
-
-            // TODO refactor with bridging and restore prompts
-            if (!server->Write(confirm_action))
-                throw std::runtime_error("Cannot request confirmation from client. Aborting...");
-            DeleteRequest client_response;
-            if (!server->Read(&client_response))
-                throw std::runtime_error("Cannot get confirmation from client. Aborting...");
-
-            if (!(purge_snapshots = client_response.purge_snapshots()))
-                return context->set_value(grpc::Status{grpc::CANCELLED, "Cancelled."});
-        }
-
-        // start with deleted instances, to avoid iterator invalidation when moving instances there
-        for (const auto* selection :
-             {&instance_selection.deleted_selection, &instance_selection.operative_selection})
-        {
-            for (const auto& vm_it : *selection)
-            {
-                const auto& instance_name = vm_it->first;
-
-                auto snapshot_pick_it = instance_snapshots_map.find(instance_name);
-                const auto& [pick, all] = snapshot_pick_it == instance_snapshots_map.end()
-                                            ? SnapshotPick{{}, true}
-                                            : snapshot_pick_it->second;
-
-                if (!all || !purge) // if we're not purging the instance, we need to delete
-                                    // specified snapshots
-                    for (const auto& snapshot_name : pick)
-                        vm_it->second->delete_snapshot(snapshot_name);
-
-                if (all) // we're asked to delete the VM
-                    instances_dirty |= delete_vm(vm_it, purge, response);
-            }
-        }
-
-        if (instances_dirty)
-            persist_instances();
+        if (!(purge_snapshots = client_response.purge_snapshots()))
+            return context->set_value(grpc::Status{grpc::CANCELLED, "Cancelled."});
     }
+
+    // start with deleted instances, to avoid iterator invalidation when moving instances there
+    for (const auto* selection :
+         {&instance_selection.deleted_selection, &instance_selection.operative_selection})
+    {
+        for (const auto& vm_it : *selection)
+        {
+            const auto& instance_name = vm_it->first;
+
+            auto snapshot_pick_it = instance_snapshots_map.find(instance_name);
+            const auto& [pick, all] = snapshot_pick_it == instance_snapshots_map.end()
+                                        ? SnapshotPick{{}, true}
+                                        : snapshot_pick_it->second;
+
+            if (!all || !purge) // if we're not purging the instance, we need to delete
+                                // specified snapshots
+                for (const auto& snapshot_name : pick)
+                    vm_it->second->delete_snapshot(snapshot_name);
+
+            if (all) // we're asked to delete the VM
+                instances_dirty |= delete_vm(vm_it, purge, response);
+        }
+    }
+
+    if (instances_dirty)
+        persist_instances();
 
     server->Write(response);
     context->set_value(status);

--- a/tests/unit/daemon_test_fixture.cpp
+++ b/tests/unit/daemon_test_fixture.cpp
@@ -701,6 +701,13 @@ template grpc::Status mpt::DaemonTestFixture::call_daemon_slot(
     StrictMock<mpt::MockServerReaderWriter<mp::UmountReply, mp::UmountRequest>>&&);
 template grpc::Status mpt::DaemonTestFixture::call_daemon_slot(
     mp::Daemon&,
+    void (mp::Daemon::*)(const mp::DeleteRequest*,
+                         grpc::ServerReaderWriterInterface<mp::DeleteReply, mp::DeleteRequest>*,
+                         mp::DaemonRpcContext*),
+    const mp::DeleteRequest&,
+    StrictMock<mpt::MockServerReaderWriter<mp::DeleteReply, mp::DeleteRequest>>&);
+template grpc::Status mpt::DaemonTestFixture::call_daemon_slot(
+    mp::Daemon&,
     void (mp::Daemon::*)(mp::LaunchRequest const*,
                          grpc::ServerReaderWriterInterface<mp::LaunchReply, mp::LaunchRequest>*,
                          mp::DaemonRpcContext*),

--- a/tests/unit/test_daemon.cpp
+++ b/tests/unit/test_daemon.cpp
@@ -1752,6 +1752,32 @@ TEST_F(Daemon, releasesMacsOfPurgedInstancesButKeepsTheRest)
                   fmt::format("name=eth0,mac={}", mac3)}); // mac is free after purge, so accepted
 }
 
+TEST_F(Daemon, deletePurgesFoundInstancesEvenWhenOthersAreMissing)
+{
+    use_a_mock_vm_factory();
+    mp::Daemon daemon{config_builder.build()};
+
+    send_command({"launch", "--name", "vm1"});
+
+    mp::DeleteRequest request;
+    request.set_purge(true);
+    request.add_instance_snapshot_pairs()->set_instance_name("vm1");
+    request.add_instance_snapshot_pairs()->set_instance_name("missing-vm");
+
+    mp::DeleteReply reply;
+    StrictMock<mpt::MockServerReaderWriter<mp::DeleteReply, mp::DeleteRequest>> server;
+    EXPECT_CALL(server, Write(_, _)).WillOnce(DoAll(SaveArg<0>(&reply), Return(true)));
+
+    auto status = call_daemon_slot(daemon, &mp::Daemon::delet, request, server);
+
+    // the whole request is still reported as failed, since one of the named instances is missing
+    EXPECT_EQ(status.error_code(), grpc::StatusCode::NOT_FOUND);
+    EXPECT_THAT(status.error_message(), HasSubstr("instance \"missing-vm\" does not exist"));
+
+    // but the instance that does exist is not held hostage by the one that doesn't
+    EXPECT_THAT(reply.purged_instances(), Contains(Eq("vm1")));
+}
+
 TEST_F(Daemon, deleteRemovesUnavailableInstances)
 {
     auto mock_factory = use_a_mock_vm_factory();


### PR DESCRIPTION
Fixes #5177.

`Daemon::delet()` only ran its deletion loop when `select_instances_and_react()` returned an OK status. Since that status turns into `NOT_FOUND` as soon as one of the requested instance names doesn't exist, the whole request was dropped, including the instances that were found and could have been deleted or purged.

This moves the missing-instance check out of the way of the deletion loop. Instances that are found now get deleted/purged regardless of whether other names in the same request are missing. The overall RPC status still reports an error naming the missing instance(s), so `multipass delete a b c` with a bad name still exits non-zero and tells you which name was wrong, it just no longer holds `a` and `b` hostage.

This lines up with the behavior maintainers agreed on in #687 back in 2019 (existing instances get deleted, it's still an error if any of them don't exist), which as far as I can tell never actually got implemented.

Added a daemon test (`deletePurgesFoundInstancesEvenWhenOthersAreMissing`) that launches one instance, sends a purge request naming that instance plus a nonexistent one, and checks that the real instance ends up in `purged_instances` while the RPC status is still `NOT_FOUND` for the missing one.

**Build/test status**: built and ran this on a clean Ubuntu 24.04 VM (clang-19, vcpkg deps built from source, `-DMULTIPASS_ENABLE_TESTS=ON -DMULTIPASS_ENABLE_FLUTTER_GUI=OFF`), since I didn't have the toolchain locally. `multipass_cpp_tests`: 3906/3906 passing, including all 57 `Daemon.*` tests and the new one. Also ran `clang-format-19 --dry-run` against the diff and fixed the one line it flagged. First pass at this actually caught a real `-Werror` unused-variable bug in my own test that a plain code read had missed, so glad I didn't skip it.
