### PR TITLE
[hcs] Ensure VM endpoints are deleted

### DIFF
--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_api.cpp
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_api.cpp
@@ -68,6 +68,13 @@ HRESULT HCNAPI::HcnEnumerateEndpoints(PCWSTR Query, PWSTR* Endpoints, PWSTR* Err
 {
     return ::HcnEnumerateEndpoints(Query, Endpoints, ErrorRecord);
 }
+HRESULT HCNAPI::HcnQueryEndpointProperties(HCN_ENDPOINT Endpoint,
+                                           PCWSTR Query,
+                                           PWSTR* Properties,
+                                           PWSTR* ErrorRecord) const
+{
+    return ::HcnQueryEndpointProperties(Endpoint, Query, Properties, ErrorRecord);
+}
 HRESULT HCNAPI::HcnEnumerateNetworks(PCWSTR Query, PWSTR* Networks, PWSTR* ErrorRecord) const
 {
     return ::HcnEnumerateNetworks(Query, Networks, ErrorRecord);

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_api.h
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_api.h
@@ -52,6 +52,10 @@ struct HCNAPI : public Singleton<HCNAPI>
     [[nodiscard]] virtual HRESULT HcnEnumerateEndpoints(PCWSTR Query,
                                                         PWSTR* Endpoints,
                                                         PWSTR* ErrorRecord) const;
+    [[nodiscard]] virtual HRESULT HcnQueryEndpointProperties(HCN_ENDPOINT Endpoint,
+                                                             PCWSTR Query,
+                                                             PWSTR* Properties,
+                                                             PWSTR* ErrorRecord) const;
     [[nodiscard]] virtual HRESULT HcnEnumerateNetworks(PCWSTR Query,
                                                        PWSTR* Networks,
                                                        PWSTR* ErrorRecord) const;

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_create_endpoint_params.cpp
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_create_endpoint_params.cpp
@@ -49,10 +49,14 @@ auto fmt::formatter<CreateEndpointParameters, Char>::format(const CreateEndpoint
         }},
         "HostComputeNetwork": "{0}",
         "Policies": [],
-        "MacAddress" : {1}
+        "MacAddress" : {1},
+        "Name": {2}
     }})json");
 
