### PR TITLE
[doc] Clarify cloud-init network handling

### DIFF
--- a/docs/reference/command-line-interface/launch.md
+++ b/docs/reference/command-line-interface/launch.md
@@ -24,6 +24,10 @@ If you want your instance to have a name of your choice, use the `--name` option
 
 By passing a filename or an URL to `--cloud-init`, you can provide user data to [`cloud-init`](https://cloud-init.io/) to customise the instance on first boot. See [cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) for examples.
 
+```{note}
+The `--cloud-init` option accepts user data only. A top-level `network` key belongs to cloud-init's separate network configuration and cannot be supplied through this option. Multipass generates that configuration for the default interface and any interfaces requested with `--network`. See [Set up custom networking](how-to-guides-manage-instances-set-up-custom-networking) for the supported options.
+```
+
 Use the `--network` option to {ref}`create-an-instance-with-multiple-network-interfaces`.
 
 Passing `--bridged` and `--network bridged` are shortcuts to `--network <name>`, where `<name>` is configured via `multipass set local.bridged-interface`.


### PR DESCRIPTION
# Description

- Clarifies that `--cloud-init` accepts user data rather than a separate cloud-init network configuration.
- Explains that Multipass generates network configuration for the default interface and interfaces requested with `--network`.
- Points readers to the existing custom networking documentation.

## Related Issue(s)

Closes #3947

## Testing

- `git diff --check`
- Built the Sphinx documentation and verified that the new note renders on the `launch` command page with a valid internal link.

## Checklist

- [x] My code follows the [contributing guidelines](https://github.com/canonical/multipass/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [Canonical CLA](https://canonical.com/legal/contributors)
- [x] No unit tests were appropriate for this documentation-only change
- [x] No integration tests were appropriate for this documentation-only change
- [x] I have updated documentation
- [x] I have tested the changes locally

## Additional Notes

The full strict documentation build also reported the repository's existing Git timestamp warnings because the source checkout was shallow; the edited page itself rendered successfully.
