### PR TITLE
[tests-cli] Bump exec timeout to 270s

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -174,7 +174,7 @@ def pytest_addoption(parser):
             ("mount", 180),
             ("restart", 240),
             ("delete", 90),
-            ("exec", 90),
+            ("exec", 270),
             ("start", 180),
             ("umount", 45),
         ],


### PR DESCRIPTION
Exec may start the instance if stopped and 90 seconds deadline might not be sufficient to perform the startup and the execution.

Bump the timeout to 180 + 90 to accommodate the start() possibility.

