### PR TITLE
[base-vm] Check VM state in ssh_exec_process

### DIFF
--- a/src/platform/backends/shared/base_virtual_machine.cpp
+++ b/src/platform/backends/shared/base_virtual_machine.cpp
@@ -247,6 +247,14 @@ std::unique_ptr<mp::SSHProcess> mp::BaseVirtualMachine::ssh_exec_process(const s
 
     std::optional<std::string> log_details = std::nullopt;
     bool reconnect = true;
+
+    // Fail fast: a stale cached session would block forever (established timeout is LONG_MAX).
+    if (!MP_UTILS.is_running(current_state()))
+    {
+        drop_ssh_session();
+        throw SSHVMNotRunning{"SSH unavailable on instance {}: not running", vm_name};
+    }
+
     while (true)
     {
         assert(reconnect && "we should have thrown otherwise");
@@ -527,12 +535,12 @@ std::shared_ptr<const mp::Snapshot> mp::BaseVirtualMachine::take_snapshot(
     auto rollback_on_failure = make_take_snapshot_rollback(it);
 
     // get instance id from cloud-init file and pass to make_specific_snapshot
-    auto ret = head_snapshot = it->second =
-        make_specific_snapshot(sname,
-                               comment,
-                               get_instance_id_from_the_cloud_init(),
-                               specs,
-                               head_snapshot);
+    auto ret = head_snapshot = it->second = make_specific_snapshot(
+        sname,
+        comment,
+        get_instance_id_from_the_cloud_init(),
+        specs,
+        head_snapshot);
     ret->capture();
 
     ++snapshot_count;
@@ -657,8 +665,8 @@ void mp::BaseVirtualMachine::rename_snapshot(const std::string& old_name,
         throw SnapshotNameTakenException{vm_name, new_name};
 
     auto snapshot_node = snapshots.extract(old_it);
-    const auto reinsert_guard =
-        make_reinsert_guard(snapshot_node); // we want this to execute both on failure & success
+    const auto reinsert_guard = make_reinsert_guard(
+        snapshot_node); // we want this to execute both on failure & success
 
     snapshot_node.key() = new_name;
     snapshot_node.mapped()->set_name(new_name);
@@ -787,10 +795,10 @@ void mp::BaseVirtualMachine::persist_generic_snapshot_info() const
     auto count_path = instance_dir.filePath(count_filename);
 
     QFile head_file{head_path};
-    auto head_file_rollback =
-        make_common_file_rollback(head_path,
-                                  head_file,
-                                  std::to_string(head_snapshot->get_parents_index()) + "\n");
+    auto head_file_rollback = make_common_file_rollback(
+        head_path,
+        head_file,
+        std::to_string(head_snapshot->get_parents_index()) + "\n");
     persist_head_snapshot_index(head_path);
 
     QFile count_file{count_path};
@@ -935,8 +943,10 @@ auto mp::BaseVirtualMachine::try_to_ssh() -> utils::TimeoutAction
 
 void mp::BaseVirtualMachine::ssh_and_cross_to_running()
 {
-    auto new_session =
-        std::make_unique<PlainSSHSession>(ssh_hostname(), ssh_port(), ssh_username(), key_provider);
+    auto new_session = std::make_unique<PlainSSHSession>(ssh_hostname(),
+                                                         ssh_port(),
+                                                         ssh_username(),
+                                                         key_provider);
 
     std::lock_guard lock{state_mutex};
     ssh_session = std::move(new_session);

--- a/tests/unit/test_base_virtual_machine.cpp
+++ b/tests/unit/test_base_virtual_machine.cpp
@@ -884,9 +884,9 @@ TEST_F(BaseVM, restoresSnapshotsWithExtraInterfaceDiff)
     const auto& snapshot = *snapshot_album[0];
 
     mp::VMSpecs new_specs = original_specs;
-    new_specs.extra_interfaces =
-        std::vector<mp::NetworkInterface>{{"id", "52:54:00:56:78:91", true},
-                                          {"id", "52:54:00:56:78:92", true}};
+    new_specs.extra_interfaces = std::vector<mp::NetworkInterface>{
+        {"id", "52:54:00:56:78:91", true},
+        {"id", "52:54:00:56:78:92", true}};
 
     // the ref return functions can not use the default mock behavior, so they need to be specified
     EXPECT_CALL(snapshot, get_mounts).WillOnce(ReturnRef(original_specs.mounts));
@@ -1008,8 +1008,9 @@ TEST_F(BaseVM, loadsSnasphots)
     static const auto index_digits_regex = n_occurrences(digit_char_class, 4);
     static const auto file_regex = fmt::format(R"(.*{}\.snapshot\.json)", index_digits_regex);
 
-    auto& expectation =
-        EXPECT_CALL(vm, make_specific_snapshot(mpt::match_qstring(MatchesRegex(file_regex))));
+    auto& expectation = EXPECT_CALL(
+        vm,
+        make_specific_snapshot(mpt::match_qstring(MatchesRegex(file_regex))));
 
     using NiceMockSnapshot = NiceMock<mpt::MockSnapshot>;
     std::array<std::shared_ptr<NiceMockSnapshot>, num_snapshots> snapshot_bag{};
@@ -1434,12 +1435,31 @@ TEST_F(BaseVM, sshExecProcessRefusesToExecuteIfVMIsNotRunning)
                          mpt::match_what(HasSubstr("not running")));
 }
 
+TEST_F(BaseVM, sshExecProcessThrowsIfVMIsStopped)
+{
+    static constexpr auto* cmd = ":";
+
+    auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
+    EXPECT_CALL(*mock_utils_ptr, is_running)
+        .Times(2)
+        .WillOnce(Return(true))
+        .WillOnce(Return(false));
+
+    vm.simulate_ssh_exec_process();
+    vm.renew_ssh_session();
+
+    MP_EXPECT_THROW_THAT(
+        vm.ssh_exec_process(cmd),
+        mp::SSHException,
+        mpt::match_what(HasSubstr("SSH unavailable on instance mock-vm: not running")));
+}
+
 TEST_F(BaseVM, sshExecProcessRunsDirectlyIfConnected)
 {
     static constexpr auto* cmd = ":";
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
-    EXPECT_CALL(*mock_utils_ptr, is_running).WillOnce(Return(true));
+    EXPECT_CALL(*mock_utils_ptr, is_running).Times(2).WillRepeatedly(Return(true));
     EXPECT_CALL(vm, make_ssh_process(cmd, _))
         .WillOnce(Return(std::make_unique<NiceMock<mpt::MockSSHProcess>>()));
 
@@ -1454,7 +1474,7 @@ TEST_F(BaseVM, sshExecProcessReconnectsIfDisconnected)
     static constexpr auto* cmd = ":";
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
-    EXPECT_CALL(*mock_utils_ptr, is_running).WillOnce(Return(true));
+    EXPECT_CALL(*mock_utils_ptr, is_running).Times(2).WillRepeatedly(Return(true));
     EXPECT_CALL(vm, make_ssh_process(cmd, _))
         .WillOnce(Return(std::make_unique<NiceMock<mpt::MockSSHProcess>>()));
 
@@ -1486,7 +1506,7 @@ TEST_F(BaseVM, sshExecProcessRethrowsSSHExceptionsWhenConnected)
     static constexpr auto* cmd = ":";
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
-    EXPECT_CALL(*mock_utils_ptr, is_running).WillOnce(Return(true));
+    EXPECT_CALL(*mock_utils_ptr, is_running).Times(2).WillRepeatedly(Return(true));
     EXPECT_CALL(vm, make_ssh_process(cmd, _)).WillOnce(Throw(mp::SSHException{"intentional"}));
 
     vm.simulate_ssh_exec_process();
@@ -1502,7 +1522,7 @@ TEST_F(BaseVM, sshExecProcessPropagatesNonSSHExceptions)
     static constexpr auto* cmd = "wrong";
 
     auto [mock_utils_ptr, guard] = mpt::MockUtils::inject();
-    EXPECT_CALL(*mock_utils_ptr, is_running).WillOnce(Return(true));
+    EXPECT_CALL(*mock_utils_ptr, is_running).Times(2).WillRepeatedly(Return(true));
     EXPECT_CALL(vm, make_ssh_process(cmd, _)).WillOnce(Throw(std::runtime_error{"intentional"}));
 
     vm.simulate_ssh_exec_process();


### PR DESCRIPTION
The VM might have been shut down while the cached session is alive, and given that the SSH session's established state does not have a timeout, it might wedge the caller forever.

Check if the VM is running before proceeding with the exec.

## Related Issue(s)

#5235 

MULTI-2902