-    return json_template.format_to(ctx, params.network_guid, value_or_null(params.mac_address));
+    return json_template.format_to(ctx,
+                                   params.network_guid,
+                                   value_or_null(params.mac_address),
+                                   value_or_null(params.name));
 }
 
 template auto fmt::formatter<CreateEndpointParameters, char>::format<fmt::format_context>(

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_create_endpoint_params.h
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_create_endpoint_params.h
@@ -51,6 +51,15 @@ struct CreateEndpointParameters
      * not specified, where applicable.
      */
     std::optional<std::string> mac_address;
+
+    /**
+     * A deterministic, instance-based name tagged onto the endpoint (optional).
+     *
+     * This allows the endpoint to be discovered and removed later on by name,
+     * without needing to reopen (or even know the RuntimeId of) the compute
+     * system that it was originally attached to.
+     */
+    std::optional<std::string> name;
 };
 
 } // namespace multipass::hyperv::hcn

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_endpoint_naming.h
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_endpoint_naming.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+
+#include <string>
+
+namespace multipass::hyperv::hcn
+{
+
+/**
+ * Compute the deterministic endpoint `Name` tag for a given instance.
+ *
+ * All endpoints created for a given instance (the primary/management endpoint
+ * as well as any extra interfaces) are tagged with the same name. This allows
+ * the endpoints belonging to an instance to be discovered and removed purely
+ * by name, without needing to know (or resolve) the instance's compute
+ * system RuntimeId -- which requires the compute system to still exist/be
+ * reopenable.
+ *
+ * @param vm_name Name of the instance.
+ * @return The deterministic endpoint name for the instance.
+ */
+inline std::string endpoint_name_for(const std::string& vm_name)
+{
+    return fmt::format("multipass-{}", vm_name);
+}
+
+} // namespace multipass::hyperv::hcn

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.cpp
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.cpp
@@ -319,8 +319,9 @@ OperationResult HCNWrapper::find_endpoints_by_name(const std::string& name,
 
     // No filter -- enumerate every endpoint known to HCN, then inspect each one's `Name`
     // individually. This does not require the owning compute system to be open/alive.
-    const auto result =
-        API().HcnEnumerateEndpoints(L"{}", out_ptr(json_output), out_ptr(result_msgbuf));
+    const auto result = API().HcnEnumerateEndpoints(L"{}",
+                                                    out_ptr(json_output),
+                                                    out_ptr(result_msgbuf));
 
     if (FAILED(result) || !json_output)
     {
@@ -351,9 +352,9 @@ OperationResult HCNWrapper::find_endpoints_by_name(const std::string& name,
 
         UniqueCotaskmemString query_result{}, query_error{};
         const auto query_status = API().HcnQueryEndpointProperties(endpoint.get(),
-                                                                    L"{}",
-                                                                    out_ptr(query_result),
-                                                                    out_ptr(query_error));
+                                                                   L"{}",
+                                                                   out_ptr(query_result),
+                                                                   out_ptr(query_error));
         if (FAILED(query_status) || !query_result)
         {
             mpl::warn(log_category,
@@ -445,8 +446,9 @@ OperationResult HCNWrapper::enumerate_networks(std::vector<std::string>& out_net
     UniqueCotaskmemString enumerate_result{}, result_msgbuf{};
 
     // List all HCN network GUIDs
-    const auto result =
-        API().HcnEnumerateNetworks(L"{}", out_ptr(enumerate_result), out_ptr(result_msgbuf));
+    const auto result = API().HcnEnumerateNetworks(L"{}",
+                                                   out_ptr(enumerate_result),
+                                                   out_ptr(result_msgbuf));
     if (enumerate_result)
     {
         // json_output would contain the network GUIDs.

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.cpp
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.cpp
@@ -322,7 +322,7 @@ OperationResult HCNWrapper::find_endpoints_by_name(const std::string& name,
     const auto result =
         API().HcnEnumerateEndpoints(L"{}", out_ptr(json_output), out_ptr(result_msgbuf));
 
-    if (!result || !json_output)
+    if (FAILED(result) || !json_output)
     {
         return {result, {result_msgbuf ? result_msgbuf.get() : L""}};
     }

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.cpp
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.cpp
@@ -186,6 +186,18 @@ std::pair<OperationResult, UniqueHcnNetwork> open_network(const std::string& net
     return std::make_pair(result, std::move(network));
 }
 
+std::pair<OperationResult, UniqueHcnEndpoint> open_endpoint(const std::string& endpoint_guid)
+{
+    mpl::trace(log_category, "open_endpoint(...) > endpoint_guid: {} ", endpoint_guid);
+
+    UniqueHcnEndpoint endpoint{};
+    const auto result = perform_hcn_operation([&](auto&& rmsgbuf) {
+        return API().HcnOpenEndpoint(guid_from_string(endpoint_guid), out_ptr(endpoint), rmsgbuf);
+    });
+
+    return std::make_pair(result, std::move(endpoint));
+}
+
 } // namespace
 
 // ---------------------------------------------------------
@@ -292,6 +304,79 @@ OperationResult HCNWrapper::enumerate_attached_endpoints(
             {
                 endpoint_guids.emplace_back(elem.as_string());
             }
+        }
+    }
+
+    return {result, {result_msgbuf ? result_msgbuf.get() : L""}};
+}
+
+OperationResult HCNWrapper::find_endpoints_by_name(const std::string& name,
+                                                   std::vector<std::string>& endpoint_guids) const
+{
+    mpl::trace(log_category, "HCNWrapper::find_endpoints_by_name(...) > name: {} ", name);
+
+    UniqueCotaskmemString json_output{}, result_msgbuf{};
+
+    // No filter -- enumerate every endpoint known to HCN, then inspect each one's `Name`
+    // individually. This does not require the owning compute system to be open/alive.
+    const auto result =
+        API().HcnEnumerateEndpoints(L"{}", out_ptr(json_output), out_ptr(result_msgbuf));
+
+    if (!result || !json_output)
+    {
+        return {result, {result_msgbuf ? result_msgbuf.get() : L""}};
+    }
+
+    const auto endpoints_as_str = wchar_to_utf8(json_output.get());
+    std::error_code ec;
+    const auto as_json = boost::json::parse(endpoints_as_str, ec);
+    if (ec)
+    {
+        return {E_FAIL, L"Json parse error"};
+    }
+
+    for (const auto& elem : as_json.as_array())
+    {
+        const std::string endpoint_guid{elem.as_string()};
+
+        const auto& [open_result, endpoint] = open_endpoint(endpoint_guid);
+        if (!endpoint)
+        {
+            mpl::warn(log_category,
+                      "find_endpoints_by_name(...) > could not open endpoint {}: {}",
+                      endpoint_guid,
+                      open_result);
+            continue;
+        }
+
+        UniqueCotaskmemString query_result{}, query_error{};
+        const auto query_status = API().HcnQueryEndpointProperties(endpoint.get(),
+                                                                    L"{}",
+                                                                    out_ptr(query_result),
+                                                                    out_ptr(query_error));
+        if (FAILED(query_status) || !query_result)
+        {
+            mpl::warn(log_category,
+                      "find_endpoints_by_name(...) > could not query endpoint {}: {}",
+                      endpoint_guid,
+                      query_status);
+            continue;
+        }
+
+        std::error_code query_ec;
+        const auto endpoint_json_str = wchar_to_utf8(query_result.get());
+        const auto endpoint_json = boost::json::parse(endpoint_json_str, query_ec);
+        if (query_ec)
+        {
+            continue;
+        }
+
+        const auto& endpoint_obj = endpoint_json.as_object();
+        if (const auto* endpoint_name = endpoint_obj.if_contains("Name");
+            endpoint_name != nullptr && endpoint_name->is_string() &&
+            endpoint_name->as_string() == name)
+        {
+            endpoint_guids.push_back(endpoint_guid);
         }
     }
 

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.h
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.h
@@ -52,9 +52,8 @@ struct HCNWrapper : public Singleton<HCNWrapper>
      * owning compute system to be open (or even alive). This is used as a fallback path
      * for cleaning up endpoints whose owning VM has already been terminated/removed.
      */
-    [[nodiscard]] virtual OperationResult find_endpoints_by_name(
-        const std::string& name,
-        std::vector<std::string>& endpoint_guids) const;
+    [[nodiscard]] virtual OperationResult
+    find_endpoints_by_name(const std::string& name, std::vector<std::string>& endpoint_guids) const;
     [[nodiscard]] virtual OperationResult enumerate_networks(
         std::vector<std::string>& network_guids) const;
     [[nodiscard]] virtual OperationResult query_network(const std::string& network_guid,

--- a/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.h
+++ b/src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.h
@@ -47,6 +47,14 @@ struct HCNWrapper : public Singleton<HCNWrapper>
     [[nodiscard]] virtual OperationResult enumerate_attached_endpoints(
         const std::string& vm_guid,
         std::vector<std::string>& endpoint_guids) const;
+    /**
+     * Find endpoints tagged with the given deterministic `Name`, without requiring the
+     * owning compute system to be open (or even alive). This is used as a fallback path
+     * for cleaning up endpoints whose owning VM has already been terminated/removed.
+     */
+    [[nodiscard]] virtual OperationResult find_endpoints_by_name(
+        const std::string& name,
+        std::vector<std::string>& endpoint_guids) const;
     [[nodiscard]] virtual OperationResult enumerate_networks(
         std::vector<std::string>& network_guids) const;
     [[nodiscard]] virtual OperationResult query_network(const std::string& network_guid,

--- a/src/platform/backends/hyperv_api/hcs_virtual_machine.cpp
+++ b/src/platform/backends/hyperv_api/hcs_virtual_machine.cpp
@@ -18,6 +18,7 @@
 #include <hyperv_api/hcs_virtual_machine.h>
 
 #include <hyperv_api/hcn/hyperv_hcn_create_endpoint_params.h>
+#include <hyperv_api/hcn/hyperv_hcn_endpoint_naming.h>
 #include <hyperv_api/hcn/hyperv_hcn_wrapper.h>
 #include <hyperv_api/hcs/hyperv_hcs_compute_system_state.h>
 #include <hyperv_api/hcs/hyperv_hcs_event_type.h>
@@ -337,19 +338,26 @@ void HCSVirtualMachine::set_compute_system_callback_handler()
 
 std::vector<hcn::CreateEndpointParameters> HCSVirtualMachine::make_endpoint_parameters() const
 {
+    // Deterministic, instance-based name tagged onto every endpoint that belongs to this
+    // VM. It allows the endpoints to be discovered and removed by name later on (e.g. during
+    // instance purge), without needing to reopen the compute system to retrieve its RuntimeId.
+    const auto endpoint_name = hcn::endpoint_name_for(description.vm_name);
+
     std::vector<hcn::CreateEndpointParameters> params{
         // The primary endpoint (management)
         {.network_guid = primary_network_guid,
          .endpoint_guid = mac2uuid(description.default_mac_address),
-         .mac_address = replace_colon_with_dash(description.default_mac_address)}};
+         .mac_address = replace_colon_with_dash(description.default_mac_address),
+         .name = endpoint_name}};
 
     // Additional endpoints, a.k.a. extra interfaces.
     std::ranges::transform(description.extra_interfaces,
                            std::back_inserter(params),
-                           [](const auto& v) -> hcn::CreateEndpointParameters {
+                           [&endpoint_name](const auto& v) -> hcn::CreateEndpointParameters {
                                return {.network_guid = multipass::utils::make_uuid(v.id),
                                        .endpoint_guid = mac2uuid(v.mac_address),
-                                       .mac_address = replace_colon_with_dash(v.mac_address)};
+                                       .mac_address = replace_colon_with_dash(v.mac_address),
+                                       .name = endpoint_name};
                            });
 
     return params;

--- a/src/platform/backends/hyperv_api/hcs_virtual_machine_factory.cpp
+++ b/src/platform/backends/hyperv_api/hcs_virtual_machine_factory.cpp
@@ -145,52 +145,15 @@ void HCSVirtualMachineFactory::remove_resources_for_impl(const std::string& name
     hcs::HcsSystemHandle handle{nullptr};
     if (HCS().open_compute_system(name, handle))
     {
-        // Grab compute system GUID before terminating it so we can use it later on for endpoint
-        // cleanup.
-        std::string vm_guid{};
-        if (!HCS().get_compute_system_guid(handle, vm_guid) || vm_guid.empty())
-        {
-            mpl::warn(log_category,
-                      "Could not retrieve VM guid for `{}`, falling back to name-based endpoint "
-                      "cleanup.",
-                      name);
-            remove_endpoints_by_name(name);
-            return;
-        }
-
         if (HCS().terminate_compute_system(handle))
         {
             mpl::warn(log_category,
                       "remove_resources_for_impl() -> Host compute system {} was still alive.",
                       name);
         }
-
-        std::vector<std::string> attached_endpoints{};
-        const auto& enumerate_result =
-            HCN().enumerate_attached_endpoints(vm_guid, attached_endpoints);
-        for (const auto& elem : attached_endpoints)
-        {
-            const auto remove_result = HCN().delete_endpoint(elem);
-
-            mpl::log(remove_result ? mpl::Level::trace : mpl::Level::warning,
-                     log_category,
-                     "remove_resources_for_impl() -> Remove attached endpoint {}: {}",
-                     elem,
-                     remove_result.code);
-        }
     }
-    else
-    {
-        // The compute system may have already been terminated (e.g. by an earlier shutdown()
-        // call during instance deletion), in which case it can no longer be reopened to
-        // retrieve its RuntimeId for `enumerate_attached_endpoints`. Fall back to discovering
-        // and removing the instance's endpoints by their deterministic `Name` tag instead.
-        mpl::info(log_category,
-                  "remove_resources_for_impl() -> Host compute system `{}` already terminated, "
-                  "falling back to name-based endpoint cleanup.",
-                  name);
-        remove_endpoints_by_name(name);
-    }
+
+    remove_endpoints_by_name(name);
 }
 
 VMImage HCSVirtualMachineFactory::prepare_source_image(const VMImage& source_image)

--- a/src/platform/backends/hyperv_api/hcs_virtual_machine_factory.cpp
+++ b/src/platform/backends/hyperv_api/hcs_virtual_machine_factory.cpp
@@ -114,15 +114,14 @@ namespace
 void remove_endpoints_by_name(const std::string& name)
 {
     std::vector<std::string> endpoints{};
-    const auto find_result =
-        HCN().find_endpoints_by_name(hcn::endpoint_name_for(name), endpoints);
+    const auto find_result = HCN().find_endpoints_by_name(hcn::endpoint_name_for(name), endpoints);
 
     if (!find_result)
     {
         mpl::warn(log_category,
-                 "remove_endpoints_by_name() -> Could not enumerate endpoints for `{}`: {}",
-                 name,
-                 find_result);
+                  "remove_endpoints_by_name() -> Could not enumerate endpoints for `{}`: {}",
+                  name,
+                  find_result);
         return;
     }
 
@@ -210,8 +209,8 @@ void HCSVirtualMachineFactory::prepare_instance_image(const VMImage& instance_im
                                                       const VirtualMachineDescription& desc)
 {
     // Resize the instance image to the desired size
-    const auto resize_result =
-        VirtDisk().resize_virtual_disk(instance_image.image_path, desc.disk_space.in_bytes());
+    const auto resize_result = VirtDisk().resize_virtual_disk(instance_image.image_path,
+                                                              desc.disk_space.in_bytes());
     if (!resize_result)
     {
         throw ImageResizeException{"Failed to resize VHDX file `{}`, virtdisk API error code `{}`",

--- a/src/platform/backends/hyperv_api/hcs_virtual_machine_factory.cpp
+++ b/src/platform/backends/hyperv_api/hcs_virtual_machine_factory.cpp
@@ -18,6 +18,7 @@
 #include <hyperv_api/hcs_virtual_machine_factory.h>
 
 #include <hyperv_api/hcn/hyperv_hcn_create_network_params.h>
+#include <hyperv_api/hcn/hyperv_hcn_endpoint_naming.h>
 #include <hyperv_api/hcn/hyperv_hcn_wrapper.h>
 #include <hyperv_api/hcs/hyperv_hcs_wrapper.h>
 #include <hyperv_api/hcs_virtual_machine.h>
@@ -108,6 +109,36 @@ VirtualMachine::UPtr HCSVirtualMachineFactory::create_virtual_machine(
                                                get_instance_directory(desc.vm_name));
 }
 
+namespace
+{
+void remove_endpoints_by_name(const std::string& name)
+{
+    std::vector<std::string> endpoints{};
+    const auto find_result =
+        HCN().find_endpoints_by_name(hcn::endpoint_name_for(name), endpoints);
+
+    if (!find_result)
+    {
+        mpl::warn(log_category,
+                 "remove_endpoints_by_name() -> Could not enumerate endpoints for `{}`: {}",
+                 name,
+                 find_result);
+        return;
+    }
+
+    for (const auto& elem : endpoints)
+    {
+        const auto remove_result = HCN().delete_endpoint(elem);
+
+        mpl::log(remove_result ? mpl::Level::trace : mpl::Level::warning,
+                 log_category,
+                 "remove_endpoints_by_name() -> Remove endpoint {}: {}",
+                 elem,
+                 remove_result.code);
+    }
+}
+} // namespace
+
 void HCSVirtualMachineFactory::remove_resources_for_impl(const std::string& name)
 {
     mpl::debug(log_category, "remove_resources_for_impl() -> VM: {}", name);
@@ -120,8 +151,10 @@ void HCSVirtualMachineFactory::remove_resources_for_impl(const std::string& name
         if (!HCS().get_compute_system_guid(handle, vm_guid) || vm_guid.empty())
         {
             mpl::warn(log_category,
-                      "Could not retrieve VM guid for `{}`, skipping endpoint cleanup.",
+                      "Could not retrieve VM guid for `{}`, falling back to name-based endpoint "
+                      "cleanup.",
                       name);
+            remove_endpoints_by_name(name);
             return;
         }
 
@@ -148,9 +181,15 @@ void HCSVirtualMachineFactory::remove_resources_for_impl(const std::string& name
     }
     else
     {
+        // The compute system may have already been terminated (e.g. by an earlier shutdown()
+        // call during instance deletion), in which case it can no longer be reopened to
+        // retrieve its RuntimeId for `enumerate_attached_endpoints`. Fall back to discovering
+        // and removing the instance's endpoints by their deterministic `Name` tag instead.
         mpl::info(log_category,
-                  "remove_resources_for_impl() -> Host compute system `{}` already terminated.",
+                  "remove_resources_for_impl() -> Host compute system `{}` already terminated, "
+                  "falling back to name-based endpoint cleanup.",
                   name);
+        remove_endpoints_by_name(name);
     }
 }
 

--- a/tests/unit/hyperv_api/mock_hyperv_hcn_api.h
+++ b/tests/unit/hyperv_api/mock_hyperv_hcn_api.h
@@ -58,6 +58,10 @@ public:
                 (PCWSTR Query, PWSTR* Networks, PWSTR* ErrorRecord),
                 (const override));
     MOCK_METHOD(HRESULT,
+                HcnQueryEndpointProperties,
+                (HCN_ENDPOINT Endpoint, PCWSTR Query, PWSTR* Properties, PWSTR* ErrorRecord),
+                (const override));
+    MOCK_METHOD(HRESULT,
                 HcnQueryNetworkProperties,
                 (HCN_NETWORK Network, PCWSTR Query, PWSTR* Properties, PWSTR* ErrorRecord),
                 (const override));

--- a/tests/unit/hyperv_api/mock_hyperv_hcn_wrapper.h
+++ b/tests/unit/hyperv_api/mock_hyperv_hcn_wrapper.h
@@ -57,6 +57,11 @@ struct MockHCNWrapper : public hyperv::hcn::HCNWrapper
                 (const, override));
 
     MOCK_METHOD(hyperv::OperationResult,
+                find_endpoints_by_name,
+                (const std::string& name, std::vector<std::string>& endpoint_guids),
+                (const, override));
+
+    MOCK_METHOD(hyperv::OperationResult,
                 enumerate_networks,
                 (std::vector<std::string> & network_guids),
                 (const, override));

--- a/tests/unit/hyperv_api/test_bb_cit_hyperv.cpp
+++ b/tests/unit/hyperv_api/test_bb_cit_hyperv.cpp
@@ -112,8 +112,8 @@ TEST_F(HyperV_ComponentIntegrationTests, spawn_empty_test_vm)
 
     // Create test VM
     {
-        const auto& [status, status_msg] =
-            HCS().create_compute_system(create_vm_parameters, handle);
+        const auto& [status, status_msg] = HCS().create_compute_system(create_vm_parameters,
+                                                                       handle);
         ASSERT_TRUE(status.success());
     }
 
@@ -220,8 +220,8 @@ TEST_F(HyperV_ComponentIntegrationTests, spawn_empty_test_vm_attach_nic_after_bo
 
     // Create test VM
     {
-        const auto& [status, status_msg] =
-            HCS().create_compute_system(create_vm_parameters, handle);
+        const auto& [status, status_msg] = HCS().create_compute_system(create_vm_parameters,
+                                                                       handle);
         ASSERT_TRUE(status.success());
         ASSERT_TRUE(status_msg.empty());
     }
@@ -242,8 +242,8 @@ TEST_F(HyperV_ComponentIntegrationTests, spawn_empty_test_vm_attach_nic_after_bo
             HcsResourcePath::NetworkAdapters(network_adapter.endpoint_guid),
             HcsRequestType::Add(),
             network_adapter};
-        const auto& [status, status_msg] =
-            HCS().modify_compute_system(handle, add_network_adapter_req);
+        const auto& [status, status_msg] = HCS().modify_compute_system(handle,
+                                                                       add_network_adapter_req);
         ASSERT_TRUE(status.success());
         ASSERT_TRUE(status_msg.empty());
     }
@@ -252,11 +252,11 @@ TEST_F(HyperV_ComponentIntegrationTests, spawn_empty_test_vm_attach_nic_after_bo
     {
         // Create another EP so we can ensure that we're only listing the EPs belonging to the VM
         {
-            const auto& [status, status_msg] =
-                HCN().create_endpoint(hyperv::hcn::CreateEndpointParameters{
-                    .network_guid = network_parameters.guid,
-                    .endpoint_guid = "aee79cf9-54d1-4653-81fb-8110db97029b",
-                });
+            const auto& [status,
+                         status_msg] = HCN().create_endpoint(hyperv::hcn::CreateEndpointParameters{
+                .network_guid = network_parameters.guid,
+                .endpoint_guid = "aee79cf9-54d1-4653-81fb-8110db97029b",
+            });
 
             ASSERT_TRUE(status.success());
             ASSERT_TRUE(status_msg.empty());
@@ -293,10 +293,10 @@ TEST_F(HyperV_ComponentIntegrationTests, endpoints_tagged_with_same_name_are_fou
     }();
 
     const std::vector<std::string> endpoint_guids{"aee79cf9-54d1-4653-81fb-8110db970200",
-                                                    "bfe89da0-65e2-5764-92fc-9221ec081311"};
+                                                  "bfe89da0-65e2-5764-92fc-9221ec081311"};
 
-    const auto make_endpoint_parameters = [&network_parameters, &endpoint_name](
-                                               const std::string& endpoint_guid) {
+    const auto make_endpoint_parameters = [&network_parameters,
+                                           &endpoint_name](const std::string& endpoint_guid) {
         hyperv::hcn::CreateEndpointParameters endpoint_parameters{};
         endpoint_parameters.network_guid = network_parameters.guid;
         endpoint_parameters.endpoint_guid = endpoint_guid;

--- a/tests/unit/hyperv_api/test_bb_cit_hyperv.cpp
+++ b/tests/unit/hyperv_api/test_bb_cit_hyperv.cpp
@@ -22,9 +22,12 @@
 
 #include <src/platform/backends/hyperv_api/hcn/hyperv_hcn_create_endpoint_params.h>
 #include <src/platform/backends/hyperv_api/hcn/hyperv_hcn_create_network_params.h>
+#include <src/platform/backends/hyperv_api/hcn/hyperv_hcn_endpoint_naming.h>
 #include <src/platform/backends/hyperv_api/hcn/hyperv_hcn_wrapper.h>
 #include <src/platform/backends/hyperv_api/hcs/hyperv_hcs_wrapper.h>
 #include <src/platform/backends/hyperv_api/virtdisk/virtdisk_wrapper.h>
+
+#include <computecore.h>
 
 namespace multipass::test
 {
@@ -272,6 +275,92 @@ TEST_F(HyperV_ComponentIntegrationTests, spawn_empty_test_vm_attach_nic_after_bo
         << "Delete endpoint failed!";
     EXPECT_TRUE(HCN().delete_network(network_parameters.guid)) << "Delete network failed!";
     handle.reset();
+}
+
+TEST_F(HyperV_ComponentIntegrationTests, endpoints_tagged_with_same_name_are_found_and_removed)
+{
+    constexpr auto vm_name = "multipass-hyperv-cit-endpoint-leak-vm";
+    const auto endpoint_name = hyperv::hcn::endpoint_name_for(vm_name);
+
+    const auto network_parameters = []() {
+        hyperv::hcn::CreateNetworkParameters network_parameters{};
+        network_parameters.name = "multipass-hyperv-cit-endpoint-leak";
+        network_parameters.guid = "c6e6a6c1-9f7e-4b8a-8f0e-6a0a6b6c6d6e";
+        network_parameters.ipams = {
+            hyperv::hcn::HcnIpam{hyperv::hcn::HcnIpamType::Static(),
+                                 {hyperv::hcn::HcnSubnet{"10.99.100.0/24"}}}};
+        return network_parameters;
+    }();
+
+    const std::vector<std::string> endpoint_guids{"aee79cf9-54d1-4653-81fb-8110db970200",
+                                                    "bfe89da0-65e2-5764-92fc-9221ec081311"};
+
+    const auto make_endpoint_parameters = [&network_parameters, &endpoint_name](
+                                               const std::string& endpoint_guid) {
+        hyperv::hcn::CreateEndpointParameters endpoint_parameters{};
+        endpoint_parameters.network_guid = network_parameters.guid;
+        endpoint_parameters.endpoint_guid = endpoint_guid;
+        // Tag the endpoint with the deterministic, instance-based name -- this is what allows
+        // it to be found and removed without needing the VM's RuntimeId.
+        endpoint_parameters.name = endpoint_name;
+        return endpoint_parameters;
+    };
+
+    // Remove remnants from previous (failed) test runs, if any.
+    {
+        std::vector<std::string> stale_endpoints{};
+        (void)HCN().find_endpoints_by_name(endpoint_name, stale_endpoints);
+        for (const auto& stale : stale_endpoints)
+            (void)HCN().delete_endpoint(stale);
+
+        for (const auto& guid : endpoint_guids)
+            (void)HCN().delete_endpoint(guid);
+        (void)HCN().delete_network(network_parameters.guid);
+    }
+
+    // Create the test network
+    {
+        const auto& [status, status_msg] = HCN().create_network(network_parameters);
+        ASSERT_TRUE(status.success());
+    }
+
+    // Create both endpoints, tagged with the same instance-based name.
+    for (const auto& guid : endpoint_guids)
+    {
+        const auto& [status, status_msg] = HCN().create_endpoint(make_endpoint_parameters(guid));
+        ASSERT_TRUE(status.success());
+    }
+
+    // Querying by name discovers *all* endpoints sharing that name.
+    {
+        std::vector<std::string> found{};
+        const auto& [status, status_msg] = HCN().find_endpoints_by_name(endpoint_name, found);
+        ASSERT_TRUE(status.success());
+        EXPECT_THAT(found, testing::UnorderedElementsAreArray(endpoint_guids));
+    }
+
+    // Deleting all discovered endpoints removes them.
+    {
+        std::vector<std::string> found{};
+        const auto& [status, status_msg] = HCN().find_endpoints_by_name(endpoint_name, found);
+        ASSERT_TRUE(status.success());
+
+        for (const auto& guid : found)
+        {
+            const auto& [del_status, del_msg] = HCN().delete_endpoint(guid);
+            EXPECT_TRUE(del_status.success());
+        }
+    }
+
+    // Verify none of them remain -- no leak.
+    {
+        std::vector<std::string> found{};
+        const auto& [status, status_msg] = HCN().find_endpoints_by_name(endpoint_name, found);
+        ASSERT_TRUE(status.success());
+        EXPECT_TRUE(found.empty());
+    }
+
+    (void)HCN().delete_network(network_parameters.guid);
 }
 
 } // namespace multipass::test

--- a/tests/unit/hyperv_api/test_ut_hyperv_hcn_api.cpp
+++ b/tests/unit/hyperv_api/test_ut_hyperv_hcn_api.cpp
@@ -529,7 +529,8 @@ TEST_F(HyperVHCNAPI_UnitTests, create_endpoint_success)
                         "HostComputeNetwork": "b70c479d-f808-4053-aafa-705bc15b6d68",
                         "Policies": [
                         ],
-                        "MacAddress": null
+                        "MacAddress": null,
+                        "Name": null
                     })""";
 
                     ASSERT_NE(nullptr, network);
@@ -639,7 +640,8 @@ TEST_F(HyperVHCNAPI_UnitTests, create_endpoint_failure)
                         "HostComputeNetwork": "b70c479d-f808-4053-aafa-705bc15b6d68",
                         "Policies": [
                         ],
-                        "MacAddress": null
+                        "MacAddress": null,
+                        "Name": null
                     })""";
 
                     ASSERT_EQ(mock_network_object, network);

--- a/tests/unit/hyperv_api/test_ut_hyperv_hcn_api.cpp
+++ b/tests/unit/hyperv_api/test_ut_hyperv_hcn_api.cpp
@@ -461,8 +461,8 @@ TEST_F(HyperVHCNAPI_UnitTests, delete_network_success)
     }
 
     { // Verify the expected outcome.
-        const auto& [status, error_msg] =
-            HCN().delete_network("af3fb745-2f23-463c-8ded-443f876d9e81");
+        const auto& [status,
+                     error_msg] = HCN().delete_network("af3fb745-2f23-463c-8ded-443f876d9e81");
         ASSERT_TRUE(status.success());
         ASSERT_TRUE(error_msg.empty());
     }
@@ -497,8 +497,8 @@ TEST_F(HyperVHCNAPI_UnitTests, delete_network_failed)
     }
 
     { // Verify the expected outcome.
-        const auto& [status, error_msg] =
-            HCN().delete_network("af3fb745-2f23-463c-8ded-443f876d9e81");
+        const auto& [status,
+                     error_msg] = HCN().delete_network("af3fb745-2f23-463c-8ded-443f876d9e81");
         ASSERT_FALSE(status.success());
         ASSERT_FALSE(error_msg.empty());
         ASSERT_STREQ(error_msg.c_str(), mock_error_msg);
@@ -726,8 +726,8 @@ TEST_F(HyperVHCNAPI_UnitTests, delete_endpoint_success)
     }
 
     { // Verify the expected outcome.
-        const auto& [status, error_msg] =
-            HCN().delete_endpoint("af3fb745-2f23-463c-8ded-443f876d9e81");
+        const auto& [status,
+                     error_msg] = HCN().delete_endpoint("af3fb745-2f23-463c-8ded-443f876d9e81");
         ASSERT_TRUE(status.success());
         ASSERT_TRUE(error_msg.empty());
     }
@@ -758,8 +758,8 @@ TEST_F(HyperVHCNAPI_UnitTests, delete_endpoint_failure)
     }
 
     { // Verify the expected outcome.
-        const auto& [status, error_msg] =
-            HCN().delete_endpoint("af3fb745-2f23-463c-8ded-443f876d9e81");
+        const auto& [status,
+                     error_msg] = HCN().delete_endpoint("af3fb745-2f23-463c-8ded-443f876d9e81");
         ASSERT_FALSE(status.success());
         ASSERT_FALSE(error_msg.empty());
         ASSERT_STREQ(error_msg.c_str(), mock_error_msg);

--- a/tests/unit/hyperv_api/test_ut_hyperv_hcs_virtual_machine_factory.cpp
+++ b/tests/unit/hyperv_api/test_ut_hyperv_hcs_virtual_machine_factory.cpp
@@ -109,7 +109,8 @@ TEST_F(HyperVHCSVirtualMachineFactory_UnitTests, remove_resources_for_impl_vm_ex
     EXPECT_CALL(mock_hcs, terminate_compute_system(Eq(mock_handle)))
         .WillOnce(Return(hcs_op_result_t{0, L""}));
 
-    EXPECT_CALL(mock_hcn, find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
+    EXPECT_CALL(mock_hcn,
+                find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
         .WillOnce(DoAll(
             [&](const std::string&, std::vector<std::string>& endpoint_guids) {
                 endpoint_guids.emplace_back("this isn't an endpoint guid");
@@ -135,7 +136,8 @@ TEST_F(HyperVHCSVirtualMachineFactory_UnitTests, remove_resources_for_impl_does_
                         SetArgReferee<1>(mock_handle),
                         Return(hcs_op_result_t{1, L""})));
 
-    EXPECT_CALL(mock_hcn, find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
+    EXPECT_CALL(mock_hcn,
+                find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
         .WillOnce(Return(hcs_op_result_t{0, L""}));
 
     std::shared_ptr<uut_t> uut{nullptr};
@@ -144,7 +146,7 @@ TEST_F(HyperVHCSVirtualMachineFactory_UnitTests, remove_resources_for_impl_does_
 }
 
 TEST_F(HyperVHCSVirtualMachineFactory_UnitTests,
-      remove_resources_for_impl_cleans_up_endpoints_by_name_when_already_terminated)
+       remove_resources_for_impl_cleans_up_endpoints_by_name_when_already_terminated)
 {
     auto vm_name = "test-vm";
     EXPECT_CALL(mock_hcs, open_compute_system(_, _))
@@ -152,7 +154,8 @@ TEST_F(HyperVHCSVirtualMachineFactory_UnitTests,
                         SetArgReferee<1>(mock_handle),
                         Return(hcs_op_result_t{1, L""})));
 
-    EXPECT_CALL(mock_hcn, find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
+    EXPECT_CALL(mock_hcn,
+                find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
         .WillOnce(DoAll(
             [&](const std::string&, std::vector<std::string>& endpoint_guids) {
                 endpoint_guids.emplace_back("endpoint-1");

--- a/tests/unit/hyperv_api/test_ut_hyperv_hcs_virtual_machine_factory.cpp
+++ b/tests/unit/hyperv_api/test_ut_hyperv_hcs_virtual_machine_factory.cpp
@@ -101,21 +101,17 @@ struct HyperVHCSVirtualMachineFactory_UnitTests : public ::testing::Test
 TEST_F(HyperVHCSVirtualMachineFactory_UnitTests, remove_resources_for_impl_vm_exists)
 {
     auto vm_name = "test-vm";
-    auto vm_guid = "this isn't a guid but this isn't a real implementation either";
     EXPECT_CALL(mock_hcs, open_compute_system(_, _))
         .WillOnce(DoAll([&](const std::string& name, hcs_handle_t&) { ASSERT_EQ(vm_name, name); },
                         SetArgReferee<1>(mock_handle),
                         Return(hcs_op_result_t{0, L""})));
 
-    EXPECT_CALL(mock_hcs, get_compute_system_guid(Eq(mock_handle), IsEmpty()))
-        .WillOnce(DoAll(SetArgReferee<1>(vm_guid), Return(hcs_op_result_t{0, L""})));
-
     EXPECT_CALL(mock_hcs, terminate_compute_system(Eq(mock_handle)))
         .WillOnce(Return(hcs_op_result_t{0, L""}));
 
-    EXPECT_CALL(mock_hcn, enumerate_attached_endpoints(Eq(vm_guid), IsEmpty()))
+    EXPECT_CALL(mock_hcn, find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
         .WillOnce(DoAll(
-            [&](const std::string& vm_guid, std::vector<std::string>& endpoint_guids) {
+            [&](const std::string&, std::vector<std::string>& endpoint_guids) {
                 endpoint_guids.emplace_back("this isn't an endpoint guid");
                 endpoint_guids.emplace_back("this isn't either");
             },
@@ -148,7 +144,7 @@ TEST_F(HyperVHCSVirtualMachineFactory_UnitTests, remove_resources_for_impl_does_
 }
 
 TEST_F(HyperVHCSVirtualMachineFactory_UnitTests,
-      remove_resources_for_impl_falls_back_to_name_based_cleanup_when_already_terminated)
+      remove_resources_for_impl_cleans_up_endpoints_by_name_when_already_terminated)
 {
     auto vm_name = "test-vm";
     EXPECT_CALL(mock_hcs, open_compute_system(_, _))

--- a/tests/unit/hyperv_api/test_ut_hyperv_hcs_virtual_machine_factory.cpp
+++ b/tests/unit/hyperv_api/test_ut_hyperv_hcs_virtual_machine_factory.cpp
@@ -139,6 +139,36 @@ TEST_F(HyperVHCSVirtualMachineFactory_UnitTests, remove_resources_for_impl_does_
                         SetArgReferee<1>(mock_handle),
                         Return(hcs_op_result_t{1, L""})));
 
+    EXPECT_CALL(mock_hcn, find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
+        .WillOnce(Return(hcs_op_result_t{0, L""}));
+
+    std::shared_ptr<uut_t> uut{nullptr};
+    ASSERT_NO_THROW(uut = construct_factory());
+    uut->remove_resources_for(vm_name);
+}
+
+TEST_F(HyperVHCSVirtualMachineFactory_UnitTests,
+      remove_resources_for_impl_falls_back_to_name_based_cleanup_when_already_terminated)
+{
+    auto vm_name = "test-vm";
+    EXPECT_CALL(mock_hcs, open_compute_system(_, _))
+        .WillOnce(DoAll([&](const std::string& name, hcs_handle_t&) { ASSERT_EQ(vm_name, name); },
+                        SetArgReferee<1>(mock_handle),
+                        Return(hcs_op_result_t{1, L""})));
+
+    EXPECT_CALL(mock_hcn, find_endpoints_by_name(Eq(fmt::format("multipass-{}", vm_name)), IsEmpty()))
+        .WillOnce(DoAll(
+            [&](const std::string&, std::vector<std::string>& endpoint_guids) {
+                endpoint_guids.emplace_back("endpoint-1");
+                endpoint_guids.emplace_back("endpoint-2");
+            },
+            Return(hcs_op_result_t{0, L""})));
+
+    EXPECT_CALL(mock_hcn, delete_endpoint(Eq("endpoint-1")))
+        .WillOnce(Return(hcs_op_result_t{0, L""}));
+    EXPECT_CALL(mock_hcn, delete_endpoint(Eq("endpoint-2")))
+        .WillOnce(Return(hcs_op_result_t{0, L""}));
+
     std::shared_ptr<uut_t> uut{nullptr};
     ASSERT_NO_THROW(uut = construct_factory());
     uut->remove_resources_for(vm_name);


### PR DESCRIPTION
The previous approach was relying on opening the VM to
obtain the RuntimeId of the VM which means VM has to be in
running state.

This patch eliminates the need by tagging the endpoints with
the VM name.

Closes: #5220 

MULTI-2898