### PR TITLE
[tests] Fix ASSERT_DEBUG_DEATH in Windows

### DIFF
--- a/tests/unit/test_cli_prompters.cpp
+++ b/tests/unit/test_cli_prompters.cpp
@@ -190,7 +190,7 @@ TEST_F(CLIPrompters, failsIfNoNetworks)
     EXPECT_CALL(mock_terminal, cin_is_live()).WillRepeatedly(Return(false));
     EXPECT_CALL(mock_terminal, cout_is_live()).WillRepeatedly(Return(false));
     // https://google.github.io/googletest/advanced.html#regular-expression-syntax
-    ASSERT_DEBUG_DEATH(prompter.bridge_prompt(nets), "[Aa]ssert");
+    ASSERT_DEBUG_DEATH(prompter.bridge_prompt(nets), "ssert");
 }
 
 TEST_P(BridgePrompterTests, correctlyReturns)

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -394,7 +394,7 @@ TEST(Utils, trimNewlineAssertionWorks)
 {
     std::string s{"wrong"};
     // https://google.github.io/googletest/advanced.html#regular-expression-syntax
-    ASSERT_DEBUG_DEATH(mp::utils::trim_newline(s), "[Aa]ssert");
+    ASSERT_DEBUG_DEATH(mp::utils::trim_newline(s), "ssert");
 }
 
 TEST_F(TestTrimUtilities, trimRvalue)


### PR DESCRIPTION
The [Aa] pattern is not supported in Windows' gtest regex implementation, whereas \\w is not supported on Mac. Trim the pattern to "ssert" to make it work on both platforms.

